### PR TITLE
feat: add Codex 5.3 Spark model option

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -21,7 +21,7 @@ export const CODEX_MODELS = {
     { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
     { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: true },
-    { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: true },
+    { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: false },
   ] satisfies SharedModelOption[],
   DEFAULT: 'gpt-5.5',
 };

--- a/common/models.ts
+++ b/common/models.ts
@@ -21,6 +21,7 @@ export const CODEX_MODELS = {
     { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
     { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: true },
+    { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: true },
   ] satisfies SharedModelOption[],
   DEFAULT: 'gpt-5.5',
 };

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -6,7 +6,7 @@ const providers = {
   getHarnessCatalog: mock(() => Promise.resolve({
     harnesses: [
       { id: 'claude', label: 'Claude', kind: 'harness', supportsFork: true, supportsImages: true, acceptsApiProviderEndpoints: true, supportedProtocols: ['anthropic-messages'], defaultModel: 'opus', models: [{ value: 'opus', label: 'Opus', supportsImages: true }] },
-      { id: 'codex', label: 'Codex', kind: 'harness', supportsFork: true, supportsImages: true, acceptsApiProviderEndpoints: true, supportedProtocols: ['openai-compatible'], defaultModel: 'gpt-5.5', models: [{ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true }, { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: true }] },
+      { id: 'codex', label: 'Codex', kind: 'harness', supportsFork: true, supportsImages: true, acceptsApiProviderEndpoints: true, supportedProtocols: ['openai-compatible'], defaultModel: 'gpt-5.5', models: [{ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true }, { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: false }] },
       { id: 'opencode', label: 'OpenCode', kind: 'harness', supportsFork: false, supportsImages: false, acceptsApiProviderEndpoints: false, supportedProtocols: [], defaultModel: '', models: [] },
       { id: 'amp', label: 'Amp', kind: 'harness', supportsFork: false, supportsImages: false, acceptsApiProviderEndpoints: false, supportedProtocols: [], defaultModel: 'default', models: [{ value: 'default', label: 'Default' }] },
       { id: 'factory', label: 'Factory', kind: 'harness', supportsFork: false, supportsImages: false, acceptsApiProviderEndpoints: false, supportedProtocols: [], defaultModel: 'claude-opus-4-6', models: [{ value: 'claude-opus-4-6', label: 'Claude Opus 4-6' }] },
@@ -52,6 +52,7 @@ describe('GET /api/v1/models', () => {
     expect(codex.models[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
     const codexModelValues = codex.models.map((model) => model.value);
     expect(codexModelValues).toContain('gpt-5.3-codex-spark');
+    expect(codex.models.find((model) => model.value === 'gpt-5.3-codex-spark')).toMatchObject({ supportsImages: false });
     expect(codexModelValues).not.toContain('gpt-5.2');
     expect(codexModelValues).not.toContain('gpt-5.2-codex');
     expect(codexModelValues).not.toContain('gpt-5.1-codex-max');

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -6,7 +6,7 @@ const providers = {
   getHarnessCatalog: mock(() => Promise.resolve({
     harnesses: [
       { id: 'claude', label: 'Claude', kind: 'harness', supportsFork: true, supportsImages: true, acceptsApiProviderEndpoints: true, supportedProtocols: ['anthropic-messages'], defaultModel: 'opus', models: [{ value: 'opus', label: 'Opus', supportsImages: true }] },
-      { id: 'codex', label: 'Codex', kind: 'harness', supportsFork: true, supportsImages: true, acceptsApiProviderEndpoints: true, supportedProtocols: ['openai-compatible'], defaultModel: 'gpt-5.5', models: [{ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true }] },
+      { id: 'codex', label: 'Codex', kind: 'harness', supportsFork: true, supportsImages: true, acceptsApiProviderEndpoints: true, supportedProtocols: ['openai-compatible'], defaultModel: 'gpt-5.5', models: [{ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true }, { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: true }] },
       { id: 'opencode', label: 'OpenCode', kind: 'harness', supportsFork: false, supportsImages: false, acceptsApiProviderEndpoints: false, supportedProtocols: [], defaultModel: '', models: [] },
       { id: 'amp', label: 'Amp', kind: 'harness', supportsFork: false, supportsImages: false, acceptsApiProviderEndpoints: false, supportedProtocols: [], defaultModel: 'default', models: [{ value: 'default', label: 'Default' }] },
       { id: 'factory', label: 'Factory', kind: 'harness', supportsFork: false, supportsImages: false, acceptsApiProviderEndpoints: false, supportedProtocols: [], defaultModel: 'claude-opus-4-6', models: [{ value: 'claude-opus-4-6', label: 'Claude Opus 4-6' }] },
@@ -51,6 +51,7 @@ describe('GET /api/v1/models', () => {
     expect(codex.defaultModel).toBe('gpt-5.5');
     expect(codex.models[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
     const codexModelValues = codex.models.map((model) => model.value);
+    expect(codexModelValues).toContain('gpt-5.3-codex-spark');
     expect(codexModelValues).not.toContain('gpt-5.2');
     expect(codexModelValues).not.toContain('gpt-5.2-codex');
     expect(codexModelValues).not.toContain('gpt-5.1-codex-max');

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -26,17 +26,18 @@ describe('ModelCatalogStore', () => {
 			expect(store.getModels('zai')).toEqual([]);
 			expect(store.getDefaultModel('claude')).toBe('opus');
 			expect(store.getDefaultModel('codex')).toBe('gpt-5.5');
-		expect(store.getModels('codex')[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
-		const codexModelValues = store.getModels('codex').map((model) => model.value);
-		expect(codexModelValues).not.toContain('gpt-5.2');
-		expect(codexModelValues).not.toContain('gpt-5.2-codex');
-		expect(codexModelValues).not.toContain('gpt-5.1-codex-max');
-		expect(codexModelValues).not.toContain('gpt-5.1-codex-mini');
-		const factoryModelValues = store.getModels('factory').map((model) => model.value);
-		expect(factoryModelValues).not.toContain('gpt-5.2');
-		expect(factoryModelValues).not.toContain('gpt-5.2-codex');
-		expect(factoryModelValues).not.toContain('gpt-5.1-codex-max');
-	});
+			expect(store.getModels('codex')[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
+			const codexModelValues = store.getModels('codex').map((model) => model.value);
+			expect(codexModelValues).toContain('gpt-5.3-codex-spark');
+			expect(codexModelValues).not.toContain('gpt-5.2');
+			expect(codexModelValues).not.toContain('gpt-5.2-codex');
+			expect(codexModelValues).not.toContain('gpt-5.1-codex-max');
+			expect(codexModelValues).not.toContain('gpt-5.1-codex-mini');
+			const factoryModelValues = store.getModels('factory').map((model) => model.value);
+			expect(factoryModelValues).not.toContain('gpt-5.2');
+			expect(factoryModelValues).not.toContain('gpt-5.2-codex');
+			expect(factoryModelValues).not.toContain('gpt-5.1-codex-max');
+		});
 
 	it('exposes default capabilities from common contract', () => {
 		const store = createModelCatalogStore();

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -29,6 +29,7 @@ describe('ModelCatalogStore', () => {
 			expect(store.getModels('codex')[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
 			const codexModelValues = store.getModels('codex').map((model) => model.value);
 			expect(codexModelValues).toContain('gpt-5.3-codex-spark');
+			expect(store.supportsImages('codex', 'gpt-5.3-codex-spark')).toBe(false);
 			expect(codexModelValues).not.toContain('gpt-5.2');
 			expect(codexModelValues).not.toContain('gpt-5.2-codex');
 			expect(codexModelValues).not.toContain('gpt-5.1-codex-max');


### PR DESCRIPTION
## Summary
- Add `gpt-5.3-codex-spark` as a selectable Codex harness model.
- Keep `gpt-5.5` as the Codex default.
- Cover the new model in server catalog and frontend fallback catalog tests.

## Notes
- `codex debug models` reports `gpt-5.3-codex-spark` as `GPT-5.3-Codex-Spark`, described as an ultra-fast coding model.
- OpenAI docs list the related `gpt-5.3-codex` coding model; Spark is exposed through the Codex CLI model catalog.

## Validation
- `bun run check`
- `bun run test`
- `timeout 30s bun run start --port 0`