### PR TITLE
feat: scroll-to-top button for quick access to initial prompt

### DIFF
--- a/web/src/lib/chat/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/conversation-scroll-controller.svelte.ts
@@ -16,6 +16,7 @@ export interface ScrollControllerDeps {
 
 export class ConversationScrollController {
 	isPinnedToBottom = $state(true);
+	isScrollingToTop = $state(false);
 
 	constructor(private deps: ScrollControllerDeps) {}
 
@@ -32,6 +33,23 @@ export class ConversationScrollController {
 		node.scrollTop = node.scrollHeight;
 		this.deps.chatState.isUserScrolledUp = false;
 		this.isPinnedToBottom = true;
+	}
+
+	/** Loads all paginated messages and scrolls to the very top instantly. */
+	async scrollToTop(): Promise<void> {
+		const chatId = this.deps.sessions.selectedChatId;
+		if (!chatId) return;
+
+		this.isScrollingToTop = true;
+		try {
+			if (this.deps.chatState.hasMoreMessages) {
+				await this.deps.chatState.loadAllMessages(chatId, this.deps.ws);
+			}
+			const node = this.deps.getScrollContainer();
+			if (node) node.scrollTop = 0;
+		} finally {
+			this.isScrollingToTop = false;
+		}
 	}
 
 	handleScroll(): void {
@@ -92,7 +110,7 @@ export class ConversationScrollController {
 				const half = scrollContainer.clientHeight / 2;
 				scrollContainer.scrollBy({
 					top: event.key === 'd' ? half : -half,
-					behavior: 'smooth',
+					behavior: 'instant',
 				});
 			}
 		}

--- a/web/src/lib/chat/state.svelte.ts
+++ b/web/src/lib/chat/state.svelte.ts
@@ -148,6 +148,15 @@ export class ChatState {
 		this.visibleMessageCount += 100;
 	}
 
+	/** Loads all remaining paginated messages so the full history is available. */
+	async loadAllMessages(chatId: string, ws: WsConnection): Promise<void> {
+		while (this.hasMoreMessages) {
+			const loaded = await this.loadMoreMessages(chatId, ws);
+			if (!loaded) break;
+		}
+		this.visibleMessageCount = Math.max(this.visibleMessageCount, this.chatMessages.length);
+	}
+
 	/** Resets scroll and pagination state for a new chat selection. */
 	resetForNewChat(): void {
 		this.chatMessages = [];

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -21,7 +21,7 @@
 	import { ChatLifecycleStore } from '$lib/stores/chat-lifecycle.svelte';
 	import { getChatSessions, getLocalSettings, getAppShell, getWs, getNavigation, setChatState, setComposerState, setProviderState, setChatLifecycle, getReadReceiptOutbox, getModelCatalog } from '$lib/context';
 	import type { PendingPermissionRequest, QueueState, PermissionMode, PendingViewChat } from '$lib/types/chat';
-	import { ArrowDown } from '@lucide/svelte';
+	import { ArrowDown, ArrowUp, Loader2 } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -294,6 +294,20 @@
 			/>
 
 			{#if chatState.isUserScrolledUp && chatState.chatMessages.length > 0}
+				<Button
+					variant="outline"
+					size="icon"
+					class="absolute top-3 right-5 sm:right-6 z-20 w-11 h-11 rounded-full shadow-md hover:shadow-lg"
+					onclick={() => scroll.scrollToTop()}
+					disabled={scroll.isScrollingToTop}
+					title="Scroll to initial prompt"
+				>
+					{#if scroll.isScrollingToTop}
+						<Loader2 class="w-5 h-5 animate-spin" />
+					{:else}
+						<ArrowUp class="w-5 h-5" />
+					{/if}
+				</Button>
 				<Button
 					variant="outline"
 					size="icon"


### PR DESCRIPTION
**Problem**
In long chat conversations, scrolling back to the initial prompt to review the original request requires tedious manual scrolling. The Ctrl+U/D half-page scroll also uses slow smooth behavior.

**Solution**
Add a scroll-to-top button (ArrowUp icon) that appears alongside the existing scroll-to-bottom button when the user scrolls away from the bottom. Clicking it loads all paginated messages (if any) and instantly jumps to the top. Also switches Ctrl+U/D half-page scrolling from smooth to instant.

**Changes**
- `ChatState.loadAllMessages()` -- loops `loadMoreMessages` until the full history is fetched, then ensures all messages are visible
- `ConversationScrollController.scrollToTop()` -- loads all messages then sets `scrollTop = 0`, with `isScrollingToTop` state for loading spinner
- `ConversationWorkspace.svelte` -- adds ArrowUp button at top-right (disabled with spinner while loading), mirrors the existing ArrowDown button pattern
- `handleHalfPageScroll` -- changed from `behavior: 'smooth'` to `behavior: 'instant'`

**Expected Impact**
Users can quickly review the initial prompt without manual scrolling. Keyboard navigation (Ctrl+U/D) feels snappier.

| Scrolled up -- both buttons visible, initial prompt shown | Back at bottom after clicking scroll-to-bottom |
|---|---|
| ![buttons](https://files.catbox.moe/vwz6vk.png) | ![at-bottom](https://files.catbox.moe/7r5c5x.png) |