### PR TITLE
perf: parse Claude JSONL output incrementally via indexOf

### DIFF
--- a/server/providers/claude-cli.js
+++ b/server/providers/claude-cli.js
@@ -365,10 +365,13 @@ class ClaudeProvider extends AbsProvider {
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop();
 
-        for (const line of lines) {
+        // Parse lines incrementally via indexOf instead of split().
+        let idx;
+        while ((idx = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+
           if (!line.trim()) continue;
           let msg;
           try {


### PR DESCRIPTION
Replaces buffer.split('\\n') with an indexOf loop for parsing Claude CLI JSONL stdout. Avoids allocating an intermediate array of all lines on every chunk read, reducing GC pressure on this streaming hot path.