### PR TITLE
web: Group adjacent read tool uses in the conversation feed

### DIFF
--- a/web/src/lib/chat/__tests__/conversation-feed-items.test.ts
+++ b/web/src/lib/chat/__tests__/conversation-feed-items.test.ts
@@ -18,7 +18,11 @@ import type { LocalNoticeRow } from '../local-notice';
 const TS = '2026-05-29T00:00:00.000Z';
 
 function rows(messages: ChatMessage[]) {
-	return messages.map((message, index) => ({ kind: 'message' as const, id: `row-${index}`, message }));
+	return messages.map((message, index) => ({
+		kind: 'message' as const,
+		id: `row-${index}`,
+		message,
+	}));
 }
 
 function notice(content: string): LocalNoticeRow {
@@ -62,6 +66,39 @@ describe('buildConversationFeedRenderItems', () => {
 		expect(items[1]).toMatchObject({ kind: 'message', message: messages[1] });
 	});
 
+	it('groups adjacent read tool uses into one render item', () => {
+		const messages = [
+			new UserMessage(TS, 'start'),
+			new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'read-2', '/tmp/b.ts'),
+			new AssistantMessage(TS, 'done'),
+		];
+
+		const items = buildConversationFeedRenderItems(rows(messages));
+
+		expect(items).toHaveLength(3);
+		expect(items[1]).toMatchObject({ kind: 'read-group' });
+		if (items[1].kind !== 'read-group') throw new Error('expected read group');
+		expect(items[1].messages.map((message) => message.filePath)).toEqual([
+			'/tmp/a.ts',
+			'/tmp/b.ts',
+		]);
+		expect(items[2]).toMatchObject({ kind: 'message', prevMessage: messages[2] });
+	});
+
+	it('keeps a single read tool use as a normal message', () => {
+		const messages = [
+			new UserMessage(TS, 'start'),
+			new ReadToolUseMessage(TS, 'read-1', '/tmp/file.ts'),
+			new AssistantMessage(TS, 'done'),
+		];
+
+		const items = buildConversationFeedRenderItems(rows(messages));
+
+		expect(items).toHaveLength(3);
+		expect(items[1]).toMatchObject({ kind: 'message', message: messages[1] });
+	});
+
 	it('groups bash tool uses across hidden tool results', () => {
 		const messages = [
 			new BashToolUseMessage(TS, 'bash-1', 'pwd'),
@@ -76,6 +113,24 @@ describe('buildConversationFeedRenderItems', () => {
 		expect(items[0]).toMatchObject({ kind: 'bash-group' });
 		if (items[0].kind !== 'bash-group') throw new Error('expected bash group');
 		expect(items[0].messages.map((message) => message.toolId)).toEqual(['bash-1', 'bash-2']);
+	});
+
+	it('groups read tool uses across hidden tool results', () => {
+		const messages = [
+			new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+			new ToolResultMessage(TS, 'read-1', { content: 'a' }, false),
+			new ReadToolUseMessage(TS, 'read-2', ''),
+			new ToolResultMessage(TS, 'read-2', { content: 'b' }, false),
+		];
+
+		const model = buildConversationFeedRenderModel(rows(messages));
+
+		expect(model.items).toHaveLength(1);
+		expect(model.items[0]).toMatchObject({ kind: 'read-group' });
+		if (model.items[0].kind !== 'read-group') throw new Error('expected read group');
+		expect(model.items[0].messages.map((message) => message.toolId)).toEqual(['read-1', 'read-2']);
+		expect(model.toolResultIndex.get('read-1')?.content).toEqual({ content: 'a' });
+		expect(model.toolResultIndex.get('read-2')?.content).toEqual({ content: 'b' });
 	});
 
 	it('keeps the group id stable as more adjacent bash tool uses arrive', () => {
@@ -93,6 +148,21 @@ describe('buildConversationFeedRenderItems', () => {
 		expect(firstItems[0].id).toBe(secondItems[0].id);
 	});
 
+	it('keeps the read group id stable as more adjacent read tool uses arrive', () => {
+		const firstBatch = [
+			new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'read-2', ''),
+		];
+		const secondBatch = [...firstBatch, new ReadToolUseMessage(TS, 'read-3', '/tmp/c.ts')];
+
+		const firstItems = buildConversationFeedRenderItems(rows(firstBatch));
+		const secondItems = buildConversationFeedRenderItems(rows(secondBatch));
+
+		expect(firstItems[0]).toMatchObject({ kind: 'read-group' });
+		expect(secondItems[0]).toMatchObject({ kind: 'read-group' });
+		expect(firstItems[0].id).toBe(secondItems[0].id);
+	});
+
 	it('builds render items and terminal lookup indexes in one pass', () => {
 		const messages = [
 			new BashToolUseMessage(TS, 'bash-1', 'pwd'),
@@ -106,7 +176,10 @@ describe('buildConversationFeedRenderItems', () => {
 
 		expect(model.items.map((item) => item.kind)).toEqual(['message', 'message']);
 		expect(model.toolResultIndex.get('bash-1')?.content).toEqual({ content: 'ok' });
-		expect(model.permissionTerminalById.get('perm-1')).toEqual({ state: 'resolved', allowed: true });
+		expect(model.permissionTerminalById.get('perm-1')).toEqual({
+			state: 'resolved',
+			allowed: true,
+		});
 		expect(model.permissionTerminalById.get('perm-2')).toEqual({
 			state: 'cancelled',
 			reason: 'cancelled',
@@ -150,6 +223,22 @@ describe('buildConversationFeedRenderItems', () => {
 		const keys = items.map((item) => item.id);
 
 		expect(items.filter((item) => item.kind === 'bash-group')).toHaveLength(2);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it('derives unique render keys for read groups with duplicate starting tool IDs', () => {
+		const messages = [
+			new ReadToolUseMessage(TS, 'dup-read', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'read-2', '/tmp/b.ts'),
+			new AssistantMessage(TS, 'separator'),
+			new ReadToolUseMessage(TS, 'dup-read', '/tmp/c.ts'),
+			new ReadToolUseMessage(TS, 'read-4', '/tmp/d.ts'),
+		];
+
+		const items = buildConversationFeedRenderItems(rows(messages));
+		const keys = items.map((item) => item.id);
+
+		expect(items.filter((item) => item.kind === 'read-group')).toHaveLength(2);
 		expect(new Set(keys).size).toBe(keys.length);
 	});
 });

--- a/web/src/lib/chat/__tests__/read-tool-group-items.test.ts
+++ b/web/src/lib/chat/__tests__/read-tool-group-items.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { ReadToolUseMessage } from '$shared/chat-types';
+import { buildReadToolGroupRenderItems, summarizeReadToolGroup } from '../read-tool-group-items';
+
+const TS = '2026-05-29T00:00:00.000Z';
+
+describe('buildReadToolGroupRenderItems', () => {
+	it('keeps duplicate tool IDs from producing duplicate Svelte keys', () => {
+		const messages = [
+			new ReadToolUseMessage(TS, 'duplicate-tool', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'duplicate-tool', '/tmp/b.ts'),
+		];
+
+		const items = buildReadToolGroupRenderItems(messages);
+
+		expect(items.map((item) => item.key)).toEqual(['duplicate-tool', 'duplicate-tool#1']);
+		expect(items.map((item) => item.displayName)).toEqual(['a.ts', 'b.ts']);
+	});
+
+	it('keeps existing keys stable when reads append to the group', () => {
+		const first = [
+			new ReadToolUseMessage(TS, 'duplicate-tool', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'duplicate-tool', ''),
+		];
+		const second = [...first, new ReadToolUseMessage(TS, 'duplicate-tool', '/tmp/c.ts')];
+
+		const firstKeys = buildReadToolGroupRenderItems(first).map((item) => item.key);
+		const secondKeys = buildReadToolGroupRenderItems(second).map((item) => item.key);
+
+		expect(secondKeys.slice(0, firstKeys.length)).toEqual(firstKeys);
+		expect(secondKeys[2]).toBe('duplicate-tool#2');
+	});
+
+	it('marks empty and whitespace paths as unknown', () => {
+		const messages = [
+			new ReadToolUseMessage(TS, 'read-1', ''),
+			new ReadToolUseMessage(TS, 'read-2', '   '),
+		];
+
+		const items = buildReadToolGroupRenderItems(messages);
+
+		expect(items.every((item) => item.isUnknown)).toBe(true);
+		expect(items.map((item) => item.displayName)).toEqual(['Unknown file', 'Unknown file']);
+	});
+
+	it('preserves read range labels', () => {
+		const messages = [new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts', 10, 5)];
+
+		const items = buildReadToolGroupRenderItems(messages);
+
+		expect(items[0].rangeLabel).toBe('Lines 10-14');
+	});
+});
+
+describe('summarizeReadToolGroup', () => {
+	it('summarizes groups where all file paths are known', () => {
+		const summary = summarizeReadToolGroup([
+			new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'read-2', '/tmp/b.ts'),
+			new ReadToolUseMessage(TS, 'read-3', '/tmp/c.ts'),
+		]);
+
+		expect(summary).toEqual({
+			totalCount: 3,
+			unknownCount: 0,
+			label: '3 files',
+		});
+	});
+
+	it('summarizes groups with known and unknown file paths', () => {
+		const summary = summarizeReadToolGroup([
+			new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+			new ReadToolUseMessage(TS, 'read-2', ''),
+			new ReadToolUseMessage(TS, 'read-3', '   '),
+			new ReadToolUseMessage(TS, 'read-4', '/tmp/d.ts'),
+			new ReadToolUseMessage(TS, 'read-5', '/tmp/e.ts'),
+		]);
+
+		expect(summary).toEqual({
+			totalCount: 5,
+			unknownCount: 2,
+			label: '5 files (2 unknown)',
+		});
+	});
+
+	it('summarizes groups where all file paths are unknown', () => {
+		const summary = summarizeReadToolGroup([
+			new ReadToolUseMessage(TS, 'read-1', ''),
+			new ReadToolUseMessage(TS, 'read-2', '   '),
+			new ReadToolUseMessage(TS, 'read-3', ''),
+			new ReadToolUseMessage(TS, 'read-4', ''),
+			new ReadToolUseMessage(TS, 'read-5', ''),
+		]);
+
+		expect(summary).toEqual({
+			totalCount: 5,
+			unknownCount: 5,
+			label: '5 unknown files',
+		});
+	});
+});

--- a/web/src/lib/chat/conversation-feed-items.ts
+++ b/web/src/lib/chat/conversation-feed-items.ts
@@ -3,6 +3,7 @@ import {
 	PermissionCancelledMessage,
 	PermissionRequestMessage,
 	PermissionResolvedMessage,
+	ReadToolUseMessage,
 	ToolResultMessage,
 } from '$shared/chat-types';
 import type { ChatMessage } from '$shared/chat-types';
@@ -27,6 +28,13 @@ export type ConversationFeedRenderItem =
 			kind: 'bash-group';
 			id: string;
 			messages: BashToolUseMessage[];
+			index: number;
+			prevMessage: ChatMessage | null;
+	  }
+	| {
+			kind: 'read-group';
+			id: string;
+			messages: ReadToolUseMessage[];
 			index: number;
 			prevMessage: ChatMessage | null;
 	  }
@@ -56,6 +64,10 @@ function shouldSkipStandaloneMessage(message: ChatMessage): boolean {
 
 function bashGroupId(rows: ChatTranscriptRow[]): string {
 	return `bash-group-${rows[0]?.id ?? 'empty'}`;
+}
+
+function readGroupId(rows: ChatTranscriptRow[]): string {
+	return `read-group-${rows[0]?.id ?? 'empty'}`;
 }
 
 export function buildConversationFeedRenderModel(
@@ -129,6 +141,48 @@ export function buildConversationFeedRenderModel(
 				items.push({
 					kind: 'bash-group',
 					id: bashGroupId(groupRows),
+					messages: group,
+					index: firstIndex,
+					prevMessage,
+				});
+			} else {
+				items.push({
+					kind: 'message',
+					id: groupRows[0].id,
+					message: group[0],
+					index: firstIndex,
+					prevMessage,
+				});
+			}
+			continue;
+		}
+
+		if (message instanceof ReadToolUseMessage) {
+			const groupRows: ChatTranscriptRow[] = [];
+			const group: ReadToolUseMessage[] = [];
+			const prevMessage = previousRenderable;
+			const firstIndex = index;
+
+			while (index < rows.length) {
+				const candidateRow = rows[index];
+				if (candidateRow.kind === 'local-notice') break;
+				const candidate = candidateRow.message;
+				if (candidate instanceof ToolResultMessage) {
+					toolResultIndex.set(candidate.toolId, candidate);
+					index += 1;
+					continue;
+				}
+				if (!(candidate instanceof ReadToolUseMessage)) break;
+				groupRows.push(candidateRow);
+				group.push(candidate);
+				previousRenderable = candidate;
+				index += 1;
+			}
+
+			if (group.length > 1) {
+				items.push({
+					kind: 'read-group',
+					id: readGroupId(groupRows),
 					messages: group,
 					index: firstIndex,
 					prevMessage,

--- a/web/src/lib/chat/read-tool-group-items.ts
+++ b/web/src/lib/chat/read-tool-group-items.ts
@@ -1,0 +1,78 @@
+import type { ReadToolUseMessage } from '$shared/chat-types';
+import { readRangePresenter } from './tool-display-presenters';
+
+export interface ReadToolGroupRenderItem {
+	key: string;
+	message: ReadToolUseMessage;
+	filePath: string;
+	displayName: string;
+	rangeLabel?: string;
+	isUnknown: boolean;
+}
+
+export interface ReadToolGroupSummary {
+	totalCount: number;
+	unknownCount: number;
+	label: string;
+}
+
+function fileCountLabel(count: number): string {
+	return count === 1 ? 'file' : 'files';
+}
+
+function readFilePath(message: ReadToolUseMessage): string {
+	return message.filePath.trim();
+}
+
+function readFileDisplayName(filePath: string): string {
+	return filePath.split('/').pop() || filePath;
+}
+
+export function summarizeReadToolGroup(messages: ReadToolUseMessage[]): ReadToolGroupSummary {
+	const totalCount = messages.length;
+	const unknownCount = messages.filter((message) => readFilePath(message).length === 0).length;
+	const fileLabel = fileCountLabel(totalCount);
+
+	if (unknownCount === totalCount) {
+		return {
+			totalCount,
+			unknownCount,
+			label: `${totalCount} unknown ${fileLabel}`,
+		};
+	}
+
+	if (unknownCount > 0) {
+		return {
+			totalCount,
+			unknownCount,
+			label: `${totalCount} ${fileLabel} (${unknownCount} unknown)`,
+		};
+	}
+
+	return {
+		totalCount,
+		unknownCount,
+		label: `${totalCount} ${fileLabel}`,
+	};
+}
+
+export function buildReadToolGroupRenderItems(
+	messages: ReadToolUseMessage[],
+): ReadToolGroupRenderItem[] {
+	const seen = new Map<string, number>();
+	return messages.map((message, index) => {
+		const baseKey = message.toolId || `missing-tool-id-${index}`;
+		const duplicateIndex = seen.get(baseKey) ?? 0;
+		seen.set(baseKey, duplicateIndex + 1);
+		const key = duplicateIndex === 0 ? baseKey : `${baseKey}#${duplicateIndex}`;
+		const filePath = readFilePath(message);
+		return {
+			key,
+			message,
+			filePath,
+			displayName: filePath ? readFileDisplayName(filePath) : 'Unknown file',
+			rangeLabel: readRangePresenter(message as unknown as Record<string, unknown>),
+			isUnknown: filePath.length === 0,
+		};
+	});
+}

--- a/web/src/lib/components/chat/ConversationTranscript.svelte
+++ b/web/src/lib/components/chat/ConversationTranscript.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ConversationMessage from './ConversationMessage.svelte';
 	import ChatBashToolGroup from './tools/ChatBashToolGroup.svelte';
+	import ChatReadToolGroup from './tools/ChatReadToolGroup.svelte';
 	import MessageRenderFallback from './MessageRenderFallback.svelte';
 	import LocalNoticeRow from './rows/LocalNoticeRow.svelte';
 	import { isToolUseMessage, PermissionRequestMessage } from '$shared/chat-types';
@@ -10,6 +11,7 @@
 	import type { ChatDisplayRow } from '$lib/chat/state.svelte';
 	import type { ConversationMessageChatContext } from '$lib/chat/conversation-message-context';
 	import { buildConversationFeedRenderModel } from '$lib/chat/conversation-feed-items';
+	import { getChatSessions, getFileViewer } from '$lib/context';
 
 	interface PermissionDecision {
 		allow: PermissionDecisionPayload['allow'];
@@ -40,6 +42,16 @@
 		onExitPlanMode,
 	}: Props = $props();
 
+	const sessions = getChatSessions();
+	const fileViewer = getFileViewer();
+
+	const activeChatContext = $derived.by((): ConversationMessageChatContext | null => {
+		if (chatContext?.chatId) return chatContext;
+		const selected = sessions.selectedChat;
+		if (!selected?.id) return null;
+		return { chatId: selected.id, projectPath: selected.projectPath ?? null };
+	});
+
 	const pendingExitPlanIds = $derived(
 		new Set(
 			pendingPermissionRequests
@@ -50,6 +62,17 @@
 
 	const renderModel = $derived(buildConversationFeedRenderModel(rows));
 	const renderItems = $derived(renderModel.items);
+
+	function handleReadFileOpen(filePath: string): void {
+		const chat = activeChatContext;
+		if (!chat?.projectPath) return;
+		fileViewer.openAuto({
+			chatId: chat.chatId,
+			projectPath: chat.projectPath,
+			relativePath: filePath,
+			source: 'tool',
+		});
+	}
 </script>
 
 <div
@@ -61,6 +84,13 @@
 		{#if item.kind === 'bash-group'}
 			<svelte:boundary>
 				<ChatBashToolGroup messages={item.messages} />
+				{#snippet failed(error)}
+					<MessageRenderFallback {error} />
+				{/snippet}
+			</svelte:boundary>
+		{:else if item.kind === 'read-group'}
+			<svelte:boundary>
+				<ChatReadToolGroup messages={item.messages} onFileOpen={handleReadFileOpen} />
 				{#snippet failed(error)}
 					<MessageRenderFallback {error} />
 				{/snippet}
@@ -77,9 +107,8 @@
 			{@const toolResult = isToolUseMessage(message)
 				? renderModel.toolResultIndex.get(message.toolId)
 				: undefined}
-			{@const exitPlanId = message.type === 'exit-plan-mode-tool-use'
-				? `plan-exit-${message.toolId}`
-				: null}
+			{@const exitPlanId =
+				message.type === 'exit-plan-mode-tool-use' ? `plan-exit-${message.toolId}` : null}
 			{@const permTerminal =
 				message instanceof PermissionRequestMessage
 					? renderModel.permissionTerminalById.get(message.permissionRequestId)

--- a/web/src/lib/components/chat/tools/ChatReadToolGroup.svelte
+++ b/web/src/lib/components/chat/tools/ChatReadToolGroup.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import type { ReadToolUseMessage } from '$shared/chat-types';
+	import ChatEventCard from '../rows/ChatEventCard.svelte';
+	import {
+		buildReadToolGroupRenderItems,
+		summarizeReadToolGroup,
+	} from '$lib/chat/read-tool-group-items';
+
+	interface Props {
+		messages: ReadToolUseMessage[];
+		onFileOpen?: (filePath: string) => void;
+	}
+
+	let { messages, onFileOpen }: Props = $props();
+
+	const summary = $derived(summarizeReadToolGroup(messages));
+	const renderItems = $derived(buildReadToolGroupRenderItems(messages));
+
+	function handleFileOpen(filePath: string): void {
+		if (!filePath) return;
+		onFileOpen?.(filePath);
+	}
+</script>
+
+<div class="group my-0.5">
+	<ChatEventCard variant="default" compact>
+		{#snippet body()}
+			<div class="mb-1.5 flex items-center gap-2 min-w-0">
+				<span class="text-[11px] font-medium text-muted-foreground tracking-wide">Read</span>
+				<span class="text-[11px] text-muted-foreground">{summary.label}</span>
+			</div>
+
+			<div class="divide-y divide-border/70">
+				{#each renderItems as item (item.key)}
+					<div class="py-1 first:pt-0 last:pb-0 min-w-0">
+						<div class="flex items-center gap-1.5 min-w-0">
+							{#if item.isUnknown || !onFileOpen}
+								<span
+									class="text-xs font-mono truncate min-w-0 {item.isUnknown
+										? 'text-muted-foreground italic'
+										: 'text-foreground'}"
+									title={item.filePath || item.displayName}
+								>
+									{item.displayName}
+								</span>
+							{:else}
+								<button
+									type="button"
+									onclick={() => handleFileOpen(item.filePath)}
+									class="text-xs text-primary hover:text-primary/80 font-mono hover:underline transition-colors truncate text-left min-w-0"
+									title={item.filePath}
+								>
+									{item.displayName}
+								</button>
+							{/if}
+						</div>
+						{#if item.rangeLabel}
+							<div class="mt-0.5 text-[11px] text-muted-foreground break-words">
+								{item.rangeLabel}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/snippet}
+	</ChatEventCard>
+</div>

--- a/web/src/lib/components/chat/tools/__tests__/ChatReadToolGroup.test.ts
+++ b/web/src/lib/components/chat/tools/__tests__/ChatReadToolGroup.test.ts
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { ReadToolUseMessage } from '$shared/chat-types';
+import ChatReadToolGroup from '../ChatReadToolGroup.svelte';
+
+const TS = '2026-05-29T00:00:00.000Z';
+
+describe('ChatReadToolGroup', () => {
+	it('renders known file counts in the header', () => {
+		render(ChatReadToolGroup, {
+			messages: [
+				new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+				new ReadToolUseMessage(TS, 'read-2', '/tmp/b.ts'),
+			],
+		});
+
+		expect(screen.getByText('Read')).toBeTruthy();
+		expect(screen.getByText('2 files')).toBeTruthy();
+	});
+
+	it('renders mixed known and unknown file counts in the header', () => {
+		render(ChatReadToolGroup, {
+			messages: [
+				new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts'),
+				new ReadToolUseMessage(TS, 'read-2', ''),
+				new ReadToolUseMessage(TS, 'read-3', '   '),
+				new ReadToolUseMessage(TS, 'read-4', '/tmp/d.ts'),
+				new ReadToolUseMessage(TS, 'read-5', '/tmp/e.ts'),
+			],
+		});
+
+		expect(screen.getByText('5 files (2 unknown)')).toBeTruthy();
+		expect(screen.getAllByText('Unknown file')).toHaveLength(2);
+	});
+
+	it('renders all-unknown file counts in the header', () => {
+		render(ChatReadToolGroup, {
+			messages: [
+				new ReadToolUseMessage(TS, 'read-1', ''),
+				new ReadToolUseMessage(TS, 'read-2', ''),
+				new ReadToolUseMessage(TS, 'read-3', ''),
+				new ReadToolUseMessage(TS, 'read-4', ''),
+				new ReadToolUseMessage(TS, 'read-5', ''),
+			],
+		});
+
+		expect(screen.getByText('5 unknown files')).toBeTruthy();
+	});
+
+	it('opens known files and leaves unknown rows inert', async () => {
+		const onFileOpen = vi.fn();
+		render(ChatReadToolGroup, {
+			messages: [
+				new ReadToolUseMessage(TS, 'read-1', '/tmp/a.ts', 3, 2),
+				new ReadToolUseMessage(TS, 'read-2', ''),
+			],
+			onFileOpen,
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'a.ts' }));
+
+		expect(onFileOpen).toHaveBeenCalledWith('/tmp/a.ts');
+		expect(screen.getByText('Lines 3-4')).toBeTruthy();
+		expect(screen.getByText('Unknown file')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
Introduces a `ChatReadToolGroup` component to group multiple back-to-back file read operations into a single collapsible card.

- Maps consecutive `ReadToolUseMessage` occurrences into a unified render group.
- Displays file count summaries, including counts of unknown file paths.
- Allows opening known files directly in the file viewer via an interactive button.
- Adds comprehensive unit tests for the grouping logic, render key stability, and Svelte component interaction.

## Summary

Describe what changed and why.

## Checklist

- [ ] Scope is focused and behavior is covered by tests
- [ ] API/WS contract changes include type and test updates
