### PR TITLE
fix: allow sidebar drops into active split view

### DIFF
--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -19,6 +19,13 @@
 	import { cn } from '$lib/utils/cn';
 	import { CHAT_TOOLBAR_TABS } from './chat-toolbar-tabs';
 
+	type SplitDropZone = 'left' | 'right' | 'top' | 'bottom' | 'center';
+	type ActiveSplitDropTarget = {
+		paneId: string;
+		zone: SplitDropZone;
+		rect: DOMRect;
+	};
+
 	// Lazy-loaded tab panels to keep the main chunk lean. Each panel
 	// pulls in heavy dependencies (CodeMirror, xterm, git logic).
 	const lazyFilesPanel = () => import('$lib/components/files/FilesPanel.svelte');
@@ -181,7 +188,7 @@
 		splitLayout.setRatioByPath(path, ratio);
 	}
 
-	function handleSplitDropChat(paneId: string, zone: 'left' | 'right' | 'top' | 'bottom' | 'center') {
+	function handleSplitDropChat(paneId: string, zone: SplitDropZone) {
 		const draggedChat = splitLayout.draggedChatId;
 		if (!draggedChat) return;
 		// Pane-to-pane drag: always swap regardless of zone to prevent duplication.
@@ -205,6 +212,10 @@
 	// Handles dropping a chat on the main workspace when split mode is off.
 	// Auto-enables split with the current chat, then splits in the dropped chat.
 	let workspaceDragOver = $state(false);
+	let activeSplitDropTarget = $state<ActiveSplitDropTarget | null>(null);
+	const showActiveSplitDropLayer = $derived(
+		splitLayout.isEnabled && activeTab === 'chat' && splitLayout.draggedChatId !== null,
+	);
 
 	function handleWorkspaceDragOver(e: DragEvent) {
 		if (splitLayout.isEnabled) return;
@@ -231,6 +242,104 @@
 			splitLayout.focusPane(initialPane.id);
 		}
 		splitLayout.endDrag();
+	}
+
+	function resolveDropZone(rect: DOMRect, clientX: number, clientY: number): SplitDropZone {
+		const x = clientX - rect.left;
+		const y = clientY - rect.top;
+		const edgeX = rect.width * 0.25;
+		const edgeY = rect.height * 0.25;
+
+		if (y < edgeY) return 'top';
+		if (y > rect.height - edgeY) return 'bottom';
+		if (x < edgeX) return 'left';
+		if (x > rect.width - edgeX) return 'right';
+		return 'center';
+	}
+
+	function resolveActiveSplitDropTarget(e: DragEvent): ActiveSplitDropTarget | null {
+		if (!splitRootEl) return null;
+
+		let fallback: { paneId: string; rect: DOMRect; distance: number } | null = null;
+		for (const pane of splitLayout.panes) {
+			const paneEl = splitRootEl.querySelector<HTMLElement>(`[data-pane-id="${pane.id}"]`);
+			if (!paneEl) continue;
+
+			const rect = paneEl.getBoundingClientRect();
+			const containsPointer =
+				e.clientX >= rect.left &&
+				e.clientX <= rect.right &&
+				e.clientY >= rect.top &&
+				e.clientY <= rect.bottom;
+			if (containsPointer) {
+				return { paneId: pane.id, zone: resolveDropZone(rect, e.clientX, e.clientY), rect };
+			}
+
+			const centerX = rect.left + rect.width / 2;
+			const centerY = rect.top + rect.height / 2;
+			const distance = Math.hypot(e.clientX - centerX, e.clientY - centerY);
+			if (!fallback || distance < fallback.distance) {
+				fallback = { paneId: pane.id, rect, distance };
+			}
+		}
+
+		if (!fallback) return null;
+		return {
+			paneId: fallback.paneId,
+			zone: resolveDropZone(fallback.rect, e.clientX, e.clientY),
+			rect: fallback.rect,
+		};
+	}
+
+	function handleActiveSplitDragOver(e: DragEvent) {
+		if (!showActiveSplitDropLayer) return;
+		const target = resolveActiveSplitDropTarget(e);
+		if (!target) return;
+
+		e.preventDefault();
+		e.stopPropagation();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+		activeSplitDropTarget = target;
+	}
+
+	function handleActiveSplitDrop(e: DragEvent) {
+		if (!showActiveSplitDropLayer) return;
+		e.preventDefault();
+		e.stopPropagation();
+
+		const target = activeSplitDropTarget ?? resolveActiveSplitDropTarget(e);
+		activeSplitDropTarget = null;
+		if (!target) {
+			splitLayout.endDrag();
+			return;
+		}
+
+		handleSplitDropChat(target.paneId, target.zone);
+	}
+
+	function handleActiveSplitDragLeave(e: DragEvent) {
+		const related = e.relatedTarget as HTMLElement | null;
+		if (!related || !(e.currentTarget as HTMLElement).contains(related)) {
+			activeSplitDropTarget = null;
+		}
+	}
+
+	function getActiveSplitPreviewClass(zone: SplitDropZone): string {
+		if (!activeSplitDropTarget || activeSplitDropTarget.zone !== zone) return 'opacity-0';
+		return 'opacity-100';
+	}
+
+	function getActiveSplitTargetStyle(): string {
+		if (!splitRootEl || !activeSplitDropTarget) return '';
+
+		const rootRect = splitRootEl.getBoundingClientRect();
+		const rect = activeSplitDropTarget.rect;
+		return [
+			`top:${rect.top - rootRect.top}px`,
+			`left:${rect.left - rootRect.left}px`,
+			`width:${rect.width}px`,
+			`height:${rect.height}px`,
+		].join(';');
 	}
 
 	// Keeps sessions.selectedChatId in sync with the split layout's focused pane.
@@ -522,6 +631,55 @@
 							style:height="{focusedOverlayRect.height}px"
 						>
 							<ConversationWorkspace onRegisterSubmit={handleRegisterSubmit} />
+						</div>
+					{/if}
+					{#if showActiveSplitDropLayer}
+						<!-- svelte-ignore a11y_no_static_element_interactions -- drag target only exists during native drag-and-drop -->
+						<div
+							class="absolute inset-0 z-40 pointer-events-auto"
+							data-split-drag-layer
+							ondragover={handleActiveSplitDragOver}
+							ondragleave={handleActiveSplitDragLeave}
+							ondrop={handleActiveSplitDrop}
+							role="region"
+							aria-label="Split view drop target"
+						>
+							<div class={cn(
+								'absolute inset-0 pointer-events-none transition-colors duration-150',
+								activeSplitDropTarget ? 'bg-background/45 backdrop-blur-[1px]' : 'bg-background/20',
+							)}></div>
+							{#if activeSplitDropTarget}
+								<div
+									class="absolute pointer-events-none transition-all duration-150"
+									style={getActiveSplitTargetStyle()}
+								>
+									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('top'), 'inset-x-3 top-3 bottom-[52%]')}>
+										<div class="flex h-full items-center justify-center">
+											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Top</span>
+										</div>
+									</div>
+									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('bottom'), 'inset-x-3 top-[52%] bottom-3')}>
+										<div class="flex h-full items-center justify-center">
+											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Bottom</span>
+										</div>
+									</div>
+									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('left'), 'inset-y-3 left-3 right-[52%]')}>
+										<div class="flex h-full items-center justify-center">
+											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Left</span>
+										</div>
+									</div>
+									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('right'), 'inset-y-3 left-[52%] right-3')}>
+										<div class="flex h-full items-center justify-center">
+											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Right</span>
+										</div>
+									</div>
+									<div class={cn('absolute bg-accent/15 border border-accent/40 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('center'), 'inset-3')}>
+										<div class="flex h-full items-center justify-center">
+											<span class="rounded-md bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent-foreground shadow-sm">Replace</span>
+										</div>
+									</div>
+								</div>
+							{/if}
 						</div>
 					{/if}
 				</div>

--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -25,6 +25,7 @@
 		zone: SplitDropZone;
 		rect: DOMRect;
 		blockedReason?: 'max-panes';
+		focusReason?: 'already-open';
 	};
 
 	// Lazy-loaded tab panels to keep the main chunk lean. Each panel
@@ -274,12 +275,20 @@
 		zone: SplitDropZone,
 		rect: DOMRect,
 	): ActiveSplitDropTarget {
+		const draggedChat = splitLayout.draggedChatId;
+		const isExistingSidebarChat =
+			!!draggedChat &&
+			!splitLayout.draggedPaneId &&
+			splitLayout.panes.some((p) => p.chatId === draggedChat);
 		return {
 			paneId,
 			zone,
 			rect,
+			focusReason: isExistingSidebarChat ? 'already-open' : undefined,
 			blockedReason:
-				splitLayout.paneCount >= 4 && isSplitEdgeZone(zone) ? 'max-panes' : undefined,
+				!isExistingSidebarChat && splitLayout.paneCount >= 4 && isSplitEdgeZone(zone)
+					? 'max-panes'
+					: undefined,
 		};
 	}
 
