### PR TITLE
WIP: AMP integration only (descoped)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Garcon
 
-Garcon is a local-first coding workspace for AI agents, with one UI for Claude, Codex, and OpenCode.
+Garcon is a local-first coding workspace for AI agents, with one UI for Claude, Codex, OpenCode, and Amp.
 
 ## Capabilities
 
-- Multi-provider chat sessions (`claude`, `codex`, `opencode`) with per-chat model selection
+- Multi-provider chat sessions (`claude`, `codex`, `opencode`, `amp`) with per-chat model selection
 - Unified coding workspace tabs: chat, files, terminal, and git
 - Full Git workbench: status, diff, staging/hunks, branches, history, commit/push/pull/fetch, worktrees, revert
 - Persistent chat history with pin/archive/reorder/read-state/fork operations
@@ -26,6 +26,7 @@ Garcon is a local-first coding workspace for AI agents, with one UI for Claude, 
   - Claude CLI (`claude`) and local Claude auth
   - Codex auth (`~/.codex/auth.json`) or `OPENAI_API_KEY`
   - OpenCode provider keys/config (through OpenCode SDK)
+  - Amp CLI (`amp`) and Amp auth (`AMP_API_KEY` or local Amp secrets file)
 
 ## Quick Start
 
@@ -66,4 +67,6 @@ Common environment variables:
 - `GARCON_TERMINAL_SHELL`
 - `GARCON_JWT_TOKEN_EXPIRY`
 - `OPENAI_API_KEY`
+- `AMP_API_KEY`
 - `CLAUDE_BINARY`
+- `AMP_BINARY`

--- a/common/models.ts
+++ b/common/models.ts
@@ -20,3 +20,13 @@ export const CODEX_MODELS = {
   ],
   DEFAULT: 'gpt-5.3-codex',
 };
+
+export const AMP_MODELS = {
+  OPTIONS: [
+    { value: 'smart', label: 'Smart' },
+    { value: 'deep', label: 'Deep' },
+    { value: 'rush', label: 'Rush' },
+    { value: 'free', label: 'Free' },
+  ],
+  DEFAULT: 'smart',
+};

--- a/common/providers.ts
+++ b/common/providers.ts
@@ -2,7 +2,7 @@
 // and frontend as the single source of truth for provider identity and
 // static capability policy.
 
-export const PROVIDERS = ['claude', 'codex', 'opencode'] as const;
+export const PROVIDERS = ['claude', 'codex', 'opencode', 'amp'] as const;
 
 export type ProviderId = (typeof PROVIDERS)[number];
 
@@ -15,6 +15,7 @@ export const PROVIDER_CAPABILITIES: Record<ProviderId, ProviderCapabilities> = {
   claude: { supportsFork: true, supportsImages: true },
   codex: { supportsFork: true, supportsImages: false },
   opencode: { supportsFork: false, supportsImages: false },
+  amp: { supportsFork: true, supportsImages: false },
 };
 
 export function isProviderId(value: unknown): value is ProviderId {

--- a/common/ws-events.ts
+++ b/common/ws-events.ts
@@ -55,6 +55,7 @@ export class ChatSessionsRunningMessage {
     claude: Array<{ id: string }>;
     codex: Array<{ id: string }>;
     opencode: Array<{ id: string }>;
+    amp: Array<{ id: string }>;
   }) { }
 }
 

--- a/server/chats/resolve-native-path.js
+++ b/server/chats/resolve-native-path.js
@@ -42,5 +42,9 @@ export async function resolveMissingNativePath(session) {
     return `opencode:${session.providerSessionId}`;
   }
 
+  if (session.provider === 'amp') {
+    return `amp:${session.providerSessionId}`;
+  }
+
   return null;
 }

--- a/server/config.js
+++ b/server/config.js
@@ -110,6 +110,11 @@ export function getClaudeBinary() {
   return process.env.CLAUDE_BINARY || 'claude';
 }
 
