### PR TITLE
fix(web): de-duplicate mobile nav and contextualize workspace header

### DIFF
--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -53,7 +53,9 @@
 	const isMobileLayout = $derived(!!onMenuClick);
 	const isChatTab = $derived(activeTab === 'chat');
 	const showTopHeader = $derived(!isChatTab);
-	const showInlineDesktopTabs = $derived(showTopHeader);
+	// The inline tab rail is desktop-only; on mobile the BottomTabBar is the sole
+	// navigation, so showing it here would duplicate that bar.
+	const showInlineDesktopTabs = $derived(showTopHeader && !isMobileLayout);
 	const showFloatingDesktopTabs = $derived(isChatTab && !isMobileLayout);
 	const hideFullscreenButtonOnGitTab = $derived(
 		activeTab === 'git' && localSettings.alwaysFullscreenOnGitPanel,
@@ -258,13 +260,17 @@
 								<Menu class="w-5 h-5" />
 							</button>
 						{/if}
+						<!-- The top header only renders on non-chat tabs, where the project
+						     context is the high-signal label and the chat title is secondary. -->
 						<div class="min-w-0 flex-1">
 							<h2 class="text-[15px] font-semibold text-foreground truncate">
-								{selectedChat.title || m.main_new_chat()}
-							</h2>
-							<div class="text-xs text-muted-foreground truncate">
 								{projectDisplayName(selectedChat.projectPath)}
-							</div>
+							</h2>
+							{#if selectedChat.title}
+								<div class="text-xs text-muted-foreground/80 truncate">
+									{selectedChat.title}
+								</div>
+							{/if}
 						</div>
 					</div>
 

--- a/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
+++ b/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
@@ -52,8 +52,34 @@ describe('WorkspaceView header visibility', () => {
 			isMobile: false,
 		});
 
-		expect(screen.getByRole('heading', { name: 'Header Test Chat' })).toBeTruthy();
+		// The heading leads with the project context, not the raw chat title.
+		expect(screen.getByRole('heading', { name: 'header-test' })).toBeTruthy();
 		expect(container.querySelector('.absolute .bg-chat-tabs-rail')).toBeNull();
+	});
+
+	it('demotes the chat title to a secondary line on non-chat tabs', () => {
+		render(WorkspaceViewTestHost, {
+			activeTab: 'files',
+			isMobile: false,
+		});
+
+		// The project name is the heading; the chat title remains as low-emphasis context.
+		expect(screen.getByRole('heading', { name: 'header-test' })).toBeTruthy();
+		expect(screen.getByText('Header Test Chat')).toBeTruthy();
+		expect(screen.queryByRole('heading', { name: 'Header Test Chat' })).toBeNull();
+	});
+
+	it('does not render the inline tab rail on mobile non-chat tabs', () => {
+		const { container } = render(WorkspaceViewTestHost, {
+			activeTab: 'files',
+			isMobile: true,
+		});
+
+		// The top header keeps its contextual project label and menu button on mobile,
+		// but the duplicated tab rail belongs solely to the BottomTabBar.
+		expect(screen.getByRole('heading', { name: 'header-test' })).toBeTruthy();
+		expect(screen.getByLabelText('Open menu')).toBeTruthy();
+		expect(container.querySelector('.bg-chat-tabs-rail')).toBeNull();
 	});
 
 	it('hides the top header on mobile chat tab', () => {


### PR DESCRIPTION
**Problem**

On mobile viewports the same five-item navigation (Menu, Chat, Git, Files, Terminal) rendered twice: the workspace top header showed the inline tab rail while the `BottomTabBar` showed the identical controls (dogfood ISSUE-007). Separately, the workspace top header led with the raw, unsummarized chat title on every non-chat tab (Files/Git/Terminal), consuming prominent space with low-signal text that is irrelevant on those tabs (dogfood ISSUE-005).

**Solution**

Gate the inline tab rail to desktop only so the `BottomTabBar` is the single mobile navigation, while keeping the header's contextual menu button and label. On non-chat tabs, lead the header with the high-signal project context and demote the chat title to a low-emphasis, single-line subtitle shown only when present. Both changes derive from existing state with no new data fetching or features.

**Changes**

- `WorkspaceView.svelte`: `showInlineDesktopTabs` now requires `!isMobileLayout`, removing the duplicated mobile tab rail.
- `WorkspaceView.svelte`: non-chat header now uses the project name as the heading and renders the chat title as a muted, truncated subtitle.
- `WorkspaceView.test.ts`: updated the desktop non-chat heading assertion and added tests for the demoted title and for the absence of the inline tab rail on mobile.

**Expected Impact**

Mobile users see one navigation bar instead of two, and the non-chat workspace header surfaces relevant project context instead of redundant chat-title text. Desktop layout is unchanged.

**Before / After**

| Before (mobile: duplicated top + bottom nav) | After (mobile: single bottom nav) |
|---|---|
| ![before](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-layout-pr4/screenshots/layout-before.png) | ![after](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-layout-pr4/screenshots/layout-after.png) |