@@ -366,9 +375,12 @@
 	function getActiveSplitPreviewTone(zone: SplitDropZone): string {
 		if (
 			activeSplitDropTarget?.zone === zone &&
-			activeSplitDropTarget.blockedReason === 'max-panes'
+			(activeSplitDropTarget.blockedReason === 'max-panes' ||
+				activeSplitDropTarget.focusReason === 'already-open')
 		) {
-			return 'bg-destructive/10 border-destructive/40';
+			return activeSplitDropTarget.blockedReason === 'max-panes'
+				? 'bg-destructive/10 border-destructive/40'
+				: 'bg-accent/15 border-accent/40';
 		}
 		return zone === 'center'
 			? 'bg-accent/15 border-accent/40'
@@ -382,6 +394,12 @@
 		) {
 			return '4 panes max';
 		}
+		if (
+			activeSplitDropTarget?.zone === zone &&
+			activeSplitDropTarget.focusReason === 'already-open'
+		) {
+			return 'Already open';
+		}
 		return fallback;
 	}
 
@@ -391,6 +409,12 @@
 			activeSplitDropTarget.blockedReason === 'max-panes'
 		) {
 			return 'bg-destructive/10 text-destructive';
+		}
+		if (
+			activeSplitDropTarget?.zone === zone &&
+			activeSplitDropTarget.focusReason === 'already-open'
+		) {
+			return 'bg-accent/15 text-accent-foreground';
 		}
 		return zone === 'center'
 			? 'bg-accent/15 text-accent-foreground'

