### PR TITLE
fix(chat): use low reasoning for generated titles

### DIFF
--- a/server/chats/__tests__/title-generator.test.js
+++ b/server/chats/__tests__/title-generator.test.js
@@ -115,6 +115,7 @@ describe('maybeGenerateChatTitle', () => {
     const [, opts] = runSingleQueryMock.mock.calls[0];
     expect(opts.provider).toBe('codex');
     expect(opts.model).toBe('gpt-5.5');
+    expect(opts.thinkingMode).toBe('none');
   });
 
   it('auto-enables and skips DeepSeek R1 when selecting OpenCode defaults', async () => {

--- a/server/chats/title-generator.js
+++ b/server/chats/title-generator.js
@@ -78,7 +78,7 @@ export async function maybeGenerateChatTitle({ chatId, projectPath, firstPrompt,
       cwd: projectPath,
       projectPath,
       permissionMode: 'default',
-      thinkingMode: 'think',
+      thinkingMode: 'none',
     });
 
     const title = normalizeTitle(titleRaw);


### PR DESCRIPTION
## Summary
- Run automatic chat title generation with `thinkingMode: none` so Codex uses low reasoning effort.
- Add coverage that Codex auto-title generation passes the low-effort thinking mode.

## Validation
- `bun test server/chats/__tests__/title-generator.test.js`
- `bun run check`
- `bun run test`
- `timeout 90s bun run start --port 0` (started on `http://0.0.0.0:21551` before timeout shutdown)