### PR TITLE
fix: don't steal focus from directory browser on path validation

### DIFF
--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -70,9 +70,9 @@
 		form.validateModelAgainstLive('opencode');
 	});
 
-	// Focus textarea when path validates successfully.
+	// Focus textarea when path validates successfully, but not while browsing.
 	$effect(() => {
-		if (form.validationStatus === 'valid') {
+		if (form.validationStatus === 'valid' && !form.showBrowser) {
 			textareaRef?.focus();
 		}
 	});


### PR DESCRIPTION
The textarea auto-focus effect fired whenever the path validated, which stole focus from the directory browser while clicking through folders. Now skips auto-focus while the browser is open.