--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -24,6 +24,7 @@
 		paneId: string;
 		zone: SplitDropZone;
 		rect: DOMRect;
+		blockedReason?: 'max-panes';
 	};
 
 	// Lazy-loaded tab panels to keep the main chunk lean. Each panel
@@ -257,6 +258,24 @@
 		return 'center';
 	}
 
+	function isSplitEdgeZone(zone: SplitDropZone): boolean {
+		return zone !== 'center';
+	}
+
+	function toActiveSplitDropTarget(
+		paneId: string,
+		zone: SplitDropZone,
+		rect: DOMRect,
+	): ActiveSplitDropTarget {
+		return {
+			paneId,
+			zone,
+			rect,
+			blockedReason:
+				splitLayout.paneCount >= 4 && isSplitEdgeZone(zone) ? 'max-panes' : undefined,
+		};
+	}
+
 	function resolveActiveSplitDropTarget(e: DragEvent): ActiveSplitDropTarget | null {
 		if (!splitRootEl) return null;
 
@@ -272,7 +291,11 @@
 				e.clientY >= rect.top &&
 				e.clientY <= rect.bottom;
 			if (containsPointer) {
-				return { paneId: pane.id, zone: resolveDropZone(rect, e.clientX, e.clientY), rect };
+				return toActiveSplitDropTarget(
+					pane.id,
+					resolveDropZone(rect, e.clientX, e.clientY),
+					rect,
+				);
 			}
 
 			const centerX = rect.left + rect.width / 2;
@@ -284,11 +307,11 @@
 		}
 
 		if (!fallback) return null;
-		return {
-			paneId: fallback.paneId,
-			zone: resolveDropZone(fallback.rect, e.clientX, e.clientY),
-			rect: fallback.rect,
-		};
+		return toActiveSplitDropTarget(
+			fallback.paneId,
+			resolveDropZone(fallback.rect, e.clientX, e.clientY),
+			fallback.rect,
+		);
 	}
 
 	function handleActiveSplitDragOver(e: DragEvent) {
@@ -298,7 +321,7 @@
 
 		e.preventDefault();
 		e.stopPropagation();
-		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+		if (e.dataTransfer) e.dataTransfer.dropEffect = target.blockedReason ? 'none' : 'move';
 		activeSplitDropTarget = target;
 	}
 
@@ -310,6 +333,10 @@
 		const target = activeSplitDropTarget ?? resolveActiveSplitDropTarget(e);
 		activeSplitDropTarget = null;
 		if (!target) {
+			splitLayout.endDrag();
+			return;
+		}
+		if (target.blockedReason) {
 			splitLayout.endDrag();
 			return;
 		}
