### PR TITLE
fix: keep sidebar bulk delete visible

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -48,6 +48,10 @@
 		--color-sidebar-badge-archived-bg: hsl(var(--sidebar-badge-archived-bg));
 		--color-sidebar-badge-archived-foreground: hsl(var(--sidebar-badge-archived-foreground));
 		--color-sidebar-badge-archived-border: hsl(var(--sidebar-badge-archived-border));
+		--color-sidebar-bulk-archive-bg: hsl(var(--sidebar-bulk-archive-bg));
+		--color-sidebar-bulk-archive-foreground: hsl(var(--sidebar-bulk-archive-foreground));
+		--color-sidebar-bulk-unarchive-bg: hsl(var(--sidebar-bulk-unarchive-bg));
+		--color-sidebar-bulk-unarchive-foreground: hsl(var(--sidebar-bulk-unarchive-foreground));
 		--color-provider-codex-bg: hsl(var(--provider-codex-bg));
 	--color-provider-codex-foreground: hsl(var(--provider-codex-foreground));
 	--color-provider-codex-border: hsl(var(--provider-codex-border));
@@ -199,6 +203,10 @@
 		--sidebar-badge-archived-bg: 215 20% 94%;
 		--sidebar-badge-archived-foreground: 215 18% 35%;
 		--sidebar-badge-archived-border: 215 16% 80%;
+		--sidebar-bulk-archive-bg: 146 60% 95%;
+		--sidebar-bulk-archive-foreground: 146 65% 24%;
+		--sidebar-bulk-unarchive-bg: 0 86% 96%;
+		--sidebar-bulk-unarchive-foreground: 0 74% 38%;
 		--provider-codex-bg: 146 48% 94%;
 	--provider-codex-foreground: 146 70% 22%;
 	--provider-codex-border: 146 35% 78%;
@@ -374,6 +382,10 @@
 		--sidebar-badge-archived-bg: 215 18% 22%;
 		--sidebar-badge-archived-foreground: 215 22% 76%;
 		--sidebar-badge-archived-border: 215 14% 34%;
+		--sidebar-bulk-archive-bg: 146 36% 24%;
+		--sidebar-bulk-archive-foreground: 146 76% 86%;
+		--sidebar-bulk-unarchive-bg: 0 34% 24%;
+		--sidebar-bulk-unarchive-foreground: 0 82% 86%;
 		--provider-codex-bg: 146 38% 22%;
 	--provider-codex-foreground: 146 70% 85%;
 	--provider-codex-border: 146 32% 36%;

--- a/web/src/lib/components/sidebar/SidebarSelectionBar.svelte
+++ b/web/src/lib/components/sidebar/SidebarSelectionBar.svelte
@@ -73,75 +73,112 @@
 		<Button
 			variant="ghost"
 			size="sm"
-			class="h-7 px-2.5 text-xs font-medium gap-1"
+			class="selection-action-button h-7 px-2.5 text-xs font-medium gap-1"
 			onclick={onDone}
 			disabled={isOperating}
+			aria-label={m.sidebar_select_done()}
+			title={m.sidebar_select_done()}
 		>
-			<Check class="size-3.5" />
-			{m.sidebar_select_done()}
+			<Check class="size-3.5 shrink-0" />
+			<span class="selection-action-label">{m.sidebar_select_done()}</span>
 		</Button>
 	</div>
 
 	<!-- Bottom row: action buttons -->
