### PR TITLE
feat(sidebar): show chat timestamps in list

### DIFF
--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -58,6 +58,7 @@
 	let {
 		session,
 		selectedChatId,
+		currentTime,
 		isPinned,
 		isArchived,
 		isReorderMode = false,
@@ -231,6 +232,8 @@
 						{isSelected}
 						{isPinned}
 						{isArchived}
+						{currentTime}
+						showTimestamp={true}
 						onTagClick={isMultiSelectMode ? undefined : onTagClick}
 						onManageTags={isMultiSelectMode ? undefined : onManageTags}
 					/>
@@ -282,6 +285,8 @@
 					{isSelected}
 					{isPinned}
 					{isArchived}
+					{currentTime}
+					showTimestamp={true}
 					onTagClick={isMultiSelectMode ? undefined : onTagClick}
 					onManageTags={isMultiSelectMode ? undefined : onManageTags}
 				/>

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -4,12 +4,15 @@
 	import type { SessionProvider } from '$lib/types/app';
 	import type { ChatSessionRecord } from '$lib/types/chat-session';
 	import { cn } from '$lib/utils/cn';
+	import { formatSidebarChatTimestamp } from './chat-timestamp.js';
 
 	interface SidebarChatSummaryProps {
 		session: ChatSessionRecord;
 		isSelected: boolean;
 		isPinned: boolean;
 		isArchived: boolean;
+		currentTime?: Date;
+		showTimestamp?: boolean;
 		onTagClick?: (tag: string) => void;
 		onManageTags?: (chatId: string, currentTags: string[]) => void;
 	}
@@ -17,6 +20,8 @@
 	let {
 		session,
 		isSelected,
+		currentTime = new Date(),
+		showTimestamp = false,
 		onTagClick,
 		onManageTags,
 	}: SidebarChatSummaryProps = $props();
@@ -29,6 +34,10 @@
 	let projectPath = $derived(session.projectPath || '');
 	let provider = $derived(session.provider || 'claude');
 	let isTagManagementEnabled = $derived(Boolean(onManageTags));
+	let activityTimestamp = $derived(session.lastActivityAt ?? session.createdAt);
+	let formattedTimestamp = $derived(
+		showTimestamp ? formatSidebarChatTimestamp(activityTimestamp, currentTime) : null
+	);
 
 	const PROVIDER_TAG_VARIANTS: Record<SessionProvider, string> = {
 		claude: 'border-provider-claude-border bg-provider-claude-bg text-provider-claude-foreground',
@@ -83,19 +92,37 @@
 
 <div class="relative min-w-0 w-full" data-slot="sidebar-chat-summary">
 	<div class="min-w-0 flex-1">
-		<div
-			class={cn(
-				'flex items-center gap-1.5 truncate text-[14px] font-medium',
-				isSelected ? 'text-sidebar-chat-item-selected-foreground' : 'text-foreground',
-			)}
-		>
-			{#if isUnread}
-				<span
-					class="h-1.5 w-1.5 shrink-0 rounded-full bg-indicator-unread"
-					aria-label={m.sidebar_chat_unread()}
-				></span>
+		<div class="flex min-w-0 items-start gap-2">
+			<div
+				class={cn(
+					'flex min-w-0 flex-1 items-center gap-1.5 truncate text-[14px] font-medium',
+					isSelected ? 'text-sidebar-chat-item-selected-foreground' : 'text-foreground',
+				)}
+			>
+				{#if isUnread}
+					<span
+						class="h-1.5 w-1.5 shrink-0 rounded-full bg-indicator-unread"
+						aria-label={m.sidebar_chat_unread()}
+					></span>
+				{/if}
+				<span class="truncate">{chatName}</span>
+			</div>
+
+			{#if formattedTimestamp}
+				<div
+					class={cn(
+						'shrink-0 text-right text-[10px] leading-[1.15] tabular-nums',
+						isSelected
+							? 'text-sidebar-chat-item-selected-foreground/75'
+							: 'text-muted-foreground',
+					)}
+					title={formattedTimestamp.tooltip}
+					aria-label={formattedTimestamp.tooltip}
+				>
+					<div>{formattedTimestamp.dateLabel}</div>
+					<div class="mt-0.5">{formattedTimestamp.timeLabel}</div>
+				</div>
 			{/if}
-			{chatName}
 		</div>
 
 		{#if projectPath}

--- a/web/src/lib/components/sidebar/__tests__/chat-timestamp.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/chat-timestamp.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatSidebarChatTimestamp } from '../chat-timestamp.js';
+
+describe('formatSidebarChatTimestamp', () => {
+	it('uses a short month-day label for timestamps in the current year', () => {
+		expect(
+			formatSidebarChatTimestamp('2026-04-18T07:30:00.000Z', new Date('2026-04-19T08:00:00.000Z'))
+		).toEqual({
+			dateLabel: 'Apr 18',
+			timeLabel: '7:30 AM',
+			tooltip: 'Apr 18, 2026, 7:30 AM',
+		});
+	});
+
+	it('falls back to a compact numeric date for older years', () => {
+		expect(
+			formatSidebarChatTimestamp('2025-12-31T23:45:00.000Z', new Date('2026-04-19T08:00:00.000Z'))
+		).toEqual({
+			dateLabel: '12/31/25',
+			timeLabel: '11:45 PM',
+			tooltip: 'Dec 31, 2025, 11:45 PM',
+		});
+	});
+
+	it('returns null for missing or invalid timestamps', () => {
+		expect(formatSidebarChatTimestamp(null, new Date('2026-04-19T08:00:00.000Z'))).toBeNull();
+		expect(
+			formatSidebarChatTimestamp('not-a-date', new Date('2026-04-19T08:00:00.000Z'))
+		).toBeNull();
+	});
+});

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -48,6 +48,8 @@ describe('shared sidebar chat row', () => {
 		expect(document.querySelectorAll('.border-sidebar-badge-pinned-border')).toHaveLength(1);
 		expect(screen.getAllByText('Shared row chat')).toHaveLength(2);
 		expect(screen.getAllByLabelText('Unread')).toHaveLength(2);
+		expect(screen.getAllByText('Jan 1')).toHaveLength(2);
+		expect(screen.getAllByText('12:00 AM')).toHaveLength(2);
 		expect(screen.getAllByTitle('/very/long/workspace/projects/feature-branch/app')).toHaveLength(2);
 		const sidebarPreview = screen.getAllByText('Latest preview text');
 		expect(sidebarPreview).toHaveLength(2);
@@ -79,6 +81,8 @@ describe('shared sidebar chat row', () => {
 		expect(option.querySelector('.border-sidebar-badge-pinned-border')).toBeNull();
 		expect(screen.getByText('Shared row chat')).toBeTruthy();
 		expect(screen.queryByLabelText('Unread')).toBeNull();
+		expect(screen.queryByText('Jan 1')).toBeNull();
+		expect(screen.queryByText('12:00 AM')).toBeNull();
 		expect(screen.getByTitle('/very/long/workspace/projects/feature-branch/app')).toBeTruthy();
 		expect(screen.getByText('Latest preview text').className).toContain('mt-0.5');
 		expect(screen.getByText('Latest preview text').className).toContain('mb-1');

--- a/web/src/lib/components/sidebar/chat-timestamp.ts
+++ b/web/src/lib/components/sidebar/chat-timestamp.ts
@@ -1,0 +1,41 @@
+export interface SidebarChatTimestamp {
+	dateLabel: string;
+	timeLabel: string;
+	tooltip: string;
+}
+
+const SHORT_MONTH_DAY_FORMATTER = new Intl.DateTimeFormat(undefined, {
+	month: 'short',
+	day: 'numeric',
+});
+
+const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+	dateStyle: 'short',
+});
+
+const SHORT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+	timeStyle: 'short',
+});
+
+const LONG_DATE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+	dateStyle: 'medium',
+	timeStyle: 'short',
+});
+
+export function formatSidebarChatTimestamp(
+	timestamp: string | null,
+	currentTime: Date,
+): SidebarChatTimestamp | null {
+	if (!timestamp) return null;
+
+	const parsed = new Date(timestamp);
+	if (Number.isNaN(parsed.getTime())) return null;
+
+	return {
+		dateLabel: parsed.getFullYear() === currentTime.getFullYear()
+			? SHORT_MONTH_DAY_FORMATTER.format(parsed)
+			: SHORT_DATE_FORMATTER.format(parsed),
+		timeLabel: SHORT_TIME_FORMATTER.format(parsed),
+		tooltip: LONG_DATE_TIME_FORMATTER.format(parsed),
+	};
+}


### PR DESCRIPTION
## Summary
- add a compact date/time block to sidebar chat rows
- keep the search dialog summary unchanged so only the main chat list gets the timestamp treatment
- cover timestamp formatting and row rendering with focused sidebar tests

## Testing
- bun run check
- bun run test
- bun run --cwd web test -- src/lib/components/sidebar/__tests__/chat-timestamp.test.ts src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
- timeout 180 bun run start --port 0
- manual browser verification in an isolated worktree on http://127.0.0.1:30560/
