### PR TITLE
fix: tighten PWA composer padding

### DIFF
--- a/web/src/lib/components/chat/ComposerBottomBar.svelte
+++ b/web/src/lib/components/chat/ComposerBottomBar.svelte
@@ -58,7 +58,7 @@
 		);
 	</script>
 
-<div class="mt-1 pt-1.5 px-2 pb-[env(safe-area-inset-bottom)]">
+<div class="mt-1 px-2 py-1.5">
 	<div class="flex min-w-0 flex-wrap items-center gap-2">
 		<div class="flex min-w-0 grow flex-wrap items-center gap-2">
 			<DropdownMenu>


### PR DESCRIPTION
## Summary
- Keeps PWA safe-area ownership on the bottom tab bar instead of the composer control row.
- Replaces the composer bottom row's `env(safe-area-inset-bottom)` padding with fixed symmetric padding.

## Why
The mobile composer and bottom tab bar both reserved bottom safe-area space. In PWA mode this makes the composer controls float too high and leaves the bottom of the composer looking over-padded above the nav.

## Screenshots
Before:

![Before PWA composer padding](https://files.catbox.moe/jtaxn0.png)

After:

![After PWA composer padding](https://files.catbox.moe/red8ov.png)

## Validation
- `bun run check`
- `bun run test`
- `bun run start --port 0 --disable-auth`
- GitHub Actions: `server-tests`, `web-tests`, `build-exe`