@@ -327,6 +354,40 @@
 	function getActiveSplitPreviewClass(zone: SplitDropZone): string {
 		if (!activeSplitDropTarget || activeSplitDropTarget.zone !== zone) return 'opacity-0';
 		return 'opacity-100';
+	}
+
+	function getActiveSplitPreviewTone(zone: SplitDropZone): string {
+		if (
+			activeSplitDropTarget?.zone === zone &&
+			activeSplitDropTarget.blockedReason === 'max-panes'
+		) {
+			return 'bg-destructive/10 border-destructive/40';
+		}
+		return zone === 'center'
+			? 'bg-accent/15 border-accent/40'
+			: 'bg-primary/12 border-primary/30';
+	}
+
+	function getActiveSplitPreviewLabel(zone: SplitDropZone, fallback: string): string {
+		if (
+			activeSplitDropTarget?.zone === zone &&
+			activeSplitDropTarget.blockedReason === 'max-panes'
+		) {
+			return '4 panes max';
+		}
+		return fallback;
+	}
+
+	function getActiveSplitPreviewLabelClass(zone: SplitDropZone): string {
+		if (
+			activeSplitDropTarget?.zone === zone &&
+			activeSplitDropTarget.blockedReason === 'max-panes'
+		) {
+			return 'bg-destructive/10 text-destructive';
+		}
+		return zone === 'center'
+			? 'bg-accent/15 text-accent-foreground'
+			: 'bg-primary/10 text-primary';
 	}
 
 	function getActiveSplitTargetStyle(): string {
@@ -653,29 +714,29 @@
 									class="absolute pointer-events-none transition-all duration-150"
 									style={getActiveSplitTargetStyle()}
 								>
-									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('top'), 'inset-x-3 top-3 bottom-[52%]')}>
+									<div class={cn('absolute border rounded-lg transition-opacity duration-150', getActiveSplitPreviewTone('top'), getActiveSplitPreviewClass('top'), 'inset-x-3 top-3 bottom-[52%]')}>
 										<div class="flex h-full items-center justify-center">
-											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Top</span>
+											<span class={cn('rounded-md px-2 py-0.5 text-[10px] font-medium shadow-sm', getActiveSplitPreviewLabelClass('top'))}>{getActiveSplitPreviewLabel('top', 'Top')}</span>
 										</div>
 									</div>
-									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('bottom'), 'inset-x-3 top-[52%] bottom-3')}>
+									<div class={cn('absolute border rounded-lg transition-opacity duration-150', getActiveSplitPreviewTone('bottom'), getActiveSplitPreviewClass('bottom'), 'inset-x-3 top-[52%] bottom-3')}>
 										<div class="flex h-full items-center justify-center">
-											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Bottom</span>
+											<span class={cn('rounded-md px-2 py-0.5 text-[10px] font-medium shadow-sm', getActiveSplitPreviewLabelClass('bottom'))}>{getActiveSplitPreviewLabel('bottom', 'Bottom')}</span>
 										</div>
 									</div>
-									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('left'), 'inset-y-3 left-3 right-[52%]')}>
+									<div class={cn('absolute border rounded-lg transition-opacity duration-150', getActiveSplitPreviewTone('left'), getActiveSplitPreviewClass('left'), 'inset-y-3 left-3 right-[52%]')}>
 										<div class="flex h-full items-center justify-center">
-											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Left</span>
+											<span class={cn('rounded-md px-2 py-0.5 text-[10px] font-medium shadow-sm', getActiveSplitPreviewLabelClass('left'))}>{getActiveSplitPreviewLabel('left', 'Left')}</span>
 										</div>
 									</div>
