### PR TITLE
[codex] add agent orchestration API

### DIFF
--- a/common/agent-orchestration.ts
+++ b/common/agent-orchestration.ts
@@ -1,0 +1,77 @@
+// Shared contracts for Garcon-owned child-agent orchestration.
+
+import type {
+  AmpAgentMode,
+  ClaudeThinkingMode,
+  PermissionMode,
+  ThinkingMode,
+} from './chat-modes.js';
+
+export type AgentOrchestrationChildStatus =
+  | 'starting'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'aborted';
+
+export interface AgentOrchestrationTaskRequest {
+  taskName: string;
+  prompt: string;
+  role?: string;
+  model?: string;
+  permissionMode?: PermissionMode;
+  thinkingMode?: ThinkingMode;
+  claudeThinkingMode?: ClaudeThinkingMode;
+  ampAgentMode?: AmpAgentMode;
+}
+
+export interface AgentOrchestrationSpawnRequest {
+  parentChatId: string;
+  tasks: AgentOrchestrationTaskRequest[];
+  concurrencyLimit?: number;
+}
+
+export interface AgentOrchestrationChild {
+  id: string;
+  parentChatId: string;
+  childChatId: string;
+  taskName: string;
+  prompt: string;
+  role?: string;
+  status: AgentOrchestrationChildStatus;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  agentId?: string;
+  agentSessionId?: string | null;
+  nativePath?: string | null;
+  model?: string | null;
+  error?: string;
+  resultPreview?: string;
+}
+
+export interface AgentOrchestration {
+  id: string;
+  parentChatId: string;
+  createdAt: string;
+  updatedAt: string;
+  status: AgentOrchestrationChildStatus;
+  concurrencyLimit: number;
+  children: AgentOrchestrationChild[];
+}
+
+export interface AgentOrchestrationWaitRequest {
+  orchestrationId: string;
+  childIds?: string[];
+  timeoutMs?: number;
+}
+
+export interface AgentOrchestrationAbortRequest {
+  orchestrationId: string;
+  childIds?: string[];
+}
+
+export function isFinalOrchestrationStatus(status: AgentOrchestrationChildStatus): boolean {
+  return status === 'completed' || status === 'failed' || status === 'aborted';
+}

--- a/server/agents/__tests__/agent-orchestrator.test.js
+++ b/server/agents/__tests__/agent-orchestrator.test.js
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { AgentOrchestrator } from '../agent-orchestrator.ts';
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-agent-orchestrator-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function createHarness(overrides = {}) {
+  const sessions = new Map(Object.entries({
+    parent: {
+      agentId: 'codex',
+      agentSessionId: 'thread-parent',
+      nativePath: '/tmp/thread-parent.jsonl',
+      projectPath: '/repo',
+      model: 'gpt-5.4-codex',
+      permissionMode: 'default',
+      thinkingMode: 'think',
+      claudeThinkingMode: 'auto',
+      ampAgentMode: 'smart',
+      tags: ['codex'],
+    },
+    ...(overrides.sessions ?? {}),
+  }));
+  const registry = {
+    getChat: mock((chatId) => sessions.get(chatId) ?? null),
+    addChat: mock((entry) => {
+      if (sessions.has(entry.id)) return false;
+      sessions.set(entry.id, { ...entry });
+      return true;
+    }),
+    updateChat: mock((chatId, patch) => {
+      const current = sessions.get(chatId);
+      if (!current) return null;
+      const next = { ...current, ...patch };
+      sessions.set(chatId, next);
+      return { id: chatId, ...next };
+    }),
+  };
+  const settings = {
+    ensureInNormal: mock(() => Promise.resolve()),
+    setSessionName: mock(() => Promise.resolve()),
+    getChatName: mock(() => null),
+  };
+  const metadata = {
+    addNewChatMetadata: mock(),
+    getChatMetadata: mock(() => ({ firstMessage: 'Parent prompt' })),
+  };
+  const queue = {
+    submit: mock(() => Promise.resolve()),
+    abort: mock(() => Promise.resolve(true)),
+  };
+  const agents = {
+    supportsFork: mock((agentId) => agentId === 'codex'),
+    isAgentSessionRunning: mock(() => false),
+  };
+  const forkAgentSession = mock(() => Promise.resolve({ agentSessionId: 'child-thread', nativePath: '/tmp/child.jsonl' }));
+  const forkChatFileCopy = mock(async ({ targetChatId, sourceSession, threadSource }) => {
+    expect(threadSource).toBe('subagent');
+    sessions.set(targetChatId, {
+      ...sourceSession,
+      agentSessionId: `thread-${targetChatId}`,
+      nativePath: `/tmp/${targetChatId}.jsonl`,
+    });
+    return {
+      chatId: targetChatId,
+      agentId: sourceSession.agentId,
+      agentSessionId: `thread-${targetChatId}`,
+      nativePath: `/tmp/${targetChatId}.jsonl`,
+    };
+  });
+  const orchestrator = new AgentOrchestrator({
+    workspaceDir: tmpDir,
+    registry,
+    settings,
+    metadata,
+    queue,
+    agents,
+    forkChatFileCopy,
+    forkAgentSession,
+  });
+  return { orchestrator, sessions, registry, settings, metadata, queue, agents, forkAgentSession, forkChatFileCopy };
+}
+
+describe('AgentOrchestrator', () => {
+  it('forks child chats, starts bounded child turns, and persists orchestration state', async () => {
+    const harness = createHarness();
+    await harness.orchestrator.init();
+
+    const orchestration = await harness.orchestrator.spawn({
+      parentChatId: 'parent',
+      concurrencyLimit: 2,
+      tasks: [
+        { taskName: 'inspect_api', prompt: 'Inspect the API shape.' },
+        { taskName: 'write_tests', prompt: 'Write focused tests.', thinkingMode: 'think-hard' },
+      ],
+    });
+
+    expect(orchestration.children).toHaveLength(2);
+    expect(orchestration.status).toBe('running');
+    expect(harness.forkChatFileCopy).toHaveBeenCalledTimes(2);
+    expect(harness.settings.setSessionName).toHaveBeenCalledWith(expect.any(String), 'Subagent: inspect_api');
+    expect(harness.queue.submit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Task name: inspect_api'),
+      expect.objectContaining({ permissionMode: 'default', thinkingMode: 'think' }),
+    );
+    expect(harness.queue.submit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Task name: write_tests'),
+      expect.objectContaining({ thinkingMode: 'think-hard' }),
+    );
+
+    const persisted = JSON.parse(await fs.readFile(path.join(tmpDir, 'agent-orchestrations.json'), 'utf8'));
+    expect(persisted.orchestrations[0].id).toBe(orchestration.id);
+  });
+
+  it('tracks messages and completion from child chat events', async () => {
+    const harness = createHarness();
+    await harness.orchestrator.init();
+    const orchestration = await harness.orchestrator.spawn({
+      parentChatId: 'parent',
+      tasks: [{ taskName: 'inspect_api', prompt: 'Inspect the API shape.' }],
+    });
+    const childChatId = orchestration.children[0].childChatId;
+
+    harness.orchestrator.recordMessages(childChatId, [
+      { type: 'assistant-message', content: 'Finished the inspection.' },
+    ]);
+    harness.orchestrator.recordFinished(childChatId);
+    await harness.orchestrator.flush();
+
+    const updated = harness.orchestrator.get(orchestration.id);
+    expect(updated.status).toBe('completed');
+    expect(updated.children[0]).toMatchObject({
+      status: 'completed',
+      resultPreview: 'Finished the inspection.',
+    });
+  });
+
+  it('waits until selected children reach final status', async () => {
+    const harness = createHarness();
+    await harness.orchestrator.init();
+    const orchestration = await harness.orchestrator.spawn({
+      parentChatId: 'parent',
+      tasks: [{ taskName: 'inspect_api', prompt: 'Inspect the API shape.' }],
+    });
+    const child = orchestration.children[0];
+
+    const waitPromise = harness.orchestrator.wait({
+      orchestrationId: orchestration.id,
+      childIds: [child.id],
+      timeoutMs: 500,
+    });
+    queueMicrotask(() => harness.orchestrator.recordFinished(child.childChatId));
+
+    const result = await waitPromise;
+    await harness.orchestrator.flush();
+    expect(result.timedOut).toBe(false);
+    expect(result.orchestration.children[0].status).toBe('completed');
+  });
+
+  it('aborts non-final child agents', async () => {
+    const harness = createHarness();
+    await harness.orchestrator.init();
+    const orchestration = await harness.orchestrator.spawn({
+      parentChatId: 'parent',
+      tasks: [{ taskName: 'inspect_api', prompt: 'Inspect the API shape.' }],
+    });
+    const child = orchestration.children[0];
+
+    const updated = await harness.orchestrator.abort({
+      orchestrationId: orchestration.id,
+      childIds: [child.id],
+    });
+    await harness.orchestrator.flush();
+
+    expect(harness.queue.abort).toHaveBeenCalledWith(child.childChatId);
+    expect(updated.children[0].status).toBe('aborted');
+  });
+
+  it('rejects parent chats that are currently processing', async () => {
+    const harness = createHarness();
+    harness.agents.isAgentSessionRunning.mockReturnValue(true);
+    await harness.orchestrator.init();
+
+    await expect(harness.orchestrator.spawn({
+      parentChatId: 'parent',
+      tasks: [{ taskName: 'inspect_api', prompt: 'Inspect the API shape.' }],
+    })).rejects.toThrow('Cannot spawn subagents while the parent chat is processing');
+  });
+});

