### PR TITLE
[codex] test: close worktree dialog in new chat form test

### DIFF
--- a/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
@@ -58,6 +58,11 @@ function makeSnapshot(overrides: Partial<RemoteSettingsSnapshot> = {}): RemoteSe
 		};
 	}
 
+function waitForDialogTeardown(): Promise<void> {
+	// Bits UI restores body scroll styles on a delayed timer after dialog close.
+	return new Promise((resolve) => window.setTimeout(resolve, 30));
+}
+
 describe('NewChatForm', () => {
 	it('shows a centered spinner and hides the composer until settings load', async () => {
 		const pending = deferred<Awaited<ReturnType<typeof settingsApi.getRemoteSettings>>>();
@@ -116,6 +121,12 @@ describe('NewChatForm', () => {
 		const worktreeDialog = await screen.findByRole('dialog', { name: 'Select worktree' });
 		expect(worktreeDialog).toBeTruthy();
 		expect(worktreeDialog.textContent).toContain('New worktree');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+		await waitFor(() => {
+			expect(screen.queryByRole('dialog', { name: 'Select worktree' })).toBeNull();
+		});
+		await waitForDialogTeardown();
 	});
 
 });


### PR DESCRIPTION
## Summary
- Fixes the Build Executable workflow failure from https://github.com/cfal/garcon/actions/runs/26933445809/job/79457762950.
- Closes the worktree picker dialog in NewChatForm.test.ts before the test finishes.
- Waits for Bits UI delayed body scroll-lock cleanup so Vitest does not tear down happy-dom while a cleanup timer can still touch document.

## Root cause
The CI test run passed all test files, then failed on an unhandled ReferenceError: document is not defined from bits-ui/dist/internal/body-scroll-lock.svelte.js. The New Chat form test opened the worktree dialog and left dialog cleanup to test teardown, which could outlive the DOM environment on CI.

## Validation
- bun run --cwd web test src/lib/components/chat/__tests__/NewChatForm.test.ts
- bun run check
- bun run test
- timeout 90s bun run start --port 0; server reached Started at http://0.0.0.0:62913 before timeout shutdown
