### PR TITLE
perf: skip stat() in directory browse endpoint

### DIFF
--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import mime from 'mime-types';
 import { parseJsonBody } from '../lib/http-native.js';
-import { listDirectory } from './projects.utils.js';
+import { listDirectory, listDirectoryNames } from './projects.utils.js';
 import { getProjectBasePath } from '../config.js';
 
 const MAX_IMAGE_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
@@ -280,8 +280,7 @@ export default function createFilesRoutes(registry) {
     }
 
     try {
-      const entries = await listDirectory(dirPath, true);
-      // Only return directories that are within the allowed base path.
+      const entries = await listDirectoryNames(dirPath, true);
       return Response.json(
         entries.filter((e) => e.type === 'directory' && isWithinBasePath(e.path))
       );

--- a/server/routes/projects.utils.js
+++ b/server/routes/projects.utils.js
@@ -56,3 +56,30 @@ export async function listDirectory(dirPath, showHidden = true) {
     return a.name.localeCompare(b.name);
   });
 }
+
+export async function listDirectoryNames(dirPath, showHidden = true) {
+  const skipNames = new Set(['node_modules', 'dist', 'build', '.git', '.svn', '.hg']);
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (error.code !== 'EACCES' && error.code !== 'EPERM') {
+      console.error('Error reading directory:', error);
+    }
+    return [];
+  }
+
+  const items = [];
+  for (const entry of entries) {
+    if (skipNames.has(entry.name)) continue;
+    if (!showHidden && entry.name.startsWith('.')) continue;
+    if (!entry.isDirectory()) continue;
+    items.push({
+      name: entry.name,
+      path: path.join(dirPath, entry.name),
+      type: 'directory',
+    });
+  }
+
+  return items.sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
The /api/v1/files/browse endpoint only needs directory names for the DirectoryBrowser component, but was calling fs.stat() on every entry to get unused metadata (size, permissions, modified). This adds a lightweight listDirectoryNames() that uses only fs.readdir withFileTypes, skipping all stat() syscalls. In directories with hundreds of entries, this eliminates hundreds of syscalls per request.