### PR TITLE
feat: add Ctrl+D shortcut to delete selected chat

### DIFF
--- a/web/src/lib/components/shared/KeyboardShortcuts.svelte
+++ b/web/src/lib/components/shared/KeyboardShortcuts.svelte
@@ -53,6 +53,11 @@
 				appShell.requestRenameSelectedChat();
 				return;
 			}
+			if (e.ctrlKey && key === 'd') {
+				e.preventDefault();
+				appShell.requestDeleteSelectedChat();
+				return;
+			}
 			if (inEditable) return;
 
 			// Ctrl+, -- open settings

--- a/web/src/lib/components/shared/__tests__/KeyboardShortcutsHarness.svelte
+++ b/web/src/lib/components/shared/__tests__/KeyboardShortcutsHarness.svelte
@@ -7,6 +7,7 @@
 			openSidebarSearch: () => void;
 			requestNewChat: () => void;
 			requestRenameSelectedChat: () => void;
+			requestDeleteSelectedChat: () => void;
 			openSettings: () => void;
 		};
 		onToggleCommandMenu?: () => void;
@@ -23,6 +24,9 @@
 		},
 		get requestRenameSelectedChat() {
 			return appShell.requestRenameSelectedChat;
+		},
+		get requestDeleteSelectedChat() {
+			return appShell.requestDeleteSelectedChat;
 		},
 		get openSettings() {
 			return appShell.openSettings;

--- a/web/src/lib/components/shared/__tests__/keyboard-shortcuts.test.ts
+++ b/web/src/lib/components/shared/__tests__/keyboard-shortcuts.test.ts
@@ -3,14 +3,19 @@ import { describe, expect, it, vi } from 'vitest';
 
 import KeyboardShortcutsHarness from './KeyboardShortcutsHarness.svelte';
 
+function createMockAppShell() {
+	return {
+		openSidebarSearch: vi.fn(),
+		requestNewChat: vi.fn(),
+		requestRenameSelectedChat: vi.fn(),
+		requestDeleteSelectedChat: vi.fn(),
+		openSettings: vi.fn(),
+	};
+}
+
 describe('KeyboardShortcuts', () => {
 	it('opens sidebar search on Ctrl-S with the same global scope as the command palette', async () => {
-		const appShell = {
-			openSidebarSearch: vi.fn(),
-			requestNewChat: vi.fn(),
-			requestRenameSelectedChat: vi.fn(),
-			openSettings: vi.fn(),
-		};
+		const appShell = createMockAppShell();
 
 		render(KeyboardShortcutsHarness, {
 			appShell,
@@ -23,12 +28,7 @@ describe('KeyboardShortcuts', () => {
 	});
 
 	it('opens sidebar search on Ctrl-S even when focus is inside an input', async () => {
-		const appShell = {
-			openSidebarSearch: vi.fn(),
-			requestNewChat: vi.fn(),
-			requestRenameSelectedChat: vi.fn(),
-			openSettings: vi.fn(),
-		};
+		const appShell = createMockAppShell();
 
 		render(KeyboardShortcutsHarness, {
 			appShell,
@@ -42,6 +42,39 @@ describe('KeyboardShortcuts', () => {
 		try {
 				input.dispatchEvent(new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true }));
 			expect(appShell.openSidebarSearch).toHaveBeenCalledTimes(1);
+		} finally {
+			input.remove();
+		}
+	});
+
+	it('requests delete on Ctrl-D', async () => {
+		const appShell = createMockAppShell();
+
+		render(KeyboardShortcutsHarness, {
+			appShell,
+			onToggleCommandMenu: vi.fn(),
+		});
+
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', ctrlKey: true }));
+
+		expect(appShell.requestDeleteSelectedChat).toHaveBeenCalledTimes(1);
+	});
+
+	it('requests delete on Ctrl-D even when focus is inside an input', async () => {
+		const appShell = createMockAppShell();
+
+		render(KeyboardShortcutsHarness, {
+			appShell,
+			onToggleCommandMenu: vi.fn(),
+		});
+
+		const input = document.createElement('input');
+		document.body.appendChild(input);
+		input.focus();
+
+		try {
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, bubbles: true }));
+			expect(appShell.requestDeleteSelectedChat).toHaveBeenCalledTimes(1);
 		} finally {
 			input.remove();
 		}

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -659,6 +659,13 @@ type SavedSearchDialogOrigin = 'manager' | 'search-dialog';
 		startRenameChat(selected.id, selected.title || m.sidebar_chats_new_chat());
 	}));
 
+	onMount(() => appShell.onDeleteSelectedChatRequested(() => {
+		if (!selectedChatId) return;
+		const selected = chats.find((chat) => chat.id === selectedChatId);
+		if (!selected) return;
+		showDeleteConfirmation(selected.id, selected.title || m.sidebar_chats_new_chat(), selected.provider);
+	}));
+
 	onMount(() => appShell.onSidebarSearchRequested(() => {
 		searchState.toggleSearchDialog();
 	}));

--- a/web/src/lib/components/sidebar/__tests__/SidebarHarness.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarHarness.svelte
@@ -16,6 +16,9 @@
 		onRenameSelectedChatRequested() {
 			return () => {};
 		},
+		onDeleteSelectedChatRequested() {
+			return () => {};
+		},
 		onSidebarSearchRequested() {
 			return () => {};
 		},

--- a/web/src/lib/stores/__tests__/app-shell.test.ts
+++ b/web/src/lib/stores/__tests__/app-shell.test.ts
@@ -115,6 +115,28 @@ describe('AppShellStore', () => {
 			store.requestRenameSelectedChat();
 			expect(cb).toHaveBeenCalledTimes(1);
 		});
+
+		it('requestDeleteSelectedChat fires callbacks', () => {
+			const store = new AppShellStore();
+			const cb = vi.fn();
+			store.onDeleteSelectedChatRequested(cb);
+
+			store.requestDeleteSelectedChat();
+			expect(cb).toHaveBeenCalledTimes(1);
+		});
+
+		it('requestDeleteSelectedChat unsubscribe removes callback', () => {
+			const store = new AppShellStore();
+			const cb = vi.fn();
+			const unsub = store.onDeleteSelectedChatRequested(cb);
+
+			store.requestDeleteSelectedChat();
+			expect(cb).toHaveBeenCalledTimes(1);
+
+			unsub();
+			store.requestDeleteSelectedChat();
+			expect(cb).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('settings tabs', () => {

--- a/web/src/lib/stores/app-shell.svelte.ts
+++ b/web/src/lib/stores/app-shell.svelte.ts
@@ -38,6 +38,7 @@ export class AppShellStore {
 	#recenterCallbacks = new Set<() => void>();
 	#composerFocusCallbacks = new Set<() => void>();
 	#renameSelectedCallbacks = new Set<() => void>();
+	#deleteSelectedCallbacks = new Set<() => void>();
 	#newChatDialogSeedCallbacks = new Set<() => void>();
 	#sidebarSearchCallbacks = new Set<() => void>();
 
@@ -94,6 +95,11 @@ export class AppShellStore {
 		return () => { this.#renameSelectedCallbacks.delete(cb); };
 	}
 
+	onDeleteSelectedChatRequested(cb: () => void): () => void {
+		this.#deleteSelectedCallbacks.add(cb);
+		return () => { this.#deleteSelectedCallbacks.delete(cb); };
+	}
+
 	onNewChatDialogSeed(cb: () => void): () => void {
 		this.#newChatDialogSeedCallbacks.add(cb);
 		return () => { this.#newChatDialogSeedCallbacks.delete(cb); };
@@ -107,6 +113,11 @@ export class AppShellStore {
 	/** Requests sidebar to open rename for the currently selected chat. */
 	requestRenameSelectedChat(): void {
 		for (const cb of this.#renameSelectedCallbacks) cb();
+	}
+
+	/** Requests sidebar to open delete confirmation for the currently selected chat. */
+	requestDeleteSelectedChat(): void {
+		for (const cb of this.#deleteSelectedCallbacks) cb();
 	}
 
 	/** Requests shell navigation to the new-chat screen. */


### PR DESCRIPTION
**Problem**
No keyboard shortcut exists for deleting a chat -- users must right-click or use the dropdown menu.

**Solution**
Add Ctrl+D as a global keyboard shortcut that opens the existing delete confirmation dialog for the currently selected chat.

**Changes**
- `app-shell.svelte.ts`: Add `#deleteSelectedCallbacks` callback set with `requestDeleteSelectedChat()` / `onDeleteSelectedChatRequested()`, following the rename callback pattern
- `KeyboardShortcuts.svelte`: Add Ctrl+D handler that calls `appShell.requestDeleteSelectedChat()`
- `Sidebar.svelte`: Register delete callback on mount to show the confirmation dialog with the selected chat's info

**Expected Impact**
Ctrl+D opens the delete confirmation dialog for the currently selected chat. The confirmation dialog still appears to prevent accidental deletion. No changes to existing shortcuts or deletion flow.