### PR TITLE
fix: auth flow and onboarding UX improvements

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -55,7 +55,7 @@ async function noauthPostRegister(request) {
 
     const setupNeeded = await needsSetup();
     if (!setupNeeded) {
-      return Response.json({ error: 'Account already configured' }, { status: 403 });
+      return Response.json({ error: 'Account already configured' }, { status: 409 });
     }
 
     const passwordHash = await Bun.password.hash(password, { algorithm: 'bcrypt', cost: 12 });

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,5 +1,7 @@
 {
   "auth_login_errors_invalid_credentials": "Invalid username or password",
+  "auth_password_hide": "Hide password",
+  "auth_password_show": "Show password",
   "auth_login_errors_required_fields": "All fields required",
   "auth_login_loading": "Signing in...",
   "auth_login_password": "Password",

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -16,6 +16,7 @@ function describeAuthError(err: unknown): string {
 	if (err instanceof ApiError) {
 		if (err.status === 401) return 'Invalid credentials. Please try again.';
 		if (err.status === 403) return 'Access denied. You do not have permission.';
+		if (err.status === 409) return err.message;
 		if (err.status >= 500) return 'Server error. Please try again later.';
 		return err.message;
 	}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -116,15 +116,23 @@
 		ws.disconnect();
 	});
 
-	// Redirects unauthenticated users, checks onboarding status
+	// Redirects unauthenticated users, checks onboarding status.
+	// Also guards /setup when account already exists.
 	$effect(() => {
 		if (auth.isLoading) return;
-		if (isPublicRoute) return;
 		if (auth.authDisabled) return;
+
+		if (page.url.pathname === '/setup' && !auth.needsSetup && !auth.isAuthenticated) {
+			goto('/login');
+			return;
+		}
+
+		if (isPublicRoute) return;
 		if (auth.needsSetup) {
 			goto('/setup');
 		} else if (!auth.isAuthenticated) {
-			goto('/login');
+			const returnTo = page.url.pathname;
+			goto(returnTo === '/' ? '/login' : `/login?returnTo=${encodeURIComponent(returnTo)}`);
 		}
 	});
 

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { getAuth } from '$lib/context';
 	import * as m from '$lib/paraglide/messages.js';
+	import Eye from '@lucide/svelte/icons/eye';
+	import EyeOff from '@lucide/svelte/icons/eye-off';
 
 	const auth = getAuth();
 
@@ -11,6 +14,13 @@
 	let password = $state('');
 	let isSubmitting = $state(false);
 	let error = $state('');
+	let showPassword = $state(false);
+
+	function getReturnTo(): string {
+		const raw = page.url.searchParams.get('returnTo');
+		if (raw && raw.startsWith('/') && !raw.startsWith('//')) return raw;
+		return '/';
+	}
 
 	async function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
@@ -26,7 +36,7 @@
 		if (!result.success) {
 			error = result.error || m.auth_login_errors_invalid_credentials();
 		} else {
-			goto('/');
+			goto(getReturnTo());
 		}
 		isSubmitting = false;
 	}
@@ -59,14 +69,31 @@
 					<label for="password" class="mb-1 block text-sm font-medium text-foreground">
 						{m.auth_login_password()}
 					</label>