-									<div class={cn('absolute bg-primary/12 border border-primary/30 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('right'), 'inset-y-3 left-[52%] right-3')}>
+									<div class={cn('absolute border rounded-lg transition-opacity duration-150', getActiveSplitPreviewTone('right'), getActiveSplitPreviewClass('right'), 'inset-y-3 left-[52%] right-3')}>
 										<div class="flex h-full items-center justify-center">
-											<span class="rounded-md bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary shadow-sm">Right</span>
+											<span class={cn('rounded-md px-2 py-0.5 text-[10px] font-medium shadow-sm', getActiveSplitPreviewLabelClass('right'))}>{getActiveSplitPreviewLabel('right', 'Right')}</span>
 										</div>
 									</div>
-									<div class={cn('absolute bg-accent/15 border border-accent/40 rounded-lg transition-opacity duration-150', getActiveSplitPreviewClass('center'), 'inset-3')}>
+									<div class={cn('absolute border rounded-lg transition-opacity duration-150', getActiveSplitPreviewTone('center'), getActiveSplitPreviewClass('center'), 'inset-3')}>
 										<div class="flex h-full items-center justify-center">
-											<span class="rounded-md bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent-foreground shadow-sm">Replace</span>
+											<span class={cn('rounded-md px-2 py-0.5 text-[10px] font-medium shadow-sm', getActiveSplitPreviewLabelClass('center'))}>Replace</span>
 										</div>
 									</div>
 								</div>

--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -199,6 +199,13 @@
 			syncFocusedChatToSessions();
 			return;
 		}
+		const existingPane = splitLayout.panes.find((p) => p.chatId === draggedChat);
+		if (existingPane) {
+			splitLayout.focusPane(existingPane.id);
+			splitLayout.endDrag();
+			syncFocusedChatToSessions();
+			return;
+		}
 		splitLayout.addChatToZone(paneId, draggedChat, zone);
 		splitLayout.endDrag();
 		syncFocusedChatToSessions();

--- a/web/src/lib/components/layout/__tests__/SplitContainerStub.svelte
+++ b/web/src/lib/components/layout/__tests__/SplitContainerStub.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { LayoutNode, PaneNode } from '$lib/stores/split-layout.svelte';
+
+	interface SplitContainerStubProps {
+		node: LayoutNode;
+	}
+
+	let { node }: SplitContainerStubProps = $props();
+
+	function collectPanes(nodeToRead: LayoutNode): PaneNode[] {
+		if (nodeToRead.type === 'pane') return [nodeToRead];
+		return [...collectPanes(nodeToRead.children[0]), ...collectPanes(nodeToRead.children[1])];
+	}
+
+	let panes = $derived(collectPanes(node));
+</script>
+
+<div data-testid="split-container-stub">
+	{#each panes as pane (pane.id)}
+		<div data-pane-id={pane.id} data-pane-body>
+			{pane.chatId}
+		</div>
+	{/each}
+</div>

--- a/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
+++ b/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
@@ -1,12 +1,29 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ConversationWorkspaceStub from './ConversationWorkspaceStub.svelte';
+import SplitContainerStub from './SplitContainerStub.svelte';
 
 vi.mock('$lib/components/chat/ConversationWorkspace.svelte', () => ({
 	default: ConversationWorkspaceStub
 }));
 
+vi.mock('$lib/components/split/SplitContainer.svelte', () => ({
+	default: SplitContainerStub
+}));
+
 import WorkspaceViewTestHarness from './WorkspaceViewTestHarness.svelte';
+
+function dispatchDragEvent(
+	target: HTMLElement,
+	type: 'dragover' | 'drop',
+	position: { clientX: number; clientY: number },
+): void {
+	const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+	Object.defineProperty(event, 'clientX', { value: position.clientX });
+	Object.defineProperty(event, 'clientY', { value: position.clientY });
+	Object.defineProperty(event, 'dataTransfer', { value: { dropEffect: 'move' } });
+	target.dispatchEvent(event);
+}
 
 describe('WorkspaceView header visibility', () => {
 	it('hides the top header on desktop when Show header is disabled on the chat tab', () => {
@@ -103,5 +120,86 @@ describe('WorkspaceView header visibility', () => {
 		expect(container.querySelector('.bg-chat-header')).toBeTruthy();
 		expect(container.querySelector('.bg-chat-tabs-rail')).toBeTruthy();
 		expect(container.querySelector('.bg-chat-tabs-active')).toBeTruthy();
+	});
+
+	it('accepts sidebar chat drops while split mode is already active', async () => {
+		const addChatToZone = vi.fn();
+		const endDrag = vi.fn();
+		const setSelectedChatId = vi.fn();
+		const root = {
+			type: 'split',
+			direction: 'horizontal',
+			ratio: 0.5,
+			children: [
+				{ type: 'pane', id: 'pane-left', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-right', chatId: 'chat-2' },
+			],
+		};
+		const splitLayout = {
+			isEnabled: true,
+			root,
+			focusedPaneId: 'pane-left',
+			draggedChatId: 'chat-3',
+			draggedPaneId: null,
+			panes: [
+				{ type: 'pane', id: 'pane-left', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-right', chatId: 'chat-2' },
+			],
+			focusedChatId: 'chat-1',
+			addChatToZone,
+			endDrag,
+			focusPane: vi.fn(),
+			replacePaneChat: vi.fn(),
+			swapPanes: vi.fn(),
+			closePane: vi.fn(),
+			setRatioByPath: vi.fn(),
+			disable: vi.fn(),
+			enableWithChat: vi.fn(),
+			setGrid: vi.fn(),
+			splitPane: vi.fn(),
+		};
+
+		const { container } = render(WorkspaceViewTestHarness, {
+			activeTab: 'chat',
+			showChatHeader: true,
+			isMobile: false,
+			splitLayout,
+			chatSessions: {
+				selectedChat: {
+					id: 'chat-1',
+					title: 'Header Test Chat',
+					projectPath: '/tmp/header-test',
+				},
+				byId: {},
+				orderedChats: [],
+				setSelectedChatId,
+			},
+		});
+
+		const rightPane = container.querySelector<HTMLElement>('[data-pane-id="pane-right"]');
+		const layer = container.querySelector<HTMLElement>('[data-split-drag-layer]');
+		expect(rightPane).toBeTruthy();
+		expect(layer).toBeTruthy();
+
+		Object.defineProperty(rightPane!, 'getBoundingClientRect', {
+			value: () => ({
+				left: 100,
+				top: 0,
+				right: 200,
+				bottom: 100,
+				width: 100,
+				height: 100,
+				x: 100,
+				y: 0,
+				toJSON: () => ({}),
+			}),
+		});
+
+		dispatchDragEvent(layer!, 'dragover', { clientX: 195, clientY: 50 });
+		dispatchDragEvent(layer!, 'drop', { clientX: 195, clientY: 50 });
+
+		expect(addChatToZone).toHaveBeenCalledWith('pane-right', 'chat-3', 'right');
+		expect(endDrag).toHaveBeenCalledOnce();
+		expect(setSelectedChatId).toHaveBeenCalledWith('chat-1');
 	});
 });

--- a/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
+++ b/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
@@ -204,6 +204,90 @@ describe('WorkspaceView header visibility', () => {
 		expect(setSelectedChatId).toHaveBeenCalledWith('chat-1');
 	});
 
+	it('focuses an existing split pane instead of duplicating a sidebar chat', async () => {
+		const addChatToZone = vi.fn();
+		const endDrag = vi.fn();
+		const focusPane = vi.fn();
+		const setSelectedChatId = vi.fn();
+		const root = {
+			type: 'split',
+			direction: 'horizontal',
+			ratio: 0.5,
+			children: [
+				{ type: 'pane', id: 'pane-left', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-right', chatId: 'chat-2' },
+			],
+		};
+		const splitLayout = {
+			isEnabled: true,
+			root,
+			focusedPaneId: 'pane-left',
+			draggedChatId: 'chat-2',
+			draggedPaneId: null,
+			paneCount: 2,
+			panes: [
+				{ type: 'pane', id: 'pane-left', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-right', chatId: 'chat-2' },
+			],
+			focusedChatId: 'chat-2',
+			addChatToZone,
+			endDrag,
+			focusPane,
+			replacePaneChat: vi.fn(),
+			swapPanes: vi.fn(),
+			closePane: vi.fn(),
+			setRatioByPath: vi.fn(),
+			disable: vi.fn(),
+			enableWithChat: vi.fn(),
+			setGrid: vi.fn(),
+			splitPane: vi.fn(),
+		};
+
+		const { container } = render(WorkspaceViewTestHarness, {
+			activeTab: 'chat',
+			showChatHeader: true,
+			isMobile: false,
+			splitLayout,
+			chatSessions: {
+				selectedChat: {
+					id: 'chat-1',
+					title: 'Header Test Chat',
+					projectPath: '/tmp/header-test',
+				},
+				byId: {},
+				orderedChats: [],
+				setSelectedChatId,
+			},
+		});
+
+		const rightPane = container.querySelector<HTMLElement>('[data-pane-id="pane-right"]');
+		const layer = container.querySelector<HTMLElement>('[data-split-drag-layer]');
+		expect(rightPane).toBeTruthy();
+		expect(layer).toBeTruthy();
+
+		Object.defineProperty(rightPane!, 'getBoundingClientRect', {
+			value: () => ({
+				left: 100,
+				top: 0,
+				right: 200,
+				bottom: 100,
+				width: 100,
+				height: 100,
+				x: 100,
+				y: 0,
+				toJSON: () => ({}),
+			}),
+		});
+
+		dispatchDragEvent(layer!, 'dragover', { clientX: 195, clientY: 50 });
+		dispatchDragEvent(layer!, 'drop', { clientX: 195, clientY: 50 });
+
+		expect(addChatToZone).not.toHaveBeenCalled();
+		expect(focusPane).toHaveBeenCalledWith('pane-right');
+		expect(endDrag).toHaveBeenCalledOnce();
+		expect(setSelectedChatId).toHaveBeenCalledWith('chat-2');
+	});
+
 	it('blocks edge drops when split view already has four panes', async () => {
 		const addChatToZone = vi.fn();
 		const endDrag = vi.fn();

--- a/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
+++ b/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
@@ -280,6 +280,9 @@ describe('WorkspaceView header visibility', () => {
 		});
 
 		dispatchDragEvent(layer!, 'dragover', { clientX: 195, clientY: 50 });
+		await tick();
+		expect(screen.getByText('Already open')).toBeTruthy();
+
 		dispatchDragEvent(layer!, 'drop', { clientX: 195, clientY: 50 });
 
 		expect(addChatToZone).not.toHaveBeenCalled();

--- a/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
+++ b/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import ConversationWorkspaceStub from './ConversationWorkspaceStub.svelte';
 import SplitContainerStub from './SplitContainerStub.svelte';
 
@@ -201,5 +202,96 @@ describe('WorkspaceView header visibility', () => {
 		expect(addChatToZone).toHaveBeenCalledWith('pane-right', 'chat-3', 'right');
 		expect(endDrag).toHaveBeenCalledOnce();
 		expect(setSelectedChatId).toHaveBeenCalledWith('chat-1');
+	});
+
+	it('blocks edge drops when split view already has four panes', async () => {
+		const addChatToZone = vi.fn();
+		const endDrag = vi.fn();
+		const root = {
+			type: 'split',
+			direction: 'horizontal',
+			ratio: 0.5,
+			children: [
+				{
+					type: 'split',
+					direction: 'vertical',
+					ratio: 0.5,
+					children: [
+						{ type: 'pane', id: 'pane-1', chatId: 'chat-1' },
+						{ type: 'pane', id: 'pane-2', chatId: 'chat-2' },
+					],
+				},
+				{
+					type: 'split',
+					direction: 'vertical',
+					ratio: 0.5,
+					children: [
+						{ type: 'pane', id: 'pane-3', chatId: 'chat-3' },
+						{ type: 'pane', id: 'pane-4', chatId: 'chat-4' },
+					],
+				},
+			],
+		};
+		const splitLayout = {
+			isEnabled: true,
+			root,
+			focusedPaneId: 'pane-1',
+			draggedChatId: 'chat-5',
+			draggedPaneId: null,
+			paneCount: 4,
+			panes: [
+				{ type: 'pane', id: 'pane-1', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-2', chatId: 'chat-2' },
+				{ type: 'pane', id: 'pane-3', chatId: 'chat-3' },
+				{ type: 'pane', id: 'pane-4', chatId: 'chat-4' },
+			],
+			focusedChatId: 'chat-1',
+			addChatToZone,
+			endDrag,
+			focusPane: vi.fn(),
+			replacePaneChat: vi.fn(),
+			swapPanes: vi.fn(),
+			closePane: vi.fn(),
+			setRatioByPath: vi.fn(),
+			disable: vi.fn(),
+			enableWithChat: vi.fn(),
+			setGrid: vi.fn(),
+			splitPane: vi.fn(),
+		};
+
+		const { container } = render(WorkspaceViewTestHarness, {
+			activeTab: 'chat',
+			showChatHeader: true,
+			isMobile: false,
+			splitLayout,
+		});
+
+		const pane = container.querySelector<HTMLElement>('[data-pane-id="pane-4"]');
+		const layer = container.querySelector<HTMLElement>('[data-split-drag-layer]');
+		expect(pane).toBeTruthy();
+		expect(layer).toBeTruthy();
+
+		Object.defineProperty(pane!, 'getBoundingClientRect', {
+			value: () => ({
+				left: 100,
+				top: 100,
+				right: 200,
+				bottom: 200,
+				width: 100,
+				height: 100,
+				x: 100,
+				y: 100,
+				toJSON: () => ({}),
+			}),
+		});
+
+		dispatchDragEvent(layer!, 'dragover', { clientX: 195, clientY: 150 });
+		await tick();
+		expect(screen.getByText('4 panes max')).toBeTruthy();
+
+		dispatchDragEvent(layer!, 'drop', { clientX: 195, clientY: 150 });
+
+		expect(addChatToZone).not.toHaveBeenCalled();
+		expect(endDrag).toHaveBeenCalledOnce();
 	});
 });

--- a/web/src/lib/components/layout/__tests__/WorkspaceViewTestHarness.svelte
+++ b/web/src/lib/components/layout/__tests__/WorkspaceViewTestHarness.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import WorkspaceView from '../WorkspaceView.svelte';
-	import { setChatSessions, setModelCatalog, setLocalSettings, setSplitLayout, setAppShell } from '$lib/context';
+	import { setChatSessions, setModelCatalog, setLocalSettings, setSplitLayout, setAppShell, setWs } from '$lib/context';
 	import type { AppTab } from '$lib/types/app';
 
 	interface WorkspaceViewTestHarnessProps {
@@ -9,6 +9,8 @@
 		alwaysFullscreenOnGitPanel?: boolean;
 		isMobile?: boolean;
 		isDesktopFullscreen?: boolean;
+		chatSessions?: unknown;
+		splitLayout?: unknown;
 	}
 
 	let {
@@ -16,16 +18,31 @@
 		showChatHeader,
 		alwaysFullscreenOnGitPanel = true,
 		isMobile = false,
-		isDesktopFullscreen = false
+		isDesktopFullscreen = false,
+		chatSessions,
+		splitLayout,
 	}: WorkspaceViewTestHarnessProps = $props();
 
-	setChatSessions({
-		selectedChat: {
-			id: 'chat-1',
-			title: 'Header Test Chat',
-			projectPath: '/tmp/header-test'
-		}
-	} as never);
+	function getChatSessionsContext(): unknown {
+		return chatSessions ?? {
+			selectedChat: {
+				id: 'chat-1',
+				title: 'Header Test Chat',
+				projectPath: '/tmp/header-test',
+			},
+			byId: {
+				'chat-1': {
+					id: 'chat-1',
+					title: 'Header Test Chat',
+					projectPath: '/tmp/header-test',
+				},
+			},
+			orderedChats: [],
+			setSelectedChatId() {},
+		};
+	}
+
+	setChatSessions(getChatSessionsContext() as never);
 
 	setLocalSettings({
 		get showChatHeader() {
@@ -49,17 +66,26 @@
 			}
 		} as never);
 
-	setSplitLayout({
-		isEnabled: false,
-		root: null,
-		focusedPaneId: null,
-		draggedChatId: null,
-		panes: [],
-		focusedChatId: null,
-	} as never);
+	function getSplitLayoutContext(): unknown {
+		return splitLayout ?? {
+			isEnabled: false,
+			root: null,
+			focusedPaneId: null,
+			draggedChatId: null,
+			draggedPaneId: null,
+			panes: [],
+			focusedChatId: null,
+		};
+	}
+
+	setSplitLayout(getSplitLayoutContext() as never);
 
 	setAppShell({
 		quietRefreshChats() {},
+	} as never);
+
+	setWs({
+		isConnected: false,
 	} as never);
 
 	function handleTabChange(_tab: AppTab): void {


### PR DESCRIPTION
## Summary
- Add an active split-view drop layer so sidebar chat drags have a reliable target even when the focused workspace overlay is above the panes.
- Resolve the hovered pane and edge from pointer geometry, preserving left/right/top/bottom/replace behavior.
- Show an explicit `4 panes max` blocked target at the split limit instead of previewing a valid fifth split that silently no-ops.
- Focus an already-open split pane when its sidebar chat is dragged again, instead of duplicating the same chat in another pane.
- Add component regression coverage for active split drops, duplicate sidebar drags, and the four-pane edge-drop limit.

## Screenshot
https://files.catbox.moe/y2bvyj.png

## Dogfood
- Hosted preview: http://127.0.0.1:19922/chat
- `agent-browser` 0.26.0 installed and used against the preview.
- Verified sidebar drag/drop adds distinct chats up to a four-pane split.
- Verified dragging an already-open sidebar chat keeps pane count at 4 and focuses the existing pane instead of duplicating it.
- Verified an extra sidebar drag at four panes shows `4 panes max` and leaves pane count at 4.
- Browser console contained only Vite debug/HMR logs; `agent-browser errors` returned empty.

## Validation
- bun run --cwd web test src/lib/components/layout/__tests__/WorkspaceView.test.ts
- bun run check
- bun run test
- timeout 120s bun run start --port 0 (build and server boot succeeded at http://0.0.0.0:19464; timeout stopped the test server)