+// Amp CLI binary path
+export function getAmpBinary() {
+  return process.env.AMP_BINARY || 'amp';
+}
+
 // JWT token expiry (secret is managed by auth/store.js).
 export function getJwtTokenExpiry() {
   return process.env.GARCON_JWT_TOKEN_EXPIRY || '30d';

--- a/server/main.js
+++ b/server/main.js
@@ -33,6 +33,7 @@ Environment Variables:
   GARCON_WS_MAX_PAYLOAD_LENGTH     WebSocket max payload length (bytes). Default: 16777216
   GARCON_HTTP_IDLE_TIMEOUT_SECONDS HTTP idle timeout seconds. Default: 120
   CLAUDE_BINARY                    Claude CLI binary path. Default: claude
+  AMP_BINARY                       Amp CLI binary path. Default: amp
   SHELL                            Fallback shell path when GARCON_TERMINAL_SHELL is unset.
 
 Notes:

--- a/server/providers/__tests__/providers-run-single-query.test.js
+++ b/server/providers/__tests__/providers-run-single-query.test.js
@@ -8,6 +8,7 @@ import { describe, it, expect, mock } from 'bun:test';
 
 const claudeMock = mock(async () => 'claude-response');
 const codexMock = mock(async () => 'codex-response');
+const ampSingleQueryMock = mock(async () => 'amp-response');
 
 mock.module('../claude-cli.js', () => ({
   runSingleQuery: claudeMock,
@@ -19,10 +20,15 @@ mock.module('../codex.js', () => ({
   CodexProvider: class { constructor() {} },
 }));
 
+mock.module('../amp.js', () => ({
+  runSingleQuery: ampSingleQueryMock,
+  AmpProvider: class { constructor() {} },
+}));
+
 // Mock the stateless loader imports that ProviderRegistry pulls in
 mock.module('../loaders/claude-history-loader.js', () => ({
   getClaudePreviewFromNativePath: mock(() => Promise.resolve(null)),
-  getClaudeSessionMessagesFromNativePath: mock(() => Promise.resolve([])),
+  loadClaudeChatMessages: mock(() => Promise.resolve([])),
 }));
 
 mock.module('../loaders/codex-history-loader.js', () => ({
@@ -35,8 +41,23 @@ mock.module('../loaders/opencode-history-loader.js', () => ({
   loadOpenCodeChatMessages: mock(() => Promise.resolve([])),
 }));
 
+mock.module('../loaders/amp-history-loader.js', () => ({
+  getAmpPreviewFromSessionId: mock(() => Promise.resolve(null)),
+  loadAmpChatMessages: mock(() => Promise.resolve([])),
+}));
+
 const opencodeMock = mock(async () => 'opencode-response');
 const mockOpencode = { runSingleQuery: opencodeMock };
+const mockAmpProvider = {
+  onMessages: mock(() => {}),
+  onProcessing: mock(() => {}),
+  onSessionCreated: mock(() => {}),
+  onFinished: mock(() => {}),
+  onFailed: mock(() => {}),
+  startPurgeTimer: mock(() => {}),
+  getRunningSessions: mock(() => []),
+  isRunning: mock(() => false),
+};
 
 const mockRegistry = {
   getChat: mock(() => null),
@@ -45,7 +66,7 @@ const mockRegistry = {
 
 import { ProviderRegistry } from '../index.js';
 
-const registry = new ProviderRegistry(mockRegistry, {}, {}, mockOpencode);
+const registry = new ProviderRegistry(mockRegistry, {}, {}, mockOpencode, mockAmpProvider);
 
 describe('providers registry runSingleQuery', () => {
   it('routes to claude by default', async () => {
@@ -66,6 +87,11 @@ describe('providers registry runSingleQuery', () => {
   it('routes to opencode provider', async () => {
     const result = await registry.runSingleQuery('test prompt', { provider: 'opencode' });
     expect(result).toBe('opencode-response');
+  });
+
+  it('routes to amp provider', async () => {
+    const result = await registry.runSingleQuery('test prompt', { provider: 'amp' });
+    expect(result).toBe('amp-response');
   });
 
   it('passes options through to the provider', async () => {

--- a/server/providers/amp.js
+++ b/server/providers/amp.js
@@ -1,0 +1,388 @@
+// Amp CLI integration. Uses `--stream-json` (Claude-compatible event
+// schema) and maps events into unified ChatMessage types.
+
+import { getAmpBinary } from '../config.js';
+import { normalizeToolResultContent } from '../chats/normalize.js';
+import { AssistantMessage, ThinkingMessage, ToolResultMessage, ErrorMessage } from '../../common/chat-types.js';
+import { convertClaudeToolUse } from './converters/claude-tool-use.js';
+import { AbsProvider } from './base.js';
+
+function extractContentParts(msg) {
+  return Array.isArray(msg?.content)
+    ? msg.content
+    : Array.isArray(msg?.message?.content)
+      ? msg.message.content
+      : [];
+}
+
+function extractToolResultId(part) {
+  return part?.tool_use_id || part?.toolUseID || part?.toolUseId || '';
+}
+
+function extractToolResultPayload(part) {
+  if (part?.run && typeof part.run === 'object') {
+    if (part.run.result !== undefined) return part.run.result;
+    if (part.run.error !== undefined) return part.run.error;
+    return part.run;
+  }
+  return part?.content;
+}
+
+function isToolResultError(part) {
+  if (typeof part?.is_error === 'boolean') return part.is_error;
+  if (typeof part?.isError === 'boolean') return part.isError;
+  if (part?.run?.status) {
+    return String(part.run.status).toLowerCase() !== 'done';
+  }
+  return false;
+}
+
+// Converts a single Amp stream event into ChatMessage objects.
+export function convertAmpEventToChatMessages(msg) {
+  const ts = new Date().toISOString();
+  const out = [];
+
+  if (msg?.type === 'assistant') {
+    const content = extractContentParts(msg);
+    for (const part of content) {
+      if (part?.type === 'text' && part.text?.trim()) {
+        out.push(new AssistantMessage(ts, part.text));
+      } else if (part?.type === 'thinking' && part.thinking) {
+        out.push(new ThinkingMessage(ts, part.thinking));
+      } else if (part?.type === 'tool_use') {
+        out.push(convertClaudeToolUse(ts, part));
+      } else if (part?.type === 'tool_result') {
+        out.push(new ToolResultMessage(
+          ts,
+          extractToolResultId(part),
+          normalizeToolResultContent(extractToolResultPayload(part)),
+          isToolResultError(part),
+        ));
+      }
+    }
+    return out;
+  }
+
+  if (msg?.type === 'user') {
+    const content = extractContentParts(msg);
+    for (const part of content) {
+      if (part?.type !== 'tool_result') continue;
+      out.push(new ToolResultMessage(
+        ts,
+        extractToolResultId(part),
+        normalizeToolResultContent(extractToolResultPayload(part)),
+        isToolResultError(part),
+      ));
+    }
+    return out;
+  }
+
+  if (msg?.type === 'error' && typeof msg.message === 'string' && msg.message.trim()) {
+    out.push(new ErrorMessage(ts, msg.message));
+  }
+
+  return out;
+}
+
+function buildAmpArgs({ sessionId, model, permissionMode = 'default' } = {}) {
+  const args = sessionId
+    ? ['threads', 'continue', sessionId]
+    : [];
+
+  args.push('--execute', '--stream-json', '--no-ide', '--no-jetbrains');
+
+  if (typeof model === 'string' && model.trim()) {
+    args.push('--mode', model);
+  }
+
+  // Amp permission controls are coarse; map bypass mode to allow-all.
+  if (permissionMode === 'bypassPermissions') {
+    args.push('--dangerously-allow-all');
+  }
+
+  return args;
+}
+
+async function runAmpExec(args, prompt, cwd) {
+  const proc = Bun.spawn([getAmpBinary(), ...args], {
+    cwd: cwd || process.cwd(),
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (proc.stdin) {
+    proc.stdin.write(String(prompt ?? ''));
+    proc.stdin.write('\n');
+    proc.stdin.end();
+  }
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    const details = (stderr || stdout || '').trim();
+    throw new Error(`Amp exec failed with code ${exitCode}: ${details}`);
+  }
+
+  return { stdout, stderr };
+}
+
+// Runs a one-shot Amp query and returns assistant text.
+export async function runSingleQuery(prompt, options = {}) {
+  const { cwd, projectPath, model, permissionMode = 'default' } = options;
+  const args = buildAmpArgs({ model, permissionMode });
+  args.push('--archive');
+
+  const { stdout } = await runAmpExec(args, prompt, cwd || projectPath);
+
+  let resultText = '';
+  let fallbackText = '';
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (msg.type === 'result' && typeof msg.result === 'string') {
+      resultText = msg.result;
+      continue;
+    }
+    if (msg.type === 'assistant') {
+      for (const part of extractContentParts(msg)) {
+        if (part?.type === 'text' && typeof part.text === 'string') {
+          fallbackText = part.text;
+        }
+      }
+    }
+  }
+
+  return (resultText || fallbackText || '').trim();
+}
+
+export class AmpProvider extends AbsProvider {
+  #sessions = new Map();
+
+  async startSession(command, options = {}) {
+    return await new Promise((resolve, reject) => {
+      let settled = false;
+
+      const onSessionStarted = (providerSessionId) => {
+        if (settled) return;
+        settled = true;
+        resolve(providerSessionId);
+      };
+
+      this.runTurn(command, { ...options, onSessionStarted }).then(() => {
+        if (settled) return;
+        settled = true;
+        reject(new Error('amp: session did not return a session ID'));
+      }).catch((error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      });
+    });
+  }
+
+  async runTurn(command, options = {}) {
+    const {
+      sessionId,
+      chatId,
+      onSessionStarted,
+      cwd,
+      projectPath,
+      model,
+      permissionMode = 'default',
+    } = options;
+
+    if (!chatId) throw new Error('chatId is required');
+
+    const args = buildAmpArgs({ sessionId, model, permissionMode });
+    const ampBinary = getAmpBinary();
+    const workingDirectory = cwd || projectPath || process.cwd();
+    const startedAt = new Date().toISOString();
+    let providerSessionId = sessionId || null;
+    let resultSeen = false;
+    let resultExitCode = 0;
+    let sessionStartedEmitted = false;
+
+    const ensureSession = (id, proc) => {
+      const existing = this.#sessions.get(id);
+      const next = {
+        status: 'running',
+        chatId,
+        startedAt: existing?.startedAt || startedAt,
+        process: proc,
+      };
+      this.#sessions.set(id, next);
+    };
+
+    const proc = Bun.spawn([ampBinary, ...args], {
+      cwd: workingDirectory,
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    if (providerSessionId) {
+      ensureSession(providerSessionId, proc);
+    }
+
+    this.emitProcessing(chatId, true);
+
+    const stdoutTask = (async () => {
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let msg;
+          try {
+            msg = JSON.parse(line);
+          } catch {
+            continue;
+          }
+
+          if (msg.type === 'system' && msg.subtype === 'init') {
+            const sid = typeof msg.session_id === 'string' ? msg.session_id : null;
+            if (sid && sid !== providerSessionId) {
+              if (providerSessionId && this.#sessions.has(providerSessionId)) {
+                const existing = this.#sessions.get(providerSessionId);
+                this.#sessions.delete(providerSessionId);
+                this.#sessions.set(sid, { ...existing, chatId, status: 'running', process: proc });
+              } else {
+                ensureSession(sid, proc);
+              }
+              providerSessionId = sid;
+            } else if (providerSessionId) {
+              ensureSession(providerSessionId, proc);
+            }
+
+            if (!sessionStartedEmitted && providerSessionId) {
+              sessionStartedEmitted = true;
+              this.emitSessionCreated(chatId);
+              if (typeof onSessionStarted === 'function') {
+                onSessionStarted(providerSessionId);
+              }
+            }
+            continue;
+          }
+
+          const chatMessages = convertAmpEventToChatMessages(msg);
+          if (chatMessages.length > 0) {
+            this.emitMessages(chatId, chatMessages);
+          }
+
+          if (msg.type === 'result') {
+            resultSeen = true;
+            resultExitCode = msg.is_error ? 1 : 0;
+            this.emitFinished(chatId, resultExitCode);
+          }
+        }
+      }
+    })();
+
+    const stderrTask = (async () => {
+      const reader = proc.stderr.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const text = decoder.decode(value, { stream: true });
+        for (const line of text.split('\n')) {
+          if (line.trim()) {
+            console.log(`amp(${String(providerSessionId || 'pending').slice(0, 8)}): stderr: ${line}`);
+          }
+        }
+      }
+    })();
+
+    if (proc.stdin) {
+      proc.stdin.write(command || '');
+      proc.stdin.write('\n');
+      proc.stdin.end();
+    }
+
+    try {
+      await Promise.all([stdoutTask, stderrTask, proc.exited]);
+      if (!resultSeen) {
+        const status = providerSessionId ? this.#sessions.get(providerSessionId)?.status : null;
+        if (status !== 'aborted') {
+          this.emitFailed(chatId, 'Amp process exited before a result event was emitted');
+        }
+      }
+      return providerSessionId;
+    } catch (error) {
+      this.emitFailed(chatId, error instanceof Error ? error.message : String(error));
+      throw error;
+    } finally {
+      if (providerSessionId) {
+        const session = this.#sessions.get(providerSessionId);
+        if (session) {
+          session.status = session.status === 'aborted' ? 'aborted' : 'completed';
+          session.process = null;
+          if (session.status !== 'aborted' && resultSeen) {
+            session.exitCode = resultExitCode;
+          }
+        }
+      }
+      this.emitProcessing(chatId, false);
+    }
+  }
+
+  abort(providerSessionId) {
+    const session = this.#sessions.get(providerSessionId);
+    if (!session) return false;
+
+    session.status = 'aborted';
+    try {
+      session.process?.kill();
+    } catch (err) {
+      console.warn(`amp: failed to abort session ${providerSessionId}:`, err);
+    }
+    return true;
+  }
+
+  isRunning(providerSessionId) {
+    const session = this.#sessions.get(providerSessionId);
+    return session?.status === 'running';
+  }
+
+  getRunningSessions() {
+    return Array.from(this.#sessions.entries())
+      .filter(([, session]) => session.status === 'running')
+      .map(([id, session]) => ({ id, status: session.status, startedAt: session.startedAt }));
+  }
+
+  startPurgeTimer() {
+    return setInterval(() => {
+      const now = Date.now();
+      const maxAge = 30 * 60 * 1000;
+
+      for (const [id, session] of this.#sessions.entries()) {
+        if (session.status !== 'running') {
+          const startedAt = new Date(session.startedAt).getTime();
+          if (now - startedAt > maxAge) {
+            this.#sessions.delete(id);
+          }
+        }
+      }
+    }, 5 * 60 * 1000);
+  }
+}
+

--- a/server/providers/index.js
+++ b/server/providers/index.js
@@ -9,11 +9,13 @@ import path from 'path';
 import { findCodexSessionFileBySessionId, getCodexSessionMeta } from '../projects/codex.js';
 import { runSingleQuery as runSingleQueryClaude } from './claude-cli.js';
 import { runSingleQuery as runSingleQueryCodex } from './codex.js';
+import { runSingleQuery as runSingleQueryAmp } from './amp.js';
 
 // Stateless loaders and preview functions
 import { getClaudePreviewFromNativePath, loadClaudeChatMessages } from './loaders/claude-history-loader.js';
 import { getCodexPreviewFromNativePath, loadCodexChatMessages } from './loaders/codex-history-loader.js';
 import { getOpenCodePreviewFromSessionId, loadOpenCodeChatMessages } from './loaders/opencode-history-loader.js';
+import { getAmpPreviewFromSessionId, loadAmpChatMessages } from './loaders/amp-history-loader.js';
 
 function encodeProjectPath(projectPath) {
   return String(projectPath || '').replace(/[\\/:\s~_]/g, '-');
@@ -51,6 +53,13 @@ async function recoverProviderSessionId(entry) {
     return meta?.id || null;
   }
 
+  if (entry.provider === 'amp') {
+    if (entry.nativePath.startsWith('amp:')) {
+      return entry.nativePath.slice('amp:'.length) || null;
+    }
+    return path.basename(entry.nativePath, '.json') || null;
+  }
+
   return null;
 }
 
@@ -59,16 +68,19 @@ export class ProviderRegistry {
   #claude;
   #codex;
   #opencode;
+  #amp;
 
   // registry: ChatRegistry
   // claude: ClaudeProvider
   // codex: CodexProvider
   // opencode: OpenCodeProvider
-  constructor(registry, claude, codex, opencode) {
+  // amp: AmpProvider
+  constructor(registry, claude, codex, opencode, amp) {
     this.#registry = registry;
     this.#claude = claude;
     this.#codex = codex;
     this.#opencode = opencode;
+    this.#amp = amp;
   }
 
   // Starts a new provider session. The chat registry entry must already
@@ -121,6 +133,17 @@ export class ProviderRegistry {
       return;
     }
 
+    if (provider === 'amp') {
+      const providerSessionId = await this.#amp.startSession(command, {
+        ...mergedOpts,
+        chatId,
+        cwd: mergedOpts.cwd || projectPath,
+      });
+      const nativePath = `amp:${providerSessionId}`;
+      this.#registry.updateChat(chatId, { providerSessionId, nativePath });
+      return;
+    }
+
     throw new Error(`Unsupported provider: ${provider}`);
   }
 
@@ -144,6 +167,8 @@ export class ProviderRegistry {
       await this.#codex.runTurn(command, { ...mergedOpts, sessionId: providerSessionId, chatId });
     } else if (provider === 'opencode') {
       await this.#opencode.runTurn(command, { ...mergedOpts, sessionId: providerSessionId, chatId });
+    } else if (provider === 'amp') {
+      await this.#amp.runTurn(command, { ...mergedOpts, sessionId: providerSessionId, chatId });
     } else {
       throw new Error(`Unsupported provider: ${provider}`);
     }
@@ -169,6 +194,10 @@ export class ProviderRegistry {
       return this.#opencode.abort(providerSessionId);
     }
 
+    if (entry.provider === 'amp') {
+      return this.#amp.abort(providerSessionId);
+    }
+
     return false;
   }
 
@@ -183,6 +212,7 @@ export class ProviderRegistry {
     if (provider === 'claude') return this.#claude.isClaudeInternalSessionRunning(providerSessionId);
     if (provider === 'codex') return this.#codex.isRunning(providerSessionId);
     if (provider === 'opencode') return this.#opencode.isRunning(providerSessionId);
+    if (provider === 'amp') return this.#amp.isRunning(providerSessionId);
     return false;
   }
 
@@ -201,6 +231,7 @@ export class ProviderRegistry {
       claude: mapToChatId(this.#claude.getRunningClaudeInternalSessions()),
       codex: mapToChatId(this.#codex.getRunningSessions()),
       opencode: mapToChatId(this.#opencode.getRunningSessions()),
+      amp: mapToChatId(this.#amp.getRunningSessions()),
     };
   }
 
@@ -244,6 +275,7 @@ export class ProviderRegistry {
     const { provider = 'claude', ...rest } = options;
     if (provider === 'codex') return runSingleQueryCodex(prompt, rest);
     if (provider === 'opencode') return this.#opencode.runSingleQuery(prompt, rest);
+    if (provider === 'amp') return runSingleQueryAmp(prompt, rest);
     return runSingleQueryClaude(prompt, rest);
   }
 
@@ -262,6 +294,10 @@ export class ProviderRegistry {
     }
     if (session.provider === 'codex') {
       return getCodexPreviewFromNativePath(session.nativePath);
+    }
+    if (session.provider === 'amp') {
+      const sessionId = session.providerSessionId || session.nativePath?.replace('amp:', '');
+      return getAmpPreviewFromSessionId(sessionId);
     }
 
     return null;
@@ -283,6 +319,10 @@ export class ProviderRegistry {
     if (session.provider === 'codex') {
       return loadCodexChatMessages(session.nativePath);
     }
+    if (session.provider === 'amp') {
+      const sessionId = session.providerSessionId || session.nativePath?.replace('amp:', '');
+      return loadAmpChatMessages(sessionId);
+    }
 
     return [];
   }
@@ -297,39 +337,45 @@ export class ProviderRegistry {
   startPurgeTimers() {
     this.#codex.startPurgeTimer();
     this.#opencode.startPurgeTimer();
+    this.#amp.startPurgeTimer();
   }
 
-  // Fan-out listener helpers. Registers the callback on all three
+  // Fan-out listener helpers. Registers the callback on all providers
   // providers so callers don't need to know the individual instances.
 
   onMessages(cb) {
     this.#claude.onMessages(cb);
     this.#codex.onMessages(cb);
     this.#opencode.onMessages(cb);
+    this.#amp.onMessages(cb);
   }
 
   onProcessing(cb) {
     this.#claude.onProcessing(cb);
     this.#codex.onProcessing(cb);
     this.#opencode.onProcessing(cb);
+    this.#amp.onProcessing(cb);
   }
 
   onSessionCreated(cb) {
     this.#claude.onSessionCreated(cb);
     this.#codex.onSessionCreated(cb);
     this.#opencode.onSessionCreated(cb);
+    this.#amp.onSessionCreated(cb);
   }
 
   onFinished(cb) {
     this.#claude.onFinished(cb);
     this.#codex.onFinished(cb);
     this.#opencode.onFinished(cb);
+    this.#amp.onFinished(cb);
   }
 
   onFailed(cb) {
     this.#claude.onFailed(cb);
     this.#codex.onFailed(cb);
     this.#opencode.onFailed(cb);
+    this.#amp.onFailed(cb);
   }
 }
 

--- a/server/providers/loaders/amp-history-loader.js
+++ b/server/providers/loaders/amp-history-loader.js
@@ -1,0 +1,196 @@
+// File-based loaders for Amp thread JSON files.
+// Native path format is either "amp:<sessionId>" or a direct JSON file path.
+
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { normalizeToolResultContent } from '../../chats/normalize.js';
+import { UserMessage, AssistantMessage, ThinkingMessage, ToolResultMessage } from '../../../common/chat-types.js';
+import { convertClaudeToolUse } from '../converters/claude-tool-use.js';
+
+function resolveSessionId(input) {
+  if (!input || typeof input !== 'string') return null;
+  if (input.startsWith('amp:')) return input.slice('amp:'.length) || null;
+  const base = path.basename(input);
+  if (base.startsWith('T-') && base.endsWith('.json')) {
+    return base.slice(0, -'.json'.length);
+  }
+  if (input.startsWith('T-')) return input;
+  return null;
+}
+
+function ampThreadPathFromSessionId(sessionId) {
+  return path.join(os.homedir(), '.local', 'share', 'amp', 'threads', `${sessionId}.json`);
+}
+
+function resolveAmpThreadPath(nativePathOrSessionId) {
+  const sessionId = resolveSessionId(nativePathOrSessionId);
+  if (sessionId) return ampThreadPathFromSessionId(sessionId);
+  return typeof nativePathOrSessionId === 'string' ? nativePathOrSessionId : null;
+}
+
+function messageTimestamp(msg, threadCreatedMs) {
+  const usageTs = msg?.usage?.timestamp;
+  if (typeof usageTs === 'string' && usageTs.trim()) return usageTs;
+
+  const sentAt = msg?.meta?.sentAt;
+  if (typeof sentAt === 'number' && Number.isFinite(sentAt)) {
+    return new Date(sentAt).toISOString();
+  }
+  if (typeof sentAt === 'string' && sentAt.trim()) {
+    const d = new Date(sentAt);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  }
+
+  if (typeof threadCreatedMs === 'number' && Number.isFinite(threadCreatedMs)) {
+    return new Date(threadCreatedMs).toISOString();
+  }
+
+  return new Date().toISOString();
+}
+
+function extractToolResultId(part) {
+  return part?.tool_use_id || part?.toolUseID || part?.toolUseId || '';
+}
+
+function extractToolResultPayload(part) {
+  if (part?.run && typeof part.run === 'object') {
+    if (part.run.result !== undefined) return part.run.result;
+    if (part.run.error !== undefined) return part.run.error;
+    return part.run;
+  }
+  return part?.content;
+}
+
+function isToolResultError(part) {
+  if (typeof part?.is_error === 'boolean') return part.is_error;
+  if (typeof part?.isError === 'boolean') return part.isError;
+  if (part?.run?.status) return String(part.run.status).toLowerCase() !== 'done';
+  return false;
+}
+
+function messageText(parts) {
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .filter((part) => part?.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text.trim())
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+function convertAmpThreadMessageToChatMessages(msg, ts) {
+  const out = [];
+  const role = msg?.role;
+  const parts = Array.isArray(msg?.content) ? msg.content : [];
+
+  if (role === 'user') {
+    for (const part of parts) {
+      if (part?.type !== 'tool_result') continue;
+      out.push(new ToolResultMessage(
+        ts,
+        extractToolResultId(part),
+        normalizeToolResultContent(extractToolResultPayload(part)),
+        isToolResultError(part),
+      ));
+    }
+
+    const text = messageText(parts);
+    if (text) out.push(new UserMessage(ts, text));
+    return out;
+  }
+
+  if (role === 'assistant') {
+    for (const part of parts) {
+      if (part?.type === 'thinking' && part.thinking) {
+        out.push(new ThinkingMessage(ts, part.thinking));
+      } else if (part?.type === 'text' && part.text?.trim()) {
+        out.push(new AssistantMessage(ts, part.text));
+      } else if (part?.type === 'tool_use') {
+        out.push(convertClaudeToolUse(ts, part));
+      } else if (part?.type === 'tool_result') {
+        out.push(new ToolResultMessage(
+          ts,
+          extractToolResultId(part),
+          normalizeToolResultContent(extractToolResultPayload(part)),
+          isToolResultError(part),
+        ));
+      }
+    }
+  }
+
+  return out;
+}
+
+async function readThread(nativePathOrSessionId) {
+  const filePath = resolveAmpThreadPath(nativePathOrSessionId);
+  if (!filePath) return null;
+
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const thread = JSON.parse(raw);
+    if (!thread || typeof thread !== 'object') return null;
+    return thread;
+  } catch {
+    return null;
+  }
+}
+
+// Reads an Amp thread JSON file and returns ChatMessage[].
+export async function loadAmpChatMessages(nativePathOrSessionId) {
+  const thread = await readThread(nativePathOrSessionId);
+  if (!thread) return [];
+
+  const messages = [];
+  const rawMessages = Array.isArray(thread.messages) ? thread.messages : [];
+  const createdMs = typeof thread.created === 'number' ? thread.created : null;
+
+  for (const msg of rawMessages) {
+    const ts = messageTimestamp(msg, createdMs);
+    messages.push(...convertAmpThreadMessageToChatMessages(msg, ts));
+  }
+
+  return messages;
+}
+
+// Builds a preview (title, first/last message, timestamps) from an Amp thread.
+export async function getAmpPreviewFromSessionId(sessionId) {
+  const thread = await readThread(sessionId);
+  if (!thread) return null;
+
+  const rawMessages = Array.isArray(thread.messages) ? thread.messages : [];
+  const createdMs = typeof thread.created === 'number' ? thread.created : null;
+
+  let firstUserMessage = '';
+  let lastMessage = '';
+  let lastActivity = null;
+  let createdAt = createdMs ? new Date(createdMs).toISOString() : null;
+
+  for (const msg of rawMessages) {
+    const ts = messageTimestamp(msg, createdMs);
+    if (!createdAt) createdAt = ts;
+    lastActivity = ts;
+
+    if (msg?.role === 'user') {
+      const text = messageText(msg.content);
+      if (text && !firstUserMessage) firstUserMessage = text;
+      if (text) lastMessage = '> ' + text;
+      continue;
+    }
+
+    if (msg?.role === 'assistant') {
+      const text = messageText(msg.content);
+      if (text) lastMessage = text;
+    }
+  }
+
+  return {
+    firstMessage: firstUserMessage || thread.title || 'Unknown Amp Session',
+    lastMessage: lastMessage || '',
+    lastActivity,
+    createdAt,
+  };
+}
+
+export { resolveAmpThreadPath, ampThreadPathFromSessionId };
+

--- a/server/routes/__tests__/chats-archive.test.js
+++ b/server/routes/__tests__/chats-archive.test.js
@@ -6,6 +6,8 @@ mock.module('../../lib/http-native.js', () => ({
 
 mock.module('../../providers/loaders/claude-history-loader.js', () => ({
   getClaudeSessionMessagesFromNativePath: mock(() => undefined),
+  getClaudePreviewFromNativePath: mock(() => undefined),
+  loadClaudeChatMessages: mock(() => []),
 }));
 
 mock.module('../../projects/codex.js', () => ({

--- a/server/routes/__tests__/chats-fork.test.js
+++ b/server/routes/__tests__/chats-fork.test.js
@@ -6,6 +6,8 @@ mock.module('../../lib/http-native.js', () => ({
 
 mock.module('../../providers/loaders/claude-history-loader.js', () => ({
   getClaudeSessionMessagesFromNativePath: mock(() => undefined),
+  getClaudePreviewFromNativePath: mock(() => undefined),
+  loadClaudeChatMessages: mock(() => []),
 }));
 
 mock.module('../../projects/codex.js', () => ({
@@ -226,4 +228,3 @@ describe('POST /api/v1/chats/fork', () => {
     expect(body.error).toBe('Disk full');
   });
 });
-

--- a/server/routes/__tests__/chats-read.test.js
+++ b/server/routes/__tests__/chats-read.test.js
@@ -6,6 +6,8 @@ mock.module('../../lib/http-native.js', () => ({
 
 mock.module('../../providers/loaders/claude-history-loader.js', () => ({
   getClaudeSessionMessagesFromNativePath: mock(() => undefined),
+  getClaudePreviewFromNativePath: mock(() => undefined),
+  loadClaudeChatMessages: mock(() => []),
 }));
 
 mock.module('../../projects/codex.js', () => ({

--- a/server/routes/__tests__/chats-reorder.test.js
+++ b/server/routes/__tests__/chats-reorder.test.js
@@ -6,6 +6,8 @@ mock.module('../../lib/http-native.js', () => ({
 
 mock.module('../../providers/loaders/claude-history-loader.js', () => ({
   getClaudeSessionMessagesFromNativePath: mock(() => undefined),
+  getClaudePreviewFromNativePath: mock(() => undefined),
+  loadClaudeChatMessages: mock(() => []),
 }));
 
 mock.module('../../projects/codex.js', () => ({

--- a/server/routes/__tests__/chats-title.test.js
+++ b/server/routes/__tests__/chats-title.test.js
@@ -6,6 +6,8 @@ mock.module('../../lib/http-native.js', () => ({
 
 mock.module('../../providers/loaders/claude-history-loader.js', () => ({
   getClaudeSessionMessagesFromNativePath: mock(() => undefined),
+  getClaudePreviewFromNativePath: mock(() => undefined),
+  loadClaudeChatMessages: mock(() => []),
 }));
 
 mock.module('../../projects/codex.js', () => ({

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -15,6 +15,7 @@ describe('GET /api/v1/models', () => {
 
     expect(body.claude).toBeDefined();
     expect(body.codex).toBeDefined();
+    expect(body.amp).toBeDefined();
     expect(body.opencode).toBeDefined();
     expect(Array.isArray(body.claude)).toBe(true);
   });
@@ -25,7 +26,7 @@ describe('GET /api/v1/models', () => {
 
     expect(body.catalog).toBeDefined();
     expect(Array.isArray(body.catalog.providers)).toBe(true);
-    expect(body.catalog.providers.length).toBe(3);
+    expect(body.catalog.providers.length).toBe(4);
 
     const claude = body.catalog.providers.find((p) => p.id === 'claude');
     expect(claude.supportsFork).toBe(true);
@@ -36,6 +37,11 @@ describe('GET /api/v1/models', () => {
     const codex = body.catalog.providers.find((p) => p.id === 'codex');
     expect(codex.supportsFork).toBe(true);
     expect(codex.supportsImages).toBe(false);
+
+    const amp = body.catalog.providers.find((p) => p.id === 'amp');
+    expect(amp.supportsFork).toBe(true);
+    expect(amp.supportsImages).toBe(false);
+    expect(amp.defaultModel).toBe('smart');
 
     const opencode = body.catalog.providers.find((p) => p.id === 'opencode');
     expect(opencode.supportsFork).toBe(false);

--- a/server/routes/amp.js
+++ b/server/routes/amp.js
@@ -1,0 +1,55 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+function hasNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+async function getAmpAuthStatus() {
+  // Check environment first so containerized deployments can inject keys.
+  if (hasNonEmptyString(process.env.AMP_API_KEY)) {
+    return { authenticated: true, email: 'API Key Auth', method: 'api_key_env' };
+  }
+
+  try {
+    const secretsPath = path.join(os.homedir(), '.local', 'share', 'amp', 'secrets.json');
+    const content = await fs.readFile(secretsPath, 'utf8');
+    const secrets = JSON.parse(content);
+    if (!secrets || typeof secrets !== 'object') {
+      return { authenticated: false, email: null, error: 'Amp secrets file is malformed.' };
+    }
+
+    const entries = Object.entries(secrets);
+    const hasApiKey = entries.some(([key, value]) => key.startsWith('apiKey@') && hasNonEmptyString(value));
+    if (hasApiKey) {
+      return { authenticated: true, email: 'Authenticated', method: 'secrets_file' };
+    }
+
+    return { authenticated: false, email: null, error: 'No usable Amp credentials were found.' };
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { authenticated: false, email: null, error: 'Amp authentication has not been configured.' };
+    }
+    return { authenticated: false, email: null, error: error.message };
+  }
+}
+
+async function getAmpAuthStatusRoute() {
+  try {
+    const result = await getAmpAuthStatus();
+    return Response.json({
+      authenticated: result.authenticated,
+      email: result.email,
+      error: result.error || null,
+    });
+  } catch (error) {
+    console.error('Error checking Amp auth status:', error);
+    return Response.json({ authenticated: false, email: null, error: error.message }, { status: 500 });
+  }
+}
+
+export default {
+  '/api/v1/amp/auth/status': { GET: getAmpAuthStatusRoute },
+};
+

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,7 @@
 import identityRoutes from './identity.js';
 import codexRoutes from './codex.js';
 import claudeRoutes from './claude.js';
+import ampRoutes from './amp.js';
 import staticRoutes from './static.js';
 import createFilesRoutes from './files.js';
 import createOpenCodeRoutes from './opencode.js';
@@ -15,6 +16,7 @@ export default function createAllRoutes(registry, settings, queue, pathCache, me
     ...identityRoutes,
     ...codexRoutes,
     ...claudeRoutes,
+    ...ampRoutes,
     ...createChatRoutes(registry, settings, queue, pathCache, metadata, historyCache, providers),
     ...createFilesRoutes(registry),
     ...createWorkspaceRoutes(settings),

--- a/server/routes/models.js
+++ b/server/routes/models.js
@@ -1,8 +1,8 @@
-// Unified model cache for all providers. Claude and Codex models are
+// Unified model cache for all providers. Claude/Codex/Amp models are
 // static; OpenCode models are fetched periodically. Serves a single
 // GET /api/models endpoint.
 
-import { CLAUDE_MODELS, CODEX_MODELS } from '../../common/models.js';
+import { CLAUDE_MODELS, CODEX_MODELS, AMP_MODELS } from '../../common/models.js';
 import { PROVIDERS, supportsFork, supportsImages } from '../../common/providers.ts';
 
 const OPENCODE_REFRESH_INTERVAL = 5 * 60 * 1000;
@@ -10,6 +10,7 @@ const OPENCODE_REFRESH_INTERVAL = 5 * 60 * 1000;
 function getDefaultModel(provider, cache) {
   if (provider === 'claude') return CLAUDE_MODELS.DEFAULT;
   if (provider === 'codex') return CODEX_MODELS.DEFAULT;
+  if (provider === 'amp') return AMP_MODELS.DEFAULT;
   return cache.opencode[0]?.value ?? '';
 }
 
@@ -30,6 +31,7 @@ export default function createModelsRoutes(providers) {
   const cache = {
     claude: CLAUDE_MODELS.OPTIONS,
     codex: CODEX_MODELS.OPTIONS,
+    amp: AMP_MODELS.OPTIONS,
     opencode: [],
   };
 
@@ -43,7 +45,7 @@ export default function createModelsRoutes(providers) {
 
   async function getModels(request, url) {
     const provider = url?.searchParams?.get('provider');
-    if (provider && cache[provider]) {
+    if (provider && Object.hasOwn(cache, provider)) {
       const catalog = buildProviderCatalog(cache);
       const filtered = { providers: catalog.providers.filter((p) => p.id === provider) };
       return Response.json({ [provider]: cache[provider], catalog: filtered });

--- a/server/server.js
+++ b/server/server.js
@@ -28,6 +28,7 @@ import { HistoryCache } from './chats/history-cache.js';
 import { ClaudeProvider } from './providers/claude-cli.js';
 import { CodexProvider } from './providers/codex.js';
 import { OpenCodeProvider } from './providers/opencode.js';
+import { AmpProvider } from './providers/amp.js';
 import { ProviderRegistry } from './providers/index.js';
 import { ChatHandler } from './ws/chat.js';
 import {
@@ -68,9 +69,10 @@ export async function startServer() {
     const claudeProvider = new ClaudeProvider();
     const codexProvider = new CodexProvider();
     const opencodeProvider = new OpenCodeProvider();
+    const ampProvider = new AmpProvider();
 
     // Tier 2: Provider registry wrapping providers + registry
-    const providerRegistry = new ProviderRegistry(chatRegistry, claudeProvider, codexProvider, opencodeProvider);
+    const providerRegistry = new ProviderRegistry(chatRegistry, claudeProvider, codexProvider, opencodeProvider, ampProvider);
 
     // Tier 3: Chat infrastructure (uses ProviderRegistry)
     const metadata = new MetadataIndex(chatRegistry, providerRegistry);

--- a/server/ws/__tests__/chat-contracts.test.js
+++ b/server/ws/__tests__/chat-contracts.test.js
@@ -19,7 +19,7 @@ import { sendWebSocketJson } from '../utils.js';
 import { resolveMissingNativePath } from '../../chats/resolve-native-path.js';
 
 const mockProviders = {
-  getRunningSessions: mock(() => ({ claude: [], codex: [], opencode: [] })),
+  getRunningSessions: mock(() => ({ claude: [], codex: [], opencode: [], amp: [] })),
   resolvePermission: mock(() => undefined),
   setPermissionMode: mock(() => Promise.resolve(undefined)),
   setModel: mock(() => Promise.resolve(undefined)),
@@ -338,7 +338,7 @@ describe('chat WebSocket handler', () => {
       expect(payload).toMatchObject({
         type: 'chat-sessions-running',
       });
-      expect(payload.sessions).toEqual({ claude: [], codex: [], opencode: [] });
+      expect(payload.sessions).toEqual({ claude: [], codex: [], opencode: [], amp: [] });
     });
   });
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -222,6 +222,7 @@
   "mobile_menu": "Menu",
   "provider_claude": "Claude",
   "provider_codex": "Codex",
+  "provider_amp": "Amp",
   "provider_opencode": "OpenCode",
   "settings_agents_auth_status_checking": "Checking...",
   "settings_agents_auth_status_connected": "Connected",

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -56,6 +56,9 @@
 	--color-provider-opencode-bg: hsl(var(--provider-opencode-bg));
 	--color-provider-opencode-foreground: hsl(var(--provider-opencode-foreground));
 	--color-provider-opencode-border: hsl(var(--provider-opencode-border));
+	--color-provider-amp-bg: hsl(var(--provider-amp-bg));
+	--color-provider-amp-foreground: hsl(var(--provider-amp-foreground));
+	--color-provider-amp-border: hsl(var(--provider-amp-border));
 	--color-indicator-unread: hsl(var(--indicator-unread));
 		--color-status-processing: hsl(var(--status-processing));
 		--color-status-processing-foreground: hsl(var(--status-processing-foreground));
@@ -187,6 +190,9 @@
 	--provider-opencode-bg: 270 65% 95%;
 	--provider-opencode-foreground: 270 60% 30%;
 	--provider-opencode-border: 270 40% 78%;
+	--provider-amp-bg: 28 100% 94%;
+	--provider-amp-foreground: 23 78% 30%;
+	--provider-amp-border: 30 55% 78%;
 	--indicator-unread: 214 90% 48%;
 		--status-processing: 214 90% 48%;
 		--status-processing-foreground: 214 85% 32%;
@@ -334,6 +340,9 @@
 	--provider-opencode-bg: 270 34% 24%;
 	--provider-opencode-foreground: 270 82% 88%;
 	--provider-opencode-border: 270 30% 36%;
+	--provider-amp-bg: 27 44% 24%;
+	--provider-amp-foreground: 33 90% 86%;
+	--provider-amp-border: 28 34% 38%;
 	--indicator-unread: 214 95% 68%;
 		--status-processing: 214 95% 68%;
 		--status-processing-foreground: 214 95% 86%;

--- a/web/src/lib/api/providers.ts
+++ b/web/src/lib/api/providers.ts
@@ -2,7 +2,7 @@
 
 import { apiGet } from './client.js';
 
-export type ProviderName = 'claude' | 'codex' | 'opencode';
+export type ProviderName = 'claude' | 'codex' | 'opencode' | 'amp';
 
 export interface ProviderAuthStatus {
 	authenticated: boolean;

--- a/web/src/lib/chat/__tests__/new-chat-form-state.test.ts
+++ b/web/src/lib/chat/__tests__/new-chat-form-state.test.ts
@@ -10,6 +10,7 @@ const mockPreferences = {
 	selectedProvider: 'claude',
 	claudeModel: 'opus',
 	codexModel: 'gpt-5.3-codex',
+	ampModel: 'smart',
 	opencodeModel: 'gpt-4o',
 	permissionMode: 'default',
 	thinkingMode: 'none'
@@ -22,6 +23,7 @@ const mockModelCatalog = {
 	getDefaultModel: vi.fn((provider: string) => {
 		if (provider === 'claude') return 'opus';
 		if (provider === 'codex') return 'gpt-5.3-codex';
+		if (provider === 'amp') return 'smart';
 		return '';
 	}),
 	getModels: vi.fn(() => []),

--- a/web/src/lib/chat/composer-controls.ts
+++ b/web/src/lib/chat/composer-controls.ts
@@ -94,6 +94,11 @@ export const PROVIDER_MENU_OPTIONS: ComposerMenuOption<SessionProvider>[] = [
 		value: 'opencode',
 		label: 'OpenCode',
 		description: 'Runs through OpenCode-compatible backends.'
+	},
+	{
+		value: 'amp',
+		label: 'Amp',
+		description: 'Amp agent modes with Claude-compatible stream events.'
 	}
 ];
 

--- a/web/src/lib/chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat-form-state.svelte.ts
@@ -21,6 +21,7 @@ export class NewChatFormState {
 	provider = $state<SessionProvider>('claude');
 	claudeModel = $state('');
 	codexModel = $state('');
+	ampModel = $state('');
 	opencodeModel = $state('');
 
 	// Path
@@ -74,6 +75,7 @@ export class NewChatFormState {
 		this.provider = preferences.selectedProvider || 'claude';
 		this.claudeModel = preferences.claudeModel || this.#modelCatalog.getDefaultModel('claude');
 		this.codexModel = preferences.codexModel || this.#modelCatalog.getDefaultModel('codex');
+		this.ampModel = preferences.ampModel || this.#modelCatalog.getDefaultModel('amp');
 		this.opencodeModel = preferences.opencodeModel || this.#modelCatalog.getDefaultModel('opencode');
 	}
 
@@ -107,6 +109,7 @@ export class NewChatFormState {
 		const opts: Record<SessionProvider, ModelOption[]> = {
 			claude: this.#modelCatalog.getModels('claude'),
 			codex: this.#modelCatalog.getModels('codex'),
+			amp: this.#modelCatalog.getModels('amp'),
 			opencode: this.#modelCatalog.getModels('opencode').length
 				? this.#modelCatalog.getModels('opencode')
 				: this.opencodeModel
@@ -120,6 +123,7 @@ export class NewChatFormState {
 		const map: Record<SessionProvider, string> = {
 			claude: this.claudeModel,
 			codex: this.codexModel,
+			amp: this.ampModel,
 			opencode: this.opencodeModel
 		};
 		return map[this.provider];
@@ -138,6 +142,7 @@ export class NewChatFormState {
 		const setterMap: Record<SessionProvider, (v: string) => void> = {
 			claude: (v) => { this.claudeModel = v; },
 			codex: (v) => { this.codexModel = v; },
+			amp: (v) => { this.ampModel = v; },
 			opencode: (v) => { this.opencodeModel = v; }
 		};
 		setterMap[this.provider](value);
@@ -156,6 +161,9 @@ export class NewChatFormState {
 		}
 		if (provider === 'codex' && !liveModels.some((m) => m.value === this.codexModel)) {
 			this.codexModel = liveModels[0].value;
+		}
+		if (provider === 'amp' && !liveModels.some((m) => m.value === this.ampModel)) {
+			this.ampModel = liveModels[0].value;
 		}
 	}
 
@@ -423,6 +431,7 @@ export class NewChatFormState {
 			}
 			this.validateModelAgainstLive('claude');
 			this.validateModelAgainstLive('codex');
+			this.validateModelAgainstLive('amp');
 			this.validateModelAgainstLive('opencode');
 		} catch (err) {
 			console.warn('[NewChatFormState] Failed to load settings and models', err);

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -67,6 +67,7 @@
 		void modelCatalog.version;
 		form.validateModelAgainstLive('claude');
 		form.validateModelAgainstLive('codex');
+		form.validateModelAgainstLive('amp');
 		form.validateModelAgainstLive('opencode');
 	});
 

--- a/web/src/lib/components/layout/__tests__/WorkspaceViewTestHarness.svelte
+++ b/web/src/lib/components/layout/__tests__/WorkspaceViewTestHarness.svelte
@@ -42,7 +42,7 @@
 			return [];
 		},
 		getProviders() {
-			return ['claude', 'codex', 'opencode'];
+			return ['claude', 'codex', 'opencode', 'amp'];
 		}
 	} as never);
 

--- a/web/src/lib/components/settings/AgentCard.svelte
+++ b/web/src/lib/components/settings/AgentCard.svelte
@@ -15,7 +15,7 @@
 		error: string | null;
 	}
 
-	type AgentId = 'claude' | 'codex' | 'opencode';
+	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp';
 
 	let {
 		agentId,
@@ -36,7 +36,8 @@
 	const borderColorClass: Record<AgentId, string> = {
 		claude: 'border-l-provider-claude-border',
 		codex: 'border-l-provider-codex-border',
-		opencode: 'border-l-provider-opencode-border'
+		opencode: 'border-l-provider-opencode-border',
+		amp: 'border-l-provider-amp-border'
 	};
 </script>
 

--- a/web/src/lib/components/settings/AgentsSection.svelte
+++ b/web/src/lib/components/settings/AgentsSection.svelte
@@ -12,47 +12,54 @@
 		error: string | null;
 	}
 
-	type AgentId = 'claude' | 'codex' | 'opencode';
+	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp';
 
 	const DEFAULT_AUTH: AuthStatus = { authenticated: false, email: null, loading: true, error: null };
 
 	const agents: { id: AgentId; name: string }[] = [
 		{ id: 'claude', name: 'Claude' },
 		{ id: 'codex', name: 'Codex' },
-		{ id: 'opencode', name: 'OpenCode' }
+		{ id: 'opencode', name: 'OpenCode' },
+		{ id: 'amp', name: 'Amp' }
 	];
 
 	let claudeAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let codexAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let opencodeAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
+	let ampAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 
 	let claudeOpen = $state(false);
 	let codexOpen = $state(false);
 	let opencodeOpen = $state(false);
+	let ampOpen = $state(false);
 
 	function authFor(agent: AgentId): AuthStatus {
 		if (agent === 'claude') return claudeAuth;
 		if (agent === 'codex') return codexAuth;
-		return opencodeAuth;
+		if (agent === 'opencode') return opencodeAuth;
+		return ampAuth;
 	}
 
 	function isOpen(agent: AgentId): boolean {
 		if (agent === 'claude') return claudeOpen;
 		if (agent === 'codex') return codexOpen;
-		return opencodeOpen;
+		if (agent === 'opencode') return opencodeOpen;
+		return ampOpen;
 	}
 
 	function setOpen(agent: AgentId, value: boolean) {
 		if (agent === 'claude') claudeOpen = value;
 		else if (agent === 'codex') codexOpen = value;
-		else opencodeOpen = value;
+		else if (agent === 'opencode') opencodeOpen = value;
+		else ampOpen = value;
 	}
 
 	async function checkAuth(agent: AgentId) {
 		const setAuth = (status: AuthStatus) => {
 			if (agent === 'claude') claudeAuth = status;
 			else if (agent === 'codex') codexAuth = status;
-			else opencodeAuth = status;
+			else if (agent === 'opencode') opencodeAuth = status;
+			else ampAuth = status;
 		};
 
 		try {
@@ -80,12 +87,13 @@
 
 	let authExpandDone = $state(false);
 	$effect(() => {
-		const allLoaded = !claudeAuth.loading && !codexAuth.loading && !opencodeAuth.loading;
+		const allLoaded = !claudeAuth.loading && !codexAuth.loading && !opencodeAuth.loading && !ampAuth.loading;
 		if (allLoaded && !authExpandDone) {
 			authExpandDone = true;
 			if (!claudeAuth.authenticated) claudeOpen = true;
 			if (!codexAuth.authenticated) codexOpen = true;
 			if (!opencodeAuth.authenticated) opencodeOpen = true;
+			if (!ampAuth.authenticated) ampOpen = true;
 		}
 	});
 
@@ -93,6 +101,7 @@
 		checkAuth('claude');
 		checkAuth('codex');
 		checkAuth('opencode');
+		checkAuth('amp');
 	});
 </script>
 

--- a/web/src/lib/components/settings/PreferencesSection.svelte
+++ b/web/src/lib/components/settings/PreferencesSection.svelte
@@ -47,7 +47,7 @@
 		// Hydrate chat title settings.
 		const chatTitle = (ui.chatTitle ?? {}) as Record<string, unknown>;
 		titleEnabled = Boolean(chatTitle.enabled);
-		titleProvider = (['claude', 'codex', 'opencode'].includes(chatTitle.provider as string)
+		titleProvider = (['claude', 'codex', 'opencode', 'amp'].includes(chatTitle.provider as string)
 			? chatTitle.provider as SessionProvider
 			: 'claude');
 		titleModel = typeof chatTitle.model === 'string' ? chatTitle.model : '';
@@ -62,6 +62,7 @@
 	function providerLabel(provider: SessionProvider): string {
 		if (provider === 'claude') return m.provider_claude();
 		if (provider === 'codex') return m.provider_codex();
+		if (provider === 'amp') return m.provider_amp();
 		return m.provider_opencode();
 	}
 

--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -91,10 +91,12 @@
 		claude: 'border-provider-claude-border bg-provider-claude-bg text-provider-claude-foreground',
 		codex: 'border-provider-codex-border bg-provider-codex-bg text-provider-codex-foreground',
 		opencode: 'border-provider-opencode-border bg-provider-opencode-bg text-provider-opencode-foreground',
+		amp: 'border-provider-amp-border bg-provider-amp-bg text-provider-amp-foreground',
 	};
 	let providerTagVariant = $derived(PROVIDER_TAG_VARIANTS[provider] ?? PROVIDER_TAG_VARIANTS.claude);
 	let providerTagLabel = $derived(
 		provider === 'codex' ? m.provider_codex()
+		: provider === 'amp' ? m.provider_amp()
 		: provider === 'opencode' ? m.provider_opencode()
 		: m.provider_claude()
 	);

--- a/web/src/lib/events/__tests__/running-chats-handler.test.ts
+++ b/web/src/lib/events/__tests__/running-chats-handler.test.ts
@@ -12,11 +12,12 @@ describe('extractRunningChatIds', () => {
 		const msg = new ChatSessionsRunningMessage({
 			claude: [{ id: 'c1' }, { id: 'c2' }],
 			codex: [{ id: 'x1' }],
+			amp: [{ id: 'a1' }],
 			opencode: [],
 		});
 
 		const ids = extractRunningChatIds(msg);
-		expect(ids).toEqual(new Set(['c1', 'c2', 'x1']));
+		expect(ids).toEqual(new Set(['c1', 'c2', 'x1', 'a1']));
 	});
 
 	it('filters out entries with missing IDs', () => {
@@ -27,6 +28,7 @@ describe('extractRunningChatIds', () => {
 			sessions: {
 				claude: [{ id: 'c1' }, { id: undefined }],
 				codex: [{}],
+				amp: [{ id: undefined }],
 				opencode: [],
 			},
 		} as unknown as ChatSessionsRunningMessage;
@@ -36,7 +38,7 @@ describe('extractRunningChatIds', () => {
 	});
 
 	it('handles empty sessions', () => {
-		const msg = new ChatSessionsRunningMessage({ claude: [], codex: [], opencode: [] });
+		const msg = new ChatSessionsRunningMessage({ claude: [], codex: [], opencode: [], amp: [] });
 
 		const ids = extractRunningChatIds(msg);
 		expect(ids.size).toBe(0);
@@ -59,6 +61,7 @@ describe('handleRunningChats', () => {
 		const msg = makeRunningChatsMsg({
 			claude: [{ id: 'a' }],
 			codex: [{ id: 'b' }],
+			amp: [{ id: 'c' }],
 			opencode: [],
 		});
 
@@ -66,14 +69,14 @@ describe('handleRunningChats', () => {
 
 		expect(reconcileProcessing).toHaveBeenCalledOnce();
 		const receivedSet = reconcileProcessing.mock.calls[0][0] as Set<string>;
-		expect(receivedSet).toEqual(new Set(['a', 'b']));
+		expect(receivedSet).toEqual(new Set(['a', 'b', 'c']));
 	});
 
 	it('passes empty set when no running chats', () => {
 		const reconcileProcessing = vi.fn();
 		const ctx: RunningChatsContext = { reconcileProcessing };
 
-		const msg = makeRunningChatsMsg({ claude: [], codex: [], opencode: [] });
+		const msg = makeRunningChatsMsg({ claude: [], codex: [], opencode: [], amp: [] });
 		handleRunningChats(msg, ctx);
 
 		const receivedSet = reconcileProcessing.mock.calls[0][0] as Set<string>;

--- a/web/src/lib/events/handlers/chat-sessions-running.ts
+++ b/web/src/lib/events/handlers/chat-sessions-running.ts
@@ -15,6 +15,7 @@ export function extractRunningChatIds(msg: ChatSessionsRunningMessage): Set<stri
       ...((msg.sessions?.claude as Array<{ id?: string }> | undefined) || []),
       ...((msg.sessions?.codex as Array<{ id?: string }> | undefined) || []),
       ...((msg.sessions?.opencode as Array<{ id?: string }> | undefined) || []),
+      ...((msg.sessions?.amp as Array<{ id?: string }> | undefined) || []),
     ]
       .map((s) => s?.id)
       .filter((id): id is string => Boolean(id)),

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -16,7 +16,9 @@ describe('ModelCatalogStore', () => {
 		const store = createModelCatalogStore();
 		expect(store.getModels('claude').length).toBeGreaterThan(0);
 		expect(store.getModels('codex').length).toBeGreaterThan(0);
+		expect(store.getModels('amp').length).toBeGreaterThan(0);
 		expect(store.getDefaultModel('claude')).toBe('opus');
+		expect(store.getDefaultModel('amp')).toBe('smart');
 	});
 
 	it('exposes default capabilities from common contract', () => {
@@ -24,9 +26,11 @@ describe('ModelCatalogStore', () => {
 		expect(store.supportsFork('claude')).toBe(true);
 		expect(store.supportsFork('codex')).toBe(true);
 		expect(store.supportsFork('opencode')).toBe(false);
+		expect(store.supportsFork('amp')).toBe(true);
 		expect(store.supportsImages('claude')).toBe(true);
 		expect(store.supportsImages('codex')).toBe(false);
 		expect(store.supportsImages('opencode')).toBe(false);
+		expect(store.supportsImages('amp')).toBe(false);
 	});
 
 	it('hydrates cached models from localStorage', () => {
@@ -56,6 +60,7 @@ describe('ModelCatalogStore', () => {
 					claude: { supportsFork: true, supportsImages: true },
 					codex: { supportsFork: true, supportsImages: false },
 					opencode: { supportsFork: false, supportsImages: false },
+					amp: { supportsFork: true, supportsImages: false },
 				},
 				lastFetchedAt: Date.now()
 			})
@@ -82,6 +87,7 @@ describe('ModelCatalogStore', () => {
 		expect(store.getModels('opencode')).toEqual([{ value: 'moonshot/kimi-k2', label: 'Kimi K2' }]);
 		expect(store.getModels('claude').length).toBeGreaterThan(0);
 		expect(store.getModels('codex').length).toBeGreaterThan(0);
+		expect(store.getModels('amp').length).toBeGreaterThan(0);
 	});
 
 	it('parses catalog.providers from API response', async () => {
@@ -90,6 +96,7 @@ describe('ModelCatalogStore', () => {
 			json: async () => ({
 				claude: [{ value: 'opus', label: 'Opus' }],
 				codex: [{ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' }],
+				amp: [{ value: 'smart', label: 'Smart' }],
 				opencode: [],
 				catalog: {
 					providers: [
@@ -111,6 +118,12 @@ describe('ModelCatalogStore', () => {
 							supportsImages: false,
 							models: [],
 						},
+						{
+							id: 'amp',
+							supportsFork: true,
+							supportsImages: false,
+							models: [{ value: 'smart', label: 'Smart' }],
+						},
 					],
 				},
 			})
@@ -121,9 +134,11 @@ describe('ModelCatalogStore', () => {
 
 		expect(store.supportsFork('claude')).toBe(true);
 		expect(store.supportsFork('opencode')).toBe(false);
+		expect(store.supportsFork('amp')).toBe(true);
 		expect(store.supportsImages('claude')).toBe(true);
 		expect(store.supportsImages('codex')).toBe(false);
 		expect(store.getModels('claude')).toEqual([{ value: 'opus', label: 'Opus' }]);
+		expect(store.getModels('amp')).toEqual([{ value: 'smart', label: 'Smart' }]);
 	});
 
 	it('falls back to legacy shape when catalog is absent', async () => {
@@ -132,6 +147,7 @@ describe('ModelCatalogStore', () => {
 			json: async () => ({
 				claude: [{ value: 'opus', label: 'Opus' }],
 				codex: [],
+				amp: [],
 				opencode: [],
 			})
 		} as unknown as Response);

--- a/web/src/lib/stores/model-catalog.svelte.ts
+++ b/web/src/lib/stores/model-catalog.svelte.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from '$lib/api/client.js';
 import type { SessionProvider } from '$lib/types/app';
-import { CLAUDE_MODELS, CODEX_MODELS } from '$shared/models';
+import { CLAUDE_MODELS, CODEX_MODELS, AMP_MODELS } from '$shared/models';
 import { PROVIDERS, PROVIDER_CAPABILITIES, type ProviderId } from '$shared/providers';
 
 export interface ModelOption {
@@ -27,6 +27,7 @@ const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
 const STATIC_FALLBACKS: ProviderModels = {
 	claude: CLAUDE_MODELS.OPTIONS,
 	codex: CODEX_MODELS.OPTIONS,
+	amp: AMP_MODELS.OPTIONS,
 	opencode: []
 };
 
@@ -62,6 +63,7 @@ function mergeWithFallbacks(models: ProviderModels): ProviderModels {
 	return {
 		claude: models.claude?.length ? models.claude : STATIC_FALLBACKS.claude,
 		codex: models.codex?.length ? models.codex : STATIC_FALLBACKS.codex,
+		amp: models.amp?.length ? models.amp : STATIC_FALLBACKS.amp,
 		opencode: models.opencode?.length ? models.opencode : STATIC_FALLBACKS.opencode
 	};
 }
@@ -181,6 +183,7 @@ export class ModelCatalogStore {
 	getDefaultModel(provider: SessionProvider): string {
 		if (provider === 'claude') return CLAUDE_MODELS.DEFAULT;
 		if (provider === 'codex') return CODEX_MODELS.DEFAULT;
+		if (provider === 'amp') return AMP_MODELS.DEFAULT;
 		return this.getModels('opencode')[0]?.value ?? '';
 	}
 

--- a/web/src/lib/stores/preferences.svelte.ts
+++ b/web/src/lib/stores/preferences.svelte.ts
@@ -3,7 +3,7 @@
 
 import type { SessionProvider } from '$lib/types/app';
 import type { PermissionMode } from '$lib/types/chat';
-import { CLAUDE_MODELS, CODEX_MODELS } from '$shared/models';
+import { CLAUDE_MODELS, CODEX_MODELS, AMP_MODELS } from '$shared/models';
 
 // Persisted preference fields.
 export type ThemeMode = 'dark' | 'light' | 'system';
@@ -20,6 +20,7 @@ export interface PreferencesState {
 	selectedProvider: SessionProvider;
 	claudeModel: string;
 	codexModel: string;
+	ampModel: string;
 	opencodeModel: string;
 	codeEditorTheme: string;
 	codeEditorWordWrap: boolean;
@@ -44,6 +45,7 @@ const DEFAULTS: PreferencesState = {
 	selectedProvider: 'claude',
 	claudeModel: CLAUDE_MODELS.DEFAULT,
 	codexModel: CODEX_MODELS.DEFAULT,
+	ampModel: AMP_MODELS.DEFAULT,
 	opencodeModel: 'anthropic/claude-sonnet-4-5',
 	codeEditorTheme: 'auto',
 	codeEditorWordWrap: false,
@@ -106,6 +108,10 @@ function readPersisted(): PreferencesState {
 						typeof parsed.codexModel === 'string'
 							? parsed.codexModel
 							: DEFAULTS.codexModel,
+					ampModel:
+						typeof parsed.ampModel === 'string'
+							? parsed.ampModel
+							: DEFAULTS.ampModel,
 					opencodeModel:
 						typeof parsed.opencodeModel === 'string'
 							? parsed.opencodeModel
@@ -167,6 +173,7 @@ export class PreferencesStore {
 	selectedProvider = $state<SessionProvider>(DEFAULTS.selectedProvider);
 	claudeModel = $state(DEFAULTS.claudeModel);
 	codexModel = $state(DEFAULTS.codexModel);
+	ampModel = $state(DEFAULTS.ampModel);
 	opencodeModel = $state(DEFAULTS.opencodeModel);
 	codeEditorTheme = $state(DEFAULTS.codeEditorTheme);
 	codeEditorWordWrap = $state(DEFAULTS.codeEditorWordWrap);
@@ -191,6 +198,7 @@ export class PreferencesStore {
 		this.selectedProvider = saved.selectedProvider;
 		this.claudeModel = saved.claudeModel;
 		this.codexModel = saved.codexModel;
+		this.ampModel = saved.ampModel;
 		this.opencodeModel = saved.opencodeModel;
 		this.codeEditorTheme = saved.codeEditorTheme;
 		this.codeEditorWordWrap = saved.codeEditorWordWrap;
@@ -215,6 +223,7 @@ export class PreferencesStore {
 			selectedProvider: this.selectedProvider,
 			claudeModel: this.claudeModel,
 			codexModel: this.codexModel,
+			ampModel: this.ampModel,
 			opencodeModel: this.opencodeModel,
 			codeEditorTheme: this.codeEditorTheme,
 			codeEditorWordWrap: this.codeEditorWordWrap,

--- a/web/src/lib/types/app.ts
+++ b/web/src/lib/types/app.ts
@@ -1,6 +1,6 @@
 // Application-level types shared across the Svelte frontend.
 
-export type SessionProvider = 'claude' | 'codex' | 'opencode';
+export type SessionProvider = 'claude' | 'codex' | 'opencode' | 'amp';
 
 export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'preview';
 

--- a/web/src/lib/types/session.ts
+++ b/web/src/lib/types/session.ts
@@ -2,7 +2,7 @@
 
 export interface ChatSession {
 	id: string;
-	provider: 'claude' | 'codex' | 'opencode';
+	provider: 'claude' | 'codex' | 'opencode' | 'amp';
 	model: string | null;
 	permissionMode?: string;
 	thinkingMode?: string;


### PR DESCRIPTION
## Summary
- add AMP provider runtime and registry wiring on the server
- add AMP auth status route and AMP history/native-path loading
- include AMP in provider/model catalogs and chat session/event contracts
- wire AMP through new-chat + settings UI paths required to start and view AMP chats
- keep test updates required for AMP model/provider routing and running-session shape

## Explicitly Descoped
- AMP-specific composer UX polish (quick smart/deep toggle)
- draft-chat provider switching enhancements in composer
- AMP as commit-message generation provider in git workbench

## Validation
- `cd web && bun run check`
- `cd server && bun test routes/__tests__/models.test.js providers/__tests__/providers-run-single-query.test.js ws/__tests__/chat-contracts.test.js`

## Known Pre-existing Failure (outside this scope)
- `server/projects/__tests__/codex.test.js` has 2 failing tests around `findCodexSessionFileBySessionId`
