### PR TITLE
fix: guard against opencode binary missing before spawn

### DIFF
--- a/server/providers/opencode.ts
+++ b/server/providers/opencode.ts
@@ -199,6 +199,11 @@ export class OpenCodeProvider extends AbsProvider {
 
     this.#initPromise = (async () => {
       try {
+        if (typeof Bun !== 'undefined' && typeof Bun.which === 'function'
+            && process.env.NODE_ENV !== 'test' && !Bun.which('opencode')) {
+          throw new Error('opencode executable not found in $PATH');
+        }
+
         const { createOpencode } = await import('@opencode-ai/sdk/v2');
         const port = 10000 + Math.floor(Math.random() * 50000);
         const result = await createOpencode({ timeout: 30000, port });


### PR DESCRIPTION
Bun's `spawn()` throws synchronously for ENOENT instead of emitting an error event, which crashes the server process when `opencode` is not installed. This adds a `Bun.which('opencode')` check before calling `createOpencode()` from the SDK, so the error is caught by the existing try-catch and propagated gracefully.

Builds on #41 which reset `#initPromise` on failure.

**Verified**: server stays up, models refresh logs a warning, site loads correctly via Cloudflare Tunnel.