### PR TITLE
feat: inline filtering in directory browser as you type

### DIFF
--- a/web/src/lib/components/chat/DirectoryBrowser.svelte
+++ b/web/src/lib/components/chat/DirectoryBrowser.svelte
@@ -29,15 +29,39 @@
 		return raw;
 	});
 
+	// Split the typed path into a browsable parent directory and a filter
+	// prefix. If the path ends with '/' or is a known directory (from the
+	// last fetch), browse it directly. Otherwise treat the last segment as
+	// a partial name filter on the parent directory.
+	let resolvedDir = $state('');
+	let filterPrefix = $state('');
+
+	$effect(() => {
+		const raw = clampedStart;
+		if (raw.endsWith('/') || raw === basePath) {
+			resolvedDir = raw;
+			filterPrefix = '';
+		} else {
+			const lastSlash = raw.lastIndexOf('/');
+			resolvedDir = lastSlash >= 0 ? raw.slice(0, lastSlash) || '/' : '/';
+			filterPrefix = lastSlash >= 0 ? raw.slice(lastSlash + 1).toLowerCase() : '';
+		}
+	});
+
 	let browsePath = $state('');
-	let entries = $state<DirectoryEntry[]>([]);
+	let allEntries = $state<DirectoryEntry[]>([]);
+	let entries = $derived(
+		filterPrefix
+			? allEntries.filter((e) => e.name.toLowerCase().startsWith(filterPrefix))
+			: allEntries
+	);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let focusIndex = $state(-1);
 
-	// Initialize browsePath from clampedStart
+	// Initialize browsePath from resolvedDir
 	$effect(() => {
-		browsePath = clampedStart;
+		browsePath = resolvedDir;
 	});
 
 	// Fetch directory contents whenever browsePath changes.
@@ -53,13 +77,13 @@
 		void browseDirectory(path, abortController.signal)
 			.then((list) => {
 				if (abortController.signal.aborted) return;
-				entries = list;
+				allEntries = list;
 				focusIndex = -1;
 				loading = false;
 			})
 			.catch((err) => {
 				if (abortController.signal.aborted) return;
-				entries = [];
+				allEntries = [];
 				error = err instanceof Error ? err.message : String(err);
 				loading = false;
 			});


### PR DESCRIPTION
## Problem

Typing a partial path like `/home/yk/pm` tried to browse `/home/yk/pm` as a directory. Since that doesn't exist, the browser showed nothing — making it impossible to find `pm-mm-rs` or `pm-alpha` by typing.

## Fix

Split the typed path into a parent directory and filter prefix when it doesn't end with `/`. The browser fetches the parent and filters entries matching the prefix inline.

**Example:** typing `/home/yk/pm` → browses `/home/yk/` → shows only `pm-alpha` and `pm-mm-rs`.