### PR TITLE
perf: precompute sanitized env for process spawning

### DIFF
--- a/server/providers/claude-cli.js
+++ b/server/providers/claude-cli.js
@@ -9,6 +9,9 @@ import { AssistantMessage, ThinkingMessage, ToolResultMessage, PermissionRequest
 import { convertClaudeToolUse } from './converters/claude-tool-use.js';
 import { AbsProvider } from './base.js';
 
+// Precomputed environment with CLAUDECODE stripped — avoids per-spawn allocation.
+const SANITIZED_ENV = (() => { const { CLAUDECODE, ...env } = process.env; return env; })();
+
 // Converts a finalized CLI assistant message to ChatMessage objects.
 function convertCLIMessageToChatMessages(msg) {
   if (msg.type !== 'assistant') return [];
@@ -61,7 +64,7 @@ async function runSingleQuery(prompt, { model, cwd, permissionMode, ...rest } = 
     stdin: 'ignore',
     stdout: 'pipe',
     stderr: 'pipe',
-    env: { ...process.env },
+    env: SANITIZED_ENV,
   });
 
   const chunks = [];
@@ -435,7 +438,7 @@ class ClaudeProvider extends AbsProvider {
       stdin: 'pipe',
       stdout: 'pipe',
       stderr: 'pipe',
-      env: { ...process.env },
+      env: SANITIZED_ENV,
     });
 
     session.process = proc;

--- a/server/ws/shell.js
+++ b/server/ws/shell.js
@@ -5,6 +5,14 @@ import { getUserShell } from '../config.js';
 
 const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
 
+// Precomputed PTY environment — avoids per-session allocation.
+const PTY_BASE_ENV = {
+  ...process.env,
+  TERM: 'xterm-256color',
+  COLORTERM: 'truecolor',
+  FORCE_COLOR: '3',
+};
+
 export class ShellManager {
   #sessions = new Map();
 
@@ -106,12 +114,7 @@ export class ShellManager {
           const termCols = data.cols || 80;
           const termRows = data.rows || 24;
 
-          const ptyEnv = {
-            ...process.env,
-            TERM: 'xterm-256color',
-            COLORTERM: 'truecolor',
-            FORCE_COLOR: '3',
-          };
+          const ptyEnv = PTY_BASE_ENV;
 
           let shell;
           let shellArgs;


### PR DESCRIPTION
Avoids rebuilding environment variable objects on every CLI/PTY spawn. The sanitized env (with CLAUDECODE stripped) and PTY env (with TERM/COLORTERM) are now computed once at module load.