### PR TITLE
fix: reduce composer default height from 360 to 140px

### DIFF
--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -193,7 +193,7 @@
 	// Composer resize via drag handle. Persists height to localStorage and
 	// mutates the DOM directly during drag to avoid render latency.
 	const COMPOSER_STORAGE_KEY = 'composerHeight';
-	const COMPOSER_DEFAULT_HEIGHT = 360;
+	const COMPOSER_DEFAULT_HEIGHT = 140;
 	const COMPOSER_MIN_HEIGHT = 52;
 	const COMPOSER_MAX_HEIGHT = 500;
 


### PR DESCRIPTION
## Summary

Reduces the prompt composer default height from 360px to 140px.

### Problem
The initial composer height of 360px consumed excessive vertical space on first load, pushing the conversation feed out of view.

### Fix
Changed `COMPOSER_DEFAULT_HEIGHT` constant from `360` to `140`. The composer remains user-resizable via the drag handle, and any custom height is persisted to localStorage.

### Testing
- `bun run check` passes (0 errors, 0 warnings)
- `bun run test` passes (all tests green)

Fixes #79
Part of #73

_Replaces PR #82 (closed due to force push after rebase)_