### PR TITLE
[codex] enable GPT-5.5 model

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -18,6 +18,7 @@ export const CLAUDE_MODELS = {
 
 export const CODEX_MODELS = {
   OPTIONS: [
+    { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
     { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: true },
     { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', supportsImages: true },
@@ -25,7 +26,7 @@ export const CODEX_MODELS = {
     { value: 'gpt-5.2', label: 'GPT-5.2', supportsImages: true },
     { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini', supportsImages: true },
   ] satisfies SharedModelOption[],
-  DEFAULT: 'gpt-5.4',
+  DEFAULT: 'gpt-5.5',
 };
 
 export const AMP_MODELS = {

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -38,6 +38,8 @@ describe('GET /api/v1/models', () => {
     const codex = body.catalog.providers.find((p) => p.id === 'codex');
     expect(codex.supportsFork).toBe(true);
     expect(codex.supportsImages).toBe(true);
+    expect(codex.defaultModel).toBe('gpt-5.5');
+    expect(codex.models[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
 
     const opencode = body.catalog.providers.find((p) => p.id === 'opencode');
     expect(opencode.supportsFork).toBe(false);

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -19,6 +19,8 @@ describe('ModelCatalogStore', () => {
 		expect(store.getModels('factory').length).toBeGreaterThan(0);
 		expect(store.getModels('zai')).toEqual([{ value: 'glm-5.1', label: 'GLM-5.1', supportsImages: false }]);
 		expect(store.getDefaultModel('claude')).toBe('opus');
+		expect(store.getDefaultModel('codex')).toBe('gpt-5.5');
+		expect(store.getModels('codex')[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
 	});
 
 	it('exposes default capabilities from common contract', () => {
@@ -173,8 +175,8 @@ describe('ModelCatalogStore', () => {
 
 		const codexModels = store.getModels('codex');
 		expect(codexModels[0]).toMatchObject({ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' });
-		// Static gpt-5.4 should be appended
-		expect(codexModels.find((m) => m.value === 'gpt-5.4')).toBeTruthy();
+		// Static GPT-5.5 should be appended
+		expect(codexModels.find((m) => m.value === 'gpt-5.5')).toBeTruthy();
 		expect(codexModels.length).toBeGreaterThan(1);
 	});
 


### PR DESCRIPTION
## Summary
- Adds `gpt-5.5` to the shared Codex model catalog.
- Makes `gpt-5.5` the default Codex model for server and frontend catalog consumers.
- Extends server route and frontend catalog tests to assert the new default and fallback behavior.

## Validation
- `bun test server/routes/__tests__/models.test.js`
- `cd web && bun run test src/lib/stores/__tests__/model-catalog.test.ts`
- `bun run test` (856 tests)
- `bun run check` (0 errors, 0 warnings)
- `timeout 90s bun run start --port 0` (built and started on `127.0.0.1:62984`, then shut down via timeout)

## Notes
- Untracked local directories `.worktrees/` and `dogfood-output/` were left out of the PR.