### PR TITLE
feat: add colorblind-friendly color mode

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -122,6 +122,8 @@
   "command_switch_to_files": "Switch to Files",
   "command_switch_to_git": "Switch to Git",
   "command_switch_to_shell": "Switch to Shell",
+  "command_toggle_colorblind": "Toggle Colorblind Mode",
+  "command_toggle_colorblind_desc": "Switch to colorblind-friendly colors",
   "editor_actions_close": "Close",
   "editor_settings_button_label": "Editor settings",
   "editor_actions_collapse": "Collapse",

--- a/web/src/lib/components/shared/CommandMenu.svelte
+++ b/web/src/lib/components/shared/CommandMenu.svelte
@@ -8,7 +8,8 @@
 	import MessageSquarePlus from '@lucide/svelte/icons/message-square-plus';
 	import Settings from '@lucide/svelte/icons/settings';
 	import FileCode from '@lucide/svelte/icons/file-code';
-	import { getNavigation, getAppShell } from '$lib/context';
+	import Eye from '@lucide/svelte/icons/eye';
+	import { getNavigation, getAppShell, getPreferences } from '$lib/context';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface CommandItem {
@@ -21,6 +22,7 @@
 
 	const navigation = getNavigation();
 	const appShell = getAppShell();
+	const preferences = getPreferences();
 
 	let isOpen = $state(false);
 	let query = $state('');
@@ -44,6 +46,13 @@
 					description: m.command_open_settings_desc(),
 					category: 'Navigation',
 					action: () => appShell.openSettings()
+				},
+				{
+					id: 'toggle-colorblind',
+					label: m.command_toggle_colorblind(),
+					description: m.command_toggle_colorblind_desc(),
+					category: 'Accessibility',
+					action: () => preferences.setPreference('colorblindMode', !preferences.colorblindMode)
 				},
 				{
 					id: 'tab-chat',
@@ -142,6 +151,7 @@
 		switch (category) {
 			case 'Chat': return MessageSquarePlus;
 			case 'Navigation': return Settings;
+			case 'Accessibility': return Eye;
 			case 'Tabs': return FileCode;
 			default: return Search;
 		}


### PR DESCRIPTION
**Problem**
Git status indicators, diff colors, and status badges rely on red/green color differentiation, which is indistinguishable for users with color vision deficiency (protanopia, deuteranopia, tritanopia).

**Solution**
Add a "Colorblind-friendly colors" toggle in settings and the command palette. When enabled, a `.colorblind` CSS class on the root element overrides color tokens with a blue/orange/teal palette that is distinguishable across all major forms of color blindness.

**Changes**
- `preferences.svelte.ts`: Added `colorblindMode` boolean preference (persisted to localStorage)
- `app.css`: Added `.colorblind` and `.dark.colorblind` CSS rule blocks overriding git, diff, and status tokens
- `+layout.svelte`: Added `$effect` to toggle `.colorblind` class on `<html>` reactively
- `PreferencesSection.svelte`: Added toggle row in the display settings card
- `CommandMenu.svelte`: Added "Toggle Colorblind Mode" command under Accessibility category
- `en.json` + paraglide regeneration for new i18n keys

**Screenshots**

Settings toggle (off):
![Settings - colorblind off](https://i.imgur.com/ec2Pdtm.png)

Settings toggle (on):
![Settings - colorblind on](https://i.imgur.com/ekoWBoh.png)

Command palette quick access (Ctrl+P):
![Command palette](https://i.imgur.com/Ejz0h6q.png)

**Expected Impact**
Users with color vision deficiency can toggle colorblind mode via settings or Ctrl+P command palette for improved legibility of git status, diffs, and status indicators. No impact on existing users when toggle is off (default).