### PR TITLE
fix: scroll shared chat links to bottom on load

### DIFF
--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import { getSharedChat } from '$lib/api/shares.js';
 	import { parseChatMessage } from '$shared/chat-types';
 	import type { ChatMessage } from '$shared/chat-types';
@@ -70,6 +70,9 @@
 			errorMsg = m.shared_view_not_found();
 		} finally {
 			isLoading = false;
+			// Scroll to bottom after messages render so shared links open at the latest message.
+			await tick();
+			window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });
 		}
 	});
 


### PR DESCRIPTION
**Problem**
Shared chat links always open at the top of the conversation, requiring the reader to manually scroll down to see the latest messages.

**Solution**
After messages are fetched and rendered, use `tick()` to wait for the DOM update, then instantly scroll the page to the bottom.

**Changes**
- `SharedChatPage.svelte`: Added `tick` import and `window.scrollTo` call in the `finally` block after loading completes.

**Expected Impact**
Shared chat links now open at the most recent messages, matching the natural reading expectation for chat conversations.