### PR TITLE
fix(chat): polish conversation padding

### DIFF
--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -98,52 +98,30 @@
 	tabindex={-1}
 	role="log"
 	aria-label="Chat messages"
-	class="h-full overflow-y-auto overflow-x-hidden scrollbar-hide px-0 pt-3 pb-10 sm:pt-4 sm:px-4 sm:pb-12 space-y-2 sm:space-y-3 relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
+	class="h-full overflow-y-auto overflow-x-hidden scrollbar-hide px-3 pt-3 pb-6 sm:px-5 sm:pt-4 sm:pb-8 lg:px-6 relative outline-none focus-visible:ring-2 focus-visible:ring-ring"
 >
-	{#if chatState.isLoadingMessages && chatState.chatMessages.length === 0}
-		<div class="text-center text-muted-foreground mt-8">
-			<div class="flex items-center justify-center space-x-2">
-				<Loader2 class="h-4 w-4 animate-spin" />
-				<p>{m.chat_chat_loading_chat_messages()}</p>
-			</div>
-		</div>
-	{:else if chatState.loadStatus === 'error' && chatState.chatMessages.length === 0}
-		<div class="text-center text-muted-foreground mt-8">
-			<div class="flex items-center justify-center space-x-2">
-				<TriangleAlert class="h-4 w-4 text-destructive" />
-				<p class="text-sm">{m.chat_feed_failed_to_load()}</p>
-			</div>
-			{#if chatState.loadError}
-				<p class="text-xs mt-1 text-muted-foreground/70">{chatState.loadError}</p>
-			{/if}
-			{#if onRetry}
-				<Button
-					variant="outline"
-					size="sm"
-					class="mt-3"
-					onclick={onRetry}
-				>
-					<RefreshCw class="h-3 w-3 mr-1" />
-					{m.chat_feed_retry()}
-				</Button>
-			{/if}
-		</div>
-	{:else if chatState.chatMessages.length === 0}
-		<div class="text-center text-muted-foreground mt-8">
-			<p class="text-sm">{m.chat_messages_no_messages()}</p>
-			<p class="text-xs mt-1">{m.chat_messages_send_first_message()}</p>
-		</div>
-	{:else}
-		{#if chatState.loadStatus === 'error' && chatState.chatMessages.length > 0}
-			<div class="text-center text-sm text-muted-foreground py-2 border-b border-border bg-destructive/5">
-				<div class="flex items-center justify-center space-x-2">
-					<TriangleAlert class="h-3 w-3 text-destructive" />
-					<span>{m.chat_feed_failed_to_refresh()}</span>
+	<div class="mx-auto flex w-full max-w-5xl flex-col gap-2 sm:gap-3">
+			{#if chatState.isLoadingMessages && chatState.chatMessages.length === 0}
+				<div class="text-center text-muted-foreground mt-8">
+					<div class="flex items-center justify-center space-x-2">
+						<Loader2 class="h-4 w-4 animate-spin" />
+						<p>{m.chat_chat_loading_chat_messages()}</p>
+					</div>
+				</div>
+			{:else if chatState.loadStatus === 'error' && chatState.chatMessages.length === 0}
+				<div class="text-center text-muted-foreground mt-8">
+					<div class="flex items-center justify-center space-x-2">
+						<TriangleAlert class="h-4 w-4 text-destructive" />
+						<p class="text-sm">{m.chat_feed_failed_to_load()}</p>
+					</div>
+					{#if chatState.loadError}
+						<p class="text-xs mt-1 text-muted-foreground/70">{chatState.loadError}</p>
+					{/if}
 					{#if onRetry}
 						<Button
-							variant="ghost"
+							variant="outline"
 							size="sm"
-							class="text-xs h-6 px-2"
+							class="mt-3"
 							onclick={onRetry}
 						>
 							<RefreshCw class="h-3 w-3 mr-1" />
@@ -151,83 +129,107 @@
 						</Button>
 					{/if}
 				</div>
-			</div>
-		{/if}
-		{#if chatState.isLoadingMoreMessages}
-			<div class="my-1 flex items-center gap-2 text-xs text-muted-foreground">
-				<div class="h-px flex-1 bg-border/70"></div>
-				<Loader2 class="h-3.5 w-3.5 animate-spin" />
-				<span>{m.chat_chat_loading_older_messages()}</span>
-				<div class="h-px flex-1 bg-border/70"></div>
-			</div>
-		{/if}
-
-		{#if chatState.hasMoreMessages && !chatState.isLoadingMoreMessages}
-			<div class="my-1 flex items-center gap-2 text-xs text-muted-foreground">
-				<div class="h-px flex-1 bg-border/70"></div>
-				{#if chatState.totalMessages > 0}
-					<span>
-						{m.chat_chat_messages_showing_of({ shown: chatState.chatMessages.length, total: chatState.totalMessages })}
-						| {m.chat_chat_messages_scroll_to_load()}
-					</span>
-				{/if}
-				<div class="h-px flex-1 bg-border/70"></div>
-			</div>
-		{/if}
-
-		{#if !chatState.hasMoreMessages && chatState.chatMessages.length > chatState.visibleMessageCount}
-			<div class="my-1 flex items-center gap-2 text-xs text-muted-foreground">
-				<div class="h-px flex-1 bg-border/70"></div>
-				<span>
-					{m.chat_chat_messages_showing_last({ count: chatState.visibleMessageCount, total: chatState.chatMessages.length })}
-				</span>
-				<Button
-					variant="link"
-					class="text-primary hover:text-primary/80 underline p-0 h-auto text-xs"
-					onclick={() => chatState.loadEarlierMessages()}
-				>
-					{m.chat_chat_messages_load_earlier()}
-				</Button>
-				<div class="h-px flex-1 bg-border/70"></div>
-			</div>
-		{/if}
-
-		{#each chatState.visibleMessages as message, index (getMessageId(message))}
-			{@const isToolResult = message instanceof ToolResultMessage}
-			{@const isPermissionTerminal = message instanceof PermissionResolvedMessage || message instanceof PermissionCancelledMessage}
-			{@const isServerExitPlanPermission = message instanceof PermissionRequestMessage && message.requestedTool.type === 'exit-plan-mode-tool-use'}
-			{#if !isToolResult && !isPermissionTerminal && !isServerExitPlanPermission}
-				{@const prevMessage = index > 0 ? chatState.visibleMessages[index - 1] : null}
-				{@const toolResult = isToolUseMessage(message)
-					? toolResultIndex.get(message.toolId)
-					: undefined}
-				{@const exitPlanId = message.type === 'exit-plan-mode-tool-use'
-					? `plan-exit-${message.toolId}`
-					: null}
-				{@const permTerminal = message instanceof PermissionRequestMessage
-					? permissionTerminalById.get(message.permissionRequestId)
-					: exitPlanId
-						? (pendingExitPlanIds.has(exitPlanId) ? undefined : { state: 'resolved' as const, allowed: true })
-						: undefined}
-				<svelte:boundary>
-					<ConversationMessage
-						{message}
-						{index}
-						{prevMessage}
-						{toolResult}
-						permissionTerminal={permTerminal}
-						{onPermissionDecision}
-						{onExitPlanMode}
-						provider={providerState.provider}
-						showThinking={localSettings.showThinking}
-					/>
-					{#snippet failed(error)}
-						<div class="px-4 py-2 text-sm text-destructive bg-destructive/10 rounded border border-destructive/20">
-							Failed to render message{error instanceof Error ? `: ${error.message}` : ''}
+			{:else if chatState.chatMessages.length === 0}
+				<div class="text-center text-muted-foreground mt-8">
+					<p class="text-sm">{m.chat_messages_no_messages()}</p>
+					<p class="text-xs mt-1">{m.chat_messages_send_first_message()}</p>
+				</div>
+			{:else}
+				{#if chatState.loadStatus === 'error' && chatState.chatMessages.length > 0}
+					<div class="text-center text-sm text-muted-foreground py-2 border-b border-border bg-destructive/5">
+						<div class="flex items-center justify-center space-x-2">
+							<TriangleAlert class="h-3 w-3 text-destructive" />
+							<span>{m.chat_feed_failed_to_refresh()}</span>
+							{#if onRetry}
+								<Button
+									variant="ghost"
+									size="sm"
+									class="text-xs h-6 px-2"
+									onclick={onRetry}
+								>
+									<RefreshCw class="h-3 w-3 mr-1" />
+									{m.chat_feed_retry()}
+								</Button>
+							{/if}
 						</div>
-					{/snippet}
-				</svelte:boundary>
+					</div>
+				{/if}
+				{#if chatState.isLoadingMoreMessages}
+					<div class="my-1 flex items-center gap-2 text-xs text-muted-foreground">
+						<div class="h-px flex-1 bg-border/70"></div>
+						<Loader2 class="h-3.5 w-3.5 animate-spin" />
+						<span>{m.chat_chat_loading_older_messages()}</span>
+						<div class="h-px flex-1 bg-border/70"></div>
+					</div>
+				{/if}
+
+				{#if chatState.hasMoreMessages && !chatState.isLoadingMoreMessages}
+					<div class="my-1 flex items-center gap-2 text-xs text-muted-foreground">
+						<div class="h-px flex-1 bg-border/70"></div>
+						{#if chatState.totalMessages > 0}
+							<span>
+								{m.chat_chat_messages_showing_of({ shown: chatState.chatMessages.length, total: chatState.totalMessages })}
+								| {m.chat_chat_messages_scroll_to_load()}
+							</span>
+						{/if}
+						<div class="h-px flex-1 bg-border/70"></div>
+					</div>
+				{/if}
+
+				{#if !chatState.hasMoreMessages && chatState.chatMessages.length > chatState.visibleMessageCount}
+					<div class="my-1 flex items-center gap-2 text-xs text-muted-foreground">
+						<div class="h-px flex-1 bg-border/70"></div>
+						<span>
+							{m.chat_chat_messages_showing_last({ count: chatState.visibleMessageCount, total: chatState.chatMessages.length })}
+						</span>
+						<Button
+							variant="link"
+							class="text-primary hover:text-primary/80 underline p-0 h-auto text-xs"
+							onclick={() => chatState.loadEarlierMessages()}
+						>
+							{m.chat_chat_messages_load_earlier()}
+						</Button>
+						<div class="h-px flex-1 bg-border/70"></div>
+					</div>
+				{/if}
+
+				{#each chatState.visibleMessages as message, index (getMessageId(message))}
+					{@const isToolResult = message instanceof ToolResultMessage}
+					{@const isPermissionTerminal = message instanceof PermissionResolvedMessage || message instanceof PermissionCancelledMessage}
+					{@const isServerExitPlanPermission = message instanceof PermissionRequestMessage && message.requestedTool.type === 'exit-plan-mode-tool-use'}
+					{#if !isToolResult && !isPermissionTerminal && !isServerExitPlanPermission}
+						{@const prevMessage = index > 0 ? chatState.visibleMessages[index - 1] : null}
+						{@const toolResult = isToolUseMessage(message)
+							? toolResultIndex.get(message.toolId)
+							: undefined}
+						{@const exitPlanId = message.type === 'exit-plan-mode-tool-use'
+							? `plan-exit-${message.toolId}`
+							: null}
+						{@const permTerminal = message instanceof PermissionRequestMessage
+							? permissionTerminalById.get(message.permissionRequestId)
+							: exitPlanId
+								? (pendingExitPlanIds.has(exitPlanId) ? undefined : { state: 'resolved' as const, allowed: true })
+								: undefined}
+						<svelte:boundary>
+							<ConversationMessage
+								{message}
+								{index}
+								{prevMessage}
+								{toolResult}
+								permissionTerminal={permTerminal}
+								{onPermissionDecision}
+								{onExitPlanMode}
+								provider={providerState.provider}
+								showThinking={localSettings.showThinking}
+							/>
+							{#snippet failed(error)}
+								<div class="px-4 py-2 text-sm text-destructive bg-destructive/10 rounded border border-destructive/20">
+									Failed to render message{error instanceof Error ? `: ${error.message}` : ''}
+								</div>
+							{/snippet}
+						</svelte:boundary>
+					{/if}
+				{/each}
 			{/if}
-		{/each}
-	{/if}
-</div>
+		</div>
+	</div>

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -177,7 +177,7 @@
 
 {#if !shouldHideThinking}
 	<div
-		class="chat-message {cssType} {isGrouped ? 'grouped' : ''} {message instanceof UserMessage ? 'flex justify-start px-3 sm:px-0 min-w-0' : 'px-3 sm:px-0'}"
+		class="chat-message {cssType} {isGrouped ? 'grouped' : ''} {message instanceof UserMessage ? 'flex justify-start min-w-0' : ''}"
 	>
 			{#if asUser}
 				<div class="flex items-end w-full sm:w-auto sm:max-w-[85%] min-w-0">

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -269,11 +269,12 @@
 	});
 </script>
 
-<div class="flex-shrink-0">
-		<div data-composer class="relative bg-card border-t border-border pb-1 sm:pb-2">
-		{#if !appShell.isMobile}
-			<!-- Invisible resize grab zone above the composer (desktop only) -->
-			<!-- svelte-ignore a11y_no_static_element_interactions -- pointer drag handle -->
+<div class="flex-shrink-0 bg-background px-3 pb-2 pt-2 sm:px-5 sm:pb-4 lg:px-6">
+	<div class="mx-auto w-full max-w-5xl">
+		<div data-composer class="relative overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+			{#if !appShell.isMobile}
+				<!-- Invisible resize grab zone above the composer (desktop only) -->
+				<!-- svelte-ignore a11y_no_static_element_interactions -- pointer drag handle -->
 			<div
 				onpointerdown={handleResizeStart}
 				class="absolute left-0 right-0 -top-1 h-3 cursor-row-resize z-10 touch-none"
@@ -304,8 +305,8 @@
 					</div>
 				{/if}
 
-				{#if composerState.images.length > 0}
-					<div class="mb-2 p-2 bg-muted/40 rounded-lg">
+					{#if composerState.images.length > 0}
+						<div class="mx-2 mt-2 p-2 bg-muted/40 rounded-lg">
 						<div class="flex flex-wrap gap-2">
 							{#each composerState.images as file, idx (file.name + idx)}
 								<div class="relative group">
@@ -364,10 +365,10 @@
 							onfocus={() => appShell.requestSidebarRecenterToSelected()}
 							placeholder={m.chat_composer_reply_placeholder()}
 							disabled={isDisabled}
-								class="block w-full px-4 py-1.5 sm:py-3 bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-ring text-foreground placeholder:text-muted-foreground disabled:opacity-50 resize-none min-h-[44px] max-h-[40vh] sm:max-h-[500px] overflow-y-auto text-base leading-6 transition-all duration-200"
-								style:min-height={appShell.isMobile ? undefined : `${composerHeight}px`}
-							></textarea>
-					</div>
+							class="block w-full px-4 py-2.5 sm:px-5 sm:py-4 bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-ring text-foreground placeholder:text-muted-foreground disabled:opacity-50 resize-none min-h-[48px] max-h-[40vh] sm:max-h-[500px] overflow-y-auto text-base leading-6 transition-all duration-200"
+							style:min-height={appShell.isMobile ? undefined : `${composerHeight}px`}
+						></textarea>
+				</div>
 				</div>
 
 				<ComposerBottomBar
@@ -402,5 +403,6 @@
 						{/snippet}
 					</ComposerBottomBar>
 				</form>
+			</div>
 		</div>
 	</div>

--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -695,7 +695,7 @@
 		<div class="flex-1 min-h-0 overflow-hidden">
 			{#if splitLayout.isEnabled && splitLayout.root && activeTab === 'chat'}
 				<!-- svelte-ignore a11y_no_static_element_interactions -- container tracks focused pane rect -->
-				<div class="h-full relative" bind:this={splitRootEl}>
+				<div class={cn('h-full relative', showFloatingDesktopTabs && 'pt-12')} bind:this={splitRootEl}>
 					<SplitContainer
 						node={splitLayout.root}
 						focusedPaneId={splitLayout.focusedPaneId}
@@ -778,7 +778,7 @@
 			{:else}
 				<!-- svelte-ignore a11y_no_static_element_interactions -- drop target for initiating split mode -->
 				<div
-					class="h-full relative"
+					class={cn('h-full relative', showFloatingDesktopTabs && 'pt-12')}
 					class:hidden={activeTab !== 'chat'}
 					ondragover={handleWorkspaceDragOver}
 					ondragleave={handleWorkspaceDragLeave}


### PR DESCRIPTION
## Summary

- Centers the conversation feed and composer in a shared `max-w-5xl` content column.
- Adds responsive chat gutters so desktop and mobile no longer feel edge-to-edge.
- Converts the composer from a full-width top-border strip into an inset rounded input surface.
- Reserves top space for floating desktop tabs so they do not overlap the first chat content.

## Dogfood

Dogfooded against a seeded local workspace on separate ports from the user's running app. The before pass showed the composer touching the window edge, inconsistent feed/composer widths, and floating tabs sitting on top of early chat content. The after pass verified the transcript and composer align as one column on desktop and mobile, with the input surface inset from the viewport.

Desktop before:

![Desktop before](https://files.catbox.moe/nh1ohs.png)

Desktop after:

![Desktop after](https://files.catbox.moe/9xprgb.png)

Mobile before:

![Mobile before](https://files.catbox.moe/z4a6fk.png)

Mobile after:

![Mobile after](https://files.catbox.moe/6gsyhl.png)

## Validation

- `bun run check`
- `bun run test 2>&1 | tee /tmp/garcon-padding-test.log`
- `GARCON_CONFIG_DIR=/tmp/garcon-dogfood-config GARCON_WORKSPACE=padding GARCON_DISABLE_AUTH=1 bun run start -- --port 18172 --project-base-dir /tmp/garcon-polish-chat-padding`
- Manual desktop and mobile dogfood screenshots captured from the hosted local app.

Build/startup emitted the existing large chunk-size warnings only.