-	<div class="flex items-center gap-1">
+	<div class="selection-action-row flex items-center gap-1">
 		{#if showPin}
 			<Button
 				variant="ghost"
 				size="sm"
-				class="h-7 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
+				class="selection-action-button h-7 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
 				onclick={onPin}
 				disabled={isOperating || count === 0}
+				aria-label={m.sidebar_select_pin()}
+				title={m.sidebar_select_pin()}
 			>
-				<Pin class="size-3.5" />
-				{m.sidebar_select_pin()}
+				<Pin class="size-3.5 shrink-0" />
+				<span class="selection-action-label">{m.sidebar_select_pin()}</span>
 			</Button>
 		{/if}
 		{#if showUnpin}
 			<Button
 				variant="ghost"
 				size="sm"
-				class="h-7 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
+				class="selection-action-button h-7 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
 				onclick={onUnpin}
 				disabled={isOperating || count === 0}
+				aria-label={m.sidebar_select_unpin()}
+				title={m.sidebar_select_unpin()}
 			>
-				<Pin class="size-3.5" />
-				{m.sidebar_select_unpin()}
+				<Pin class="size-3.5 shrink-0" />
+				<span class="selection-action-label">{m.sidebar_select_unpin()}</span>
 			</Button>
 		{/if}
 		{#if showArchive}
 			<Button
 				variant="ghost"
 				size="sm"
-				class="h-7 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
+				class="selection-action-button h-7 px-2 text-xs gap-1 text-sidebar-bulk-archive-foreground hover:text-sidebar-bulk-archive-foreground hover:bg-sidebar-bulk-archive-bg"
 				onclick={onArchive}
 				disabled={isOperating || count === 0}
+				aria-label={m.sidebar_select_archive()}
+				title={m.sidebar_select_archive()}
 			>
-				<Archive class="size-3.5" />
-				{m.sidebar_select_archive()}
+				<Archive class="size-3.5 shrink-0" />
+				<span class="selection-action-label">{m.sidebar_select_archive()}</span>
 			</Button>
 		{/if}
 		{#if showUnarchive}
 			<Button
 				variant="ghost"
 				size="sm"
-				class="h-7 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
+				class="selection-action-button h-7 px-2 text-xs gap-1 text-sidebar-bulk-unarchive-foreground hover:text-sidebar-bulk-unarchive-foreground hover:bg-sidebar-bulk-unarchive-bg"
 				onclick={onUnarchive}
 				disabled={isOperating || count === 0}
+				aria-label={m.sidebar_select_unarchive()}
+				title={m.sidebar_select_unarchive()}
 			>
-				<Archive class="size-3.5" />
-				{m.sidebar_select_unarchive()}
+				<Archive class="size-3.5 shrink-0" />
+				<span class="selection-action-label">{m.sidebar_select_unarchive()}</span>
 			</Button>
 		{/if}
 		<div class="flex-1"></div>
 		<Button
 			variant="ghost"
 			size="sm"
-			class="h-7 px-2 text-xs gap-1 text-destructive hover:text-destructive hover:bg-destructive/10"
+			class="selection-action-button h-7 px-2 text-xs gap-1 text-destructive hover:text-destructive hover:bg-destructive/10"
 			onclick={onDelete}
 			disabled={isOperating || count === 0}
+			aria-label={m.sidebar_select_delete()}
+			title={m.sidebar_select_delete()}
 		>
-			<Trash2 class="size-3.5" />
-			{m.sidebar_select_delete()}
+			<Trash2 class="size-3.5 shrink-0" />
+			<span class="selection-action-label">{m.sidebar_select_delete()}</span>
 		</Button>
 	</div>
 </div>
+
+<style>
+	:global(.selection-action-button) {
+		flex: 0 0 auto;
+	}
+
+	:global(.selection-action-label) {
+		white-space: nowrap;
+	}
+
+	.selection-action-row {
+		container-type: inline-size;
+	}
+
+	@container (max-width: 24rem) {
+		:global(.selection-action-row .selection-action-button) {
+			width: 1.75rem;
+			padding-inline: 0;
+		}
+
+		:global(.selection-action-row .selection-action-label) {
+			display: none;
+		}
+	}
+</style>

--- a/web/src/lib/components/sidebar/__tests__/SidebarSelectionBar.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/SidebarSelectionBar.test.ts
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import SidebarSelectionBar from '../SidebarSelectionBar.svelte';
+
+function renderSelectionBar() {
+	return render(SidebarSelectionBar, {
+		count: 64,
+		totalVisible: 64,
+		showPin: true,
+		showUnpin: false,
+		showArchive: true,
+		showUnarchive: true,
+		isOperating: false,
+		onSelectAll: vi.fn(),
+		onDeselectAll: vi.fn(),
+		onPin: vi.fn(),
+		onUnpin: vi.fn(),
+		onArchive: vi.fn(),
+		onUnarchive: vi.fn(),
+		onDelete: vi.fn(),
+		onDone: vi.fn(),
+	});
+}
+
+describe('SidebarSelectionBar', () => {
+	it('keeps compact action buttons accessible when labels collapse', () => {
+		renderSelectionBar();
+
+		for (const label of ['Pin', 'Archive', 'Unarchive', 'Delete']) {
+			const button = screen.getByRole('button', { name: label });
+			expect(button.classList.contains('selection-action-button')).toBe(true);
+			expect(button.getAttribute('title')).toBe(label);
+		}
+	});
+
+	it('uses distinct semantic colors for archive and unarchive actions', () => {
+		renderSelectionBar();
+
+		expect(screen.getByRole('button', { name: 'Archive' }).className).toContain(
+			'text-sidebar-bulk-archive-foreground'
+		);
+		expect(screen.getByRole('button', { name: 'Unarchive' }).className).toContain(
+			'text-sidebar-bulk-unarchive-foreground'
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Collapse bulk-selection action labels to icon-only buttons when the sidebar action row is narrow
- Keep every compact action accessible with stable aria-label/title text
- Give Archive and Unarchive distinct semantic action colors: light green for Archive, light red for Unarchive
- Add focused SidebarSelectionBar tests for compact action accessibility and action color classes

## Screenshots
- Before: https://files.catbox.moe/g3pdnq.png
- After: https://files.catbox.moe/bxbl3s.png

## Validation
- `cd web && bunx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide`
- `bun run check`
- `bun run test`
- `timeout 45s bun run start --port 0`
