### PR TITLE
feat: add GARCON_API_KEY for static Bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Common environment variables:
 
 - `GARCON_PORT`, `GARCON_BIND_ADDRESS`
 - `GARCON_CONFIG_DIR`, `GARCON_WORKSPACE_DIR`, `GARCON_WORKSPACE`
+- `GARCON_API_KEY` — static Bearer token that bypasses login/setup
 - `GARCON_PROJECT_BASE_DIR`
 - `GARCON_TERMINAL_SHELL`
 - `GARCON_JWT_TOKEN_EXPIRY`

--- a/server/config.js
+++ b/server/config.js
@@ -115,6 +115,12 @@ export function getJwtTokenExpiry() {
   return process.env.GARCON_JWT_TOKEN_EXPIRY || '30d';
 }
 
+// Static API key for token-less authentication.
+// When set, requests bearing this key (as a Bearer token) bypass JWT/setup.
+export function getApiKey() {
+  return process.env.GARCON_API_KEY || null;
+}
+
 // File access boundary
 export function getProjectBasePath() {
   if (process.env.GARCON_PROJECT_BASE_DIR) {

--- a/server/lib/api-key.js
+++ b/server/lib/api-key.js
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+import { getApiKey as getApiKeyConfig } from '../config.js';
+
+// Cached singleton so the env var is read once.
+let instance = null;
+
+// Returns an object with a verify(token) method.
+// verify() returns a user object if the token matches the configured API key,
+// or null otherwise. Uses constant-time comparison to prevent timing attacks.
+export function getApiKey() {
+  if (!instance) {
+    const key = getApiKeyConfig();
+    instance = {
+      verify(token) {
+        if (!key || !token) return null;
+        const a = Buffer.from(key);
+        const b = Buffer.from(token);
+        if (a.length !== b.length) return null;
+        if (!crypto.timingSafeEqual(a, b)) return null;
+        return { username: 'api-key' };
+      },
+    };
+  }
+  return instance;
+}

--- a/server/lib/http-native.js
+++ b/server/lib/http-native.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { getJwtSecret } from '../auth/store.js';
+import { getApiKey } from './api-key.js';
 
 // Lazily resolved on first use and cached for the process lifetime.
 let cachedSecret = null;
@@ -44,12 +45,18 @@ export function getTokenFromRequest(request) {
   return null;
 }
 
-// Verifies the JWT token. Single-user system so we only check token
-// validity, not user lookup. Returns decoded payload as user.
+// Verifies the JWT token or static API key. Single-user system so we only
+// check token validity, not user lookup. Returns decoded payload as user.
 export async function authenticateHttpRequest(request) {
   const token = getTokenFromRequest(request);
   if (!token) {
     return { user: null, errorResponse: Response.json({ error: 'Access denied. No token provided.' }, { status: 401 }) };
+  }
+
+  // Check static API key first (constant-time comparison).
+  const apiKeyUser = getApiKey().verify(token);
+  if (apiKeyUser) {
+    return { user: apiKeyUser, errorResponse: null };
   }
 
   try {

--- a/server/main.js
+++ b/server/main.js
@@ -22,6 +22,7 @@ Environment Variables:
   GARCON_CONFIG_DIR                Base config directory. Default: ~/.garcon
   GARCON_WORKSPACE_DIR             Explicit workspace directory path.
   GARCON_WORKSPACE                 Workspace suffix under config dir. Default: default
+  GARCON_API_KEY                   Static API key for Bearer auth (bypasses login/setup).
   GARCON_JWT_TOKEN_EXPIRY          JWT expiry for auth tokens. Default: 30d
   GARCON_PROJECT_BASE_DIR          Restricts project file access to this resolved path.
   GARCON_TERMINAL_SHELL            Shell executable for PTY sessions (non-Windows).

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import { getJwtSecret } from '../auth/store.js';
 import { getJwtTokenExpiry } from '../config.js';
+import { getApiKey } from '../lib/api-key.js';
 
 // Lazily resolved on first use and cached for the process lifetime.
 let cachedSecret = null;
@@ -24,6 +25,12 @@ export async function generateToken(user) {
 export async function authenticateWebSocket(token) {
   if (!token) {
     return null;
+  }
+
+  // Check static API key first.
+  const apiKeyUser = getApiKey().verify(token);
+  if (apiKeyUser) {
+    return apiKeyUser;
   }
 
   try {


### PR DESCRIPTION
When `GARCON_API_KEY` is set, requests with that value as a Bearer token bypass JWT verification and the setup/login flow.

**Usage:**
```bash
GARCON_API_KEY=my-secret-key bun server/main.js
curl -H 'Authorization: Bearer my-secret-key' http://localhost:8080/api/v1/auth/user
```

**Changes:**
- `server/lib/api-key.js` — shared helper with constant-time comparison (`crypto.timingSafeEqual`)
- `server/lib/http-native.js` — checks API key before JWT in HTTP auth
- `server/middleware/auth.js` — checks API key before JWT in WebSocket auth
- `server/config.js` — `getApiKey()` getter
- `server/main.js` — added to `--help` env var docs
- `README.md` — documented in common env vars

Tested: no token → 401, wrong key → 403, correct key → ✅ authenticated.