### PR TITLE
feat: add OpenRouter provider for multi-model chat access

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -63,16 +63,17 @@ export const FACTORY_MODELS = {
 
 export const OPENROUTER_MODELS = {
   OPTIONS: [
-    { value: 'anthropic/claude-sonnet-4', label: 'Claude Sonnet 4', supportsImages: true },
-    { value: 'anthropic/claude-haiku-4', label: 'Claude Haiku 4', supportsImages: true },
-    { value: 'openai/gpt-4o', label: 'GPT-4o', supportsImages: true },
-    { value: 'openai/gpt-4o-mini', label: 'GPT-4o Mini', supportsImages: true },
-    { value: 'google/gemini-2.5-pro-preview', label: 'Gemini 2.5 Pro', supportsImages: true },
-    { value: 'google/gemini-2.5-flash-preview', label: 'Gemini 2.5 Flash', supportsImages: true },
+    { value: 'anthropic/claude-opus-4.6', label: 'Claude Opus 4.6', supportsImages: true },
+    { value: 'anthropic/claude-sonnet-4.6', label: 'Claude Sonnet 4.6', supportsImages: true },
+    { value: 'openai/gpt-5.4', label: 'GPT-5.4', supportsImages: true },
+    { value: 'openai/gpt-5.4-mini', label: 'GPT-5.4 Mini', supportsImages: true },
+    { value: 'google/gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', supportsImages: true },
+    { value: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash', supportsImages: true },
+    { value: 'x-ai/grok-4.20', label: 'Grok 4.20', supportsImages: true },
+    { value: 'deepseek/deepseek-v3.2', label: 'DeepSeek V3.2', supportsImages: false },
+    { value: 'deepseek/deepseek-r1', label: 'DeepSeek R1', supportsImages: false },
     { value: 'meta-llama/llama-4-maverick', label: 'Llama 4 Maverick', supportsImages: true },
-    { value: 'deepseek/deepseek-chat-v3-0324', label: 'DeepSeek V3', supportsImages: false },
-    { value: 'qwen/qwen3-235b-a22b', label: 'Qwen3 235B', supportsImages: false },
-    { value: 'mistralai/mistral-large-2411', label: 'Mistral Large', supportsImages: true },
+    { value: 'qwen/qwen3.6-plus', label: 'Qwen 3.6 Plus', supportsImages: true },
   ] satisfies SharedModelOption[],
-  DEFAULT: 'anthropic/claude-sonnet-4',
+  DEFAULT: 'anthropic/claude-sonnet-4.6',
 };

--- a/common/models.ts
+++ b/common/models.ts
@@ -60,3 +60,19 @@ export const FACTORY_MODELS = {
   ] satisfies SharedModelOption[],
   DEFAULT: 'claude-opus-4-6',
 };
+
+export const OPENROUTER_MODELS = {
+  OPTIONS: [
+    { value: 'anthropic/claude-sonnet-4', label: 'Claude Sonnet 4', supportsImages: true },
+    { value: 'anthropic/claude-haiku-4', label: 'Claude Haiku 4', supportsImages: true },
+    { value: 'openai/gpt-4o', label: 'GPT-4o', supportsImages: true },
+    { value: 'openai/gpt-4o-mini', label: 'GPT-4o Mini', supportsImages: true },
+    { value: 'google/gemini-2.5-pro-preview', label: 'Gemini 2.5 Pro', supportsImages: true },
+    { value: 'google/gemini-2.5-flash-preview', label: 'Gemini 2.5 Flash', supportsImages: true },
+    { value: 'meta-llama/llama-4-maverick', label: 'Llama 4 Maverick', supportsImages: true },
+    { value: 'deepseek/deepseek-chat-v3-0324', label: 'DeepSeek V3', supportsImages: false },
+    { value: 'qwen/qwen3-235b-a22b', label: 'Qwen3 235B', supportsImages: false },
+    { value: 'mistralai/mistral-large-2411', label: 'Mistral Large', supportsImages: true },
+  ] satisfies SharedModelOption[],
+  DEFAULT: 'anthropic/claude-sonnet-4',
+};

--- a/common/providers.ts
+++ b/common/providers.ts
@@ -2,7 +2,7 @@
 // and frontend as the single source of truth for provider identity and
 // static capability policy.
 
-export const PROVIDERS = ['claude', 'codex', 'opencode', 'amp', 'factory'] as const;
+export const PROVIDERS = ['claude', 'codex', 'opencode', 'amp', 'factory', 'openrouter'] as const;
 
 export type ProviderId = (typeof PROVIDERS)[number];
 
@@ -17,6 +17,7 @@ export const PROVIDER_CAPABILITIES: Record<ProviderId, ProviderCapabilities> = {
   opencode: { supportsFork: false, supportsImages: false },
   amp: { supportsFork: false, supportsImages: false },
   factory: { supportsFork: false, supportsImages: false },
+  openrouter: { supportsFork: false, supportsImages: true },
 };
 
 export function isProviderId(value: unknown): value is ProviderId {

--- a/server/chats/resolve-native-path.js
+++ b/server/chats/resolve-native-path.js
@@ -39,5 +39,9 @@ export async function resolveMissingNativePath(session) {
     return createArtificialNativePath(session.provider, session.providerSessionId);
   }
 
+  if (session.provider === 'openrouter') {
+    return createArtificialNativePath(session.provider, session.providerSessionId);
+  }
+
   return null;
 }

--- a/server/providers/__tests__/providers-run-single-query.test.js
+++ b/server/providers/__tests__/providers-run-single-query.test.js
@@ -48,6 +48,20 @@ mock.module('../loaders/amp-history-loader.js', () => ({
   loadAmpChatMessages: mock(() => Promise.resolve([])),
 }));
 
+mock.module('../loaders/openrouter-history-loader.js', () => ({
+  getOpenRouterPreviewFromSessionId: mock(() => Promise.resolve(null)),
+  loadOpenRouterChatMessages: mock(() => Promise.resolve([])),
+}));
+
+mock.module('../openrouter-auth.js', () => ({
+  getOpenRouterAuthStatus: mock(() => Promise.resolve({ authenticated: false, canReauth: false, label: '' })),
+}));
+
+mock.module('../openrouter.js', () => ({
+  runSingleQuery: mock(async () => 'openrouter-response'),
+  OpenRouterProvider: class { constructor() {} },
+}));
+
 const opencodeMock = mock(async () => 'opencode-response');
 import { ProviderRegistry } from '../index.js';
 
@@ -57,7 +71,7 @@ describe('providers registry runSingleQuery', () => {
     getChatByProviderSessionId: mock(() => null),
   };
   const mockOpencode = { runSingleQuery: opencodeMock };
-  const registry = new ProviderRegistry(mockRegistry, {}, {}, mockOpencode, {}, {});
+  const registry = new ProviderRegistry(mockRegistry, {}, {}, mockOpencode, {}, {}, {});
 
   it('routes to claude by default', async () => {
     const result = await registry.runSingleQuery('test prompt', {});
@@ -130,7 +144,12 @@ describe('ProviderRegistry session option hydration', () => {
       runTurn: mock(() => Promise.resolve(undefined)),
       getRunningSessions: mock(() => []),
     };
-    registry = new ProviderRegistry(mockRegistry, mockClaude, mockCodex, mockOpencode, mockAmp, mockFactory);
+    const mockOpenRouter = {
+      startSession: mock(() => Promise.resolve({ providerSessionId: 'openrouter-session', nativePath: null })),
+      runTurn: mock(() => Promise.resolve(undefined)),
+      getRunningSessions: mock(() => []),
+    };
+    registry = new ProviderRegistry(mockRegistry, mockClaude, mockCodex, mockOpencode, mockAmp, mockFactory, mockOpenRouter);
   });
 
   it('hydrates permission and thinking modes from the registry on new-session startup', async () => {

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -8,12 +8,14 @@ import { createClaudeNativePath, runSingleQuery as runSingleQueryClaude } from '
 import { runSingleQuery as runSingleQueryCodex } from './codex.js';
 import { runSingleQuery as runSingleQueryAmp } from './amp-cli.js';
 import { runSingleQuery as runSingleQueryFactory } from './factory-cli.js';
+import { runSingleQuery as runSingleQueryOpenRouter } from './openrouter.js';
 import { getMaxSessions } from '../config.js';
 import { getClaudeAuthStatus } from './claude-auth.js';
 import { getCodexAuthStatus } from './codex-auth.js';
 import { getOpenCodeAuthStatus } from './opencode-auth.js';
 import { getAmpAuthStatus } from './amp-auth.js';
 import { getFactoryAuthStatus } from './factory-auth.js';
+import { getOpenRouterAuthStatus } from './openrouter-auth.js';
 import { getArtificialProviderSessionId } from '../chats/artificial-native-path.js';
 import type { OllamaBridge } from './ollama-bridge.js';
 
@@ -22,6 +24,7 @@ import { getClaudePreviewFromNativePath, loadClaudeChatMessages } from './loader
 import { getCodexPreviewFromNativePath, loadCodexChatMessages } from './loaders/codex-history-loader.js';
 import { getOpenCodePreviewFromSessionId, loadOpenCodeChatMessages } from './loaders/opencode-history-loader.js';
 import { getFactoryPreviewFromSessionId, loadFactoryChatMessagesBySessionId } from './loaders/factory-history-loader.js';
+import { getOpenRouterPreviewFromSessionId, loadOpenRouterChatMessages } from './loaders/openrouter-history-loader.js';
 import type { IChatRegistry } from '../chats/store.js';
 
 import type { AgentCommandImage } from '../../common/ws-requests.js';
@@ -43,6 +46,7 @@ const AUTH_DISPATCHERS: Record<string, (opencode: OpenCodeProviderInstance) => P
   opencode: (oc) => getOpenCodeAuthStatus(oc),
   amp: () => getAmpAuthStatus(),
   factory: () => getFactoryAuthStatus(),
+  openrouter: () => getOpenRouterAuthStatus(),
 };
 
 // Validates that a registry entry has all required execution fields.
@@ -138,6 +142,7 @@ export class ProviderRegistry {
   #opencode: OpenCodeProviderInstance;
   #amp: ExternalCliProviderInstance;
   #factory: ExternalCliProviderInstance;
+  #openrouter: ExternalCliProviderInstance;
   #ollama: OllamaBridge | null;
 
   constructor(
@@ -147,6 +152,7 @@ export class ProviderRegistry {
     opencode: OpenCodeProviderInstance,
     amp: ExternalCliProviderInstance,
     factory: ExternalCliProviderInstance,
+    openrouter: ExternalCliProviderInstance,
     ollama?: OllamaBridge | null,
   ) {
     this.#registry = registry;
@@ -155,6 +161,7 @@ export class ProviderRegistry {
     this.#opencode = opencode;
     this.#amp = amp;
     this.#factory = factory;
+    this.#openrouter = openrouter;
     this.#ollama = ollama ?? null;
 
     if (typeof registry.onChatRemoved === 'function') {
@@ -255,6 +262,12 @@ export class ProviderRegistry {
       return;
     }
 
+    if (entry.provider === 'openrouter') {
+      const { providerSessionId, nativePath } = await this.#openrouter.startSession(request);
+      this.#registry.updateChat(chatId, { providerSessionId, nativePath });
+      return;
+    }
+
     throw new Error(`Unsupported provider: ${entry.provider}`);
   }
 
@@ -318,6 +331,8 @@ export class ProviderRegistry {
       await this.#amp.runTurn(request);
     } else if (provider === 'factory') {
       await this.#factory.runTurn(request);
+    } else if (provider === 'openrouter') {
+      await this.#openrouter.runTurn(request);
     } else {
       throw new Error(`Unsupported provider: ${provider}`);
     }
@@ -351,6 +366,10 @@ export class ProviderRegistry {
       return this.#factory.abort(providerSessionId);
     }
 
+    if (entry.provider === 'openrouter') {
+      return this.#openrouter.abort(providerSessionId);
+    }
+
     return false;
   }
 
@@ -367,6 +386,7 @@ export class ProviderRegistry {
     if (provider === 'opencode') return this.#opencode.isRunning(providerSessionId);
     if (provider === 'amp') return this.#amp.isRunning(providerSessionId);
     if (provider === 'factory') return this.#factory.isRunning(providerSessionId);
+    if (provider === 'openrouter') return this.#openrouter.isRunning(providerSessionId);
     return false;
   }
 
@@ -387,6 +407,7 @@ export class ProviderRegistry {
       opencode: mapToChatId(this.#opencode.getRunningSessions()),
       amp: mapToChatId(this.#amp.getRunningSessions()),
       factory: mapToChatId(this.#factory.getRunningSessions()),
+      openrouter: mapToChatId(this.#openrouter.getRunningSessions()),
     };
   }
 
@@ -396,7 +417,8 @@ export class ProviderRegistry {
       (this.#codex.getRunningSessions?.()?.length ?? 0) +
       (this.#opencode.getRunningSessions?.()?.length ?? 0) +
       (this.#amp.getRunningSessions?.()?.length ?? 0) +
-      (this.#factory.getRunningSessions?.()?.length ?? 0)
+      (this.#factory.getRunningSessions?.()?.length ?? 0) +
+      (this.#openrouter.getRunningSessions?.()?.length ?? 0)
     );
   }
 
@@ -475,6 +497,7 @@ export class ProviderRegistry {
     if (provider === 'opencode') return this.#opencode.runSingleQuery(prompt, rest);
     if (provider === 'amp') return runSingleQueryAmp(prompt, rest);
     if (provider === 'factory') return runSingleQueryFactory(prompt, rest);
+    if (provider === 'openrouter') return runSingleQueryOpenRouter(prompt, rest);
     return runSingleQueryClaude(prompt, rest);
   }
 
@@ -499,6 +522,10 @@ export class ProviderRegistry {
     }
     if (session.provider === 'codex') {
       return getCodexPreviewFromNativePath(session.nativePath);
+    }
+    if (session.provider === 'openrouter') {
+      const sessionId = session.providerSessionId || getArtificialProviderSessionId(session.nativePath, 'openrouter');
+      return getOpenRouterPreviewFromSessionId(sessionId);
     }
 
     return null;
@@ -526,6 +553,10 @@ export class ProviderRegistry {
     if (session.provider === 'codex') {
       return loadCodexChatMessages(session.nativePath);
     }
+    if (session.provider === 'openrouter') {
+      const sessionId = session.providerSessionId || getArtificialProviderSessionId(session.nativePath, 'openrouter');
+      return loadOpenRouterChatMessages(sessionId);
+    }
 
     return [];
   }
@@ -534,6 +565,7 @@ export class ProviderRegistry {
   async getModels(provider: ProviderName): Promise<Array<{ value: string; label: string; supportsImages?: boolean }>> {
     if (provider === 'opencode') return this.#opencode.getModels();
     if (provider === 'factory') return this.#factory.getModels?.() ?? [];
+    if (provider === 'openrouter') return this.#openrouter.getModels?.() ?? [];
     return [];
   }
 
@@ -557,6 +589,7 @@ export class ProviderRegistry {
     this.#opencode.startPurgeTimer();
     this.#amp.startPurgeTimer();
     this.#factory.startPurgeTimer();
+    this.#openrouter.startPurgeTimer();
     this.#claude.startPurgeTimer();
   }
 
@@ -569,6 +602,7 @@ export class ProviderRegistry {
     this.#opencode.onMessages(cb);
     this.#amp.onMessages(cb);
     this.#factory.onMessages(cb);
+    this.#openrouter.onMessages(cb);
   }
 
   onProcessing(cb: (chatId: string, isProcessing: boolean) => void): void {
@@ -577,6 +611,7 @@ export class ProviderRegistry {
     this.#opencode.onProcessing(cb);
     this.#amp.onProcessing(cb);
     this.#factory.onProcessing(cb);
+    this.#openrouter.onProcessing(cb);
   }
 
   onSessionCreated(cb: (chatId: string) => void): void {
@@ -585,6 +620,7 @@ export class ProviderRegistry {
     this.#opencode.onSessionCreated(cb);
     this.#amp.onSessionCreated(cb);
     this.#factory.onSessionCreated(cb);
+    this.#openrouter.onSessionCreated(cb);
   }
 
   onFinished(cb: (chatId: string, exitCode: number) => void): void {
@@ -593,6 +629,7 @@ export class ProviderRegistry {
     this.#opencode.onFinished(cb);
     this.#amp.onFinished(cb);
     this.#factory.onFinished(cb);
+    this.#openrouter.onFinished(cb);
   }
 
   onFailed(cb: (chatId: string, errorMessage: string) => void): void {
@@ -601,5 +638,6 @@ export class ProviderRegistry {
     this.#opencode.onFailed(cb);
     this.#amp.onFailed(cb);
     this.#factory.onFailed(cb);
+    this.#openrouter.onFailed(cb);
   }
 }

--- a/server/providers/index.ts
+++ b/server/providers/index.ts
@@ -112,6 +112,7 @@ interface OpenCodeProviderInstance {
   runSingleQuery(prompt: string, options?: Record<string, unknown>): Promise<string>;
   resolvePermission(permissionRequestId: string, decision: { allow: boolean; alwaysAllow?: boolean }): Promise<void>;
   evictChat(chatId: string): void;
+  shutdown?(): void;
   startPurgeTimer(): ReturnType<typeof setInterval>;
   onMessages(cb: (chatId: string, messages: unknown[]) => void): void;
   onProcessing(cb: (chatId: string, isProcessing: boolean) => void): void;
@@ -591,6 +592,12 @@ export class ProviderRegistry {
     this.#factory.startPurgeTimer();
     this.#openrouter.startPurgeTimer();
     this.#claude.startPurgeTimer();
+  }
+
+  // Shuts down long-lived provider processes (e.g. the opencode server).
+  // Called during garcon graceful shutdown to prevent orphaned processes.
+  shutdown(): void {
+    this.#opencode.shutdown?.();
   }
 
   // Fan-out listener helpers. Registers the callback on all

--- a/server/providers/loaders/openrouter-history-loader.ts
+++ b/server/providers/loaders/openrouter-history-loader.ts
@@ -1,0 +1,68 @@
+// Loads OpenRouter session history from persisted JSONL files.
+
+import { promises as fs } from 'fs';
+import { AssistantMessage, UserMessage, type ChatMessage } from '../../../common/chat-types.js';
+import { getSessionFilePath, isValidSessionId } from '../openrouter-paths.js';
+
+interface StoredMessage {
+  content?: string;
+  role?: string;
+  timestamp?: string;
+}
+
+export async function loadOpenRouterChatMessages(sessionId: string | null | undefined): Promise<ChatMessage[]> {
+  if (!sessionId || !isValidSessionId(sessionId)) return [];
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(getSessionFilePath(sessionId), 'utf8');
+  } catch {
+    return [];
+  }
+
+  const messages: ChatMessage[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line) as StoredMessage;
+      const timestamp = entry.timestamp || new Date().toISOString();
+      const content = entry.content || '';
+      if (entry.role === 'user' && content) {
+        messages.push(new UserMessage(timestamp, content));
+      } else if (entry.role === 'assistant' && content) {
+        messages.push(new AssistantMessage(timestamp, content));
+      }
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+
+  return messages;
+}
+
+export interface OpenRouterPreview {
+  createdAt: string | null;
+  firstMessage: string;
+  lastActivity: string | null;
+  lastMessage: string;
+}
+
+export async function getOpenRouterPreviewFromSessionId(sessionId: string | null | undefined): Promise<OpenRouterPreview | null> {
+  if (!sessionId) return null;
+
+  const messages = await loadOpenRouterChatMessages(sessionId);
+  if (messages.length === 0) return null;
+
+  const firstUser = messages.find((msg) => msg.type === 'user-message');
+  const lastMsg = [...messages].reverse().find(
+    (msg) => msg.type === 'assistant-message' || msg.type === 'user-message',
+  );
+  const lastTimestamp = [...messages].reverse().find((msg) => msg.timestamp)?.timestamp ?? null;
+
+  return {
+    createdAt: messages[0]?.timestamp ?? null,
+    firstMessage: firstUser?.type === 'user-message' ? firstUser.content : 'OpenRouter Session',
+    lastActivity: lastTimestamp,
+    lastMessage: lastMsg && ('content' in lastMsg) ? (lastMsg as { content: string }).content : 'OpenRouter Session',
+  };
+}

--- a/server/providers/opencode.ts
+++ b/server/providers/opencode.ts
@@ -167,6 +167,20 @@ export class OpenCodeProvider extends AbsProvider {
     super();
   }
 
+  // Shuts down the spawned opencode server process (if any).
+  // Called during garcon graceful shutdown to prevent orphaned processes.
+  shutdown(): void {
+    if (this.#client && typeof this.#client.close === 'function') {
+      try {
+        this.#client.close();
+      } catch {
+        // Best-effort cleanup.
+      }
+      this.#client = null;
+      this.#initPromise = null;
+    }
+  }
+
   // Returns true if the opencode binary is on $PATH, without spawning a server.
   isAvailable(): boolean {
     if (this.#available !== null) return this.#available;

--- a/server/providers/openrouter-auth.ts
+++ b/server/providers/openrouter-auth.ts
@@ -1,0 +1,8 @@
+// Auth status for OpenRouter. Checks OPENROUTER_API_KEY env var.
+
+export async function getOpenRouterAuthStatus() {
+  if (typeof process.env.OPENROUTER_API_KEY === 'string' && process.env.OPENROUTER_API_KEY.trim()) {
+    return { authenticated: true, canReauth: false as const, label: '' };
+  }
+  return { authenticated: false, canReauth: false as const, label: '' };
+}

--- a/server/providers/openrouter-paths.ts
+++ b/server/providers/openrouter-paths.ts
@@ -1,0 +1,22 @@
+// Shared path helpers for OpenRouter session storage.
+// Used by both the provider and the history loader.
+
+import path from 'path';
+import { getWorkspaceDir } from '../config.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidSessionId(sessionId: string): boolean {
+  return UUID_RE.test(sessionId);
+}
+
+export function getSessionDir(): string {
+  return path.join(getWorkspaceDir(), 'openrouter-sessions');
+}
+
+export function getSessionFilePath(sessionId: string): string {
+  if (!isValidSessionId(sessionId)) {
+    throw new Error(`Invalid OpenRouter session ID: ${sessionId}`);
+  }
+  return path.join(getSessionDir(), `${sessionId}.jsonl`);
+}

--- a/server/providers/openrouter.ts
+++ b/server/providers/openrouter.ts
@@ -1,0 +1,416 @@
+// OpenRouter provider. Streams chat completions from the OpenRouter API
+// (OpenAI-compatible) and maintains per-session conversation history.
+// No tool use or agent loop -- pure multi-turn chat.
+//
+// Image data is stored in the in-memory session for context continuity
+// but only plain text is persisted to JSONL (images are not recoverable
+// after a server restart by design).
+
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import { AssistantMessage, type ChatMessage } from '../../common/chat-types.js';
+import { OPENROUTER_MODELS, type SharedModelOption } from '../../common/models.js';
+import { AbsProvider } from './base.js';
+import { createArtificialNativePath } from '../chats/artificial-native-path.js';
+import { getSessionDir, getSessionFilePath } from './openrouter-paths.js';
+import type { StartSessionRequest, StartedProviderSession, ResumeTurnRequest, AgentCommandImage } from './types.js';
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const MODEL_CACHE_TTL_MS = 5 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const STREAM_TIMEOUT_MS = 5 * 60_000;
+const MAX_MESSAGES_PER_SESSION = 200;
+
+interface ConversationMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+}
+
+interface OpenRouterSession {
+  abortController: AbortController | null;
+  aborted: boolean;
+  chatId: string;
+  id: string;
+  isRunning: boolean;
+  messages: ConversationMessage[];
+  model: string;
+  startTime: number;
+}
+
+function getApiKey(): string {
+  return process.env.OPENROUTER_API_KEY || '';
+}
+
+function makeHeaders(apiKey: string): Record<string, string> {
+  return {
+    'Authorization': `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    'HTTP-Referer': 'https://github.com/cfal/garcon',
+    'X-Title': 'Garcon',
+  };
+}
+
+// Converts image attachments to the OpenAI multimodal content format.
+function buildUserContent(
+  text: string,
+  images?: AgentCommandImage[],
+): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
+  if (!images?.length) return text;
+  const parts: Array<{ type: string; text?: string; image_url?: { url: string } }> = [
+    { type: 'text', text },
+  ];
+  for (const image of images) {
+    if (!image.data) continue;
+    parts.push({ type: 'image_url', image_url: { url: image.data } });
+  }
+  return parts;
+}
+
+// Extracts plain text from a conversation message's content field.
+function extractTextContent(content: ConversationMessage['content']): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((part) => part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text!)
+    .join('\n');
+}
+
+export async function runSingleQuery(prompt: string, options: Record<string, unknown> = {}): Promise<string> {
+  const apiKey = getApiKey();
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY is not set');
+
+  const model = typeof options.model === 'string' && options.model
+    ? options.model
+    : OPENROUTER_MODELS.DEFAULT;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${OPENROUTER_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: makeHeaders(apiKey),
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OpenRouter API error ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+    return data.choices?.[0]?.message?.content?.trim() || '';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export class OpenRouterProvider extends AbsProvider {
+  #sessions = new Map<string, OpenRouterSession>();
+  #modelCache: SharedModelOption[] | null = null;
+  #modelCacheTime = 0;
+  #modelFetchPromise: Promise<SharedModelOption[]> | null = null;
+
+  async #ensureSessionDir(): Promise<void> {
+    await fs.mkdir(getSessionDir(), { recursive: true });
+  }
+
+  async #persistMessage(sessionId: string, role: string, content: string): Promise<void> {
+    await this.#ensureSessionDir();
+    const line = JSON.stringify({ role, content, timestamp: new Date().toISOString() }) + '\n';
+    await fs.appendFile(getSessionFilePath(sessionId), line);
+  }
+
+  async #streamCompletion(session: OpenRouterSession): Promise<string> {
+    const apiKey = getApiKey();
+    if (!apiKey) {
+      throw new Error('OPENROUTER_API_KEY is not set');
+    }
+
+    const abortController = new AbortController();
+    session.abortController = abortController;
+
+    // Wall-clock timeout for the entire streaming response.
+    const streamTimer = setTimeout(() => abortController.abort(), STREAM_TIMEOUT_MS);
+
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+    try {
+      const response = await fetch(`${OPENROUTER_BASE_URL}/chat/completions`, {
+        method: 'POST',
+        headers: makeHeaders(apiKey),
+        body: JSON.stringify({
+          model: session.model,
+          messages: session.messages,
+          stream: true,
+        }),
+        signal: abortController.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`OpenRouter API error ${response.status}: ${errorText}`);
+      }
+
+      reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let accumulated = '';
+      let lastStreamError = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop()!;
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6).trim();
+          if (data === '[DONE]') continue;
+
+          try {
+            const parsed = JSON.parse(data) as {
+              choices?: Array<{ delta?: { content?: string } }>;
+              error?: { message?: string };
+            };
+            // Capture stream-level errors (e.g. rate limit mid-stream).
+            if (parsed.error?.message) {
+              lastStreamError = parsed.error.message;
+              continue;
+            }
+            const delta = parsed.choices?.[0]?.delta?.content;
+            if (typeof delta === 'string') {
+              accumulated += delta;
+            }
+          } catch {
+            // Skip malformed chunks.
+          }
+        }
+      }
+
+      // If the model produced no output but reported an error, surface it.
+      if (!accumulated.trim() && lastStreamError) {
+        throw new Error(`OpenRouter stream error: ${lastStreamError}`);
+      }
+
+      return accumulated;
+    } finally {
+      clearTimeout(streamTimer);
+      session.abortController = null;
+      if (reader) {
+        reader.cancel().catch(() => {});
+      }
+    }
+  }
+
+  async #runTurnInternal(session: OpenRouterSession): Promise<void> {
+    session.isRunning = true;
+    session.aborted = false;
+    this.emitProcessing(session.chatId, true);
+
+    try {
+      const response = await this.#streamCompletion(session);
+
+      if (session.aborted) return;
+
+      if (!response.trim()) {
+        this.emitFailed(session.chatId, 'Empty response from OpenRouter');
+        return;
+      }
+
+      // Append assistant response to conversation history.
+      session.messages.push({ role: 'assistant', content: response });
+
+      const timestamp = new Date().toISOString();
+      this.emitMessages(session.chatId, [new AssistantMessage(timestamp, response)]);
+      this.emitFinished(session.chatId, 0);
+
+      // Persist asynchronously.
+      void this.#persistMessage(session.id, 'assistant', response).catch((err) => {
+        console.warn(`openrouter(${session.id.slice(0, 8)}): persist failed:`, err.message);
+      });
+    } catch (error: unknown) {
+      if (session.aborted) return;
+      const message = error instanceof Error ? error.message : String(error);
+      this.emitFailed(session.chatId, message);
+    } finally {
+      session.isRunning = false;
+      this.emitProcessing(session.chatId, false);
+    }
+  }
+
+  async startSession(request: StartSessionRequest): Promise<StartedProviderSession> {
+    const sessionId = crypto.randomUUID();
+    const userContent = buildUserContent(request.command, request.images);
+    const textContent = extractTextContent(userContent);
+
+    const session: OpenRouterSession = {
+      abortController: null,
+      aborted: false,
+      chatId: request.chatId,
+      id: sessionId,
+      isRunning: false,
+      messages: [{ role: 'user', content: userContent }],
+      model: request.model || OPENROUTER_MODELS.DEFAULT,
+      startTime: Date.now(),
+    };
+
+    this.#sessions.set(sessionId, session);
+    this.emitSessionCreated(request.chatId);
+
+    // Persist the user message.
+    void this.#persistMessage(sessionId, 'user', textContent).catch((err) => {
+      console.warn(`openrouter(${sessionId.slice(0, 8)}): persist failed:`, err.message);
+    });
+
+    // Run the turn asynchronously (caller doesn't wait for completion).
+    void this.#runTurnInternal(session);
+
+    return {
+      providerSessionId: sessionId,
+      nativePath: createArtificialNativePath('openrouter', sessionId),
+    };
+  }
+
+  async runTurn(request: ResumeTurnRequest): Promise<void> {
+    const session = this.#sessions.get(request.providerSessionId);
+    if (!session) {
+      throw new Error(`Unknown OpenRouter session: ${request.providerSessionId}`);
+    }
+    if (session.isRunning) {
+      throw new Error(`Session ${request.providerSessionId} is already running`);
+    }
+
+    // Allow model changes between turns.
+    if (request.model) {
+      session.model = request.model;
+    }
+
+    const userContent = buildUserContent(request.command, request.images);
+    const textContent = extractTextContent(userContent);
+
+    // Enforce message cap to prevent unbounded memory/context growth.
+    if (session.messages.length >= MAX_MESSAGES_PER_SESSION) {
+      // Keep the first message (initial system/user context) and trim
+      // the oldest middle messages to stay under the cap.
+      const first = session.messages[0];
+      session.messages = [first, ...session.messages.slice(-(MAX_MESSAGES_PER_SESSION - 2))];
+    }
+
+    session.messages.push({ role: 'user', content: userContent });
+    session.chatId = request.chatId;
+
+    void this.#persistMessage(session.id, 'user', textContent).catch((err) => {
+      console.warn(`openrouter(${session.id.slice(0, 8)}): persist failed:`, err.message);
+    });
+
+    await this.#runTurnInternal(session);
+  }
+
+  abort(providerSessionId: string): boolean {
+    const session = this.#sessions.get(providerSessionId);
+    if (!session?.isRunning) return false;
+    // Set aborted flag and cancel the HTTP request. The running
+    // #runTurnInternal coroutine will see session.aborted=true and
+    // exit cleanly, emitting processing=false in its own finally block.
+    session.aborted = true;
+    session.abortController?.abort();
+    return true;
+  }
+
+  isRunning(providerSessionId: string): boolean {
+    return this.#sessions.get(providerSessionId)?.isRunning === true;
+  }
+
+  getRunningSessions(): Array<{ id: string; startedAt: string; status: string }> {
+    return Array.from(this.#sessions.values())
+      .filter((session) => session.isRunning)
+      .map((session) => ({
+        id: session.id,
+        startedAt: new Date(session.startTime).toISOString(),
+        status: 'running',
+      }));
+  }
+
+  // Fetches models from OpenRouter API with caching and deduplication.
+  async getModels(): Promise<SharedModelOption[]> {
+    if (this.#modelCache && Date.now() - this.#modelCacheTime < MODEL_CACHE_TTL_MS) {
+      return this.#modelCache;
+    }
+
+    // Deduplicate concurrent fetches to prevent cache stampede.
+    if (this.#modelFetchPromise) return this.#modelFetchPromise;
+
+    this.#modelFetchPromise = this.#fetchModels();
+    try {
+      return await this.#modelFetchPromise;
+    } finally {
+      this.#modelFetchPromise = null;
+    }
+  }
+
+  async #fetchModels(): Promise<SharedModelOption[]> {
+    const apiKey = getApiKey();
+    if (!apiKey) return OPENROUTER_MODELS.OPTIONS;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(`${OPENROUTER_BASE_URL}/models`, {
+        headers: { 'Authorization': `Bearer ${apiKey}` },
+        signal: controller.signal,
+      });
+      if (!response.ok) return OPENROUTER_MODELS.OPTIONS;
+
+      const data = await response.json() as {
+        data?: Array<{
+          id: string;
+          name?: string;
+          architecture?: { modality?: string };
+        }>;
+      };
+
+      if (!Array.isArray(data.data)) return OPENROUTER_MODELS.OPTIONS;
+
+      const models: SharedModelOption[] = data.data
+        .filter((model) => model.id && model.name)
+        .map((model) => ({
+          value: model.id,
+          label: model.name!,
+          supportsImages: model.architecture?.modality?.includes('image') ?? false,
+        }));
+
+      if (models.length > 0) {
+        this.#modelCache = models;
+        this.#modelCacheTime = Date.now();
+        return models;
+      }
+    } catch (error) {
+      console.warn('openrouter: model fetch failed:', error instanceof Error ? error.message : error);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    return OPENROUTER_MODELS.OPTIONS;
+  }
+
+  startPurgeTimer(): ReturnType<typeof setInterval> {
+    const maxAge = 30 * 60 * 1000;
+    return setInterval(() => {
+      const now = Date.now();
+      for (const [id, session] of this.#sessions.entries()) {
+        if (!session.isRunning && now - session.startTime > maxAge) {
+          this.#sessions.delete(id);
+        }
+      }
+    }, 5 * 60 * 1000);
+  }
+}

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -26,7 +26,7 @@ describe('GET /api/v1/models', () => {
 
     expect(body.catalog).toBeDefined();
     expect(Array.isArray(body.catalog.providers)).toBe(true);
-    expect(body.catalog.providers.length).toBe(5);
+    expect(body.catalog.providers.length).toBe(6);
 
     const claude = body.catalog.providers.find((p) => p.id === 'claude');
     expect(claude.supportsFork).toBe(true);

--- a/server/routes/models.js
+++ b/server/routes/models.js
@@ -2,7 +2,7 @@
 // static; OpenCode models are fetched periodically. Serves a single
 // GET /api/models endpoint.
 
-import { AMP_MODELS, CLAUDE_MODELS, CODEX_MODELS, FACTORY_MODELS } from '../../common/models.js';
+import { AMP_MODELS, CLAUDE_MODELS, CODEX_MODELS, FACTORY_MODELS, OPENROUTER_MODELS } from '../../common/models.js';
 import { PROVIDERS, supportsFork, supportsImages } from '../../common/providers.ts';
 import { getFactoryDefaultModel } from '../providers/factory-models.js';
 
@@ -13,6 +13,7 @@ function getDefaultModel(provider, cache, factoryDefaultModel) {
   if (provider === 'codex') return CODEX_MODELS.DEFAULT;
   if (provider === 'amp') return AMP_MODELS.DEFAULT;
   if (provider === 'factory') return factoryDefaultModel;
+  if (provider === 'openrouter') return OPENROUTER_MODELS.DEFAULT;
   return cache.opencode[0]?.value ?? '';
 }
 
@@ -35,6 +36,7 @@ export default function createModelsRoutes(providers, ollamaBridge) {
     codex: CODEX_MODELS.OPTIONS,
     amp: AMP_MODELS.OPTIONS,
     factory: FACTORY_MODELS.OPTIONS,
+    openrouter: OPENROUTER_MODELS.OPTIONS,
     opencode: [],
   };
   let factoryDefaultModel = FACTORY_MODELS.DEFAULT;
@@ -65,6 +67,14 @@ export default function createModelsRoutes(providers, ollamaBridge) {
     }
   }
 
+  async function refreshOpenRouterCache() {
+    try {
+      cache.openrouter = await providers.getModels('openrouter');
+    } catch (error) {
+      console.warn('models: openrouter refresh failed:', error.message);
+    }
+  }
+
   async function refreshFactoryCache() {
     try {
       cache.factory = await providers.getModels('factory');
@@ -87,8 +97,10 @@ export default function createModelsRoutes(providers, ollamaBridge) {
 
   refreshOpenCodeCache();
   refreshFactoryCache();
+  refreshOpenRouterCache();
   setInterval(refreshOpenCodeCache, OPENCODE_REFRESH_INTERVAL);
   setInterval(refreshFactoryCache, OPENCODE_REFRESH_INTERVAL);
+  setInterval(refreshOpenRouterCache, OPENCODE_REFRESH_INTERVAL);
 
   return {
     '/api/v1/models': { GET: getModels },

--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,7 @@ import { CodexProvider } from './providers/codex.js';
 import { OpenCodeProvider } from './providers/opencode.js';
 import { AmpProvider } from './providers/amp-cli.js';
 import { FactoryProvider } from './providers/factory-cli.js';
+import { OpenRouterProvider } from './providers/openrouter.js';
 import { ProviderRegistry } from './providers/index.js';
 import { OllamaBridge } from './providers/ollama-bridge.js';
 import { ChatHandler } from './ws/chat.js';
@@ -88,6 +89,7 @@ export async function startServer() {
     const opencodeProvider = new OpenCodeProvider();
     const ampProvider = new AmpProvider();
     const factoryProvider = new FactoryProvider();
+    const openrouterProvider = new OpenRouterProvider();
 
     // Tier 1.5: Ollama bridge (local model support)
     const ollamaBridge = new OllamaBridge();
@@ -101,7 +103,7 @@ export async function startServer() {
     }
 
     // Tier 2: Provider registry wrapping providers + registry
-    const providerRegistry = new ProviderRegistry(chatRegistry, claudeProvider, codexProvider, opencodeProvider, ampProvider, factoryProvider, ollamaBridge);
+    const providerRegistry = new ProviderRegistry(chatRegistry, claudeProvider, codexProvider, opencodeProvider, ampProvider, factoryProvider, openrouterProvider, ollamaBridge);
 
     // Tier 3: Chat infrastructure (uses ProviderRegistry)
     const metadata = new MetadataIndex(chatRegistry, providerRegistry);

--- a/server/server.js
+++ b/server/server.js
@@ -324,6 +324,7 @@ export async function startServer() {
             }
           }
         }
+        providerRegistry.shutdown();
         historyCache.destroy();
         await chatRegistry.flush();
       } catch (err) {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -62,6 +62,9 @@
 	--color-provider-factory-bg: hsl(var(--provider-factory-bg));
 	--color-provider-factory-foreground: hsl(var(--provider-factory-foreground));
 	--color-provider-factory-border: hsl(var(--provider-factory-border));
+	--color-provider-openrouter-bg: hsl(var(--provider-openrouter-bg));
+	--color-provider-openrouter-foreground: hsl(var(--provider-openrouter-foreground));
+	--color-provider-openrouter-border: hsl(var(--provider-openrouter-border));
 	--color-indicator-unread: hsl(var(--indicator-unread));
 		--color-status-processing: hsl(var(--status-processing));
 		--color-status-processing-foreground: hsl(var(--status-processing-foreground));
@@ -199,6 +202,9 @@
 	--provider-factory-bg: 192 84% 94%;
 	--provider-factory-foreground: 192 84% 24%;
 	--provider-factory-border: 192 44% 76%;
+	--provider-openrouter-bg: 152 68% 93%;
+	--provider-openrouter-foreground: 152 60% 26%;
+	--provider-openrouter-border: 152 40% 74%;
 	--indicator-unread: 214 90% 48%;
 		--status-processing: 214 90% 48%;
 		--status-processing-foreground: 214 85% 32%;
@@ -358,6 +364,9 @@
 	--provider-factory-bg: 192 44% 20%;
 	--provider-factory-foreground: 192 86% 86%;
 	--provider-factory-border: 192 34% 34%;
+	--provider-openrouter-bg: 152 36% 20%;
+	--provider-openrouter-foreground: 152 68% 84%;
+	--provider-openrouter-border: 152 28% 34%;
 	--indicator-unread: 214 95% 68%;
 		--status-processing: 214 95% 68%;
 		--status-processing-foreground: 214 95% 86%;

--- a/web/src/lib/api/providers.ts
+++ b/web/src/lib/api/providers.ts
@@ -2,7 +2,7 @@
 
 import { apiGet, apiPost } from './client.js';
 
-export type ProviderName = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory';
+export type ProviderName = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory' | 'openrouter';
 export type BrowserLoginProviderName = 'claude' | 'codex';
 
 export interface ProviderAuthStatus {

--- a/web/src/lib/chat/composer-controls.ts
+++ b/web/src/lib/chat/composer-controls.ts
@@ -116,6 +116,11 @@ export const PROVIDER_MENU_GROUPS: ProviderMenuGroup[] = [
 				value: 'factory',
 				label: 'Factory',
 				description: 'Factory Droid via the external droid CLI.'
+			},
+			{
+				value: 'openrouter',
+				label: 'OpenRouter',
+				description: 'Access many models via OpenRouter API.'
 			}
 		]
 	}

--- a/web/src/lib/chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat-form-state.svelte.ts
@@ -32,6 +32,7 @@ export class NewChatFormState {
 	opencodeModel = $state('');
 	ampModel = $state('');
 	factoryModel = $state('');
+	openrouterModel = $state('');
 
 	// Path
 	projectPath = $state('');
@@ -125,7 +126,8 @@ export class NewChatFormState {
 				? this.#modelCatalog.getModels('factory')
 				: this.factoryModel
 					? [{ value: this.factoryModel, label: this.factoryModel }]
-					: []
+					: [],
+			openrouter: this.#modelCatalog.getModels('openrouter')
 		};
 		return opts[this.provider];
 	}
@@ -136,7 +138,8 @@ export class NewChatFormState {
 			codex: this.codexModel,
 			opencode: this.opencodeModel,
 			amp: this.ampModel,
-			factory: this.factoryModel
+			factory: this.factoryModel,
+			openrouter: this.openrouterModel
 		};
 		return map[this.provider];
 	}
@@ -155,7 +158,8 @@ export class NewChatFormState {
 			codex: (v) => { this.codexModel = v; },
 			opencode: (v) => { this.opencodeModel = v; },
 			amp: (v) => { this.ampModel = v; },
-			factory: (v) => { this.factoryModel = v; }
+			factory: (v) => { this.factoryModel = v; },
+			openrouter: (v) => { this.openrouterModel = v; }
 		};
 		setterMap[this.provider](value);
 	}
@@ -180,6 +184,9 @@ export class NewChatFormState {
 		if (provider === 'factory' && !liveModels.some((m) => m.value === this.factoryModel)) {
 			this.factoryModel = liveModels[0].value;
 		}
+		if (provider === 'openrouter' && !liveModels.some((m) => m.value === this.openrouterModel)) {
+			this.openrouterModel = liveModels[0].value;
+		}
 	}
 
 	applyResolvedModel(provider: SessionProvider, model: string): void {
@@ -192,6 +199,7 @@ export class NewChatFormState {
 		if (provider === 'opencode') this.opencodeModel = resolvedModel;
 		if (provider === 'amp') this.ampModel = resolvedModel;
 		if (provider === 'factory') this.factoryModel = resolvedModel;
+		if (provider === 'openrouter') this.openrouterModel = resolvedModel;
 	}
 
 	// Images (delegated to ImageAttachmentState)

--- a/web/src/lib/components/settings/AgentCard.svelte
+++ b/web/src/lib/components/settings/AgentCard.svelte
@@ -21,7 +21,7 @@
 		error: string | null;
 	}
 
-	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory';
+	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory' | 'openrouter';
 
 	let {
 		agentId,
@@ -61,7 +61,8 @@
 		codex: 'border-l-provider-codex-border',
 		opencode: 'border-l-provider-opencode-border',
 		amp: 'border-l-provider-amp-border',
-		factory: 'border-l-provider-factory-border'
+		factory: 'border-l-provider-factory-border',
+		openrouter: 'border-l-provider-openrouter-border'
 	};
 
 	// Authenticated with no reauth option and no CLI-only content -- nothing to expand.

--- a/web/src/lib/components/settings/AgentsSection.svelte
+++ b/web/src/lib/components/settings/AgentsSection.svelte
@@ -16,7 +16,7 @@
 		error: string | null;
 	}
 
-	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory';
+	type AgentId = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory' | 'openrouter';
 	type BrowserLoginAgentId = 'claude' | 'codex';
 	type AgentConfig = { id: AgentId; name: string; cliOnly?: boolean; loginCommand?: string };
 
@@ -32,7 +32,8 @@
 
 	const secondaryAgents: AgentConfig[] = [
 		{ id: 'amp', name: 'Amp', cliOnly: true, loginCommand: 'amp login' },
-		{ id: 'factory', name: 'Factory', cliOnly: true, loginCommand: 'droid' }
+		{ id: 'factory', name: 'Factory', cliOnly: true, loginCommand: 'droid' },
+		{ id: 'openrouter', name: 'OpenRouter', cliOnly: true, loginCommand: 'export OPENROUTER_API_KEY=...' }
 	];
 
 	const authPollTimers: Partial<Record<AgentId, ReturnType<typeof setTimeout>>> = {};
@@ -45,12 +46,14 @@
 	let opencodeAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let ampAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 	let factoryAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
+	let openrouterAuth = $state<AuthStatus>({ ...DEFAULT_AUTH });
 
 	let claudeOpen = $state(false);
 	let codexOpen = $state(false);
 	let opencodeOpen = $state(false);
 	let ampOpen = $state(false);
 	let factoryOpen = $state(false);
+	let openrouterOpen = $state(false);
 
 	let moreProvidersOpen = $state(false);
 
@@ -63,6 +66,7 @@
 		if (agent === 'codex') return codexAuth;
 		if (agent === 'amp') return ampAuth;
 		if (agent === 'factory') return factoryAuth;
+		if (agent === 'openrouter') return openrouterAuth;
 		return opencodeAuth;
 	}
 
@@ -71,6 +75,7 @@
 		if (agent === 'codex') return codexOpen;
 		if (agent === 'amp') return ampOpen;
 		if (agent === 'factory') return factoryOpen;
+		if (agent === 'openrouter') return openrouterOpen;
 		return opencodeOpen;
 	}
 
@@ -79,6 +84,7 @@
 		else if (agent === 'codex') codexOpen = value;
 		else if (agent === 'amp') ampOpen = value;
 		else if (agent === 'factory') factoryOpen = value;
+		else if (agent === 'openrouter') openrouterOpen = value;
 		else opencodeOpen = value;
 	}
 
@@ -87,6 +93,7 @@
 		else if (agent === 'codex') codexAuth = status;
 		else if (agent === 'amp') ampAuth = status;
 		else if (agent === 'factory') factoryAuth = status;
+		else if (agent === 'openrouter') openrouterAuth = status;
 		else opencodeAuth = status;
 	}
 

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -36,6 +36,7 @@
 		opencode: 'border-provider-opencode-border bg-provider-opencode-bg text-provider-opencode-foreground',
 		amp: 'border-provider-amp-border bg-provider-amp-bg text-provider-amp-foreground',
 		factory: 'border-provider-factory-border bg-provider-factory-bg text-provider-factory-foreground',
+		openrouter: 'border-provider-openrouter-border bg-provider-openrouter-bg text-provider-openrouter-foreground',
 	};
 
 	let providerTagVariant = $derived(

--- a/web/src/lib/stores/model-catalog.svelte.ts
+++ b/web/src/lib/stores/model-catalog.svelte.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from '$lib/api/client.js';
 import type { SessionProvider } from '$lib/types/app';
-import { AMP_MODELS, CLAUDE_MODELS, CODEX_MODELS, FACTORY_MODELS } from '$shared/models';
+import { AMP_MODELS, CLAUDE_MODELS, CODEX_MODELS, FACTORY_MODELS, OPENROUTER_MODELS } from '$shared/models';
 import { PROVIDERS, PROVIDER_CAPABILITIES, type ProviderId } from '$shared/providers';
 
 export interface ModelOption {
@@ -32,6 +32,7 @@ const STATIC_FALLBACKS: ProviderModels = {
 	opencode: [],
 	amp: AMP_MODELS.OPTIONS,
 	factory: FACTORY_MODELS.OPTIONS,
+	openrouter: OPENROUTER_MODELS.OPTIONS,
 };
 
 // Default capabilities derived from the shared common contract. Used when
@@ -82,6 +83,7 @@ function mergeWithFallbacks(models: ProviderModels): ProviderModels {
 		codex: mergeStaticModels(models.codex, STATIC_FALLBACKS.codex!),
 		amp: STATIC_FALLBACKS.amp!,
 		factory: mergeStaticModels(models.factory, STATIC_FALLBACKS.factory!),
+		openrouter: mergeStaticModels(models.openrouter, STATIC_FALLBACKS.openrouter!),
 		opencode: models.opencode?.length ? models.opencode : STATIC_FALLBACKS.opencode
 	};
 }
@@ -203,6 +205,7 @@ export class ModelCatalogStore {
 		if (provider === 'codex') return CODEX_MODELS.DEFAULT;
 		if (provider === 'amp') return AMP_MODELS.DEFAULT;
 		if (provider === 'factory') return FACTORY_MODELS.DEFAULT;
+		if (provider === 'openrouter') return OPENROUTER_MODELS.DEFAULT;
 		return this.getModels('opencode')[0]?.value ?? '';
 	}
 

--- a/web/src/lib/types/app.ts
+++ b/web/src/lib/types/app.ts
@@ -2,7 +2,7 @@
 
 import type { AmpAgentMode, ClaudeThinkingMode, PermissionMode, ThinkingMode } from '$shared/chat-modes';
 
-export type SessionProvider = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory';
+export type SessionProvider = 'claude' | 'codex' | 'opencode' | 'amp' | 'factory' | 'openrouter';
 
 export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'preview';
 


### PR DESCRIPTION
**Problem**
Users are limited to agent-based providers (Claude, Codex, OpenCode, Amp, Factory) and cannot access the broad ecosystem of LLM models available through OpenRouter.

**Solution**
Add OpenRouter as a new provider that streams chat completions via the OpenAI-compatible API. This enables access to 350+ models (Claude, GPT, Gemini, Llama, DeepSeek, Qwen, Mistral, etc.) through a single API key.

**Changes**
- New server provider (`server/providers/openrouter.ts`) with SSE streaming, conversation history, session persistence, abort support, and dynamic model fetching
- Shared path helpers (`openrouter-paths.ts`) with UUID validation to prevent path traversal
- Auth check via `OPENROUTER_API_KEY` env var
- History loader for JSONL-persisted sessions
- Full registry wiring: start/resume/abort sessions, model list, auth status, preview/history loading, purge timers, fan-out listeners
- Frontend: provider menu entry, model catalog integration, settings page agent card, sidebar tag colors (green theme)
- Updated tests for provider count and registry constructor

Key design decisions:
- Pure chat completions (no tool use / agent loop) -- appropriate for OpenRouter's API proxy role
- Stream timeout (5min) and request timeout (30s) on all fetch calls
- Message cap (200) per session to prevent unbounded memory/context growth
- Cache-stampede protection on model fetching
- Abort propagates through the running coroutine rather than force-setting state externally

**Expected Impact**
Users can now chat with any model available on OpenRouter by setting `OPENROUTER_API_KEY` and selecting "OpenRouter" in the provider dropdown. Models are fetched dynamically with static fallbacks.

**Screenshots**

Settings showing OpenRouter authenticated:
![settings](https://litter.catbox.moe/x7fxw6.png)

Provider dropdown with OpenRouter:
![provider-dropdown](https://litter.catbox.moe/3r61ci.png)

Model selection (350+ models):
![models](https://litter.catbox.moe/7hxg8h.png)

Chat interface with OpenRouter session:
![chat](https://litter.catbox.moe/91r58c.png)