### PR TITLE
fix: humanize Codex provider errors for UI display

### DIFF
--- a/server/providers/__tests__/codex-humanize-error.test.js
+++ b/server/providers/__tests__/codex-humanize-error.test.js
@@ -1,0 +1,51 @@
+// Tests for humanizeCodexError -- verifies raw SDK/CLI errors are
+// translated into actionable user-facing messages.
+
+import { describe, it, expect } from 'bun:test';
+import { humanizeCodexError } from '../codex.ts';
+
+describe('humanizeCodexError', () => {
+  it('detects missing CLI', () => {
+    const msg = humanizeCodexError(new Error('spawn codex ENOENT'));
+    expect(msg).toContain('not installed');
+  });
+
+  it('detects auth failure', () => {
+    const msg = humanizeCodexError(new Error('401 Unauthorized'));
+    expect(msg).toContain('authentication failed');
+  });
+
+  it('detects rate limit', () => {
+    const msg = humanizeCodexError(new Error('429 rate limit exceeded'));
+    expect(msg).toContain('rate limit');
+  });
+
+  it('detects invalid model', () => {
+    const msg = humanizeCodexError(new Error('model gpt-99 does not exist'));
+    expect(msg).toContain('model not available');
+  });
+
+  it('detects network errors', () => {
+    const msg = humanizeCodexError(new Error('ECONNREFUSED 127.0.0.1:443'));
+    expect(msg).toContain('network connection');
+  });
+
+  it('strips stack traces from exit code errors', () => {
+    const msg = humanizeCodexError(
+      new Error('Codex Exec exited with code 1: Reading prompt from stdin...\n      at run (/home/user/node_modules/@openai/codex-sdk/dist/index.js:277:19)')
+    );
+    expect(msg).toContain('Codex process failed');
+    expect(msg).not.toContain('at run');
+    expect(msg).not.toContain('node_modules');
+  });
+
+  it('falls back to prefixed raw message for unknown errors', () => {
+    const msg = humanizeCodexError(new Error('something unexpected'));
+    expect(msg).toBe('Codex error: something unexpected');
+  });
+
+  it('handles string errors', () => {
+    const msg = humanizeCodexError('raw string error');
+    expect(msg).toBe('Codex error: raw string error');
+  });
+});

--- a/server/providers/codex.ts
+++ b/server/providers/codex.ts
@@ -187,6 +187,34 @@ function codexSandboxOptions(permissionMode: PermissionMode): { sandboxMode: str
   return CODEX_SANDBOX[permissionMode] ?? CODEX_SANDBOX.default;
 }
 
+// Translates raw Codex SDK/CLI errors into actionable user-facing messages.
+export function humanizeCodexError(error: any): string {
+  const raw = String(error?.message || error || '');
+
+  if (/not found|ENOENT.*codex|spawn codex/i.test(raw)) {
+    return 'Codex CLI is not installed or not in PATH. Install it with: npm i -g @openai/codex';
+  }
+  if (/authentication|unauthorized|401|api.?key/i.test(raw)) {
+    return 'Codex authentication failed. Run "codex" in your terminal to sign in.';
+  }
+  if (/rate.?limit|429/i.test(raw)) {
+    return 'Codex rate limit exceeded. Please wait a moment and try again.';
+  }
+  if (/model.*not.?found|invalid.*model|does not exist/i.test(raw)) {
+    return `Codex model not available. Check your model selection or Codex configuration.`;
+  }
+  if (/ECONNREFUSED|ENOTFOUND|network|timeout|ETIMEDOUT/i.test(raw)) {
+    return 'Codex could not connect to the API. Check your network connection.';
+  }
+  if (/exited with (code|signal)/i.test(raw)) {
+    // Strip internal stack trace paths, keep the meaningful part.
+    const cleaned = raw.replace(/\s+at\s+\S+.*$/gm, '').trim();
+    return `Codex process failed: ${cleaned}`;
+  }
+
+  return `Codex error: ${raw}`;
+}
+
 async function runCodexExec(args: string[], input: string): Promise<{ stdout: string; stderr: string }> {
   const proc = Bun.spawn(['codex', ...args], {
     stdin: new Blob([input]),
@@ -455,7 +483,7 @@ export class CodexProvider extends AbsProvider {
 
       if (!wasAborted) {
         console.error('codex: error:', error);
-        this.emitFailed(chatId, error.message);
+        this.emitFailed(chatId, humanizeCodexError(error));
       }
 
     } finally {


### PR DESCRIPTION
## Problem

Raw Codex SDK/CLI errors (stack traces, internal file paths, exit codes) were shown verbatim in the chat error card, forcing users to dig through server logs to understand what went wrong.

Example of what users saw:
```
Codex Exec exited with code 1: Reading prompt from stdin...
    at run (/home/user/node_modules/@openai/codex-sdk/dist/index.js:277:19)
```

## Solution

Adds `humanizeCodexError()` that translates common failure modes into actionable, user-facing messages:

| Error type | User sees |
|---|---|
| Missing CLI | "Codex CLI is not installed or not in PATH. Install it with: npm i -g @openai/codex" |
| Auth failure | "Codex authentication failed. Run codex in your terminal to sign in." |
| Rate limit | "Codex rate limit exceeded. Please wait a moment and try again." |
| Invalid model | "Codex model not available. Check your model selection or Codex configuration." |
| Network error | "Codex could not connect to the API. Check your network connection." |
| Exit code | Strips stack traces, keeps meaningful error text |

## Testing

- Added `codex-humanize-error.test.js` with 8 test cases covering all error categories
- All 708 existing tests pass