### PR TITLE
feat: add OpenRouter provider with Gemini model support

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -28,3 +28,12 @@ export const AMP_MODELS = {
   ],
   DEFAULT: 'default',
 };
+
+export const OPENROUTER_MODELS = {
+  OPTIONS: [
+    { value: 'google/gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+    { value: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    { value: 'google/gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
+  ],
+  DEFAULT: 'google/gemini-2.5-pro',
+};

--- a/common/providers.ts
+++ b/common/providers.ts
@@ -2,7 +2,7 @@
 // and frontend as the single source of truth for provider identity and
 // static capability policy.
 
-export const PROVIDERS = ['claude', 'codex', 'opencode', 'amp'] as const;
+export const PROVIDERS = ['claude', 'codex', 'opencode', 'amp', 'openrouter'] as const;
 
 export type ProviderId = (typeof PROVIDERS)[number];
 
@@ -16,6 +16,7 @@ export const PROVIDER_CAPABILITIES: Record<ProviderId, ProviderCapabilities> = {
   codex: { supportsFork: true, supportsImages: true },
   opencode: { supportsFork: false, supportsImages: false },
   amp: { supportsFork: false, supportsImages: false },
+  openrouter: { supportsFork: false, supportsImages: true },
 };
 
 export function isProviderId(value: unknown): value is ProviderId {

--- a/common/ws-events.ts
+++ b/common/ws-events.ts
@@ -56,6 +56,7 @@ export class ChatSessionsRunningMessage {
     codex: Array<{ id: string }>;
     opencode: Array<{ id: string }>;
     amp: Array<{ id: string }>;
+    openrouter: Array<{ id: string }>;
   }) { }
 }
 

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -12,6 +12,7 @@ import { getClaudeAuthStatus } from './claude-auth.js';
 import { getCodexAuthStatus } from './codex-auth.js';
 import { getOpenCodeAuthStatus } from './opencode-auth.js';
 import { getAmpAuthStatus } from './amp-auth.js';
+import { getOpenRouterAuthStatus } from './openrouter-auth.js';
 
 // Stateless loaders and preview functions
 import { getClaudePreviewFromNativePath, loadClaudeChatMessages } from './loaders/claude-history-loader.js';
@@ -37,6 +38,7 @@ const AUTH_DISPATCHERS: Record<string, (opencode: OpenCodeProviderInstance) => P
   codex: () => getCodexAuthStatus(),
   opencode: (oc) => getOpenCodeAuthStatus(oc),
   amp: () => getAmpAuthStatus(),
+  openrouter: () => getOpenRouterAuthStatus(),
 };
 
 // Validates that a registry entry has all required execution fields.
@@ -120,12 +122,27 @@ interface AmpProviderInstance {
   onFailed(cb: (chatId: string, errorMessage: string) => void): void;
 }
 
