### PR TITLE
[codex] Remove legacy GPT model options

### DIFF
--- a/common/generation-defaults.ts
+++ b/common/generation-defaults.ts
@@ -6,7 +6,7 @@ export const GENERATION_PROVIDER_PRIORITY = ['claude', 'codex', 'opencode', 'ope
 
 export const GENERATION_MODEL_DEFAULTS = {
   claude: 'haiku',
-  codex: 'gpt-5.1-codex-mini',
+  codex: 'gpt-5.5',
   amp: 'smart',
   factory: 'claude-opus-4-6',
   openrouter: 'anthropic/claude-sonnet-4.6',

--- a/common/models.ts
+++ b/common/models.ts
@@ -21,10 +21,6 @@ export const CODEX_MODELS = {
     { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
     { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: true },
-    { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', supportsImages: true },
-    { value: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max', supportsImages: true },
-    { value: 'gpt-5.2', label: 'GPT-5.2', supportsImages: true },
-    { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini', supportsImages: true },
   ] satisfies SharedModelOption[],
   DEFAULT: 'gpt-5.5',
 };
@@ -45,8 +41,6 @@ export const FACTORY_MODELS = {
     { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', supportsImages: true },
     { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', supportsImages: true },
     { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', supportsImages: true },
-    { value: 'gpt-5.2', label: 'GPT-5.2', supportsImages: true },
-    { value: 'gpt-5.2-codex', label: 'GPT-5.2-Codex', supportsImages: true },
     { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
     { value: 'gpt-5.4-fast', label: 'GPT-5.4 Fast Mode', supportsImages: true },
     { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini', supportsImages: true },
@@ -57,7 +51,6 @@ export const FACTORY_MODELS = {
     { value: 'glm-5', label: 'Droid Core (GLM-5)', supportsImages: false },
     { value: 'kimi-k2.5', label: 'Droid Core (Kimi K2.5)', supportsImages: true },
     { value: 'minimax-m2.5', label: 'Droid Core (MiniMax M2.5)', supportsImages: false },
-    { value: 'gpt-5.1-codex-max', label: 'GPT-5.1-Codex-Max', supportsImages: true },
   ] satisfies SharedModelOption[],
   DEFAULT: 'claude-opus-4-6',
 };

--- a/server/chats/__tests__/title-generator.test.js
+++ b/server/chats/__tests__/title-generator.test.js
@@ -114,7 +114,7 @@ describe('maybeGenerateChatTitle', () => {
     expect(runSingleQueryMock).toHaveBeenCalledTimes(1);
     const [, opts] = runSingleQueryMock.mock.calls[0];
     expect(opts.provider).toBe('codex');
-    expect(opts.model).toBe('gpt-5.1-codex-mini');
+    expect(opts.model).toBe('gpt-5.5');
   });
 
   it('auto-enables and skips DeepSeek R1 when selecting OpenCode defaults', async () => {

--- a/server/routes/__tests__/app.test.js
+++ b/server/routes/__tests__/app.test.js
@@ -221,10 +221,10 @@ describe('GET /api/app/settings', () => {
     expect(body.version).toBe(1);
     expect(body.uiEffective.chatTitle.enabled).toBe(true);
     expect(body.uiEffective.chatTitle.provider).toBe('codex');
-    expect(body.uiEffective.chatTitle.model).toBe('gpt-5.1-codex-mini');
+    expect(body.uiEffective.chatTitle.model).toBe('gpt-5.5');
     expect(body.uiEffective.commitMessage.enabled).toBe(true);
     expect(body.uiEffective.commitMessage.provider).toBe('codex');
-    expect(body.uiEffective.commitMessage.model).toBe('gpt-5.1-codex-mini');
+    expect(body.uiEffective.commitMessage.model).toBe('gpt-5.5');
   });
 
   it('preserves persisted commitMessage extra fields in uiEffective', async () => {
@@ -233,7 +233,7 @@ describe('GET /api/app/settings', () => {
       commitMessage: {
         enabled: true,
         provider: 'codex',
-        model: 'gpt-5.1-codex-mini',
+        model: 'gpt-5.5',
         customPrompt: 'Write a short message',
         useCommonDirPrefix: true,
       },
@@ -245,7 +245,7 @@ describe('GET /api/app/settings', () => {
     expect(body.version).toBe(3);
     expect(body.uiEffective.commitMessage.enabled).toBe(true);
     expect(body.uiEffective.commitMessage.provider).toBe('codex');
-    expect(body.uiEffective.commitMessage.model).toBe('gpt-5.1-codex-mini');
+    expect(body.uiEffective.commitMessage.model).toBe('gpt-5.5');
     expect(body.uiEffective.commitMessage.customPrompt).toBe('Write a short message');
     expect(body.uiEffective.commitMessage.useCommonDirPrefix).toBe(true);
   });

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -40,6 +40,11 @@ describe('GET /api/v1/models', () => {
     expect(codex.supportsImages).toBe(true);
     expect(codex.defaultModel).toBe('gpt-5.5');
     expect(codex.models[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
+    const codexModelValues = codex.models.map((model) => model.value);
+    expect(codexModelValues).not.toContain('gpt-5.2');
+    expect(codexModelValues).not.toContain('gpt-5.2-codex');
+    expect(codexModelValues).not.toContain('gpt-5.1-codex-max');
+    expect(codexModelValues).not.toContain('gpt-5.1-codex-mini');
 
     const opencode = body.catalog.providers.find((p) => p.id === 'opencode');
     expect(opencode.supportsFork).toBe(false);
@@ -50,6 +55,10 @@ describe('GET /api/v1/models', () => {
     expect(factory.supportsImages).toBe(false);
     expect(Array.isArray(factory.models)).toBe(true);
     expect(factory.defaultModel).toBe('claude-opus-4-6');
+    const factoryModelValues = factory.models.map((model) => model.value);
+    expect(factoryModelValues).not.toContain('gpt-5.2');
+    expect(factoryModelValues).not.toContain('gpt-5.2-codex');
+    expect(factoryModelValues).not.toContain('gpt-5.1-codex-max');
 
     const zai = body.catalog.providers.find((p) => p.id === 'zai');
     expect(zai.supportsFork).toBe(false);

--- a/server/settings/__tests__/generation-effective.test.js
+++ b/server/settings/__tests__/generation-effective.test.js
@@ -37,7 +37,7 @@ describe('resolveEffectiveGenerationConfig', () => {
     expect(result).toEqual({
       enabled: true,
       provider: 'codex',
-      model: 'gpt-5.1-codex-mini',
+      model: 'gpt-5.5',
       source: 'auto',
     });
   });

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -21,6 +21,15 @@ describe('ModelCatalogStore', () => {
 		expect(store.getDefaultModel('claude')).toBe('opus');
 		expect(store.getDefaultModel('codex')).toBe('gpt-5.5');
 		expect(store.getModels('codex')[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
+		const codexModelValues = store.getModels('codex').map((model) => model.value);
+		expect(codexModelValues).not.toContain('gpt-5.2');
+		expect(codexModelValues).not.toContain('gpt-5.2-codex');
+		expect(codexModelValues).not.toContain('gpt-5.1-codex-max');
+		expect(codexModelValues).not.toContain('gpt-5.1-codex-mini');
+		const factoryModelValues = store.getModels('factory').map((model) => model.value);
+		expect(factoryModelValues).not.toContain('gpt-5.2');
+		expect(factoryModelValues).not.toContain('gpt-5.2-codex');
+		expect(factoryModelValues).not.toContain('gpt-5.1-codex-max');
 	});
 
 	it('exposes default capabilities from common contract', () => {


### PR DESCRIPTION
## Summary
- Keeps GPT-5.5 as the first/default Codex model.
- Removes GPT-5.1/GPT-5.2 Codex entries from the shared model selection contract.
- Updates automatic Codex title/commit generation defaults to GPT-5.5 and covers the contract in server and web tests.

## Validation
- `bun test server/routes/__tests__/models.test.js`
- `bun run --cwd web test src/lib/stores/__tests__/model-catalog.test.ts`
- `bun test server/settings/__tests__/generation-effective.test.js server/routes/__tests__/app.test.js server/chats/__tests__/title-generator.test.js`
- `bun run check`
- `bun run test`
- `timeout 30s bun run start --port 0` (build completed and server started at `http://127.0.0.1:44032`; timeout then stopped the foreground process)