### PR TITLE
fix: preserve scroll position when loading older messages

### DIFF
--- a/web/src/lib/chat/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/__tests__/conversation-scroll-controller.test.ts
@@ -96,6 +96,57 @@ describe('ConversationScrollController', () => {
 		cleanup?.();
 	});
 
+	it('preserves the viewport anchor after older messages render', async () => {
+		const scroller = { scrollTop: 40, scrollHeight: 800, clientHeight: 400 } as HTMLDivElement;
+		const chatState = {
+			isUserScrolledUp: true,
+			loadMoreMessages: vi.fn(async () => {
+				Object.defineProperty(scroller, 'scrollHeight', { value: 1100, configurable: true });
+				return true;
+			}),
+		};
+
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: chatState as never,
+			sessions: { selectedChatId: 'chat-1' },
+		});
+
+		controller.isPinnedToBottom = false;
+		await controller.loadMoreMessagesPreservingAnchor('chat-1', 800, 40);
+
+		expect(chatState.loadMoreMessages).toHaveBeenCalledWith('chat-1');
+		expect(scroller.scrollTop).toBe(340);
+		expect(chatState.isUserScrolledUp).toBe(true);
+		expect(controller.isPinnedToBottom).toBe(false);
+	});
+
+	it('does not restore an older-message anchor after switching chats', async () => {
+		const scroller = { scrollTop: 40, scrollHeight: 800, clientHeight: 400 } as HTMLDivElement;
+		const sessions = { selectedChatId: 'chat-1' };
+		const chatState = {
+			isUserScrolledUp: true,
+			loadMoreMessages: vi.fn(async () => {
+				sessions.selectedChatId = 'chat-2';
+				Object.defineProperty(scroller, 'scrollHeight', { value: 1100, configurable: true });
+				return true;
+			}),
+		};
+
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: chatState as never,
+			sessions,
+		});
+
+		await controller.loadMoreMessagesPreservingAnchor('chat-1', 800, 40);
+
+		expect(scroller.scrollTop).toBe(40);
+		expect(chatState.loadMoreMessages).toHaveBeenCalledWith('chat-1');
+	});
+
 	it('keeps the viewport pinned to bottom when the scroll container height changes', () => {
 		const scrollToBottom = vi.spyOn(ConversationScrollController.prototype, 'scrollToBottom');
 		const scroller = { scrollTop: 120, scrollHeight: 800, clientHeight: 520 } as HTMLDivElement;

--- a/web/src/lib/chat/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/conversation-scroll-controller.svelte.ts
@@ -2,15 +2,16 @@
 // near-bottom detection, pinned-to-bottom state, infinite scroll
 // loading, and layout resize reconciliation.
 
-	import { reconcileScrollAfterHeightDelta } from '$lib/chat/scroll-anchor';
-	import type { ChatState } from '$lib/chat/state.svelte';
+import { tick } from 'svelte';
+import { reconcileScrollAfterHeightDelta } from '$lib/chat/scroll-anchor';
+import type { ChatState } from '$lib/chat/state.svelte';
 
 export interface ScrollControllerDeps {
 	getScrollContainer: () => HTMLDivElement | null;
-		getQueueContainer: () => HTMLDivElement | undefined;
-		chatState: ChatState;
-		sessions: { selectedChatId: string | null };
-	}
+	getQueueContainer: () => HTMLDivElement | undefined;
+	chatState: ChatState;
+	sessions: { selectedChatId: string | null };
+}
 
 export class ConversationScrollController {
 	isPinnedToBottom = $state(true);
@@ -40,9 +41,9 @@ export class ConversationScrollController {
 
 		this.isScrollingToTop = true;
 		try {
-				if (this.deps.chatState.hasMoreMessages) {
-					await this.deps.chatState.loadAllMessages(chatId);
-				}
+			if (this.deps.chatState.hasMoreMessages) {
+				await this.deps.chatState.loadAllMessages(chatId);
+			}
 			const node = this.deps.getScrollContainer();
 			if (node) node.scrollTop = 0;
 		} finally {
@@ -60,17 +61,26 @@ export class ConversationScrollController {
 		if (node.scrollTop < 100 && this.deps.chatState.hasMoreMessages) {
 			const chatId = this.deps.sessions.selectedChatId;
 			if (chatId) {
-				const prevHeight = node.scrollHeight;
-				const prevTop = node.scrollTop;
-					this.deps.chatState.loadMoreMessages(chatId).then((loaded) => {
-					const container = this.deps.getScrollContainer();
-					if (loaded && container) {
-						const newHeight = container.scrollHeight;
-						container.scrollTop = prevTop + (newHeight - prevHeight);
-					}
-				});
+				void this.loadMoreMessagesPreservingAnchor(chatId, node.scrollHeight, node.scrollTop);
 			}
 		}
+	}
+
+	async loadMoreMessagesPreservingAnchor(chatId: string, prevHeight: number, prevTop: number): Promise<void> {
+		const loaded = await this.deps.chatState.loadMoreMessages(chatId);
+		if (!loaded) return;
+		if (this.deps.sessions.selectedChatId !== chatId) return;
+
+		await tick();
+		if (this.deps.sessions.selectedChatId !== chatId) return;
+
+		const container = this.deps.getScrollContainer();
+		if (!container) return;
+
+		const newHeight = container.scrollHeight;
+		container.scrollTop = prevTop + (newHeight - prevHeight);
+		this.deps.chatState.isUserScrolledUp = true;
+		this.isPinnedToBottom = false;
 	}
 
 	// Creates a ResizeObserver for the queue controls container that

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -245,9 +245,11 @@
 	// calls from loadChat fire against an undefined container.
 	$effect(() => {
 		const _container = scrollContainer;
-		if (_container && chatState.displayMessageCount > 0) {
-			requestAnimationFrame(() => scroll.scrollToBottom());
-		}
+		untrack(() => {
+			if (_container && chatState.displayMessageCount > 0 && localSettings.autoScrollToBottom) {
+				requestAnimationFrame(() => scroll.scrollToBottom());
+			}
+		});
 	});
 
 	// Preserves viewport anchoring when queue controls change height.


### PR DESCRIPTION
## Summary
- stop the chat mount autoscroll effect from retriggering when older messages are prepended
- preserve the viewport anchor after load-more waits for Svelte to flush rendered messages
- guard anchor restoration if the user switches chats while older messages are still loading
- add regression coverage for anchor preservation and stale chat-switch behavior

## Review fix
- Rebased onto current cfal/garcon main.
- Added a selected-chat guard around the async anchor restore path so a completed older-message load cannot mutate the next chat's scroll position after navigation.

## Validation
- bun run --cwd web test -- src/lib/chat/__tests__/conversation-scroll-controller.test.ts src/lib/chat/__tests__/conversation-feed-items.test.ts
- bun run --cwd web i18n:compile
- bun run check
- bun run test
- timeout 30s bun run start --port 0