--- a/server/agents/__tests__/codex-app-server.test.js
+++ b/server/agents/__tests__/codex-app-server.test.js
@@ -253,6 +253,20 @@ describe('Codex app-server request builders', () => {
     });
   });
 
+  it('marks subagent thread/fork params with the Codex thread source', () => {
+    const params = buildThreadForkParams({
+      agentSessionId: 'thread-1',
+      model: 'gpt-5.4-codex',
+      projectPath: '/repo',
+      threadSource: 'subagent',
+    });
+
+    expect(params).toMatchObject({
+      threadId: 'thread-1',
+      threadSource: 'subagent',
+    });
+  });
+
   it('builds turn/start input and thinking effort', () => {
     const params = buildTurnStartParams({
       threadId: 'thread-1',
@@ -583,6 +597,7 @@ describe('CodexAppServerRuntime', () => {
         model: 'gpt-5.4-codex',
         projectPath: '/repo',
       },
+      threadSource: 'subagent',
       envOverrides: { OPENAI_API_KEY: 'endpoint-key' },
       codexConfig: {
         env: { CODEX_HOME: '/tmp/codex-home' },
@@ -597,6 +612,7 @@ describe('CodexAppServerRuntime', () => {
     });
     expect(operationClient.forkThread).toHaveBeenCalledWith(expect.objectContaining({
       threadId: 'thread-1',
+      threadSource: 'subagent',
       config: { model_provider: 'custom-openai' },
     }));
     expect(operationClient.unsubscribeThread).toHaveBeenCalledWith('forked-thread');

--- a/server/agents/agent-orchestrator.ts
+++ b/server/agents/agent-orchestrator.ts
@@ -1,0 +1,520 @@
+// Coordinates Garcon-owned child agents using forked chat sessions.
+
+import { EventEmitter } from 'events';
+import crypto from 'crypto';
+import path from 'path';
+import { promises as fs } from 'fs';
+import {
+  isAmpAgentMode,
+  isClaudeThinkingMode,
+  isPermissionMode,
+  isThinkingMode,
+  normalizeAmpAgentMode,
+  normalizeClaudeThinkingMode,
+  normalizePermissionMode,
+  normalizeThinkingMode,
+} from '../../common/chat-modes.js';
+import type { RunAgentTurnOptions } from './session-types.js';
+import type { IChatRegistry } from '../chats/store.js';
+import { writeJsonFileAtomic } from '../lib/json-file-store.js';
+import {
+  type AgentOrchestration,
+  type AgentOrchestrationAbortRequest,
+  type AgentOrchestrationChild,
+  type AgentOrchestrationChildStatus,
+  type AgentOrchestrationSpawnRequest,
+  type AgentOrchestrationTaskRequest,
+  type AgentOrchestrationWaitRequest,
+  isFinalOrchestrationStatus,
+} from '../../common/agent-orchestration.js';
+
+const STORE_VERSION = 1;
+const DEFAULT_CONCURRENCY_LIMIT = 3;
+const MAX_CONCURRENCY_LIMIT = 8;
+const DEFAULT_WAIT_TIMEOUT_MS = 60_000;
+const MAX_WAIT_TIMEOUT_MS = 10 * 60_000;
+const TASK_NAME_RE = /^[a-z][a-z0-9_]{0,63}$/;
+
+interface SettingsDep {
+  ensureInNormal(chatId: string): Promise<void>;
+  setSessionName(chatId: string, title: string): Promise<void>;
+}
+
+interface MetadataDep {
+  addNewChatMetadata(chatId: string, command: string): void;
+}
+
+interface QueueDep {
+  submit(chatId: string, command: string, options: RunAgentTurnOptions): Promise<void>;
+  abort(chatId: string): Promise<boolean>;
+}
+
+interface AgentsDep {
+  supportsFork(agentId: string): boolean;
+  isAgentSessionRunning(agentId: string, agentSessionId: string | null | undefined): boolean;
+}
+
+interface ForkChatDep {
+  sourceSession: unknown;
+  sourceChatId: string;
+  targetChatId: string;
+  registry: IChatRegistry;
+  settings: SettingsDep;
+  metadata: MetadataDep;
+  forkAgentSession?: (args: {
+    sourceSession: unknown;
+    sourceChatId: string;
+    targetChatId: string;
+    threadSource?: 'user' | 'subagent';
+  }) => Promise<{ agentSessionId: string; nativePath: string | null } | null>;
+  supportsFork?: (agentId: string) => boolean;
+  threadSource?: 'user' | 'subagent';
+}
+
+export interface AgentOrchestratorOptions {
+  workspaceDir: string;
+  registry: IChatRegistry;
+  settings: SettingsDep;
+  metadata: MetadataDep;
+  queue: QueueDep;
+  agents: AgentsDep;
+  forkChatFileCopy: (args: ForkChatDep) => Promise<{
+    chatId: string;
+    agentId: string;
+    agentSessionId: string;
+    nativePath: string | null;
+  }>;
+  forkAgentSession?: ForkChatDep['forkAgentSession'];
+}
+
+interface PersistedOrchestrationSnapshot {
+  version: number;
+  orchestrations: AgentOrchestration[];
+}
+
+type ChildUpdatedCallback = (orchestration: AgentOrchestration, child: AgentOrchestrationChild) => void;
+
+export class AgentOrchestrator extends EventEmitter {
+  #workspaceDir: string;
+  #registry: IChatRegistry;
+  #settings: SettingsDep;
+  #metadata: MetadataDep;
+  #queue: QueueDep;
+  #agents: AgentsDep;
+  #forkChatFileCopy: AgentOrchestratorOptions['forkChatFileCopy'];
+  #forkAgentSession: AgentOrchestratorOptions['forkAgentSession'];
+  #orchestrations = new Map<string, AgentOrchestration>();
+  #childToOrchestration = new Map<string, string>();
+  #saveScheduled = false;
+
+  constructor(options: AgentOrchestratorOptions) {
+    super();
+    this.#workspaceDir = options.workspaceDir;
+    this.#registry = options.registry;
+    this.#settings = options.settings;
+    this.#metadata = options.metadata;
+    this.#queue = options.queue;
+    this.#agents = options.agents;
+    this.#forkChatFileCopy = options.forkChatFileCopy;
+    this.#forkAgentSession = options.forkAgentSession;
+  }
+
+  async init(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.#storePath(), 'utf8');
+      const parsed = JSON.parse(raw) as Partial<PersistedOrchestrationSnapshot>;
+      const orchestrations = Array.isArray(parsed.orchestrations) ? parsed.orchestrations : [];
+      for (const orchestration of orchestrations) {
+        const normalized = normalizePersistedOrchestration(orchestration);
+        this.#orchestrations.set(normalized.id, normalized);
+        for (const child of normalized.children) {
+          this.#childToOrchestration.set(child.childChatId, normalized.id);
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
+  onChildUpdated(cb: ChildUpdatedCallback): void {
+    this.on('child-updated', cb);
+  }
+
+  list(parentChatId?: string): AgentOrchestration[] {
+    const values = Array.from(this.#orchestrations.values());
+    const filtered = parentChatId ? values.filter((item) => item.parentChatId === parentChatId) : values;
+    return filtered.map(cloneOrchestration);
+  }
+
+  get(orchestrationId: string): AgentOrchestration | null {
+    const orchestration = this.#orchestrations.get(orchestrationId);
+    return orchestration ? cloneOrchestration(orchestration) : null;
+  }
+
+  async spawn(request: AgentOrchestrationSpawnRequest): Promise<AgentOrchestration> {
+    const parentChatId = requireNonEmptyString(request.parentChatId, 'parentChatId');
+    const parent = this.#registry.getChat(parentChatId);
+    if (!parent) throw new Error(`Parent chat not found: ${parentChatId}`);
+    if (!parent.agentSessionId) throw new Error(`Parent chat has no agent session: ${parentChatId}`);
+    if (!this.#agents.supportsFork(parent.agentId)) {
+      throw new Error(`Fork unsupported for agent: ${parent.agentId}`);
+    }
+    if (this.#agents.isAgentSessionRunning(parent.agentId, parent.agentSessionId)) {
+      throw new Error('Cannot spawn subagents while the parent chat is processing');
+    }
+
+    const tasks = normalizeTasks(request.tasks);
+    const now = new Date().toISOString();
+    const orchestration: AgentOrchestration = {
+      id: crypto.randomUUID(),
+      parentChatId,
+      createdAt: now,
+      updatedAt: now,
+      status: 'starting',
+      concurrencyLimit: clampConcurrency(request.concurrencyLimit),
+      children: tasks.map((task) => ({
+        id: crypto.randomUUID(),
+        parentChatId,
+        childChatId: this.#nextChatId(),
+        taskName: task.taskName,
+        prompt: task.prompt,
+        role: task.role,
+        status: 'starting',
+        createdAt: now,
+        updatedAt: now,
+        model: task.model ?? parent.model ?? null,
+      })),
+    };
+
+    this.#orchestrations.set(orchestration.id, orchestration);
+    for (const child of orchestration.children) {
+      this.#childToOrchestration.set(child.childChatId, orchestration.id);
+    }
+    await this.#saveNow();
+
+    await runBounded(orchestration.children, orchestration.concurrencyLimit, (child) =>
+      this.#startChild(orchestration, child, tasks.find((task) => task.taskName === child.taskName)!, parentChatId),
+    );
+
+    this.#refreshStatus(orchestration);
+    await this.#saveNow();
+    return cloneOrchestration(orchestration);
+  }
+
+  async wait(request: AgentOrchestrationWaitRequest): Promise<{
+    orchestration: AgentOrchestration;
+    timedOut: boolean;
+  }> {
+    const orchestration = this.#requireOrchestration(request.orchestrationId);
+    const childIds = new Set(request.childIds?.filter(Boolean) ?? orchestration.children.map((child) => child.id));
+    const timeoutMs = clampWaitTimeout(request.timeoutMs);
+
+    if (this.#areChildrenFinal(orchestration, childIds)) {
+      return { orchestration: cloneOrchestration(orchestration), timedOut: false };
+    }
+
+    return new Promise((resolve) => {
+      let done = false;
+      const cleanup = () => {
+        done = true;
+        clearTimeout(timeout);
+        this.off('child-updated', onUpdate);
+      };
+      const finish = (timedOut: boolean) => {
+        if (done) return;
+        cleanup();
+        resolve({ orchestration: cloneOrchestration(orchestration), timedOut });
+      };
+      const onUpdate = (updated: AgentOrchestration) => {
+        if (updated.id !== orchestration.id) return;
+        if (this.#areChildrenFinal(orchestration, childIds)) finish(false);
+      };
+      const timeout = setTimeout(() => finish(true), timeoutMs);
+      this.on('child-updated', onUpdate);
+    });
+  }
+
+  async abort(request: AgentOrchestrationAbortRequest): Promise<AgentOrchestration> {
+    const orchestration = this.#requireOrchestration(request.orchestrationId);
+    const childIds = new Set(request.childIds?.filter(Boolean) ?? orchestration.children.map((child) => child.id));
+    await Promise.all(orchestration.children
+      .filter((child) => childIds.has(child.id) && !isFinalOrchestrationStatus(child.status))
+      .map(async (child) => {
+        await this.#queue.abort(child.childChatId).catch(() => false);
+        this.#updateChild(orchestration, child, 'aborted');
+      }));
+    this.#refreshStatus(orchestration);
+    await this.#saveNow();
+    return cloneOrchestration(orchestration);
+  }
+
+  recordMessages(chatId: string, messages: unknown[]): void {
+    const located = this.#locateChild(chatId);
+    if (!located) return;
+    const preview = latestPreviewText(messages);
+    if (!preview) return;
+    located.child.resultPreview = preview;
+    located.child.updatedAt = new Date().toISOString();
+    this.#scheduleSave();
+  }
+
+  recordFinished(chatId: string): void {
+    const located = this.#locateChild(chatId);
+    if (!located) return;
+    this.#updateChild(located.orchestration, located.child, 'completed');
+  }
+
+  recordFailed(chatId: string, error: string): void {
+    const located = this.#locateChild(chatId);
+    if (!located) return;
+    located.child.error = error;
+    this.#updateChild(located.orchestration, located.child, 'failed');
+  }
+
+  async flush(): Promise<void> {
+    await this.#saveNow();
+  }
+
+  async #startChild(
+    orchestration: AgentOrchestration,
+    child: AgentOrchestrationChild,
+    task: AgentOrchestrationTaskRequest,
+    parentChatId: string,
+  ): Promise<void> {
+    const sourceSession = this.#registry.getChat(parentChatId);
+    if (!sourceSession) throw new Error(`Parent chat not found: ${parentChatId}`);
+
+    try {
+      const forked = await this.#forkChatFileCopy({
+        sourceSession,
+        sourceChatId: parentChatId,
+        targetChatId: child.childChatId,
+        registry: this.#registry,
+        settings: this.#settings,
+        metadata: this.#metadata,
+        forkAgentSession: this.#forkAgentSession,
+        supportsFork: this.#agents.supportsFork.bind(this.#agents),
+        threadSource: 'subagent',
+      });
+      await this.#settings.setSessionName(child.childChatId, `Subagent: ${task.taskName}`);
+      child.agentId = forked.agentId;
+      child.agentSessionId = forked.agentSessionId;
+      child.nativePath = forked.nativePath;
+      child.startedAt = new Date().toISOString();
+      this.#updateChild(orchestration, child, 'running');
+      await this.#queue.submit(child.childChatId, buildChildPrompt(parentChatId, task), runOptionsForTask(sourceSession, task));
+    } catch (error) {
+      child.error = (error as Error).message;
+      this.#updateChild(orchestration, child, 'failed');
+    }
+  }
+
+  #requireOrchestration(orchestrationId: string): AgentOrchestration {
+    const id = requireNonEmptyString(orchestrationId, 'orchestrationId');
+    const orchestration = this.#orchestrations.get(id);
+    if (!orchestration) throw new Error(`Orchestration not found: ${id}`);
+    return orchestration;
+  }
+
+  #locateChild(chatId: string): { orchestration: AgentOrchestration; child: AgentOrchestrationChild } | null {
+    const orchestrationId = this.#childToOrchestration.get(chatId);
+    if (!orchestrationId) return null;
+    const orchestration = this.#orchestrations.get(orchestrationId);
+    const child = orchestration?.children.find((candidate) => candidate.childChatId === chatId);
+    return orchestration && child ? { orchestration, child } : null;
+  }
+
+  #updateChild(
+    orchestration: AgentOrchestration,
+    child: AgentOrchestrationChild,
+    status: AgentOrchestrationChildStatus,
+  ): void {
+    const now = new Date().toISOString();
+    child.status = status;
+    child.updatedAt = now;
+    if (isFinalOrchestrationStatus(status)) child.completedAt = child.completedAt ?? now;
+    this.#refreshStatus(orchestration);
+    this.emit('child-updated', cloneOrchestration(orchestration), { ...child });
+    this.#scheduleSave();
+  }
+
+  #refreshStatus(orchestration: AgentOrchestration): void {
+    orchestration.updatedAt = new Date().toISOString();
+    if (orchestration.children.every((child) => child.status === 'completed')) {
+      orchestration.status = 'completed';
+    } else if (orchestration.children.some((child) => child.status === 'failed')) {
+      orchestration.status = 'failed';
+    } else if (orchestration.children.every((child) => isFinalOrchestrationStatus(child.status))) {
+      orchestration.status = 'aborted';
+    } else if (orchestration.children.some((child) => child.status === 'running')) {
+      orchestration.status = 'running';
+    } else {
+      orchestration.status = 'starting';
+    }
+  }
+
+  #areChildrenFinal(orchestration: AgentOrchestration, childIds: Set<string>): boolean {
+    return orchestration.children
+      .filter((child) => childIds.has(child.id))
+      .every((child) => isFinalOrchestrationStatus(child.status));
+  }
+
+  #nextChatId(): string {
+    let candidate = '';
+    do {
+      candidate = String(Date.now() * 1000 + Math.floor(Math.random() * 1000));
+    } while (this.#registry.getChat(candidate));
+    return candidate;
+  }
+
+  #storePath(): string {
+    return path.join(this.#workspaceDir, 'agent-orchestrations.json');
+  }
+
+  #scheduleSave(): void {
+    if (this.#saveScheduled) return;
+    this.#saveScheduled = true;
+    queueMicrotask(() => {
+      this.#saveScheduled = false;
+      this.#saveNow().catch((error) => {
+        console.warn('orchestrator: failed to persist state:', error.message);
+      });
+    });
+  }
+
+  async #saveNow(): Promise<void> {
+    const snapshot: PersistedOrchestrationSnapshot = {
+      version: STORE_VERSION,
+      orchestrations: Array.from(this.#orchestrations.values()).map(cloneOrchestration),
+    };
+    await writeJsonFileAtomic(this.#storePath(), snapshot);
+  }
+}
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${field} is required`);
+  return value.trim();
+}
+
+function normalizeTasks(tasks: unknown): AgentOrchestrationTaskRequest[] {
+  if (!Array.isArray(tasks) || tasks.length === 0) throw new Error('tasks must contain at least one task');
+  if (tasks.length > 16) throw new Error('tasks cannot contain more than 16 entries');
+  return tasks.map((raw, index) => {
+    if (!raw || typeof raw !== 'object') throw new Error(`tasks[${index}] must be an object`);
+    const record = raw as Record<string, unknown>;
+    const taskName = requireNonEmptyString(record.taskName, `tasks[${index}].taskName`);
+    if (!TASK_NAME_RE.test(taskName)) {
+      throw new Error(`tasks[${index}].taskName must use lowercase letters, digits, and underscores`);
+    }
+    const prompt = requireNonEmptyString(record.prompt, `tasks[${index}].prompt`);
+    return {
+      taskName,
+      prompt,
+      role: typeof record.role === 'string' && record.role.trim() ? record.role.trim() : undefined,
+      model: typeof record.model === 'string' && record.model.trim() ? record.model.trim() : undefined,
+      permissionMode: isPermissionMode(record.permissionMode) ? record.permissionMode : undefined,
+      thinkingMode: isThinkingMode(record.thinkingMode) ? record.thinkingMode : undefined,
+      claudeThinkingMode: isClaudeThinkingMode(record.claudeThinkingMode) ? record.claudeThinkingMode : undefined,
+      ampAgentMode: isAmpAgentMode(record.ampAgentMode) ? record.ampAgentMode : undefined,
+    };
+  });
+}
+
+function clampConcurrency(value: unknown): number {
+  const parsed = typeof value === 'number' ? Math.floor(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) return DEFAULT_CONCURRENCY_LIMIT;
+  return Math.min(Math.max(parsed, 1), MAX_CONCURRENCY_LIMIT);
+}
+
+function clampWaitTimeout(value: unknown): number {
+  const parsed = typeof value === 'number' ? Math.floor(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) return DEFAULT_WAIT_TIMEOUT_MS;
+  return Math.min(Math.max(parsed, 0), MAX_WAIT_TIMEOUT_MS);
+}
+
+function runOptionsForTask(
+  parent: { permissionMode?: unknown; thinkingMode?: unknown; claudeThinkingMode?: unknown; ampAgentMode?: unknown },
+  task: AgentOrchestrationTaskRequest,
+): RunAgentTurnOptions {
+  return {
+    model: task.model,
+    permissionMode: normalizePermissionMode(task.permissionMode ?? parent.permissionMode),
+    thinkingMode: normalizeThinkingMode(task.thinkingMode ?? parent.thinkingMode),
+    claudeThinkingMode: normalizeClaudeThinkingMode(task.claudeThinkingMode ?? parent.claudeThinkingMode),
+    ampAgentMode: normalizeAmpAgentMode(task.ampAgentMode ?? parent.ampAgentMode),
+  };
+}
+
+function buildChildPrompt(parentChatId: string, task: AgentOrchestrationTaskRequest): string {
+  const roleLine = task.role ? `Role: ${task.role}\n` : '';
+  return `You are a Garcon-orchestrated subagent.
+Parent chat: ${parentChatId}
+Task name: ${task.taskName}
+${roleLine}Work only on this task. Return a concise final answer with the concrete result, changed files if any, and remaining risks.
+
+${task.prompt}`;
+}
+
+async function runBounded<T>(
+  items: T[],
+  concurrencyLimit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(concurrencyLimit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const item = items[cursor];
+      cursor += 1;
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}
+
+function latestPreviewText(messages: unknown[]): string | null {
+  for (const message of [...messages].reverse()) {
+    if (!message || typeof message !== 'object') continue;
+    const record = message as Record<string, unknown>;
+    if (record.type !== 'assistant-message' && record.type !== 'error-message') continue;
+    if (typeof record.content === 'string' && record.content.trim()) return record.content.trim();
+  }
+  return null;
+}
+
+function normalizePersistedOrchestration(raw: AgentOrchestration): AgentOrchestration {
+  const children = Array.isArray(raw.children) ? raw.children : [];
+  const orchestration: AgentOrchestration = {
+    id: typeof raw.id === 'string' ? raw.id : crypto.randomUUID(),
+    parentChatId: typeof raw.parentChatId === 'string' ? raw.parentChatId : '',
+    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString(),
+    updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : new Date().toISOString(),
+    status: normalizeStatus(raw.status),
+    concurrencyLimit: clampConcurrency(raw.concurrencyLimit),
+    children: children.map((child) => ({
+      ...child,
+      id: typeof child.id === 'string' ? child.id : crypto.randomUUID(),
+      parentChatId: typeof child.parentChatId === 'string' ? child.parentChatId : raw.parentChatId,
+      childChatId: typeof child.childChatId === 'string' ? child.childChatId : '',
+      taskName: typeof child.taskName === 'string' ? child.taskName : 'task',
+      prompt: typeof child.prompt === 'string' ? child.prompt : '',
+      status: normalizeStatus(child.status),
+      createdAt: typeof child.createdAt === 'string' ? child.createdAt : new Date().toISOString(),
+      updatedAt: typeof child.updatedAt === 'string' ? child.updatedAt : new Date().toISOString(),
+    })),
+  };
+  return orchestration;
+}
+
+function normalizeStatus(value: unknown): AgentOrchestrationChildStatus {
+  if (value === 'starting' || value === 'running' || value === 'completed' || value === 'failed' || value === 'aborted') {
+    return value;
+  }
+  return 'failed';
+}
+
+function cloneOrchestration(orchestration: AgentOrchestration): AgentOrchestration {
+  return {
+    ...orchestration,
+    children: orchestration.children.map((child) => ({ ...child })),
+  };
+}

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -34,7 +34,9 @@ export interface InitializeResponse {
 
 export interface CodexThread {
   id: string;
+  sessionId?: string;
   forkedFromId: string | null;
+  parentThreadId?: string | null;
   preview: string;
   ephemeral: boolean;
   modelProvider: string;
@@ -45,6 +47,7 @@ export interface CodexThread {
   cwd: string;
   cliVersion: string;
   source: unknown;
+  threadSource?: 'user' | 'subagent' | 'memory_consolidation' | null;
   agentNickname: string | null;
   agentRole: string | null;
   gitInfo: unknown;

--- a/server/agents/codex/app-server/request-builders.ts
+++ b/server/agents/codex/app-server/request-builders.ts
@@ -87,6 +87,7 @@ export function buildThreadForkParams(sourceSession: {
   model?: string | null;
   projectPath: string;
   codexConfig?: CodexProviderConfig;
+  threadSource?: 'user' | 'subagent' | 'memory_consolidation';
 }): Record<string, unknown> {
   const params: Record<string, unknown> = {
     threadId: sourceSession.agentSessionId,
@@ -96,6 +97,7 @@ export function buildThreadForkParams(sourceSession: {
     excludeTurns: true,
   };
   if (sourceSession.codexConfig?.config) params.config = sourceSession.codexConfig.config;
+  if (sourceSession.threadSource) params.threadSource = sourceSession.threadSource;
   return params;
 }
 

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -47,6 +47,7 @@ interface RunningCodexSession {
 
 interface CodexForkSessionRequest {
   sourceSession: AgentChatEntry;
+  threadSource?: 'user' | 'subagent' | 'memory_consolidation';
   envOverrides?: Record<string, string>;
   codexConfig?: StartSessionRequest['codexConfig'];
 }
@@ -241,6 +242,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         model: sourceSession.model,
         projectPath: sourceSession.projectPath,
         codexConfig: args.codexConfig,
+        threadSource: args.threadSource,
       }));
       await this.#unsubscribeBestEffort(client, forked.thread.id);
       const nativePath = await waitForMaterializedThread(forked.thread, {

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -132,6 +132,7 @@ export class AgentRegistry {
     sourceSession: AgentChatEntry;
     sourceChatId: string;
     targetChatId: string;
+    threadSource?: 'user' | 'subagent' | 'memory_consolidation';
   }): Promise<StartedAgentSession | null> {
     return this.#runtime.forkAgentSession(args);
   }

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -246,6 +246,7 @@ export class AgentRuntimeRouter {
     sourceSession: AgentChatEntry;
     sourceChatId: string;
     targetChatId: string;
+    threadSource?: 'user' | 'subagent' | 'memory_consolidation';
   }): Promise<StartedAgentSession | null> {
     const agent = this.#directory.get(args.sourceSession.agentId);
     if (!agent?.forkSession) return null;
@@ -264,6 +265,7 @@ export class AgentRuntimeRouter {
         model: selection.model,
         ...selectionRequestFields(selection),
       },
+      threadSource: args.threadSource,
       ...runtimeConfig,
     });
   }

--- a/server/agents/session-types.ts
+++ b/server/agents/session-types.ts
@@ -89,6 +89,8 @@ export interface StartedAgentSession {
   nativePath: string | null;
 }
 
+export type AgentThreadSource = 'user' | 'subagent' | 'memory_consolidation';
+
 // Claude start requires a pre-generated agentSessionId.
 export interface ClaudeStartSessionRequest extends StartSessionRequest {
   agentSessionId: string;

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -5,6 +5,7 @@ import type {
   AgentEventMetadata,
   AgentSessionSettingsPatch,
   CodexProviderConfig,
+  AgentThreadSource,
   ResumeTurnRequest,
   StartSessionRequest,
   StartedAgentSession,
@@ -83,6 +84,7 @@ export interface ForkAgentSessionArgs {
   sourceSession: AgentChatEntry;
   sourceChatId: string;
   targetChatId: string;
+  threadSource?: AgentThreadSource;
   envOverrides?: StartSessionRequest['envOverrides'];
   codexConfig?: StartSessionRequest['codexConfig'];
 }

--- a/server/chats/__tests__/fork-chat.test.js
+++ b/server/chats/__tests__/fork-chat.test.js
@@ -260,9 +260,14 @@ describe('forkChatFileCopy', () => {
       settings,
       metadata,
       forkAgentSession,
+      threadSource: 'subagent',
     });
 
-    expect(forkAgentSession).toHaveBeenCalledTimes(1);
+    expect(forkAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      sourceChatId: '300',
+      targetChatId: '301',
+      threadSource: 'subagent',
+    }));
     expect(result.agentSessionId).toBe('codex-fork-thread');
     expect(result.nativePath).toBe(nativeForkPath);
     expect(registry.getChat('301')).toMatchObject({

--- a/server/chats/fork-chat.js
+++ b/server/chats/fork-chat.js
@@ -61,6 +61,7 @@ export async function forkChatFileCopy({
   metadata,
   forkAgentSession,
   supportsFork,
+  threadSource = undefined,
 }) {
   const sourceAgentId = sourceSession.agentId;
   if (supportsFork && !supportsFork(sourceAgentId)) {
@@ -77,7 +78,7 @@ export async function forkChatFileCopy({
   const forkTitle = `${sourceTitle} (${nextForkOrdinal})`;
 
   const nativeFork = forkAgentSession
-    ? await forkAgentSession({ sourceSession, sourceChatId, targetChatId })
+    ? await forkAgentSession({ sourceSession, sourceChatId, targetChatId, threadSource })
     : null;
 
   let newAgentSessionId = nativeFork?.agentSessionId || null;

--- a/server/routes/__tests__/agent-orchestrations.test.js
+++ b/server/routes/__tests__/agent-orchestrations.test.js
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const parseJsonBody = mock(() => Promise.resolve({}));
+
+mock.module('../../lib/http-request.js', () => ({
+  parseJsonBody,
+}));
+
+import createAgentOrchestrationRoutes from '../agent-orchestrations.ts';
+
+describe('agent orchestration routes', () => {
+  const orchestration = {
+    id: 'orch-1',
+    parentChatId: 'parent',
+    createdAt: '2026-06-07T00:00:00.000Z',
+    updatedAt: '2026-06-07T00:00:00.000Z',
+    status: 'running',
+    concurrencyLimit: 2,
+    children: [],
+  };
+  const orchestrator = {
+    spawn: mock(() => Promise.resolve(orchestration)),
+    list: mock(() => [orchestration]),
+    get: mock(() => orchestration),
+    wait: mock(() => Promise.resolve({ orchestration, timedOut: false })),
+    abort: mock(() => Promise.resolve({ ...orchestration, status: 'aborted' })),
+  };
+  const routes = createAgentOrchestrationRoutes(orchestrator);
+
+  beforeEach(() => {
+    parseJsonBody.mockClear();
+    for (const fn of Object.values(orchestrator)) fn.mockClear();
+  });
+
+  it('spawns an orchestration through the REST contract', async () => {
+    parseJsonBody.mockResolvedValueOnce({
+      parentChatId: 'parent',
+      concurrencyLimit: 2,
+      tasks: [{ taskName: 'inspect_api', prompt: 'Inspect the API shape.' }],
+    });
+
+    const response = await routes['/api/v1/agents/orchestrations'].POST(
+      new Request('http://localhost/api/v1/agents/orchestrations', { method: 'POST' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(orchestrator.spawn).toHaveBeenCalledWith({
+      parentChatId: 'parent',
+      concurrencyLimit: 2,
+      tasks: [{ taskName: 'inspect_api', prompt: 'Inspect the API shape.' }],
+    });
+    expect(body).toEqual({ success: true, orchestration });
+  });
+
+  it('lists orchestrations filtered by parentChatId', async () => {
+    const url = new URL('http://localhost/api/v1/agents/orchestrations?parentChatId=parent');
+
+    const response = await routes['/api/v1/agents/orchestrations'].GET(new Request(url), url);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(orchestrator.list).toHaveBeenCalledWith('parent');
+    expect(body).toEqual({ success: true, orchestrations: [orchestration] });
+  });
+
+  it('returns one orchestration by id', async () => {
+    const url = new URL('http://localhost/api/v1/agents/orchestrations?orchestrationId=orch-1');
+
+    const response = await routes['/api/v1/agents/orchestrations'].GET(new Request(url), url);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(orchestrator.get).toHaveBeenCalledWith('orch-1');
+    expect(body).toEqual({ success: true, orchestration });
+  });
+
+  it('waits for orchestration children', async () => {
+    parseJsonBody.mockResolvedValueOnce({ orchestrationId: 'orch-1', childIds: ['child-1'], timeoutMs: 10 });
+
+    const response = await routes['/api/v1/agents/orchestrations/wait'].POST(
+      new Request('http://localhost/api/v1/agents/orchestrations/wait', { method: 'POST' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(orchestrator.wait).toHaveBeenCalledWith({
+      orchestrationId: 'orch-1',
+      childIds: ['child-1'],
+      timeoutMs: 10,
+    });
+    expect(body).toEqual({ success: true, orchestration, timedOut: false });
+  });
+
+  it('aborts orchestration children', async () => {
+    parseJsonBody.mockResolvedValueOnce({ orchestrationId: 'orch-1', childIds: ['child-1'] });
+
+    const response = await routes['/api/v1/agents/orchestrations/abort'].POST(
+      new Request('http://localhost/api/v1/agents/orchestrations/abort', { method: 'POST' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(orchestrator.abort).toHaveBeenCalledWith({ orchestrationId: 'orch-1', childIds: ['child-1'] });
+    expect(body.orchestration.status).toBe('aborted');
+  });
+});

--- a/server/routes/agent-orchestrations.ts
+++ b/server/routes/agent-orchestrations.ts
@@ -1,0 +1,76 @@
+// REST contract for Garcon-owned child-agent orchestration.
+
+import { parseJsonBody } from '../lib/http-request.js';
+import type { AgentOrchestrator } from '../agents/agent-orchestrator.js';
+import type {
+  AgentOrchestrationAbortRequest,
+  AgentOrchestrationSpawnRequest,
+  AgentOrchestrationWaitRequest,
+} from '../../common/agent-orchestration.js';
+
+type RouteHandler = (request: Request, url: URL) => Promise<Response> | Response;
+type RouteMap = Record<string, Record<string, RouteHandler>>;
+
+function jsonError(error: string, status: number): Response {
+  return Response.json({ success: false, error }, { status });
+}
+
+export default function createAgentOrchestrationRoutes(orchestrator: AgentOrchestrator): RouteMap {
+  async function postSpawn(request: Request): Promise<Response> {
+    try {
+      const body = await parseJsonBody(request) as Partial<AgentOrchestrationSpawnRequest>;
+      const orchestration = await orchestrator.spawn({
+        parentChatId: String(body.parentChatId ?? ''),
+        tasks: Array.isArray(body.tasks) ? body.tasks : [],
+        concurrencyLimit: body.concurrencyLimit,
+      });
+      return Response.json({ success: true, orchestration }, { status: 202 });
+    } catch (error) {
+      return jsonError((error as Error).message, 400);
+    }
+  }
+
+  function getList(_request: Request, url: URL): Response {
+    const orchestrationId = url.searchParams.get('orchestrationId');
+    if (orchestrationId) {
+      const orchestration = orchestrator.get(orchestrationId);
+      if (!orchestration) return jsonError('Orchestration not found', 404);
+      return Response.json({ success: true, orchestration });
+    }
+    const parentChatId = url.searchParams.get('parentChatId') ?? undefined;
+    return Response.json({ success: true, orchestrations: orchestrator.list(parentChatId) });
+  }
+
+  async function postWait(request: Request): Promise<Response> {
+    try {
+      const body = await parseJsonBody(request) as Partial<AgentOrchestrationWaitRequest>;
+      const result = await orchestrator.wait({
+        orchestrationId: String(body.orchestrationId ?? ''),
+        childIds: Array.isArray(body.childIds) ? body.childIds.filter((id): id is string => typeof id === 'string') : undefined,
+        timeoutMs: body.timeoutMs,
+      });
+      return Response.json({ success: true, ...result });
+    } catch (error) {
+      return jsonError((error as Error).message, 400);
+    }
+  }
+
+  async function postAbort(request: Request): Promise<Response> {
+    try {
+      const body = await parseJsonBody(request) as Partial<AgentOrchestrationAbortRequest>;
+      const orchestration = await orchestrator.abort({
+        orchestrationId: String(body.orchestrationId ?? ''),
+        childIds: Array.isArray(body.childIds) ? body.childIds.filter((id): id is string => typeof id === 'string') : undefined,
+      });
+      return Response.json({ success: true, orchestration });
+    } catch (error) {
+      return jsonError((error as Error).message, 400);
+    }
+  }
+
+  return {
+    '/api/v1/agents/orchestrations': { GET: getList, POST: postSpawn },
+    '/api/v1/agents/orchestrations/wait': { POST: postWait },
+    '/api/v1/agents/orchestrations/abort': { POST: postAbort },
+  };
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,7 @@ import authRoutes from './auth.js';
 import staticRoutes from './static.js';
 import createFilesRoutes from './files.js';
 import createAgentRoutes from './agents.js';
+import createAgentOrchestrationRoutes from './agent-orchestrations.js';
 import createApiProviderRoutes from './api-providers.js';
 import createModelsRoutes from './models.js';
 import createGitRoutes from './git.js';
@@ -9,11 +10,12 @@ import createChatRoutes from './chats.js';
 import createShareRoutes from './shares.js';
 import createWorkspaceRoutes from './workspace.js';
 
-export default function createAllRoutes(registry, settings, queue, pathCache, metadata, historyCache, agents, pendingInputs, telegramNotifier, telegramSettings, shareStore, apiProviders, chatCommands) {
+export default function createAllRoutes(registry, settings, queue, pathCache, metadata, historyCache, agents, pendingInputs, telegramNotifier, telegramSettings, shareStore, apiProviders, chatCommands, agentOrchestrator) {
   return {
     ...staticRoutes,
     ...authRoutes,
     ...createAgentRoutes({ agents, apiProviders }),
+    ...(agentOrchestrator ? createAgentOrchestrationRoutes(agentOrchestrator) : {}),
     ...createApiProviderRoutes(apiProviders),
     ...createChatRoutes(registry, settings, queue, pathCache, metadata, historyCache, agents, pendingInputs, chatCommands),
     ...createShareRoutes(shareStore, registry, settings, metadata, historyCache),

--- a/server/server.js
+++ b/server/server.js
@@ -37,6 +37,7 @@ import { ApiProviderEndpointResolver } from './api-providers/endpoint-resolver.j
 import { ApiProviderService } from './api-providers/service.js';
 import { CommandLedger } from './commands/command-ledger.js';
 import { ChatCommandService } from './commands/chat-command-service.js';
+import { AgentOrchestrator } from './agents/agent-orchestrator.js';
 import { ChatHandler } from './ws/chat.js';
 import { TelegramNotifier } from './notifications/telegram.js';
 import { TelegramSettingsStore } from './notifications/telegram-settings-store.js';
@@ -130,6 +131,17 @@ export async function startServer() {
       queue,
       ledger: commandLedger,
     });
+    const agentOrchestrator = new AgentOrchestrator({
+      workspaceDir,
+      registry: chatRegistry,
+      settings,
+      metadata,
+      queue,
+      agents: agentRegistry,
+      forkChatFileCopy,
+      forkAgentSession: agentRegistry.forkAgentSession.bind(agentRegistry),
+    });
+    await agentOrchestrator.init();
 
     // Telegram notifications wire themselves to agent and queue events.
     const telegramSettings = new TelegramSettingsStore();
@@ -151,7 +163,7 @@ export async function startServer() {
     // Build route and WS handler tables
     const routes = createAllRoutes(
       chatRegistry, settings, queue, pathCache, metadata, historyCache,
-      agentRegistry, pendingInputs, telegramNotifier, telegramSettings, shareStore, apiProviders, chatCommands,
+      agentRegistry, pendingInputs, telegramNotifier, telegramSettings, shareStore, apiProviders, chatCommands, agentOrchestrator,
     );
 
     const chatHandler = new ChatHandler(agentRegistry, queue, historyCache, chatRegistry, pendingInputs, {
@@ -260,6 +272,7 @@ export async function startServer() {
     // HistoryCache's init() already self-wired appendMessages via
     // agentRegistry.onMessages(), so only broadcast wiring is needed here.
     agentRegistry.onMessages((chatId, messages, metadata) => {
+      agentOrchestrator.recordMessages(chatId, messages);
       broadcast(new AgentRunOutputMessage(chatId, messages, metadata?.turnId, metadata?.clientRequestId, metadata?.upstreamRequestId));
       pendingInputs.reconcile(chatId).catch((err) => {
         console.warn('pending-inputs: reconcile after messages failed:', err.message);
@@ -272,6 +285,7 @@ export async function startServer() {
       broadcast(new ChatSessionCreatedMessage(chatId));
     });
     agentRegistry.onFinished((chatId, exitCode, metadata) => {
+      agentOrchestrator.recordFinished(chatId);
       broadcast(new AgentRunFinishedMessage(chatId, exitCode, metadata?.turnId, metadata?.clientRequestId, metadata?.upstreamRequestId));
       pendingInputs.reconcile(chatId).catch((err) => {
         console.warn('pending-inputs: reconcile after finish failed:', err.message);
@@ -285,6 +299,7 @@ export async function startServer() {
       });
     });
     agentRegistry.onFailed((chatId, errorMessage, metadata) => {
+      agentOrchestrator.recordFailed(chatId, errorMessage);
       broadcast(new AgentRunFailedMessage(chatId, errorMessage, metadata?.turnId, metadata?.clientRequestId, metadata?.upstreamRequestId));
       pendingInputs.reconcile(chatId).catch((err) => {
         console.warn('pending-inputs: reconcile after failure failed:', err.message);
@@ -366,6 +381,7 @@ export async function startServer() {
         agentRegistry.shutdown();
         historyCache.destroy();
         await metadata.flush();
+        await agentOrchestrator.flush();
         await chatRegistry.flush();
       } catch (err) {
         console.warn('server: shutdown cleanup error:', err.message);


### PR DESCRIPTION
## Summary
- Add shared contracts for Garcon-owned child-agent orchestration.
- Add an AgentOrchestrator service plus REST endpoints to spawn, list, wait for, and abort child-agent work.
- Thread Codex fork metadata through native forks so child sessions are marked with `threadSource: subagent`.
- Add orchestrator, route, fork-chat, and Codex request-builder coverage.

## Validation
- `bun run check`
- `bun run test` (96 files, 1060 tests)
- `GARCON_DISABLE_AUTH=true GARCON_CONFIG_DIR=/tmp/... GARCON_WORKSPACE_DIR=/tmp/... GARCON_PROJECT_BASE_DIR=/tmp/... timeout 45s bun run start --port 0` started successfully on a random port before timeout shutdown.

## Notes
- Full live parent-child provider execution was not exercised in dogfood because it requires a real parent native session and provider/runtime resources. The server service and REST lifecycle are covered by focused tests.