### PR TITLE
fix: detect API key env vars in provider auth status

### DIFF
--- a/server/routes/claude.js
+++ b/server/routes/claude.js
@@ -3,6 +3,11 @@ import path from 'path';
 import os from 'os';
 
 async function getClaudeAuthStatus() {
+  // Check ANTHROPIC_API_KEY env var first.
+  if (typeof process.env.ANTHROPIC_API_KEY === 'string' && process.env.ANTHROPIC_API_KEY.trim()) {
+    return { authenticated: true, email: null, method: 'api_key_env' };
+  }
+
   try {
     const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
     const content = await fs.readFile(credPath, 'utf8');
@@ -11,30 +16,32 @@ async function getClaudeAuthStatus() {
     if (oauth && oauth.accessToken) {
       const isExpired = oauth.expiresAt && Date.now() >= oauth.expiresAt;
       if (!isExpired) {
-        return { authenticated: true, email: creds.email || creds.user || null };
+        return { authenticated: true, email: creds.email || creds.user || null, method: 'credentials_file' };
       }
     }
-    return { authenticated: false, email: null };
+    return { authenticated: false, email: null, method: null };
   } catch {
-    return { authenticated: false, email: null };
+    return { authenticated: false, email: null, method: null };
   }
 }
 
 async function getClaudeAuthStatusRoute(request, url) {
 
   try {
-    const credentialsResult = await getClaudeAuthStatus();
-    if (credentialsResult.authenticated) {
+    const result = await getClaudeAuthStatus();
+    if (result.authenticated) {
       return Response.json({
         authenticated: true,
-        email: credentialsResult.email || 'Authenticated session',
-        method: 'credentials_file',
+        email: result.method === 'api_key_env'
+          ? 'API Key Auth'
+          : (result.email || 'Authenticated session'),
+        method: result.method,
       });
     }
     return Response.json({
       authenticated: false,
       email: null,
-      error: credentialsResult.error || 'No active Claude authentication session was found.',
+      error: 'No active Claude authentication session was found.',
     });
   } catch (error) {
     return Response.json({ authenticated: false, email: null, error: error.message }, { status: 500 });

--- a/server/routes/codex.js
+++ b/server/routes/codex.js
@@ -3,6 +3,11 @@ import path from 'path';
 import os from 'os';
 
 async function getCodexAuthStatus() {
+  // Check OPENAI_API_KEY env var first.
+  if (typeof process.env.OPENAI_API_KEY === 'string' && process.env.OPENAI_API_KEY.trim()) {
+    return { authenticated: true, email: 'API Key Auth', method: 'api_key_env' };
+  }
+
   try {
     const authPath = path.join(os.homedir(), '.codex', 'auth.json');
     const content = await fs.readFile(authPath, 'utf8');
@@ -21,10 +26,10 @@ async function getCodexAuthStatus() {
           email = 'Authenticated';
         }
       }
-      return { authenticated: true, email };
+      return { authenticated: true, email, method: 'credentials_file' };
     }
     if (auth.OPENAI_API_KEY) {
-      return { authenticated: true, email: 'API Key Auth' };
+      return { authenticated: true, email: 'API Key Auth', method: 'api_key_file' };
     }
     return { authenticated: false, email: null, error: 'No usable Codex credentials were found.' };
   } catch (error) {


### PR DESCRIPTION
The Claude CLI and Codex SDK already support API key env vars (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`), and the providers pass them through via `process.env`. However the auth status routes only checked credential files, so the Settings UI showed providers as **disconnected** even when API keys were set.

**Changes:**
- **Claude** (`server/routes/claude.js`): Check `ANTHROPIC_API_KEY` env var before falling back to `~/.claude/.credentials.json`
- **Codex** (`server/routes/codex.js`): Check `OPENAI_API_KEY` env var before falling back to `~/.codex/auth.json`
- Both routes now return a `method` field (`api_key_env`, `credentials_file`, `api_key_file`) so the UI can distinguish auth mechanisms
- Env var checks use `typeof + trim()` to avoid false positives from empty strings