### PR TITLE
ui: move sidebar menu button to top-right

### DIFF
--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -178,7 +178,7 @@
 	<!-- Status corner badge overlays chat content without affecting layout flow. -->
 		{#if isPinned || isArchived}
 			<div
-				class="absolute top-1 right-1 z-20 pointer-events-none w-5 h-5 rounded-full border flex items-center justify-center {cornerBadgeClass}"
+				class={cn("absolute top-1 right-1 z-20 pointer-events-none w-5 h-5 rounded-full border flex items-center justify-center [@media(hover:hover)_and_(pointer:fine)]:group-hover:opacity-0 transition-opacity", menuOpen && "!opacity-0", cornerBadgeClass)}
 				aria-hidden="true"
 			>
 				{#if isPinned}
@@ -259,7 +259,7 @@
 	<div
 		class={cn(
 			"absolute z-20",
-			!isAtCursor && "sidebar-item-menu-anchor right-1 bottom-1 opacity-100 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within:opacity-100",
+			!isAtCursor && "sidebar-item-menu-anchor right-1 top-1 opacity-100 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within:opacity-100",
 			!isAtCursor && menuOpen && "!opacity-100"
 		)}
 		style={isAtCursor ? `left:${rightClickPos!.x}px;top:${rightClickPos!.y}px` : ''}


### PR DESCRIPTION
**Problem**
The three-dot kebab menu on sidebar chat items is positioned at the bottom-right, which is far from the chat title and less discoverable.

**Solution**
Move the menu button anchor from `bottom-1` to `top-1`, placing it beside the chat title at top-right for easier access.

**Changes**
- `SidebarChatItem.svelte`: Changed menu anchor position from `bottom-1` to `top-1`
- Added hover-hide and menu-open-hide on the pin/archive badge to prevent overlap with the menu button at the same position

**Expected Impact**
The three-dot menu now appears at the top-right of each sidebar chat item on hover, next to the chat title. The pin/archive badge gracefully hides when the menu is visible.