### PR TITLE
[codex] Polish mobile composer UX

### DIFF
--- a/web/src/lib/components/chat/ComposerBottomBar.svelte
+++ b/web/src/lib/components/chat/ComposerBottomBar.svelte
@@ -129,23 +129,29 @@
 				{/if}
 			</div>
 
-		<div
-			class="flex min-w-0 items-center justify-between gap-2 sm:ml-auto sm:basis-auto sm:justify-end"
-			class:basis-full={mobileRightGroupFullRow}
-		>
-				{#if selectorsSide === 'right' && modelSelector}
+			<div
+				class="flex min-w-0 items-center justify-between gap-2 sm:ml-auto sm:basis-auto sm:justify-end {mobileRightGroupFullRow ? 'order-first sm:order-none' : ''}"
+				class:basis-full={mobileRightGroupFullRow}
+			>
+				{#if mobileRightGroupFullRow}
+					<div class="min-w-0 flex-1 sm:flex-none">
+						{#if selectorsSide === 'right' && modelSelector}
+							{@render modelSelector()}
+						{/if}
+					</div>
+				{:else if selectorsSide === 'right' && modelSelector}
 					{@render modelSelector()}
 				{/if}
 
-			<button
-				type="button"
-				onclick={onSend}
-				disabled={!canSend}
-				class="inline-flex size-9 items-center justify-center rounded-full border transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background disabled:bg-muted disabled:text-muted-foreground disabled:border-border disabled:cursor-not-allowed {sendButtonClass}"
-				title={sendTitle}
-			>
-				<Send class="size-4" />
-			</button>
+				<button
+					type="button"
+					onclick={onSend}
+					disabled={!canSend}
+					class="inline-flex size-9 items-center justify-center rounded-full border transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background disabled:bg-muted disabled:text-muted-foreground disabled:border-border disabled:cursor-not-allowed {sendButtonClass}"
+					title={sendTitle}
+				>
+					<Send class="size-4" />
+				</button>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

- Reorder the mobile new-chat composer controls so the model/send row stays stable and easier to scan.
- Keep the utility buttons available below the primary model/send row on narrow screens.

## Dogfood Evidence

Mobile new-chat composer before: https://files.catbox.moe/wgt1u1.png

Mobile new-chat composer after: https://files.catbox.moe/4lh4w2.png

Desktop new-chat after: https://files.catbox.moe/yw39s4.png

Local report: dogfood-output/ui-smooth/report.md (not committed; screenshots are hosted above).

## Validation

- bun run check
- bun run --cwd web test -- NewChatForm.test.ts WorkspaceView.test.ts

Note: the first-run sidebar copy change was reverted per request.