-					<Input
-						type="password"
-						id="password"
-						bind:value={password}
-						placeholder={m.auth_login_placeholders_password()}
-						required
-						disabled={isSubmitting}
-					/>
+					<div class="relative">
+						<Input
+							type={showPassword ? 'text' : 'password'}
+							id="password"
+							bind:value={password}
+							placeholder={m.auth_login_placeholders_password()}
+							required
+							disabled={isSubmitting}
+							class="pr-10"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground"
+							onclick={() => (showPassword = !showPassword)}
+							aria-label={showPassword ? m.auth_password_hide() : m.auth_password_show()}
+						>
+							{#if showPassword}
+								<EyeOff class="size-4" />
+							{:else}
+								<Eye class="size-4" />
+							{/if}
+						</Button>
+					</div>
 				</div>
 
 				{#if error}

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -5,6 +5,8 @@
 	import { getAuth } from '$lib/context';
 	import * as m from '$lib/paraglide/messages.js';
 	import Shield from '@lucide/svelte/icons/shield';
+	import Eye from '@lucide/svelte/icons/eye';
+	import EyeOff from '@lucide/svelte/icons/eye-off';
 
 	const auth = getAuth();
 
@@ -13,6 +15,8 @@
 	let confirmPassword = $state('');
 	let isSubmitting = $state(false);
 	let error = $state('');
+	let showPassword = $state(false);
+	let showConfirmPassword = $state(false);
 
 	async function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
@@ -95,28 +99,62 @@
 					<label for="password" class="mb-1 block text-sm font-medium text-foreground">
 						{m.auth_login_password()}
 					</label>
-					<Input
-						type="password"
-						id="password"
-						bind:value={password}
-						placeholder={m.auth_login_placeholders_password()}
-						required
-						disabled={isSubmitting}
-					/>
+					<div class="relative">
+						<Input
+							type={showPassword ? 'text' : 'password'}
+							id="password"
+							bind:value={password}
+							placeholder={m.auth_login_placeholders_password()}
+							required
+							disabled={isSubmitting}
+							class="pr-10"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground"
+							onclick={() => (showPassword = !showPassword)}
+							aria-label={showPassword ? m.auth_password_hide() : m.auth_password_show()}
+						>
+							{#if showPassword}
+								<EyeOff class="size-4" />
+							{:else}
+								<Eye class="size-4" />
+							{/if}
+						</Button>
+					</div>
 				</div>
 
 				<div>
 					<label for="confirmPassword" class="mb-1 block text-sm font-medium text-foreground">
 						{m.auth_setup_confirm_password()}
 					</label>
-					<Input
-						type="password"
-						id="confirmPassword"
-						bind:value={confirmPassword}
-						placeholder={m.auth_setup_confirm_password_placeholder()}
-						required
-						disabled={isSubmitting}
-					/>
+					<div class="relative">
+						<Input
+							type={showConfirmPassword ? 'text' : 'password'}
+							id="confirmPassword"
+							bind:value={confirmPassword}
+							placeholder={m.auth_setup_confirm_password_placeholder()}
+							required
+							disabled={isSubmitting}
+							class="pr-10"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:text-foreground"
+							onclick={() => (showConfirmPassword = !showConfirmPassword)}
+							aria-label={showConfirmPassword ? m.auth_password_hide() : m.auth_password_show()}
+						>
+							{#if showConfirmPassword}
+								<EyeOff class="size-4" />
+							{:else}
+								<Eye class="size-4" />
+							{/if}
+						</Button>
+					</div>
 				</div>
 
 				{#if error}


### PR DESCRIPTION
## Summary

Fixes authentication flow issues and onboarding UX problems found during QA.

### Changes
- **Return-to URL preservation (#74)**: Unauthenticated users redirected to `/login` now carry a `?returnTo=` parameter so they land back on the intended page after login.
- **409 for existing account (#75)**: `POST /api/v1/auth/register` now returns `409 Conflict` instead of `403 Forbidden` when an account already exists. The client-side error mapper passes the server message through for 409 status.
- **Password visibility toggles (#78)**: Login and setup forms now have eye/eye-off toggle buttons on password fields using Lucide icons and shadcn-svelte Button.
- **Setup route guard (#81)**: Navigating to `/setup` when an account already exists and the user is not authenticated now redirects to `/login` instead of showing a broken setup form.

### Screenshots

#### Login page with password visibility toggle
![Login page](https://files.catbox.moe/7tl1nf.png)

#### Password revealed
![Password visible](https://files.catbox.moe/vks8qf.png)

#### Setup page with password toggles
![Setup page](https://files.catbox.moe/vlgxdp.png)

### Testing
- `bun run check` passes (0 errors, 0 warnings)
- `bun run test` passes (all tests green)

Fixes #74, #75, #78, #81
Part of #73