### PR TITLE
feat: split-screen UX improvements

### DIFF
--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -222,6 +222,17 @@
 		}
 	});
 
+	// Scrolls to bottom when the scroll container mounts (e.g. after
+	// split-pane focus change remounts ConversationWorkspace in a new pane).
+	// The bind:this resolves after initial render, so earlier scrollToBottom
+	// calls from loadChat fire against an undefined container.
+	$effect(() => {
+		const _container = scrollContainer;
+		if (_container && chatState.chatMessages.length > 0) {
+			requestAnimationFrame(() => scroll.scrollToBottom());
+		}
+	});
+
 	// Preserves viewport anchoring when queue controls change height.
 	$effect(() => {
 		const _host = queueControlsContainer;

--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import type { AppTab } from '$lib/types/app';
 	import { untrack } from 'svelte';
-	import { getChatSessions, getLocalSettings, getSplitLayout } from '$lib/context';
+	import { getChatSessions, getLocalSettings, getSplitLayout, getAppShell } from '$lib/context';
+	import { deleteChat } from '$lib/api/chats';
 	import Menu from '@lucide/svelte/icons/menu';
 	import Maximize2 from '@lucide/svelte/icons/maximize-2';
 	import Minimize2 from '@lucide/svelte/icons/minimize-2';
@@ -13,6 +14,8 @@
 	import ConversationWorkspace from '$lib/components/chat/ConversationWorkspace.svelte';
 	import ShareChatDialog from '$lib/components/chat/ShareChatDialog.svelte';
 	import SplitContainer from '$lib/components/split/SplitContainer.svelte';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils/cn';
 	import { CHAT_TOOLBAR_TABS } from './chat-toolbar-tabs';
 
@@ -41,6 +44,7 @@
 	const sessions = getChatSessions();
 	const localSettings = getLocalSettings();
 	const splitLayout = getSplitLayout();
+	const appShell = getAppShell();
 
 	// Derives selected chat from the canonical session store.
 	const selectedChat = $derived(sessions.selectedChat);
@@ -74,6 +78,38 @@
 	function closeShareDialog() {
 		shareChatId = null;
 		shareChatTitle = '';
+	}
+
+	// Delete confirmation state for split-pane delete action.
+	let deleteConfirmation = $state<{ paneId: string; chatId: string; chatTitle: string } | null>(null);
+
+	function handleSplitDeleteChat(paneId: string) {
+		const pane = splitLayout.panes.find((p) => p.id === paneId);
+		if (!pane) return;
+		const record = sessions.byId[pane.chatId];
+		deleteConfirmation = {
+			paneId,
+			chatId: pane.chatId,
+			chatTitle: record?.title || 'Untitled',
+		};
+	}
+
+	async function confirmSplitDelete() {
+		if (!deleteConfirmation) return;
+		const { paneId, chatId } = deleteConfirmation;
+		deleteConfirmation = null;
+		// Close the pane first, then delete the chat server-side.
+		handleSplitClosePane(paneId);
+		try {
+			await deleteChat(chatId);
+			appShell.quietRefreshChats();
+		} catch (err) {
+			console.error('[WorkspaceView] Failed to delete chat:', err);
+		}
+	}
+
+	function cancelSplitDelete() {
+		deleteConfirmation = null;
 	}
 
 	function handleRegisterSubmit(fn: (message: string) => Promise<boolean>): void {
@@ -410,6 +446,7 @@
 					draggedChatId={splitLayout.draggedChatId}
 					onFocusPane={handleSplitFocusPane}
 					onClosePane={handleSplitClosePane}
+					onDeleteChat={handleSplitDeleteChat}
 					onSetRatio={handleSplitSetRatio}
 					onDropChat={handleSplitDropChat}
 					{focusedPaneContent}
@@ -453,4 +490,23 @@
 	{/if}
 
 	<ShareChatDialog chatId={shareChatId} chatTitle={shareChatTitle} onClose={closeShareDialog} />
+
+	<!-- Delete confirmation dialog for split-pane delete action -->
+	<Dialog.Root open={deleteConfirmation !== null} onOpenChange={(open) => { if (!open) cancelSplitDelete(); }}>
+		<Dialog.Content>
+			<Dialog.Header class="min-w-0">
+				<Dialog.Title>{m.sidebar_delete_confirmation_delete_chat()}</Dialog.Title>
+				<Dialog.Description class="min-w-0 max-w-full">
+					<span class="font-medium text-foreground block w-full min-w-0 max-w-full truncate">
+						{deleteConfirmation?.chatTitle || m.sidebar_chats_unnamed()}
+					</span>
+					{m.sidebar_delete_confirmation_cannot_undo()}
+				</Dialog.Description>
+			</Dialog.Header>
+			<Dialog.Footer>
+				<Button variant="outline" onclick={cancelSplitDelete}>{m.sidebar_actions_cancel()}</Button>
+				<Button variant="destructive" onclick={() => { void confirmSplitDelete(); }}>{m.sidebar_actions_delete()}</Button>
+			</Dialog.Footer>
+		</Dialog.Content>
+	</Dialog.Root>
 </div>

--- a/web/src/lib/components/layout/__tests__/WorkspaceViewTestHarness.svelte
+++ b/web/src/lib/components/layout/__tests__/WorkspaceViewTestHarness.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import WorkspaceView from '../WorkspaceView.svelte';
-	import { setChatSessions, setModelCatalog, setLocalSettings, setSplitLayout } from '$lib/context';
+	import { setChatSessions, setModelCatalog, setLocalSettings, setSplitLayout, setAppShell } from '$lib/context';
 	import type { AppTab } from '$lib/types/app';
 
 	interface WorkspaceViewTestHarnessProps {
@@ -53,6 +53,10 @@
 		draggedChatId: null,
 		panes: [],
 		focusedChatId: null,
+	} as never);
+
+	setAppShell({
+		quietRefreshChats() {},
 	} as never);
 
 	function handleTabChange(_tab: AppTab): void {

--- a/web/src/lib/components/split/ChatPane.svelte
+++ b/web/src/lib/components/split/ChatPane.svelte
@@ -7,6 +7,7 @@
 	import { parseChatMessages, type ChatMessage, UserMessage, AssistantMessage, ErrorMessage } from '$shared/chat-types';
 	import { ChatLogQueryRequest } from '$shared/ws-requests';
 	import X from '@lucide/svelte/icons/x';
+	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import MessageSquare from '@lucide/svelte/icons/message-square';
 	import DropZoneOverlay from './DropZoneOverlay.svelte';
 
@@ -17,11 +18,12 @@
 		draggedChatId: string | null;
 		onFocus: () => void;
 		onClose: () => void;
+		onDelete: () => void;
 		onDrop: (zone: 'left' | 'right' | 'top' | 'bottom' | 'center') => void;
 		focusedContent?: Snippet;
 	}
 
-	let { paneId, chatId, isFocused, draggedChatId, onFocus, onClose, onDrop, focusedContent }: ChatPaneProps = $props();
+	let { paneId, chatId, isFocused, draggedChatId, onFocus, onClose, onDelete, onDrop, focusedContent }: ChatPaneProps = $props();
 
 	const sessions = getChatSessions();
 	const ws = getWs();
@@ -118,9 +120,12 @@
 		}
 	}
 