+interface OpenRouterProviderInstance {
+  startSession(request: StartSessionRequest): Promise<StartedProviderSession>;
+  runTurn(request: ResumeTurnRequest): Promise<void>;
+  isRunning(providerSessionId: string): boolean;
+  abort(providerSessionId: string): boolean;
+  getRunningSessions(): Array<{ id: string; status: string; startedAt: string }>;
+  startPurgeTimer(): ReturnType<typeof setInterval>;
+  onMessages(cb: (chatId: string, messages: unknown[]) => void): void;
+  onProcessing(cb: (chatId: string, isProcessing: boolean) => void): void;
+  onSessionCreated(cb: (chatId: string) => void): void;
+  onFinished(cb: (chatId: string, exitCode: number) => void): void;
+  onFailed(cb: (chatId: string, errorMessage: string) => void): void;
+}
+
 export class ProviderRegistry {
   #registry: IChatRegistry;
   #claude: ClaudeProviderInstance;
   #codex: CodexProviderInstance;
   #opencode: OpenCodeProviderInstance;
   #amp: AmpProviderInstance;
+  #openrouter: OpenRouterProviderInstance;
 
   constructor(
     registry: IChatRegistry,
@@ -133,12 +150,14 @@ export class ProviderRegistry {
     codex: CodexProviderInstance,
     opencode: OpenCodeProviderInstance,
     amp: AmpProviderInstance,
+    openrouter: OpenRouterProviderInstance,
   ) {
     this.#registry = registry;
     this.#claude = claude;
     this.#codex = codex;
     this.#opencode = opencode;
     this.#amp = amp;
+    this.#openrouter = openrouter;
 
     if (typeof registry.onChatRemoved === 'function') {
       registry.onChatRemoved((chatId: string) => {
@@ -217,6 +236,12 @@ export class ProviderRegistry {
       return;
     }
 
+    if (entry.provider === 'openrouter') {
+      const { providerSessionId, nativePath } = await this.#openrouter.startSession(request);
+      this.#registry.updateChat(chatId, { providerSessionId, nativePath });
+      return;
+    }
+
     throw new Error(`Unsupported provider: ${entry.provider}`);
   }
 
@@ -261,6 +286,8 @@ export class ProviderRegistry {
         chatId,
         cwd: entry.projectPath,
       });
+    } else if (provider === 'openrouter') {
+      await this.#openrouter.runTurn(request);
     } else {
       throw new Error(`Unsupported provider: ${provider}`);
     }
@@ -290,6 +317,10 @@ export class ProviderRegistry {
       return this.#amp.abort(providerSessionId);
     }
 
+    if (entry.provider === 'openrouter') {
+      return this.#openrouter.abort(providerSessionId);
+    }
+
     return false;
   }
 
@@ -305,6 +336,7 @@ export class ProviderRegistry {
     if (provider === 'codex') return this.#codex.isRunning(providerSessionId);
     if (provider === 'opencode') return this.#opencode.isRunning(providerSessionId);
     if (provider === 'amp') return this.#amp.isRunning(providerSessionId);
+    if (provider === 'openrouter') return this.#openrouter.isRunning(providerSessionId);
     return false;
   }
 
@@ -324,6 +356,7 @@ export class ProviderRegistry {
       codex: mapToChatId(this.#codex.getRunningSessions()),
       opencode: mapToChatId(this.#opencode.getRunningSessions()),
       amp: mapToChatId(this.#amp.getRunningSessions()),
+      openrouter: mapToChatId(this.#openrouter.getRunningSessions()),
     };
   }
 
@@ -332,7 +365,8 @@ export class ProviderRegistry {
       (this.#claude.getRunningClaudeInternalSessions?.()?.length ?? 0) +
       (this.#codex.getRunningSessions?.()?.length ?? 0) +
       (this.#opencode.getRunningSessions?.()?.length ?? 0) +
-      (this.#amp.getRunningSessions?.()?.length ?? 0)
+      (this.#amp.getRunningSessions?.()?.length ?? 0) +
+      (this.#openrouter.getRunningSessions?.()?.length ?? 0)
     );
   }
 
@@ -384,8 +418,8 @@ export class ProviderRegistry {
   async getPreview(session: ProviderChatEntry | null): Promise<unknown> {
     if (!session?.provider) return null;
 
-    if (session.provider === 'amp') {
-      return null; // Amp history loading is not yet supported
+    if (session.provider === 'amp' || session.provider === 'openrouter') {
+      return null;
     }
     if (session.provider === 'opencode') {
       const sessionId = session.providerSessionId || session.nativePath?.replace('opencode:', '');
@@ -406,8 +440,8 @@ export class ProviderRegistry {
   async loadMessages(session: ProviderChatEntry | null): Promise<unknown[]> {
     if (!session?.provider) return [];
 
-    if (session.provider === 'amp') {
-      return []; // Amp history loading is not yet supported
+    if (session.provider === 'amp' || session.provider === 'openrouter') {
+      return [];
     }
     if (session.provider === 'opencode') {
       const sessionId = session.providerSessionId || session.nativePath?.replace('opencode:', '');
@@ -450,6 +484,7 @@ export class ProviderRegistry {
     this.#opencode.startPurgeTimer();
     this.#amp.startPurgeTimer();
     this.#claude.startPurgeTimer();
+    this.#openrouter.startPurgeTimer();
   }
 
   // Fan-out listener helpers. Registers the callback on all
@@ -460,6 +495,7 @@ export class ProviderRegistry {
     this.#codex.onMessages(cb);
     this.#opencode.onMessages(cb);
     this.#amp.onMessages(cb);
+    this.#openrouter.onMessages(cb);
   }
 
   onProcessing(cb: (chatId: string, isProcessing: boolean) => void): void {
@@ -467,6 +503,7 @@ export class ProviderRegistry {
     this.#codex.onProcessing(cb);
     this.#opencode.onProcessing(cb);
     this.#amp.onProcessing(cb);
+    this.#openrouter.onProcessing(cb);
   }
 
   onSessionCreated(cb: (chatId: string) => void): void {
@@ -474,6 +511,7 @@ export class ProviderRegistry {
     this.#codex.onSessionCreated(cb);
     this.#opencode.onSessionCreated(cb);
     this.#amp.onSessionCreated(cb);
+    this.#openrouter.onSessionCreated(cb);
   }
 
   onFinished(cb: (chatId: string, exitCode: number) => void): void {
@@ -481,6 +519,7 @@ export class ProviderRegistry {
     this.#codex.onFinished(cb);
     this.#opencode.onFinished(cb);
     this.#amp.onFinished(cb);
+    this.#openrouter.onFinished(cb);
   }
 
   onFailed(cb: (chatId: string, errorMessage: string) => void): void {
@@ -488,5 +527,6 @@ export class ProviderRegistry {
     this.#codex.onFailed(cb);
     this.#opencode.onFailed(cb);
     this.#amp.onFailed(cb);
+    this.#openrouter.onFailed(cb);
   }
 }

--- a/server/providers/loaders/openrouter-history-loader.ts
+++ b/server/providers/loaders/openrouter-history-loader.ts
@@ -1,0 +1,12 @@
+// Stub history loader for OpenRouter. Sessions are in-memory only;
+// persistence can be added as a follow-up.
+
+import type { ChatMessage } from '../../../common/chat-types.js';
+
+export function loadOpenRouterChatMessages(_sessionId: string | null | undefined): ChatMessage[] {
+  return [];
+}
+
+export function getOpenRouterPreview(_sessionId: string | null | undefined): null {
+  return null;
+}

--- a/server/providers/openrouter-auth.ts
+++ b/server/providers/openrouter-auth.ts
@@ -1,0 +1,10 @@
+// Checks OpenRouter authentication by verifying the OPENROUTER_API_KEY
+// environment variable is set.
+
+export async function getOpenRouterAuthStatus() {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (apiKey && apiKey.trim().length > 0) {
+    return { authenticated: true, canReauth: false as const, label: 'API Key' };
+  }
+  return { authenticated: false, canReauth: false as const, label: '' };
+}

--- a/server/providers/openrouter.ts
+++ b/server/providers/openrouter.ts
@@ -1,0 +1,271 @@
+// OpenRouter API provider. Sends chat completions via the OpenAI-compatible
+// streaming endpoint at openrouter.ai. Sessions are maintained as in-memory
+// conversation histories (no CLI process to spawn).
+
+import crypto from 'crypto';
+import { AbsProvider } from './base.js';
+import { AssistantMessage, ThinkingMessage } from '../../common/chat-types.js';
+import type { StartSessionRequest, ResumeTurnRequest, StartedProviderSession } from './types.js';
+
+const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+interface OpenRouterChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface OpenRouterSession {
+  id: string;
+  chatId: string;
+  messages: OpenRouterChatMessage[];
+  isRunning: boolean;
+  finalized: boolean;
+  aborted: boolean;
+  abortController: AbortController | null;
+  turnResolve: ((value?: unknown) => void) | null;
+  startTime: number;
+  model: string;
+}
+
+// Represents a single delta chunk from the SSE stream.
+interface OpenRouterStreamDelta {
+  choices?: Array<{
+    delta?: {
+      content?: string | null;
+      role?: string;
+    };
+    finish_reason?: string | null;
+  }>;
+}
+
+function getApiKey(): string {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key?.trim()) {
+    throw new Error('OPENROUTER_API_KEY environment variable is not set');
+  }
+  return key.trim();
+}
+
+function createSession(chatId: string, model: string): OpenRouterSession {
+  return {
+    id: crypto.randomUUID(),
+    chatId,
+    messages: [],
+    isRunning: true,
+    finalized: false,
+    aborted: false,
+    abortController: null,
+    turnResolve: null,
+    startTime: Date.now(),
+    model,
+  };
+}
+
+class OpenRouterProvider extends AbsProvider {
+  #runningSessions = new Map<string, OpenRouterSession>();
+
+  constructor() {
+    super();
+  }
+
+  async startSession({ command, chatId, model }: StartSessionRequest): Promise<StartedProviderSession> {
+    if (!chatId) throw new Error('chatId is required when starting an OpenRouter session');
+
+    const session = createSession(chatId, model);
+    this.#runningSessions.set(session.id, session);
+
+    session.messages.push(
+      { role: 'system', content: 'You are a helpful coding assistant.' },
+      { role: 'user', content: command },
+    );
+
+    this.emitProcessing(chatId, true);
+    this.emitSessionCreated(chatId);
+
+    this.#streamCompletion(session).catch((err) => {
+      console.error(`openrouter(${session.id.slice(0, 8)}): stream error:`, (err as Error).message);
+    });
+
+    return {
+      providerSessionId: session.id,
+      nativePath: `openrouter:${session.id}`,
+    };
+  }
+
+  async runTurn({ command, providerSessionId, chatId }: ResumeTurnRequest): Promise<void> {
+    if (!providerSessionId) throw new Error('Cannot resume without session ID');
+    if (!chatId) throw new Error('Cannot resume without chat ID');
+
+    let session = this.#runningSessions.get(providerSessionId);
+    if (!session) {
+      throw new Error(`OpenRouter session not found: ${providerSessionId}`);
+    }
+
+    if (session.isRunning) {
+      throw new Error(`Session ${providerSessionId} is already running`);
+    }
+    if (chatId !== session.chatId) {
+      throw new Error('Chat ID mismatch');
+    }
+
+    session.isRunning = true;
+    session.finalized = false;
+    session.aborted = false;
+
+    session.messages.push({ role: 'user', content: command });
+
+    this.emitProcessing(chatId, true);
+
+    try {
+      await this.#streamCompletion(session);
+    } catch (err) {
+      if (!session.aborted) {
+        console.error(`openrouter(${session.id.slice(0, 8)}): turn error:`, (err as Error).message);
+      }
+    }
+  }
+
+  async #streamCompletion(session: OpenRouterSession): Promise<void> {
+    const apiKey = getApiKey();
+    const controller = new AbortController();
+    session.abortController = controller;
+
+    let fullContent = '';
+
+    try {
+      const response = await fetch(OPENROUTER_API_URL, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': 'https://github.com/cfal/garcon',
+          'X-Title': 'Garcon',
+        },
+        body: JSON.stringify({
+          model: session.model,
+          messages: session.messages,
+          stream: true,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`OpenRouter API error ${response.status}: ${errorText.slice(0, 200)}`);
+      }
+
+      if (!response.body) {
+        throw new Error('OpenRouter response has no body');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop()!;
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === 'data: [DONE]') continue;
+          if (!trimmed.startsWith('data: ')) continue;
+
+          const jsonStr = trimmed.slice(6);
+          let chunk: OpenRouterStreamDelta;
+          try {
+            chunk = JSON.parse(jsonStr) as OpenRouterStreamDelta;
+          } catch {
+            continue;
+          }
+
+          const delta = chunk.choices?.[0]?.delta;
+          if (delta?.content) {
+            fullContent += delta.content;
+          }
+        }
+      }
+
+      if (fullContent.trim()) {
+        session.messages.push({ role: 'assistant', content: fullContent });
+
+        const now = new Date().toISOString();
+        this.emitMessages(session.chatId, [
+          new AssistantMessage(now, fullContent),
+        ]);
+      }
+
+      this.emitFinished(session.chatId, 0);
+      this.#finalizeTurn(session);
+    } catch (err) {
+      if (session.aborted) {
+        this.#finalizeTurn(session);
+        return;
+      }
+
+      const message = (err as Error).message || 'Unknown error';
+      this.emitFailed(session.chatId, `OpenRouter: ${message}`);
+      this.#finalizeTurn(session);
+    }
+  }
+
+  // Idempotent turn finalizer.
+  #finalizeTurn(session: OpenRouterSession): void {
+    if (session.finalized) return;
+    session.finalized = true;
+
+    const wasRunning = session.isRunning;
+    session.isRunning = false;
+    session.abortController = null;
+    if (wasRunning) this.emitProcessing(session.chatId, false);
+
+    const resolve = session.turnResolve;
+    session.turnResolve = null;
+    resolve?.();
+  }
+
+  abort(providerSessionId: string): boolean {
+    const session = this.#runningSessions.get(providerSessionId);
+    if (!session || !session.isRunning) return false;
+
+    session.aborted = true;
+    session.abortController?.abort();
+    this.#finalizeTurn(session);
+    return true;
+  }
+
+  isRunning(providerSessionId: string): boolean {
+    const session = this.#runningSessions.get(providerSessionId);
+    return session?.isRunning === true;
+  }
+
+  getRunningSessions(): Array<{ id: string; status: string; startedAt: string }> {
+    return Array.from(this.#runningSessions.entries())
+      .filter(([, s]) => s.isRunning)
+      .map(([id, s]) => ({
+        id,
+        status: 'running',
+        startedAt: new Date(s.startTime).toISOString(),
+      }));
+  }
+
+  startPurgeTimer(): ReturnType<typeof setInterval> {
+    const maxAge = 30 * 60 * 1000;
+
+    return setInterval(() => {
+      const now = Date.now();
+
+      for (const [id, session] of this.#runningSessions.entries()) {
+        if (!session.isRunning && (now - session.startTime > maxAge)) {
+          this.#runningSessions.delete(id);
+        }
+      }
+    }, 5 * 60 * 1000);
+  }
+}
+
+export { OpenRouterProvider };

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -22,7 +22,7 @@ async function readJsonBody(request) {
 // parameters, delegates to the git service, and maps errors to HTTP
 // responses via git.toHttpError(). No business logic lives here.
 function isAllowedGenerationProvider(value) {
-  return value === 'claude' || value === 'codex' || value === 'opencode' || value === 'amp';
+  return value === 'claude' || value === 'codex' || value === 'opencode' || value === 'amp' || value === 'openrouter';
 }
 
 function hasOwn(source, key) {
@@ -214,7 +214,7 @@ export default function createGitRoutes(providers, settings) {
         return Response.json({ error: 'Missing required parameters: project and files.' }, { status: 400 });
       }
       if (hasOwn(body, 'provider') && !isAllowedGenerationProvider(body.provider)) {
-        return Response.json({ error: 'Invalid provider. Expected one of: claude, codex, opencode, amp.' }, { status: 400 });
+        return Response.json({ error: 'Invalid provider. Expected one of: claude, codex, opencode, amp, openrouter.' }, { status: 400 });
       }
 
       const persistedConfig = await resolveCommitMessageConfig(settings, providers);

--- a/server/routes/models.js
+++ b/server/routes/models.js
@@ -2,7 +2,7 @@
 // static; OpenCode models are fetched periodically. Serves a single
 // GET /api/models endpoint.
 
-import { CLAUDE_MODELS, CODEX_MODELS, AMP_MODELS } from '../../common/models.js';
+import { CLAUDE_MODELS, CODEX_MODELS, AMP_MODELS, OPENROUTER_MODELS } from '../../common/models.js';
 import { PROVIDERS, supportsFork, supportsImages } from '../../common/providers.ts';
 
 const OPENCODE_REFRESH_INTERVAL = 5 * 60 * 1000;
@@ -11,6 +11,7 @@ function getDefaultModel(provider, cache) {
   if (provider === 'claude') return CLAUDE_MODELS.DEFAULT;
   if (provider === 'codex') return CODEX_MODELS.DEFAULT;
   if (provider === 'amp') return AMP_MODELS.DEFAULT;
+  if (provider === 'openrouter') return OPENROUTER_MODELS.DEFAULT;
   return cache.opencode[0]?.value ?? '';
 }
 
@@ -32,6 +33,7 @@ export default function createModelsRoutes(providers) {
     claude: CLAUDE_MODELS.OPTIONS,
     codex: CODEX_MODELS.OPTIONS,
     amp: AMP_MODELS.OPTIONS,
+    openrouter: OPENROUTER_MODELS.OPTIONS,
     opencode: [],
   };
 

--- a/server/server.js
+++ b/server/server.js
@@ -33,6 +33,7 @@ import { ClaudeProvider } from './providers/claude-cli.js';
 import { CodexProvider } from './providers/codex.js';
 import { OpenCodeProvider } from './providers/opencode.js';
 import { AmpProvider } from './providers/amp-cli.js';
+import { OpenRouterProvider } from './providers/openrouter.js';
 import { ProviderRegistry } from './providers/index.js';
 import { ChatHandler } from './ws/chat.js';
 import { TelegramNotifier } from './notifications/telegram.js';
@@ -82,9 +83,10 @@ export async function startServer() {
     const codexProvider = new CodexProvider();
     const opencodeProvider = new OpenCodeProvider();
     const ampProvider = new AmpProvider();
+    const openrouterProvider = new OpenRouterProvider();
 
     // Tier 2: Provider registry wrapping providers + registry
-    const providerRegistry = new ProviderRegistry(chatRegistry, claudeProvider, codexProvider, opencodeProvider, ampProvider);
+    const providerRegistry = new ProviderRegistry(chatRegistry, claudeProvider, codexProvider, opencodeProvider, ampProvider, openrouterProvider);
 
     // Tier 3: Chat infrastructure (uses ProviderRegistry)
     const metadata = new MetadataIndex(chatRegistry, providerRegistry);

--- a/server/settings/generation-effective.js
+++ b/server/settings/generation-effective.js
@@ -5,7 +5,7 @@ import {
 } from '../../common/generation-defaults.ts';
 
 function isProvider(value) {
-  return value === 'claude' || value === 'codex' || value === 'opencode' || value === 'amp';
+  return value === 'claude' || value === 'codex' || value === 'opencode' || value === 'amp' || value === 'openrouter';
 }
 
 function pickAutoProvider(authByProvider) {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -59,6 +59,9 @@
 	--color-provider-amp-bg: hsl(var(--provider-amp-bg));
 	--color-provider-amp-foreground: hsl(var(--provider-amp-foreground));
 	--color-provider-amp-border: hsl(var(--provider-amp-border));
+	--color-provider-openrouter-bg: hsl(var(--provider-openrouter-bg));
+	--color-provider-openrouter-foreground: hsl(var(--provider-openrouter-foreground));
+	--color-provider-openrouter-border: hsl(var(--provider-openrouter-border));
 	--color-indicator-unread: hsl(var(--indicator-unread));
 		--color-status-processing: hsl(var(--status-processing));
 		--color-status-processing-foreground: hsl(var(--status-processing-foreground));
@@ -193,6 +196,9 @@
 	--provider-amp-bg: 28 90% 95%;
 	--provider-amp-foreground: 28 80% 28%;
 	--provider-amp-border: 28 50% 78%;
+	--provider-openrouter-bg: 200 90% 95%;
+	--provider-openrouter-foreground: 200 70% 28%;
+	--provider-openrouter-border: 200 45% 78%;
 	--indicator-unread: 214 90% 48%;
 		--status-processing: 214 90% 48%;
 		--status-processing-foreground: 214 85% 32%;
@@ -343,6 +349,9 @@
 	--provider-amp-bg: 28 46% 22%;
 	--provider-amp-foreground: 28 90% 86%;
 	--provider-amp-border: 28 36% 36%;
+	--provider-openrouter-bg: 200 42% 22%;
+	--provider-openrouter-foreground: 200 90% 86%;
+	--provider-openrouter-border: 200 34% 36%;
 	--indicator-unread: 214 95% 68%;
 		--status-processing: 214 95% 68%;
 		--status-processing-foreground: 214 95% 86%;

--- a/web/src/lib/api/providers.ts
+++ b/web/src/lib/api/providers.ts
@@ -2,7 +2,7 @@
 
 import { apiGet } from './client.js';
 
-export type ProviderName = 'claude' | 'codex' | 'opencode' | 'amp';
+export type ProviderName = 'claude' | 'codex' | 'opencode' | 'amp' | 'openrouter';
 
 export interface ProviderAuthStatus {
 	authenticated: boolean;

--- a/web/src/lib/components/git/CommitMessageSettingsModal.svelte
+++ b/web/src/lib/components/git/CommitMessageSettingsModal.svelte
@@ -68,7 +68,7 @@ Return only the commit message now.`;
 				const effectiveCommitMessage = (uiEffective.commitMessage ?? {}) as Record<string, unknown>;
 				const cm = { ...persistedCommitMessage, ...effectiveCommitMessage } as Record<string, unknown>;
 				enabled = cm.enabled !== false;
-			if (['claude', 'codex', 'opencode', 'amp'].includes(cm.provider as string)) {
+			if (['claude', 'codex', 'opencode', 'amp', 'openrouter'].includes(cm.provider as string)) {
 				provider = cm.provider as SessionProvider;
 			}
 			if (typeof cm.model === 'string') model = cm.model;

--- a/web/src/lib/components/settings/AgentCard.svelte
+++ b/web/src/lib/components/settings/AgentCard.svelte
@@ -16,7 +16,7 @@
 		error: string | null;
 	}
 
-	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp';
+	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp' | 'openrouter';
 
 	let {
 		agentId,
@@ -25,7 +25,8 @@
 		open = false,
 		onOpenChange,
 		onLogin,
-		cliOnly = false
+		cliOnly = false,
+		authHint = ''
 	}: {
 		agentId: AgentId;
 		agentName: string;
@@ -34,17 +35,19 @@
 		onOpenChange?: (open: boolean) => void;
 		onLogin: () => void;
 		cliOnly?: boolean;
+		authHint?: string;
 	} = $props();
 
 	const borderColorClass: Record<AgentId, string> = {
 		claude: 'border-l-provider-claude-border',
 		codex: 'border-l-provider-codex-border',
 		opencode: 'border-l-provider-opencode-border',
-		amp: 'border-l-provider-amp-border'
+		amp: 'border-l-provider-amp-border',
+		openrouter: 'border-l-provider-openrouter-border'
 	};
 
-	// Authenticated with no reauth option and no CLI-only content -- nothing to expand.
-	let expandable = $derived(!auth.loading && !(auth.authenticated && !auth.canReauth && !cliOnly));
+	// Authenticated with no reauth option and no CLI-only/hint content -- nothing to expand.
+	let expandable = $derived(!auth.loading && !(auth.authenticated && !auth.canReauth && !cliOnly && !authHint));
 </script>
 
 {#if expandable}
@@ -78,7 +81,9 @@
 
 	<Collapsible.Content>
 		<div class="border-t border-border px-4 py-3 space-y-4">
-			{#if cliOnly}
+			{#if authHint}
+				<div class="text-xs text-muted-foreground">{authHint}</div>
+			{:else if cliOnly}
 				<div class="text-xs text-muted-foreground">
 					{#if auth.authenticated}
 						Authenticated via CLI. To switch accounts, run <code class="rounded bg-muted px-1 py-0.5 font-mono text-foreground">{agentName.toLowerCase()} login</code> in your terminal.

--- a/web/src/lib/components/settings/AgentsSection.svelte
+++ b/web/src/lib/components/settings/AgentsSection.svelte
@@ -16,7 +16,7 @@
 		error: string | null;
 	}
 
-	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp';
+	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp' | 'openrouter';
 
 	const DEFAULT_AUTH: AuthStatus = { authenticated: false, canReauth: true, label: '', loading: true, error: null };
 
@@ -27,18 +27,21 @@
 	];
 
 	const secondaryAgents: { id: AgentId; name: string }[] = [
-		{ id: 'amp', name: 'Amp' }
+		{ id: 'amp', name: 'Amp' },
+		{ id: 'openrouter', name: 'OpenRouter' }
 	];
 
 	let claudeAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let codexAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let opencodeAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let ampAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
+	let openrouterAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 
 	let claudeOpen = $state(false);
 	let codexOpen = $state(false);
 	let opencodeOpen = $state(false);
 	let ampOpen = $state(false);
+	let openrouterOpen = $state(false);
 
 	let moreProvidersOpen = $state(false);
 
@@ -46,6 +49,7 @@
 		if (agent === 'claude') return claudeAuth;
 		if (agent === 'codex') return codexAuth;
 		if (agent === 'amp') return ampAuth;
+		if (agent === 'openrouter') return openrouterAuth;
 		return opencodeAuth;
 	}
 
@@ -53,6 +57,7 @@
 		if (agent === 'claude') return claudeOpen;
 		if (agent === 'codex') return codexOpen;
 		if (agent === 'amp') return ampOpen;
+		if (agent === 'openrouter') return openrouterOpen;
 		return opencodeOpen;
 	}
 
@@ -60,6 +65,7 @@
 		if (agent === 'claude') claudeOpen = value;
 		else if (agent === 'codex') codexOpen = value;
 		else if (agent === 'amp') ampOpen = value;
+		else if (agent === 'openrouter') openrouterOpen = value;
 		else opencodeOpen = value;
 	}
 
@@ -68,6 +74,7 @@
 			if (agent === 'claude') claudeAuth = status;
 			else if (agent === 'codex') codexAuth = status;
 			else if (agent === 'amp') ampAuth = status;
+			else if (agent === 'openrouter') openrouterAuth = status;
 			else opencodeAuth = status;
 		};
 
@@ -92,29 +99,30 @@
 	}
 
 	function handleLogin(agent: AgentId) {
-		if (agent === 'amp') return;
+		if (agent === 'amp' || agent === 'openrouter') return;
 		const loginUrl = `/api/v1/${agent}/auth/login`;
 		window.open(loginUrl, '_blank', 'width=800,height=600');
 	}
 
 	// Count how many secondary providers are connected
 	let secondaryConnectedCount = $derived(
-		[ampAuth].filter((a) => a.authenticated).length
+		[ampAuth, openrouterAuth].filter((a) => a.authenticated).length
 	);
 
 	let authExpandDone = $state(false);
 	$effect(() => {
-		const allLoaded = !claudeAuth.loading && !codexAuth.loading && !opencodeAuth.loading && !ampAuth.loading;
+		const allLoaded = !claudeAuth.loading && !codexAuth.loading && !opencodeAuth.loading && !ampAuth.loading && !openrouterAuth.loading;
 		if (allLoaded && !authExpandDone) {
 			authExpandDone = true;
 			if (!claudeAuth.authenticated) claudeOpen = true;
 			if (!codexAuth.authenticated) codexOpen = true;
 			if (!opencodeAuth.authenticated) opencodeOpen = true;
-			// Auto-expand the "More providers" section if Amp is connected
-			if (ampAuth.authenticated) {
+			// Auto-expand the "More providers" section if any secondary provider is connected
+			if (ampAuth.authenticated || openrouterAuth.authenticated) {
 				moreProvidersOpen = true;
 			}
 			if (!ampAuth.authenticated) ampOpen = true;
+			if (!openrouterAuth.authenticated) openrouterOpen = true;
 		}
 	});
 
@@ -123,6 +131,7 @@
 		checkAuth('codex');
 		checkAuth('opencode');
 		checkAuth('amp');
+		checkAuth('openrouter');
 	});
 </script>
 
@@ -163,6 +172,7 @@
 						onOpenChange={(v) => setOpen(agent.id, v)}
 						onLogin={() => handleLogin(agent.id)}
 						cliOnly={agent.id === 'amp'}
+					authHint={agent.id === 'openrouter' ? 'Set the OPENROUTER_API_KEY environment variable and restart the server to authenticate.' : ''}
 					/>
 				{/each}
 			</div>

--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -92,12 +92,14 @@
 		codex: 'border-provider-codex-border bg-provider-codex-bg text-provider-codex-foreground',
 		opencode: 'border-provider-opencode-border bg-provider-opencode-bg text-provider-opencode-foreground',
 		amp: 'border-provider-amp-border bg-provider-amp-bg text-provider-amp-foreground',
+		openrouter: 'border-provider-openrouter-border bg-provider-openrouter-bg text-provider-openrouter-foreground',
 	};
 	let providerTagVariant = $derived(PROVIDER_TAG_VARIANTS[provider] ?? PROVIDER_TAG_VARIANTS.claude);
 	let providerTagLabel = $derived(
 		provider === 'codex' ? m.provider_codex()
 		: provider === 'opencode' ? m.provider_opencode()
 		: provider === 'amp' ? m.provider_amp()
+		: provider === 'openrouter' ? 'OpenRouter'
 		: m.provider_claude()
 	);
 

--- a/web/src/lib/stores/git-workbench.svelte.ts
+++ b/web/src/lib/stores/git-workbench.svelte.ts
@@ -910,7 +910,7 @@ export class GitWorkbenchStore {
 			const cm = { ...persistedCommitMessage, ...effectiveCommitMessage } as Record<string, unknown>;
 			this.commitGenerationEnabled = cm.enabled !== false;
 			const provider = cm.provider as string;
-			if (['claude', 'codex', 'opencode', 'amp'].includes(provider)) {
+			if (['claude', 'codex', 'opencode', 'amp', 'openrouter'].includes(provider)) {
 				this.commitProvider = provider;
 			}
 			if (typeof cm.model === 'string' && cm.model) {

--- a/web/src/lib/types/app.ts
+++ b/web/src/lib/types/app.ts
@@ -2,7 +2,7 @@
 
 import type { PermissionMode, ThinkingMode } from '$shared/chat-modes';
 
-export type SessionProvider = 'claude' | 'codex' | 'opencode' | 'amp';
+export type SessionProvider = 'claude' | 'codex' | 'opencode' | 'amp' | 'openrouter';
 
 export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'preview';
 


### PR DESCRIPTION
Adds an `openrouter` provider — pure HTTP streaming via the OpenRouter API (OpenAI-compatible). No CLI process; sessions are in-memory conversation histories.

**Auth:** `OPENROUTER_API_KEY` env var.

**Models:** Gemini 2.5 Pro (default), Gemini 2.5 Flash, Gemini 2.0 Flash.

## Changes (19 files, +402/-28)

**New files:**
- `server/providers/openrouter.ts` — SSE streaming provider extending `AbsProvider`
- `server/providers/openrouter-auth.ts` — env var auth check
- `server/providers/loaders/openrouter-history-loader.ts` — stub (in-memory only)

**Wiring:**
- `common/providers.ts` — registered in `PROVIDERS` + capabilities
- `common/models.ts` — model list
- `common/ws-events.ts` — running sessions type
- `server/providers/index.ts` — full `ProviderRegistry` integration
- `server/server.js` — composition root
- `server/routes/models.js`, `server/routes/git.js`, `server/settings/generation-effective.js` — provider validation

**Frontend:**
- Settings UI card under "More providers"
- Sidebar chat tags, CSS theme vars (light + dark)
- Type unions in `providers.ts`, `app.ts`

## Not included (follow-ups)
- Tool/function calling
- Persistent history
- Incremental streaming (currently buffers full response)
- Settings UI for API key

Closes #86