### PR TITLE
fix: add /setup and /login SPA route fallbacks

### DIFF
--- a/server/routes/static.js
+++ b/server/routes/static.js
@@ -50,6 +50,8 @@ routes['/icon-512.png'] = { GET: noauthServeStatic('icon-512.png') };
 routes['/site.webmanifest'] = { GET: noauthServeStatic('site.webmanifest') };
 routes['/_app/*'] = { GET: markRouteNoAuth(noauthServeFile) };
 routes['/chat/:id'] = { GET: noauthServeStatic('index.html') };
+routes['/setup'] = { GET: noauthServeStatic('index.html') };
+routes['/login'] = { GET: noauthServeStatic('index.html') };
 //routes['/*'] = { GET: noauthServeFile };
 
 export default routes;


### PR DESCRIPTION
Navigating directly to `/setup` or `/login` returns a 404 because these SPA routes are missing from the static route config.

This adds them as `index.html` fallbacks, matching the existing pattern used for `/chat/:id`.