### PR TITLE
fix: merge static models into cached/remote model lists

### DIFF
--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -123,7 +123,37 @@ describe('ModelCatalogStore', () => {
 		expect(store.supportsFork('opencode')).toBe(false);
 		expect(store.supportsImages('claude')).toBe(true);
 		expect(store.supportsImages('codex')).toBe(false);
-		expect(store.getModels('claude')).toEqual([{ value: 'opus', label: 'Opus' }]);
+		// Remote had only opus; static sonnet+haiku are appended
+		const claudeModels = store.getModels('claude');
+		expect(claudeModels[0]).toEqual({ value: 'opus', label: 'Opus' });
+		expect(claudeModels.find((m) => m.value === 'sonnet')).toBeTruthy();
+	});
+
+	it('merges missing static models into cached results', async () => {
+		vi.mocked(clientApi.apiFetch).mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				catalog: {
+					providers: [
+						{
+							id: 'codex',
+							supportsFork: true,
+							supportsImages: false,
+							models: [{ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' }],
+						},
+					],
+				},
+			})
+		} as unknown as Response);
+
+		const store = createModelCatalogStore();
+		await store.forceRefresh();
+
+		const codexModels = store.getModels('codex');
+		expect(codexModels[0]).toEqual({ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' });
+		// Static gpt-5.4 should be appended
+		expect(codexModels.find((m) => m.value === 'gpt-5.4')).toBeTruthy();
+		expect(codexModels.length).toBeGreaterThan(1);
 	});
 
 	it('falls back to legacy shape when catalog is absent', async () => {
@@ -139,7 +169,10 @@ describe('ModelCatalogStore', () => {
 		const store = createModelCatalogStore();
 		await store.forceRefresh();
 
-		expect(store.getModels('claude')).toEqual([{ value: 'opus', label: 'Opus' }]);
+		// Remote had only opus; static sonnet+haiku are merged in
+		const claudeModels = store.getModels('claude');
+		expect(claudeModels[0]).toEqual({ value: 'opus', label: 'Opus' });
+		expect(claudeModels.find((m) => m.value === 'sonnet')).toBeTruthy();
 		// Falls back to default capabilities from common contract
 		expect(store.supportsFork('claude')).toBe(true);
 		expect(store.supportsImages('claude')).toBe(true);

--- a/web/src/lib/stores/model-catalog.svelte.ts
+++ b/web/src/lib/stores/model-catalog.svelte.ts
@@ -59,12 +59,21 @@ function normalizeProviderModels(value: unknown): ProviderModels {
 	return normalized;
 }
 
+// Ensures static models for claude/codex are always present in the result,
+// even when a cached or server list is missing newly added entries.
+function mergeStaticModels(remote: ModelOption[] | undefined, fallback: ModelOption[]): ModelOption[] {
+	if (!remote?.length) return fallback;
+	const seen = new Set(remote.map((m) => m.value));
+	const missing = fallback.filter((m) => !seen.has(m.value));
+	return missing.length ? [...remote, ...missing] : remote;
+}
+
 function mergeWithFallbacks(models: ProviderModels): ProviderModels {
 	return {
-		claude: models.claude?.length ? models.claude : STATIC_FALLBACKS.claude,
-		codex: models.codex?.length ? models.codex : STATIC_FALLBACKS.codex,
-		opencode: models.opencode?.length ? models.opencode : STATIC_FALLBACKS.opencode,
-		amp: models.amp?.length ? models.amp : STATIC_FALLBACKS.amp
+		claude: mergeStaticModels(models.claude, STATIC_FALLBACKS.claude!),
+		codex: mergeStaticModels(models.codex, STATIC_FALLBACKS.codex!),
+		amp: mergeStaticModels(models.amp, STATIC_FALLBACKS.amp!),
+		opencode: models.opencode?.length ? models.opencode : STATIC_FALLBACKS.opencode
 	};
 }
 


### PR DESCRIPTION
**Problem**
Static models (claude, codex, amp) were only used as fallbacks when the cached or remote list was completely empty. A stale `localStorage` cache or partial server response that omitted a newly added model (e.g. GPT-5.4) would leave it invisible in the UI until the user manually cleared storage.

**Solution**
`mergeWithFallbacks` now appends any missing static models to the end of the remote/cached list using a lightweight `Set`-based dedup. Only static providers (claude, codex, amp) are affected; opencode remains dynamic-only.

**Changes**
- Added `mergeStaticModels()` helper in `model-catalog.svelte.ts` that appends missing static entries to the remote list
- Updated `mergeWithFallbacks()` to use it for claude/codex/amp
- Added test for partial server response merging missing static models
- Updated existing tests to reflect merged results

**Expected Impact**
Newly added static models always appear in the dropdown regardless of cache state. No performance impact -- runs once per hydration/refresh with arrays of ~6 items.