-	// Scrolls to bottom after DOM updates whenever messages change.
+	// Scrolls to bottom after DOM updates whenever messages change or the
+	// scroll container mounts (e.g. when pane transitions from focused to
+	// unfocused and the read-only message list appears).
 	$effect(() => {
 		messages;
+		scrollContainer;
 		tick().then(() => {
 			if (scrollContainer) {
 				scrollContainer.scrollTop = scrollContainer.scrollHeight;
@@ -145,9 +150,11 @@
 
 <div
 	class={cn(
-		'h-full w-full flex flex-col relative overflow-hidden',
-		'border border-transparent transition-colors duration-150',
-		isFocused ? 'border-primary/40' : 'border-border/50 hover:border-border',
+		'h-full w-full flex flex-col relative overflow-hidden rounded-lg group/pane',
+		'border transition-all duration-200',
+		isFocused
+			? 'border-primary/40 shadow-sm shadow-primary/10'
+			: 'border-border/40 hover:border-border/70',
 	)}
 	role="region"
 	aria-label="Chat pane: {chatTitle}"
@@ -155,13 +162,13 @@
 	<!-- Pane Header: draggable for rearranging, drop target for swap/replace -->
 	<div
 		class={cn(
-			'flex items-center gap-2 px-3 py-1.5 flex-shrink-0 select-none cursor-grab',
-			'border-b transition-colors duration-100',
+			'flex items-center gap-1.5 px-2.5 py-1 flex-shrink-0 select-none cursor-grab',
+			'border-b transition-all duration-150',
 			headerDropHover
 				? 'bg-accent/30 border-accent/50'
 				: isFocused
-					? 'bg-primary/5 border-primary/20'
-					: 'bg-muted/30 border-border/50 hover:bg-muted/50',
+					? 'bg-primary/5 border-primary/15'
+					: 'bg-muted/20 border-border/30 hover:bg-muted/40',
 		)}
 		draggable={true}
 		onclick={onFocus}
@@ -174,28 +181,45 @@
 		role="button"
 		tabindex="0"
 	>
-		<MessageSquare class="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
-		<span class="text-xs font-medium text-foreground truncate flex-1 min-w-0">
+		<MessageSquare class={cn(
+			'w-3 h-3 flex-shrink-0 transition-colors duration-150',
+			isFocused ? 'text-primary/70' : 'text-muted-foreground/60',
+		)} />
+		<span class={cn(
+			'text-[11px] font-medium truncate flex-1 min-w-0 transition-colors duration-150',
+			isFocused ? 'text-foreground' : 'text-muted-foreground',
+		)}>
 			{chatTitle}
 		</span>
 		{#if providerLabel}
-			<span class="text-[10px] text-muted-foreground bg-muted/60 px-1.5 py-0.5 rounded flex-shrink-0">
+			<span class="text-[9px] text-muted-foreground/70 bg-muted/40 px-1 py-px rounded flex-shrink-0">
 				{providerLabel}
 			</span>
 		{/if}
 		{#if isProcessing}
-			<span class="relative flex h-2 w-2 flex-shrink-0">
+			<span class="relative flex h-1.5 w-1.5 flex-shrink-0">
 				<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary/50 opacity-75"></span>
-				<span class="relative inline-flex rounded-full h-2 w-2 bg-primary"></span>
+				<span class="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary"></span>
 			</span>
 		{/if}
-		<button
-			class="p-0.5 rounded hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-colors flex-shrink-0"
-			onclick={(e) => { e.stopPropagation(); onClose(); }}
-			aria-label="Close pane"
+		<div class="flex items-center gap-0.5 flex-shrink-0 opacity-0 group-hover/pane:opacity-100 transition-opacity duration-150"
+			 class:opacity-100={isFocused}
 		>
-			<X class="w-3 h-3" />
-		</button>
+			<button
+				class="p-0.5 rounded hover:bg-destructive/10 hover:text-destructive text-muted-foreground/50 hover:text-destructive transition-colors flex-shrink-0"
+				onclick={(e) => { e.stopPropagation(); onDelete(); }}
+				aria-label="Delete chat"
+			>
+				<Trash2 class="w-2.5 h-2.5" />
+			</button>
+			<button
+				class="p-0.5 rounded hover:bg-destructive/10 hover:text-destructive text-muted-foreground/50 hover:text-destructive transition-colors flex-shrink-0"
+				onclick={(e) => { e.stopPropagation(); onClose(); }}
+				aria-label="Close pane"
+			>
+				<X class="w-2.5 h-2.5" />
+			</button>
+		</div>
 	</div>
 
 	<!-- Content area: full interactive workspace for focused pane, read-only for others -->
@@ -207,19 +231,22 @@
 		<!-- svelte-ignore a11y_no_noninteractive_element_interactions a11y_click_events_have_key_events -- click delegates focus to this pane -->
 		<div
 			bind:this={scrollContainer}
-			class="flex-1 min-h-0 overflow-y-auto px-3 py-2 space-y-2"
+			class={cn(
+				'flex-1 min-h-0 overflow-y-auto px-3 py-2 space-y-1.5 scrollbar-hide',
+				!isFocused && 'opacity-75',
+			)}
 			onclick={onFocus}
 			role="log"
 		>
 			{#if isLoading}
 				<div class="flex items-center justify-center h-full">
 					<div class="flex items-center gap-2 text-muted-foreground text-xs">
-						<div class="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
-						Loading messages...
+						<div class="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
+						<span class="text-[11px]">Loading...</span>
 					</div>
 				</div>
 			{:else if messages.length === 0}
-				<div class="flex items-center justify-center h-full text-muted-foreground text-xs">
+				<div class="flex items-center justify-center h-full text-muted-foreground/60 text-[11px]">
 					No messages yet
 				</div>
 			{:else}
@@ -229,11 +256,11 @@
 					{#if text && role}
 						<div
 							class={cn(
-								'text-xs leading-relaxed rounded-lg px-3 py-2 max-w-full',
+								'text-[11px] leading-relaxed rounded-md px-2.5 py-1.5 max-w-full',
 								role === 'user'
-									? 'bg-primary/10 text-foreground ml-8'
+									? 'bg-primary/8 text-foreground ml-6'
 									: role === 'assistant'
-										? 'bg-muted/50 text-foreground mr-4'
+										? 'bg-muted/40 text-foreground mr-3'
 										: 'bg-destructive/10 text-destructive',
 							)}
 						>
@@ -245,9 +272,9 @@
 		</div>
 	{/if}
 
-	<!-- Focus indicator bar at bottom -->
+	<!-- Focus indicator: thin accent bar at top instead of bottom for cleaner look -->
 	{#if isFocused}
-		<div class="h-0.5 bg-primary/40 flex-shrink-0"></div>
+		<div class="absolute top-0 left-2 right-2 h-0.5 bg-primary/50 rounded-b-full"></div>
 	{/if}
 
 	<!-- Drop zone overlay for drag-and-drop -->

--- a/web/src/lib/components/split/DropZoneOverlay.svelte
+++ b/web/src/lib/components/split/DropZoneOverlay.svelte
@@ -98,31 +98,31 @@
 	</div>
 
 	<!-- Visual feedback layer (pointer-events-none, purely decorative) -->
-	<div class={cn('absolute inset-0 pointer-events-none transition-colors duration-100', hoveredZone !== null && 'bg-primary/5')}>
+	<div class={cn('absolute inset-0 pointer-events-none transition-all duration-200', hoveredZone !== null ? 'bg-background/60 backdrop-blur-[1px]' : 'bg-background/30')}>
 		<!-- Split preview: highlighted half showing where the new pane goes -->
-		<div class={cn('absolute bg-primary/15 border-2 border-primary/40 rounded-md transition-all duration-150', previewClass('top'), 'inset-x-2 top-2 bottom-[52%]')}>
+		<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-all duration-200', previewClass('top'), 'inset-x-3 top-3 bottom-[52%]')}>
 			<div class="flex items-center justify-center h-full">
-				<span class="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">Split Top</span>
+				<span class="text-[10px] font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-md shadow-sm">Top</span>
 			</div>
 		</div>
-		<div class={cn('absolute bg-primary/15 border-2 border-primary/40 rounded-md transition-all duration-150', previewClass('bottom'), 'inset-x-2 top-[52%] bottom-2')}>
+		<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-all duration-200', previewClass('bottom'), 'inset-x-3 top-[52%] bottom-3')}>
 			<div class="flex items-center justify-center h-full">
-				<span class="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">Split Bottom</span>
+				<span class="text-[10px] font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-md shadow-sm">Bottom</span>
 			</div>
 		</div>
-		<div class={cn('absolute bg-primary/15 border-2 border-primary/40 rounded-md transition-all duration-150', previewClass('left'), 'inset-y-2 left-2 right-[52%]')}>
+		<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-all duration-200', previewClass('left'), 'inset-y-3 left-3 right-[52%]')}>
 			<div class="flex items-center justify-center h-full">
-				<span class="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">Split Left</span>
+				<span class="text-[10px] font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-md shadow-sm">Left</span>
 			</div>
 		</div>
-		<div class={cn('absolute bg-primary/15 border-2 border-primary/40 rounded-md transition-all duration-150', previewClass('right'), 'inset-y-2 left-[52%] right-2')}>
+		<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-all duration-200', previewClass('right'), 'inset-y-3 left-[52%] right-3')}>
 			<div class="flex items-center justify-center h-full">
-				<span class="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">Split Right</span>
+				<span class="text-[10px] font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-md shadow-sm">Right</span>
 			</div>
 		</div>
-		<div class={cn('absolute bg-accent/20 border-2 border-accent/50 rounded-md transition-all duration-150', previewClass('center'), 'inset-2')}>
+		<div class={cn('absolute bg-accent/15 border border-accent/40 rounded-lg transition-all duration-200', previewClass('center'), 'inset-3')}>
 			<div class="flex items-center justify-center h-full">
-				<span class="text-xs font-medium text-accent-foreground bg-accent/20 px-2 py-0.5 rounded">Replace</span>
+				<span class="text-[10px] font-medium text-accent-foreground bg-accent/15 px-2 py-0.5 rounded-md shadow-sm">Replace</span>
 			</div>
 		</div>
 	</div>

--- a/web/src/lib/components/split/SplitContainer.svelte
+++ b/web/src/lib/components/split/SplitContainer.svelte
@@ -12,6 +12,7 @@
 		draggedChatId: string | null;
 		onFocusPane: (paneId: string) => void;
 		onClosePane: (paneId: string) => void;
+		onDeleteChat: (paneId: string) => void;
 		onSetRatio: (path: number[], ratio: number) => void;
 		onDropChat: (paneId: string, zone: 'left' | 'right' | 'top' | 'bottom' | 'center') => void;
 		focusedPaneContent?: Snippet;
@@ -24,6 +25,7 @@
 		draggedChatId,
 		onFocusPane,
 		onClosePane,
+		onDeleteChat,
 		onSetRatio,
 		onDropChat,
 		focusedPaneContent,
@@ -58,6 +60,7 @@
 		{draggedChatId}
 		onFocus={() => onFocusPane(node.id)}
 		onClose={() => onClosePane(node.id)}
+		onDelete={() => onDeleteChat(node.id)}
 		onDrop={(zone) => onDropChat(node.id, zone)}
 		focusedContent={focusedPaneContent}
 	/>
@@ -68,14 +71,14 @@
 	<!-- svelte-ignore a11y_no_static_element_interactions -- pointerdown captures resize start position -->
 	<div
 		bind:this={containerEl}
-		class="h-full w-full flex overflow-hidden"
+		class="h-full w-full flex overflow-hidden gap-0.5 p-px"
 		class:flex-row={isHorizontal}
 		class:flex-col={!isHorizontal}
 		onpointerdown={handleResizeStart}
 	>
 		<div
-			class="overflow-hidden min-w-0 min-h-0"
-			style:flex={`0 0 calc(${firstPercent}% - 2px)`}
+			class="overflow-hidden min-w-0 min-h-0 rounded-lg"
+			style:flex={`0 0 calc(${firstPercent}% - 3px)`}
 		>
 			<Self
 				node={node.children[0]}
@@ -84,6 +87,7 @@
 				{draggedChatId}
 				{onFocusPane}
 				{onClosePane}
+				{onDeleteChat}
 				{onSetRatio}
 				{onDropChat}
 				{focusedPaneContent}
@@ -96,8 +100,8 @@
 		/>
 
 		<div
-			class="overflow-hidden min-w-0 min-h-0"
-			style:flex={`0 0 calc(${secondPercent}% - 2px)`}
+			class="overflow-hidden min-w-0 min-h-0 rounded-lg"
+			style:flex={`0 0 calc(${secondPercent}% - 3px)`}
 		>
 			<Self
 				node={node.children[1]}
@@ -106,6 +110,7 @@
 				{draggedChatId}
 				{onFocusPane}
 				{onClosePane}
+				{onDeleteChat}
 				{onSetRatio}
 				{onDropChat}
 				{focusedPaneContent}

--- a/web/src/lib/components/split/SplitResizer.svelte
+++ b/web/src/lib/components/split/SplitResizer.svelte
@@ -46,8 +46,7 @@
 <div
 	class={cn(
 		'relative flex-shrink-0 group select-none touch-none z-10',
-		isHorizontal ? 'w-1 cursor-col-resize' : 'h-1 cursor-row-resize',
-		isDragging && 'bg-primary/20',
+		isHorizontal ? 'w-1.5 cursor-col-resize' : 'h-1.5 cursor-row-resize',
 	)}
 	onpointerdown={handlePointerDown}
 	role="separator"
@@ -55,25 +54,46 @@
 	aria-label="Resize panes"
 	tabindex="-1"
 >
-	<!-- Wider hit area for easier grabbing -->
+	<!-- Wide invisible hit area for easy grabbing -->
 	<div
 		class={cn(
 			'absolute z-10',
 			isHorizontal
-				? 'inset-y-0 -left-1.5 w-4'
-				: 'inset-x-0 -top-1.5 h-4',
+				? 'inset-y-0 -left-2 w-5'
+				: 'inset-x-0 -top-2 h-5',
 		)}
 	></div>
-	<!-- Visual indicator line -->
+	<!-- Track background -->
 	<div
 		class={cn(
-			'absolute transition-colors duration-100',
+			'absolute rounded-full transition-all duration-150',
 			isHorizontal
-				? 'inset-y-0 left-0 w-px'
-				: 'inset-x-0 top-0 h-px',
+				? 'inset-y-0 left-0 right-0'
+				: 'inset-x-0 top-0 bottom-0',
 			isDragging
-				? 'bg-primary/40'
-				: 'bg-border group-hover:bg-primary/30',
+				? 'bg-primary/30'
+				: 'bg-transparent group-hover:bg-primary/10',
 		)}
 	></div>
+	<!-- Center grip dots (visible on hover/drag) -->
+	<div
+		class={cn(
+			'absolute transition-opacity duration-150 flex items-center justify-center',
+			isHorizontal
+				? 'inset-y-0 left-0 right-0'
+				: 'inset-x-0 top-0 bottom-0',
+			isDragging
+				? 'opacity-100'
+				: 'opacity-0 group-hover:opacity-100',
+		)}
+	>
+		<div class={cn(
+			'flex gap-0.5',
+			isHorizontal ? 'flex-col' : 'flex-row',
+		)}>
+			{#each [0, 1, 2] as _}
+				<div class="w-0.5 h-0.5 rounded-full bg-primary/50"></div>
+			{/each}
+		</div>
+	</div>
 </div>


### PR DESCRIPTION
**Problem**
Split-screen mode had several UX issues: chats didn't scroll to bottom when navigating between panes, no way to delete chats directly from split view, and the overall visual polish felt rough (thin resizers, jarring transitions, flat pane borders).

**Solution**
Fix scroll-to-bottom behavior for both focused and unfocused panes during split-mode navigation, add a delete button with confirmation dialog to pane headers, and overhaul the visual design of split components.

**Changes**
- Fix scroll-to-bottom on split-pane focus change by adding a scroll-on-mount effect in ConversationWorkspace and tracking scrollContainer availability in ChatPane
- Add trash button (Trash2 icon) next to close button in split pane headers with confirmation dialog reusing existing delete chat API
- Rounded pane corners with subtle shadow on focused pane and top accent bar indicator
- Wider resizer with grip dots that appear on hover/drag
- Smoother drop zone overlays with backdrop blur and refined visual hierarchy
- Better focused/unfocused visual distinction (opacity, border, shadow transitions)
- Pane header buttons auto-hide on unfocused panes and appear on hover

**Expected Impact**
Split-screen mode feels significantly more polished and functional. Users can now delete chats without leaving split view, and the scroll-to-bottom fix eliminates the need to manually scroll after switching panes.

**Screenshots**

Normal chat view:
![Normal chat](https://files.catbox.moe/2xvyju.png)

Split view enabled (single pane):
![Split single](https://files.catbox.moe/ytlxfi.png)

4-pane grid layout:
![Grid layout](https://files.catbox.moe/t2cosc.png)

Focus switched to different pane:
![Focus change](https://files.catbox.moe/drpp4w.png)

Delete confirmation dialog:
![Delete dialog](https://files.catbox.moe/lg9iei.png)