### PR TITLE
fix: use Z.AI coding endpoint as default base URL

### DIFF
--- a/server/providers/zai.ts
+++ b/server/providers/zai.ts
@@ -6,7 +6,7 @@ import {
 } from './openai-compatible-chat-provider.js';
 import { getSessionDir, getSessionFilePath } from './zai-paths.js';
 
-const DEFAULT_ZAI_BASE_URL = 'https://api.z.ai/api/paas/v4';
+const DEFAULT_ZAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4';
 
 function getApiKey(): string {
   return process.env.ZAI_API_KEY || '';


### PR DESCRIPTION
The generic `api.z.ai/api/paas/v4` endpoint returns `insufficient balance` (code 1113) for API keys on the coding tier. The correct default for GLM coding/completion models is `api.z.ai/api/coding/paas/v4`, matching what OpenClaw uses in its ZAI provider.

**Change:** `DEFAULT_ZAI_BASE_URL` → `https://api.z.ai/api/coding/paas/v4`

**Verified:** real completion succeeds on the coding endpoint, fails on the generic one with the same key.

Targeting `feat/zai-glm-5-1` so this can merge into the PR branch before it hits main.