### PR TITLE
fix: prevent unhandled promise rejections from crashing the server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -53,6 +53,10 @@ import {
 import createAllRoutes from './routes/index.js';
 
 export async function startServer() {
+  process.on('unhandledRejection', (err) => {
+    console.error('unhandled rejection (non-fatal):', err?.message || err);
+  });
+
   try {
     const workspaceDir = getWorkspaceDir();
 


### PR DESCRIPTION
## Problem

The server crashes when the OpenCode provider's `#ensureOpenCodeServer()` rejects because the `opencode` binary is missing. When multiple callers race on the same `#initPromise` (e.g., `refreshOpenCodeCache` and `startSession`), one rejection is caught but the other propagates as an unhandled rejection. Bun 1.3.0 treats unhandled rejections as fatal, killing the entire process.

## Fix

Adds a `process.on('unhandledRejection')` handler at server startup that logs the error instead of letting it crash the process.

## Testing

- Restarted the server with `opencode` missing from PATH
- Confirmed the server stays alive (previously crashed immediately)
- Verified end-to-end chat flow works: sent "What is 2 + 2?" via Claude and got a response