### PR TITLE
fix(web): dark-mode sidebar, single-button rows, scannable chat titles

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -656,6 +656,8 @@
 	"sidebar_actions_settings": "Settings",
 	"sidebar_app_title": "Garcon",
 	"sidebar_chat_more_actions": "Chat actions",
+	"sidebar_chat_open": "Open chat {name}",
+	"sidebar_chat_open_with_time": "Open chat {name}, last active {time}",
 	"sidebar_chat_unread": "Unread",
 	"sidebar_chats_archive": "Archive",
 	"sidebar_chats_details": "Details",

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -20,6 +20,25 @@
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<link rel="manifest" href="/site.webmanifest" />
 		<title>Garcon</title>
+		<script>
+			// Applies the persisted theme before first paint so the shell (sidebar
+			// included) never flashes light while waiting for hydration. The key and
+			// shape mirror LOCAL_STORAGE_KEYS.localSettings; +layout.svelte keeps the
+			// class in sync at runtime.
+			(function () {
+				try {
+					var raw = localStorage.getItem('pref_local_settings');
+					var theme = raw ? JSON.parse(raw).theme : 'system';
+					var isDark =
+						theme === 'dark' ||
+						(theme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+					document.documentElement.classList.toggle('dark', isDark);
+					document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+				} catch (e) {
+					/* storage or JSON unavailable; runtime theme effect will apply it */
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -2,7 +2,6 @@
 	import { onMount } from 'svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { cn } from '$lib/utils/cn';
-	import { Button } from '$lib/components/ui/button';
 	import { getAppShell, getModelCatalog, getSplitLayout } from '$lib/context';
 	import Pin from '@lucide/svelte/icons/pin';
 	import Archive from '@lucide/svelte/icons/archive';
@@ -24,6 +23,7 @@
 		DropdownMenuSeparator,
 	} from '$lib/components/ui/dropdown-menu';
 	import SidebarChatSummary from './SidebarChatSummary.svelte';
+	import { formatSidebarChatTimestamp } from './chat-timestamp.js';
 	import type { SessionAgentId } from '$lib/types/app';
 	import type { ChatSessionRecord } from '$lib/types/chat-session';
 
@@ -87,6 +87,18 @@
 	let isSelected = $derived(selectedChatId === session.id);
 	let agentId = $derived(session.agentId || 'claude');
 	let canNativeDrag = $derived(enableNativeDrag && !isMultiSelectMode);
+
+	// Concise accessible name for the row's primary control so screen readers
+	// announce the chat title and recency instead of the entire summary block.
+	let rowAriaLabel = $derived.by(() => {
+		const timestamp = formatSidebarChatTimestamp(
+			session.lastActivityAt ?? session.createdAt,
+			currentTime,
+		);
+		return timestamp
+			? m.sidebar_chat_open_with_time({ name: chatName, time: timestamp.label })
+			: m.sidebar_chat_open({ name: chatName });
+	});
 
 	function handleItemClick(e: MouseEvent) {
 		if (isMultiSelectMode) {
@@ -261,6 +273,34 @@
 	</div>
 {/snippet}
 
+<!--
+	The row is a presentation container holding a single stretched primary
+	button plus independently interactive siblings (tags, overflow, actions).
+	The primary button carries a concise aria-label and no text descendants,
+	so its accessible name stays short and no button nests inside another.
+	The visible content layer is pointer-events-none so clicks fall through to
+	the stretched button, while interactive children re-enable pointer events.
+-->
+{#snippet rowBody(extraButtonClass: string)}
+	<button
+		type="button"
+		class={cn('absolute inset-0 z-0 rounded-none', extraButtonClass)}
+		aria-label={rowAriaLabel}
+		aria-current={!isMultiSelectMode && isSelected ? 'true' : undefined}
+		draggable={canNativeDrag ? true : undefined}
+		ondragstart={canNativeDrag ? handleDragStart : undefined}
+		ondragend={canNativeDrag ? handleDragEnd : undefined}
+		oncontextmenu={handleRightClick}
+		onclick={handleItemClick}
+	></button>
+	<div
+		class="pointer-events-none relative z-10 flex min-w-0 flex-1 items-center [&_a]:pointer-events-auto [&_button]:pointer-events-auto"
+	>
+		{@render selectionCheckbox()}
+		{@render chatSummary()}
+	</div>
+{/snippet}
+
 <div class="chat-item-root group relative" bind:this={itemEl}>
 	{#if isMobile}
 		<div
@@ -273,16 +313,16 @@
 				!isMultiSelectMode && isProcessing && 'border-l-[3px] border-l-status-processing',
 			)}
 		>
-			<button
+			<div
 				class={cn(
-					'flex-1 min-w-0 text-left py-[5px] pr-2 mx-0 my-0 rounded-none hover:bg-sidebar-chat-item-hover-bg active:scale-[0.98] transition-[background-color,color,transform] duration-150 relative flex items-center',
+					'relative flex min-w-0 flex-1 items-center py-[5px] pr-2',
 					isMultiSelectMode ? 'pl-1' : 'pl-[7px]',
 				)}
-				onclick={handleItemClick}
 			>
-				{@render selectionCheckbox()}
-				{@render chatSummary()}
-			</button>
+				{@render rowBody(
+					'text-left hover:bg-sidebar-chat-item-hover-bg active:scale-[0.98] transition-[background-color,transform] duration-150',
+				)}
+			</div>
 			{#if !isMultiSelectMode}
 				<button
 					type="button"
@@ -296,29 +336,20 @@
 			{/if}
 		</div>
 	{:else}
-		<div>
-			<Button
-				variant="ghost"
-				draggable={canNativeDrag ? true : undefined}
-				ondragstart={canNativeDrag ? handleDragStart : undefined}
-				ondragend={canNativeDrag ? handleDragEnd : undefined}
-				oncontextmenu={handleRightClick}
-				class={cn(
-					'w-full justify-start pr-2 h-auto font-normal text-left rounded-none bg-sidebar-chat-item-bg hover:bg-sidebar-chat-item-hover-bg transition-colors duration-200 border-b border-border/30',
-					isMultiSelectMode
-						? 'py-[5px] pl-1 border-l-0'
-						: 'py-[5px] pl-[7px] border-l-2 border-l-transparent',
-					!isMultiSelectMode &&
-						isSelected &&
-						'bg-sidebar-chat-item-selected-bg text-sidebar-chat-item-selected-foreground',
-					!isMultiSelectMode && isProcessing && 'border-l-[3px] border-l-status-processing',
-					isMultiSelectMode && isMultiSelected && 'bg-primary/8',
-				)}
-				onclick={handleItemClick}
-			>
-				{@render selectionCheckbox()}
-				{@render chatSummary()}
-			</Button>
+		<div
+			class={cn(
+				'relative flex min-w-0 items-center pr-2 bg-sidebar-chat-item-bg transition-colors duration-200 border-b border-border/30',
+				isMultiSelectMode
+					? 'py-[5px] pl-1 border-l-0'
+					: 'py-[5px] pl-[7px] border-l-2 border-l-transparent',
+				!isMultiSelectMode &&
+					isSelected &&
+					'bg-sidebar-chat-item-selected-bg text-sidebar-chat-item-selected-foreground',
+				!isMultiSelectMode && isProcessing && 'border-l-[3px] border-l-status-processing',
+				isMultiSelectMode && isMultiSelected && 'bg-primary/8',
+			)}
+		>
+			{@render rowBody('hover:bg-sidebar-chat-item-hover-bg transition-colors duration-200')}
 		</div>
 	{/if}
 

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -95,7 +95,7 @@
 	<div class="min-w-0 flex-1">
 		<div
 			class={cn(
-				'flex min-w-0 items-center gap-1.5 truncate text-[14px] font-medium',
+				'flex min-w-0 items-center gap-1.5 truncate text-[14px] font-semibold tracking-tight',
 				isSelected ? 'text-sidebar-chat-item-selected-foreground' : 'text-foreground',
 			)}
 		>
@@ -105,7 +105,7 @@
 					aria-label={m.sidebar_chat_unread()}
 				></span>
 			{/if}
-			<span class="truncate">{chatName}</span>
+			<span class="truncate" title={chatName}>{chatName}</span>
 		</div>
 
 		{#if projectPath || formattedTimestamp}
@@ -141,8 +141,8 @@
 
 		<div
 			class={cn(
-				'mb-1 mt-0.5 truncate text-[13px] italic',
-				isSelected ? 'text-sidebar-chat-item-selected-foreground/90' : 'text-foreground/80',
+				'mb-1 mt-0.5 truncate text-[12px] leading-[1.3]',
+				isSelected ? 'text-sidebar-chat-item-selected-foreground/80' : 'text-muted-foreground',
 			)}
 		>
 			{lastMessage || '\u00A0'}

--- a/web/src/lib/components/sidebar/SidebarContent.svelte
+++ b/web/src/lib/components/sidebar/SidebarContent.svelte
@@ -66,7 +66,7 @@
 
 <ScrollArea
 	bind:viewportRef
-	class="flex-1 overflow-y-auto overscroll-contain"
+	class="flex-1 overflow-y-auto overscroll-contain bg-sidebar-chat-item-bg"
 	scrollbarYClasses="w-1.5"
 >
 	<SidebarChatList

--- a/web/src/lib/components/sidebar/SidebarVirtualSortableChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarVirtualSortableChatList.svelte
@@ -696,7 +696,7 @@
 
 <div
 	bind:this={listEl}
-	class="relative min-h-full"
+	class="relative min-h-full bg-sidebar-chat-item-bg"
 	style={`height:${totalHeight}px;`}
 	data-sidebar-virtual-list
 	data-sidebar-filtered={isFiltered ? 'true' : 'false'}

--- a/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
@@ -129,7 +129,8 @@ describe('SidebarVirtualSortableChatList', () => {
 		expect(screen.getByText('Chat 0')).toBeTruthy();
 		expect(screen.queryByText('Chat 499')).toBeNull();
 		expect(document.querySelectorAll('[data-sidebar-virtual-row]').length).toBeLessThan(40);
-		expect(screen.getByText('Chat 0').closest('button')?.hasAttribute('draggable')).toBe(false);
+		const firstRowButton = screen.getByRole('button', { name: /Open chat Chat 0/ });
+		expect(firstRowButton.hasAttribute('draggable')).toBe(false);
 	});
 
 	it('updates visible rows when the shared viewport scrolls', async () => {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -38,9 +38,8 @@ describe('shared sidebar chat row', () => {
 			session: createChat(),
 		});
 
-		expect(screen.getByText('Shared row chat').closest('button')?.getAttribute('draggable')).toBe(
-			'true',
-		);
+		const rowButton = screen.getByRole('button', { name: /Open chat Shared row chat/ });
+		expect(rowButton.getAttribute('draggable')).toBe('true');
 	});
 
 	it('omits native row dragging for Pragmatic wrappers', () => {
@@ -49,9 +48,28 @@ describe('shared sidebar chat row', () => {
 			enableNativeDrag: false,
 		});
 
-		expect(screen.getByText('Shared row chat').closest('button')?.hasAttribute('draggable')).toBe(
-			false,
-		);
+		const rowButton = screen.getByRole('button', { name: /Open chat Shared row chat/ });
+		expect(rowButton.hasAttribute('draggable')).toBe(false);
+	});
+
+	it('exposes a single concise accessible name on the row control', () => {
+		render(SidebarChatItemHost, {
+			session: createChat(),
+			onTagClick: vi.fn(),
+			onManageTags: vi.fn(),
+		});
+
+		const rowButton = screen.getByRole('button', { name: /Open chat Shared row chat/ });
+		// The primary control carries the whole accessible name; the long preview,
+		// project path, and provider tag must not leak into it.
+		expect(rowButton.textContent?.trim()).toBe('');
+		expect(rowButton.getAttribute('aria-label')).toContain('Shared row chat');
+		expect(rowButton.getAttribute('aria-label')).not.toContain('Latest preview text');
+
+		// Tag and overflow buttons are siblings, never nested inside the row button.
+		const tagButton = screen.getByRole('button', { name: 'ops' });
+		expect(tagButton.closest('button')).toBe(tagButton);
+		expect(rowButton.querySelector('button')).toBeNull();
 	});
 
 	it('renders the shared chat summary inside the sidebar item shell', async () => {


### PR DESCRIPTION
**Problem**
In dark mode the sidebar chat list rendered as a bright white column against the otherwise dark shell (dogfood ISSUE-006): the persisted theme was only applied after hydration, so the SPA painted the light shell first. Each chat row was also a `button` nested inside another `button` (plus a "Chat actions" button), producing invalid HTML and a giant concatenated accessible name spanning title, path, timestamp, full preview, and provider tag (ISSUE-002). Titles were hard to scan because they were not visually dominant over the message preview (ISSUE-001).

**Solution**
Apply the persisted theme before first paint with a small inline bootstrap so the sidebar (and whole shell) never flashes light, and anchor the chat-list body to a dark-aware surface token. Refactor each row into a single stretched primary button carrying a concise `aria-label` (chat title + last-active time), with tags and the actions menu as non-nested siblings. Sharpen the title/preview type hierarchy and keep consistent single-line truncation.

**Changes**
- `app.html`: pre-hydration theme bootstrap that sets `.dark` and `color-scheme` from persisted settings before first paint.
- `SidebarContent.svelte` / `SidebarVirtualSortableChatList.svelte`: chat-list body now carries the dark-aware `bg-sidebar-chat-item-bg` surface instead of relying solely on inherited background.
- `SidebarChatItem.svelte`: row is a presentation container with one stretched primary `button` (concise `aria-label`, handles select / ctrl+select / shift-select / context-menu / native drag); the content layer is `pointer-events-none` so clicks fall through while tags, overflow, and the actions menu remain independently interactive siblings (no button-in-button).
- `SidebarChatSummary.svelte`: title is `font-semibold tracking-tight` and dominant; preview is smaller and muted; both truncate to a single line with ellipsis.
- `messages/en.json`: adds `sidebar_chat_open` / `sidebar_chat_open_with_time` for the row accessible name.
- Tests updated for the new single-control row structure.

**Expected Impact**
Dark mode is consistent across the entire sidebar with no light flash; each row is a single valid, keyboard-reachable control with a short, meaningful screen-reader name; chat titles are easier to scan. All existing selection, multi-select, context-menu, and drag-reorder behavior is preserved. `bun run check` and `bun run test` pass.


**Before / After**

| Before (dark theme, white sidebar) | After (dark theme, dark sidebar) |
|---|---|
| ![before](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-sidebar-pr5/screenshots/sidebar-before.png) | ![after](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-sidebar-pr5/screenshots/sidebar-after.png) |

