### PR TITLE
fix: strip CLAUDECODE env var when spawning claude CLI

### DIFF
--- a/server/providers/claude-cli.js
+++ b/server/providers/claude-cli.js
@@ -61,7 +61,7 @@ async function runSingleQuery(prompt, { model, cwd, permissionMode, ...rest } = 
     stdin: 'ignore',
     stdout: 'pipe',
     stderr: 'pipe',
-    env: { ...process.env },
+    env: (() => { const { CLAUDECODE, ...env } = process.env; return env; })(),
   });
 
   const chunks = [];
@@ -435,7 +435,7 @@ class ClaudeProvider extends AbsProvider {
       stdin: 'pipe',
       stdout: 'pipe',
       stderr: 'pipe',
-      env: { ...process.env },
+      env: (() => { const { CLAUDECODE, ...env } = process.env; return env; })(),
     });
 
     session.process = proc;


### PR DESCRIPTION
## Problem

When garcon's server inherits `CLAUDECODE=1` from its parent shell (e.g. when started from within a Claude Code session), the spawned `claude` binary refuses to run:

```
Error: Claude Code cannot be launched inside another Claude Code session.
```

## Fix

Strip the `CLAUDECODE` env var via destructuring at both `Bun.spawn()` call sites in `claude-cli.js`. Uses omission rather than `undefined` assignment to avoid any edge case where a runtime might stringify `undefined`.

Only `CLAUDECODE` is stripped — other `CLAUDE_*` / `ANTHROPIC_*` vars are preserved as they may be needed for auth/config.