### PR TITLE
Add background git freshness polling and staleness detection

### DIFF
--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -86,7 +86,7 @@ describe('createGitService', () => {
 	      'commit', 'getBranches', 'checkout', 'createBranch',
 	      'getCommits', 'getCommitDiff', 'generateCommitMessageForFiles',
 	      'getRemoteStatus', 'getRemotes', 'fetch', 'pull', 'push',
-	      'discard', 'deleteUntracked', 'getWorkbenchSnapshot',
+	      'discard', 'deleteUntracked', 'getWorkbenchSnapshot', 'getWorkbenchFingerprint',
 	      'getReviewFileBodies', 'stageSelection', 'stageHunk',
 	      'getWorktrees', 'getTargetCandidates', 'createWorktree', 'removeWorktree',
 	      'commitIndex', 'stageFile', 'revertLastCommit',
@@ -393,6 +393,86 @@ describe('getWorkbenchSnapshot', () => {
       } finally {
         await fs.rm(projectPath, { recursive: true, force: true });
       }
+    }
+  });
+});
+
+describe('getWorkbenchFingerprint', () => {
+  it('matches the ready snapshot baseline for the same workbench state', async () => {
+    const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-git-freshness-baseline-'));
+    const git = createGitService({ agents: mockAgents, classifyGitError: mockClassifyGitError });
+
+    try {
+      await initRepoWithCommit(projectPath);
+      await fs.writeFile(path.join(projectPath, 'a.txt'), 'one\nchanged\n', 'utf-8');
+
+      const snapshot = await git.getWorkbenchSnapshot({ projectPath, mode: 'working', context: 5 });
+      const current = await git.getWorkbenchFingerprint({ projectPath });
+
+      expect(snapshot.status).toBe('ready');
+      expect(current.status).toBe('ready');
+      expect(snapshot.workbenchFingerprint).toBe(current.fingerprint);
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('changes for same-status edits, untracked edits, staged changes, and HEAD changes', async () => {
+    const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-git-freshness-changes-'));
+    const git = createGitService({ agents: mockAgents, classifyGitError: mockClassifyGitError });
+
+    try {
+      await initRepoWithCommit(projectPath);
+      const base = await git.getWorkbenchFingerprint({ projectPath });
+      expect(base.status).toBe('ready');
+
+      await fs.writeFile(path.join(projectPath, 'a.txt'), 'one\nfirst modified state\n', 'utf-8');
+      const modified = await git.getWorkbenchFingerprint({ projectPath });
+      expect(modified.status).toBe('ready');
+      expect(modified.fingerprint).not.toBe(base.fingerprint);
+
+      await fs.writeFile(path.join(projectPath, 'a.txt'), 'one\nsecond modified state with more bytes\n', 'utf-8');
+      const sameStatusModified = await git.getWorkbenchFingerprint({ projectPath });
+      expect(sameStatusModified.status).toBe('ready');
+      expect(sameStatusModified.fingerprint).not.toBe(modified.fingerprint);
+
+      await fs.writeFile(path.join(projectPath, 'space and\ttab.txt'), 'new\n', 'utf-8');
+      const untracked = await git.getWorkbenchFingerprint({ projectPath });
+      expect(untracked.status).toBe('ready');
+      expect(untracked.fingerprint).not.toBe(sameStatusModified.fingerprint);
+
+      await fs.writeFile(path.join(projectPath, 'space and\ttab.txt'), 'new\nchanged\n', 'utf-8');
+      const editedUntracked = await git.getWorkbenchFingerprint({ projectPath });
+      expect(editedUntracked.status).toBe('ready');
+      expect(editedUntracked.fingerprint).not.toBe(untracked.fingerprint);
+
+      await runGitCommand(projectPath, ['add', 'a.txt']);
+      const staged = await git.getWorkbenchFingerprint({ projectPath });
+      expect(staged.status).toBe('ready');
+      expect(staged.fingerprint).not.toBe(editedUntracked.fingerprint);
+
+      await runGitCommand(projectPath, ['commit', '-m', 'update tracked file']);
+      const committed = await git.getWorkbenchFingerprint({ projectPath });
+      expect(committed.status).toBe('ready');
+      expect(committed.fingerprint).not.toBe(staged.fingerprint);
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a typed non-repository fingerprint response', async () => {
+    const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-git-freshness-not-repo-'));
+    const git = createGitService({ agents: mockAgents, classifyGitError: mockClassifyGitError });
+
+    try {
+      const result = await git.getWorkbenchFingerprint({ projectPath });
+      expect(result).toMatchObject({
+        status: 'not-git-repository',
+        project: projectPath,
+        fingerprint: null,
+      });
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
     }
   });
 });

--- a/server/git/diff-engine.ts
+++ b/server/git/diff-engine.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { GIT_REVIEW_DOCUMENT_LIMITS } from './types.js';
+import {
+  GIT_REVIEW_DOCUMENT_LIMITS,
+  GIT_WORKBENCH_FINGERPRINT_VERSION,
+} from './types.js';
 import { GitDomainError } from './git-types.js';
 import type {
   ChangeEntry,
@@ -16,6 +19,8 @@ import type {
   GitReviewFileBody,
   GitReviewFileSummary,
   GitReviewLimitReason,
+  GitWorkbenchFingerprintOptions,
+  GitWorkbenchFingerprintResponse,
   GitWorkbenchSnapshotOptions,
   GitWorkbenchSnapshotResponse,
   GitRenderedDiffRow,
@@ -839,6 +844,116 @@ function parseLsTreeZ(output: string): Map<string, string> {
   return map;
 }
 
+function uniqueGitPaths(paths: string[]): string[] {
+  return Array.from(new Set(paths.filter(Boolean))).sort();
+}
+
+async function loadFingerprintIndexEntries(
+  projectPath: string,
+  paths: string[],
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const entries: string[] = [];
+  for (const chunk of chunkGitPathspecs(paths)) {
+    try {
+      const { stdout } = await runGit(projectPath, ['ls-files', '-s', '-z', '--', ...chunk], { signal });
+      for (const [filePath, entry] of parseLsFilesStageZ(stdout)) {
+        entries.push(`${filePath}\x00${entry}`);
+      }
+    } catch {
+      // Status output still captures the changed path. Missing index metadata should not make freshness fail.
+    }
+  }
+  return entries.sort();
+}
+
+async function worktreeStatFingerprint(projectPath: string, file: string): Promise<string> {
+  try {
+    const filePath = resolvePathWithinProject(projectPath, file);
+    const stats = await fs.stat(filePath);
+    const kind = stats.isFile() ? 'file' : 'not-file';
+    return [
+      kind,
+      file,
+      stats.size,
+      Math.trunc(stats.mtimeMs),
+      Math.trunc(stats.ctimeMs),
+    ].join(':');
+  } catch {
+    return `missing:${file}`;
+  }
+}
+
+function shouldStatWorktreeForFingerprint(entry: PorcelainStatusEntry): boolean {
+  if (entry.workTreeStatus === 'D') return false;
+  if (entry.indexStatus === '?' || entry.workTreeStatus === '?') return true;
+  return hasWorkTreeChange(entry.workTreeStatus);
+}
+
+async function loadFingerprintWorktreeStats(
+  projectPath: string,
+  entries: PorcelainStatusEntry[],
+): Promise<string[]> {
+  const paths = uniqueGitPaths(
+    entries
+      .filter(shouldStatWorktreeForFingerprint)
+      .map((entry) => entry.path),
+  );
+  return (await mapWithConcurrencyResult(
+    paths,
+    16,
+    (filePath) => worktreeStatFingerprint(projectPath, filePath),
+  )).sort();
+}
+
+interface WorkbenchFingerprintInput {
+  projectPath: string;
+  repoRoot: string;
+  branch: string;
+  head: string;
+  statusOutput: string;
+  workingStatsOutput: string;
+  cachedStatsOutput: string;
+  unmergedOutput: string;
+  statusEntries: PorcelainStatusEntry[];
+  signal?: AbortSignal;
+}
+
+async function buildWorkbenchFingerprintFromInputs({
+  projectPath,
+  repoRoot,
+  branch,
+  head,
+  statusOutput,
+  workingStatsOutput,
+  cachedStatsOutput,
+  unmergedOutput,
+  statusEntries,
+  signal,
+}: WorkbenchFingerprintInput): Promise<{ fingerprint: string; changedPathCount: number }> {
+  const changedPaths = uniqueGitPaths(statusEntries.map((entry) => entry.path));
+  const [indexEntryTokens, worktreeStatTokens] = await Promise.all([
+    loadFingerprintIndexEntries(projectPath, changedPaths, signal),
+    loadFingerprintWorktreeStats(projectPath, statusEntries),
+  ]);
+
+  const fingerprint = `v${GIT_WORKBENCH_FINGERPRINT_VERSION}:${hashString([
+    `git-workbench-fingerprint-v${GIT_WORKBENCH_FINGERPRINT_VERSION}`,
+    projectPath,
+    repoRoot,
+    branch,
+    head,
+    statusOutput,
+    workingStatsOutput,
+    cachedStatsOutput,
+    unmergedOutput,
+    ...indexEntryTokens,
+    ...worktreeStatTokens,
+  ].join('\x1f'))}`;
+
+  return { fingerprint, changedPathCount: changedPaths.length };
+}
+
 async function loadBatchedFingerprintInputs(
   projectPath: string,
   files: TreeNode[],
@@ -1259,6 +1374,74 @@ function notRepositorySnapshot(projectPath: string): GitWorkbenchSnapshotRespons
   };
 }
 
+function notRepositoryFingerprint(projectPath: string): GitWorkbenchFingerprintResponse {
+  return {
+    status: 'not-git-repository',
+    project: projectPath,
+    fingerprintVersion: GIT_WORKBENCH_FINGERPRINT_VERSION,
+    fingerprint: null,
+    message: 'Git is not initialized in this directory.',
+  };
+}
+
+async function getWorkbenchFingerprint({
+  projectPath,
+  trace,
+  signal,
+}: GitWorkbenchFingerprintOptions): Promise<GitWorkbenchFingerprintResponse> {
+  try {
+    await fs.access(projectPath);
+  } catch {
+    return notRepositoryFingerprint(projectPath);
+  }
+
+  const [
+    repoRootResult,
+    branchResult,
+    headResult,
+    statusResult,
+    workingStatsResult,
+    cachedStatsResult,
+    unmergedResult,
+  ] = await Promise.allSettled([
+    runGitTraced(projectPath, ['rev-parse', '--show-toplevel'], trace, { signal }),
+    runGitTraced(projectPath, ['branch', '--show-current'], trace, { signal }),
+    runGitTraced(projectPath, ['rev-parse', 'HEAD'], trace, { signal }),
+    runGitTraced(projectPath, ['status', '--porcelain=v1', '-z', '-uall'], trace, { signal }),
+    runGitTraced(projectPath, ['diff', '--numstat', '-z'], trace, { signal }),
+    runGitTraced(projectPath, ['diff', '--cached', '--numstat', '-z'], trace, { signal }),
+    runGitTraced(projectPath, ['ls-files', '-u', '-z'], trace, { signal }),
+  ]);
+
+  if (repoRootResult.status === 'rejected') return notRepositoryFingerprint(projectPath);
+  if (statusResult.status === 'rejected') throw statusResult.reason;
+
+  const repoRoot = repoRootResult.value.stdout.trim() || projectPath;
+  const branch = branchResult.status === 'fulfilled' ? branchResult.value.stdout.trim() : '';
+  const head = headResult.status === 'fulfilled' ? headResult.value.stdout.trim() : '';
+  const statusEntries = parsePorcelainV1Z(statusResult.value.stdout);
+  const { fingerprint, changedPathCount } = await buildWorkbenchFingerprintFromInputs({
+    projectPath,
+    repoRoot,
+    branch,
+    head,
+    statusOutput: statusResult.value.stdout,
+    workingStatsOutput: workingStatsResult.status === 'fulfilled' ? workingStatsResult.value.stdout : '',
+    cachedStatsOutput: cachedStatsResult.status === 'fulfilled' ? cachedStatsResult.value.stdout : '',
+    unmergedOutput: unmergedResult.status === 'fulfilled' ? unmergedResult.value.stdout : '',
+    statusEntries,
+    signal,
+  });
+
+  return {
+    status: 'ready',
+    project: projectPath,
+    fingerprintVersion: GIT_WORKBENCH_FINGERPRINT_VERSION,
+    fingerprint,
+    changedPathCount,
+  };
+}
+
 async function getWorkbenchSnapshot({
   projectPath,
   mode,
@@ -1281,6 +1464,7 @@ async function getWorkbenchSnapshot({
     statusResult,
     workingStatsResult,
     cachedStatsResult,
+    unmergedResult,
   ] = await Promise.allSettled([
     runGitTraced(projectPath, ['rev-parse', '--show-toplevel'], trace, { signal }),
     runGitTraced(projectPath, ['branch', '--show-current'], trace, { signal }),
@@ -1288,6 +1472,7 @@ async function getWorkbenchSnapshot({
     runGitTraced(projectPath, ['status', '--porcelain=v1', '-z', '-uall'], trace, { signal }),
     runGitTraced(projectPath, ['diff', '--numstat', '-z'], trace, { signal }),
     runGitTraced(projectPath, ['diff', '--cached', '--numstat', '-z'], trace, { signal }),
+    runGitTraced(projectPath, ['ls-files', '-u', '-z'], trace, { signal }),
   ]);
 
   if (repoRootResult.status === 'rejected') return notRepositorySnapshot(projectPath);
@@ -1296,6 +1481,7 @@ async function getWorkbenchSnapshot({
   const effectiveMode = mode === 'staged' ? 'staged' : 'working';
   const repoRoot = repoRootResult.value.stdout.trim() || projectPath;
   const branch = branchResult.status === 'fulfilled' ? branchResult.value.stdout.trim() : '';
+  const head = headResult.status === 'fulfilled' ? headResult.value.stdout.trim() : '';
   const hasCommits = headResult.status === 'fulfilled';
   const statusEntries = parsePorcelainV1Z(statusResult.value.stdout);
   const workingStats = workingStatsResult.status === 'fulfilled'
@@ -1310,6 +1496,18 @@ async function getWorkbenchSnapshot({
     mode: effectiveMode,
     context,
     treeRoot: tree.root,
+    signal,
+  });
+  const { fingerprint } = await buildWorkbenchFingerprintFromInputs({
+    projectPath,
+    repoRoot,
+    branch,
+    head,
+    statusOutput: statusResult.value.stdout,
+    workingStatsOutput: workingStatsResult.status === 'fulfilled' ? workingStatsResult.value.stdout : '',
+    cachedStatsOutput: cachedStatsResult.status === 'fulfilled' ? cachedStatsResult.value.stdout : '',
+    unmergedOutput: unmergedResult.status === 'fulfilled' ? unmergedResult.value.stdout : '',
+    statusEntries,
     signal,
   });
   const selected = chooseSelectedFile(reviewSummary.files, selectedFile);
@@ -1338,6 +1536,7 @@ async function getWorkbenchSnapshot({
       Math.max(0, Math.min(bodyCandidateCount, GIT_REVIEW_DOCUMENT_LIMITS.maxBodyBatchFiles)),
     ),
     snapshotId: reviewSummary.documentId,
+    workbenchFingerprint: fingerprint,
   };
 }
 
@@ -1551,6 +1750,7 @@ async function mapWithConcurrencyResult<T, R>(
 export function createDiffEngine() {
   return {
     getWorkbenchSnapshot,
+    getWorkbenchFingerprint,
     getReviewFileBodies,
     stageSelection,
     stageHunk,

--- a/server/git/types.ts
+++ b/server/git/types.ts
@@ -74,6 +74,8 @@ export const GIT_REVIEW_DOCUMENT_LIMITS = Object.freeze({
   bodyConcurrency: 4,
 });
 
+export const GIT_WORKBENCH_FINGERPRINT_VERSION = 1;
+
 export interface DiffStats {
   additions: number;
   deletions: number;
@@ -361,6 +363,7 @@ export interface GitWorkbenchSnapshotReady {
   selectedFile: string | null;
   firstBodyCandidates: string[];
   snapshotId: string;
+  workbenchFingerprint: string;
 }
 
 export interface GitWorkbenchSnapshotNotRepository {
@@ -383,6 +386,40 @@ export interface GitWorkbenchSnapshotOptions extends ProjectOptions {
   context: number;
   selectedFile?: string | null;
   bodyCandidateCount?: number;
+}
+
+export type GitWorkbenchFingerprintResponse =
+  | GitWorkbenchFingerprintReady
+  | GitWorkbenchFingerprintNotRepository
+  | GitWorkbenchFingerprintUnknown;
+
+export interface GitWorkbenchFingerprintReady {
+  status: 'ready';
+  project: string;
+  fingerprintVersion: typeof GIT_WORKBENCH_FINGERPRINT_VERSION;
+  fingerprint: string;
+  changedPathCount: number;
+}
+
+export interface GitWorkbenchFingerprintNotRepository {
+  status: 'not-git-repository';
+  project: string;
+  fingerprintVersion: typeof GIT_WORKBENCH_FINGERPRINT_VERSION;
+  fingerprint: null;
+  message: string;
+}
+
+export interface GitWorkbenchFingerprintUnknown {
+  status: 'unknown';
+  project: string;
+  fingerprintVersion: typeof GIT_WORKBENCH_FINGERPRINT_VERSION;
+  fingerprint: null;
+  message: string;
+}
+
+export interface GitWorkbenchFingerprintOptions extends ProjectOptions {
+  trace?: GitCommandTrace[];
+  signal?: AbortSignal;
 }
 
 export interface StageSelectionOptions extends FileOptions {
@@ -582,6 +619,7 @@ export interface GitService {
   discard(options: FileOptions): Promise<unknown>;
   deleteUntracked(options: FileOptions): Promise<unknown>;
   getWorkbenchSnapshot(options: GitWorkbenchSnapshotOptions): Promise<GitWorkbenchSnapshotResponse>;
+  getWorkbenchFingerprint(options: GitWorkbenchFingerprintOptions): Promise<GitWorkbenchFingerprintResponse>;
   getReviewFileBodies(options: ReviewFileBodiesOptions): Promise<GitReviewFileBodiesResponse>;
   stageSelection(options: StageSelectionOptions): Promise<unknown>;
   stageHunk(options: StageHunkOptions): Promise<unknown>;

--- a/server/routes/__tests__/git-workbench.test.js
+++ b/server/routes/__tests__/git-workbench.test.js
@@ -281,6 +281,77 @@ describe('POST /api/v1/git/workbench/snapshot validation', () => {
   });
 });
 
+describe('POST /api/v1/git/workbench/fingerprint validation', () => {
+  const handler = routes['/api/v1/git/workbench/fingerprint'].POST;
+
+  beforeEach(() => {
+    parseJsonBody.mockClear();
+    restoreConsoleDebug();
+  });
+
+  it('returns 400 when project is missing', async () => {
+    parseJsonBody.mockImplementation(() => Promise.resolve({}));
+    const response = await handler(makeRequest({}));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Missing required parameter: project.');
+  });
+
+  it('returns typed non-repository responses', async () => {
+    const projectPath = await fs.mkdtemp(path.join(projectBasePath, 'garcon-git-fingerprint-not-repo-'));
+
+    try {
+      parseJsonBody.mockImplementation(() => Promise.resolve({ project: projectPath }));
+      const response = await handler(makeRequest({}));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        status: 'not-git-repository',
+        project: projectPath,
+        fingerprint: null,
+      });
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('emits a safe route trace for successful workbench fingerprint loads', async () => {
+    const projectPath = await fs.mkdtemp(path.join(projectBasePath, 'garcon-git-fingerprint-trace-'));
+    process.env.GARCON_LOG_LEVEL = 'debug';
+    console.debug = mock(() => undefined);
+
+    try {
+      await runGitCommand(projectPath, ['init']);
+      parseJsonBody.mockImplementation(() => Promise.resolve({ project: projectPath }));
+      const response = await handler(makeRequest({}));
+      const responseText = await response.text();
+      const body = JSON.parse(responseText);
+      const responseBytes = Buffer.byteLength(responseText);
+      const traceLog = console.debug.mock.calls.find(
+        (call) => call[0] === '[routes:git]' && call[1] === 'git workbench route',
+      )?.[2];
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe('ready');
+      expect(body.fingerprint).toStartWith('v1:');
+      expect(traceLog).toMatchObject({
+        route: 'workbench-fingerprint',
+        responseBytes,
+        slowestCommand: expect.objectContaining({
+          args: expect.any(Array),
+          durationMs: expect.any(Number),
+        }),
+      });
+      expect(traceLog.commandCount).toBeGreaterThanOrEqual(4);
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+      restoreConsoleDebug();
+    }
+  });
+});
+
 describe('POST /api/v1/git/worktrees/create boundary validation', () => {
   const handler = routes['/api/v1/git/worktrees/create'].POST;
 
@@ -472,6 +543,7 @@ describe('malformed JSON body', () => {
 	      '/api/v1/git/commit-index': 'POST',
 	      '/api/v1/git/stage-file': 'POST',
 	      '/api/v1/git/workbench/snapshot': 'POST',
+	      '/api/v1/git/workbench/fingerprint': 'POST',
 	      '/api/v1/git/review-document/files': 'POST',
 	      '/api/v1/git/stage-selection': 'POST',
 	      '/api/v1/git/stage-hunk': 'POST',

--- a/server/routes/git.ts
+++ b/server/routes/git.ts
@@ -513,6 +513,28 @@ export default function createGitRoutes(
     }
   }
 
+  async function postWorkbenchFingerprint(body: JsonBody, request: Request): Promise<Response> {
+    try {
+      const input = asJsonBody(body);
+      const project = requiredString(input.project);
+
+      if (!project) {
+        return Response.json({ error: 'Missing required parameter: project.' }, { status: 400 });
+      }
+
+      const trace: GitCommandTrace[] = [];
+      const startedAt = performance.now();
+      const result = await git.getWorkbenchFingerprint({
+        projectPath: project,
+        trace,
+        signal: request.signal,
+      });
+      return traceJsonResponse('workbench-fingerprint', startedAt, trace, result);
+    } catch (error) {
+      return git.toHttpError(error);
+    }
+  }
+
   async function postReviewDocumentFiles(body: JsonBody, request: Request): Promise<Response> {
     try {
       const input = asJsonBody(body);
@@ -980,6 +1002,7 @@ export default function createGitRoutes(
     '/api/v1/git/discard': { POST: withJsonBody(postDiscard) },
     '/api/v1/git/delete-untracked': { POST: withJsonBody(postDeleteUntracked) },
     '/api/v1/git/workbench/snapshot': { POST: withJsonBody(postWorkbenchSnapshot) },
+    '/api/v1/git/workbench/fingerprint': { POST: withJsonBody(postWorkbenchFingerprint) },
     '/api/v1/git/review-document/files': { POST: withJsonBody(postReviewDocumentFiles) },
     '/api/v1/git/stage-selection': { POST: withJsonBody(postStageSelection) },
     '/api/v1/git/stage-hunk': { POST: withJsonBody(postStageHunk) },

--- a/web/src/lib/api/__tests__/git-contract.test.ts
+++ b/web/src/lib/api/__tests__/git-contract.test.ts
@@ -14,6 +14,7 @@ import {
 	gitDiscard,
 	gitDeleteUntracked,
 	getGitWorkbenchSnapshot,
+	getGitWorkbenchFingerprint,
 	getGitReviewFileBodies,
 	getGitConflictDetails,
 	getGitTargetCandidates,
@@ -238,6 +239,7 @@ describe('git API contract', () => {
 			selectedFile: null,
 			firstBodyCandidates: [],
 			snapshotId: 'doc',
+			workbenchFingerprint: 'v1:baseline',
 		};
 		fetchMock.mockResolvedValue(jsonResponse(payload));
 
@@ -281,6 +283,28 @@ describe('git API contract', () => {
 		expect(body.context).toBe(3);
 		expect(body.selectedFile).toBeNull();
 		expect(body.bodyCandidateCount).toBe(8);
+	});
+
+	it('getGitWorkbenchFingerprint posts the current workbench fingerprint request', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({
+			status: 'ready',
+			project: '/project',
+			fingerprintVersion: 1,
+			fingerprint: 'v1:current',
+			changedPathCount: 2,
+		}));
+
+		const result = await getGitWorkbenchFingerprint('/project');
+
+		expect(result.status).toBe('ready');
+		if (result.status === 'ready') {
+			expect(result.fingerprint).toBe('v1:current');
+			expect(result.changedPathCount).toBe(2);
+		}
+		const [url, opts] = fetchMock.mock.calls[0];
+		expect(url).toBe('/api/v1/git/workbench/fingerprint');
+		expect(opts.method).toBe('POST');
+		expect(JSON.parse(opts.body)).toEqual({ project: '/project' });
 	});
 
 	it('getGitConflictDetails returns bounded conflict content metadata', async () => {

--- a/web/src/lib/api/git.ts
+++ b/web/src/lib/api/git.ts
@@ -10,6 +10,8 @@ import { apiGet, apiPost, type ApiFetchOptions } from './client.js';
 export type GitChangeKind = 'modified' | 'added' | 'deleted' | 'untracked' | 'renamed';
 export type GitStatusCode = ' ' | 'M' | 'A' | 'D' | 'R' | 'C' | 'U' | '?' | '!';
 export type GitFileReviewCategory = 'normal' | 'generated' | 'lockfile' | 'binary' | 'large';
+export const GIT_FRESHNESS_POLL_MS = 15_000;
+export const GIT_WORKBENCH_FINGERPRINT_VERSION = 1;
 export type GitDiffLimitReason =
 	| 'patch-too-large'
 	| 'too-many-rows'
@@ -194,6 +196,7 @@ export interface GitWorkbenchSnapshotReady {
 	selectedFile: string | null;
 	firstBodyCandidates: string[];
 	snapshotId: string;
+	workbenchFingerprint: string;
 }
 
 export interface GitWorkbenchSnapshotNotRepository {
@@ -210,6 +213,35 @@ export interface GitWorkbenchSnapshotNotRepository {
 export type GitWorkbenchSnapshotResponse =
 	| GitWorkbenchSnapshotReady
 	| GitWorkbenchSnapshotNotRepository;
+
+export type GitWorkbenchFingerprintResponse =
+	| GitWorkbenchFingerprintReady
+	| GitWorkbenchFingerprintNotRepository
+	| GitWorkbenchFingerprintUnknown;
+
+export interface GitWorkbenchFingerprintReady {
+	status: 'ready';
+	project: string;
+	fingerprintVersion: typeof GIT_WORKBENCH_FINGERPRINT_VERSION;
+	fingerprint: string;
+	changedPathCount: number;
+}
+
+export interface GitWorkbenchFingerprintNotRepository {
+	status: 'not-git-repository';
+	project: string;
+	fingerprintVersion: typeof GIT_WORKBENCH_FINGERPRINT_VERSION;
+	fingerprint: null;
+	message: string;
+}
+
+export interface GitWorkbenchFingerprintUnknown {
+	status: 'unknown';
+	project: string;
+	fingerprintVersion: typeof GIT_WORKBENCH_FINGERPRINT_VERSION;
+	fingerprint: null;
+	message: string;
+}
 
 export interface GitReviewCommentDraft {
 	id: string;
@@ -518,6 +550,17 @@ export async function getGitWorkbenchSnapshot(
 			bodyCandidateCount,
 		},
 		fetchOptions,
+	);
+}
+
+export async function getGitWorkbenchFingerprint(
+	project: string,
+	options?: ApiFetchOptions,
+): Promise<GitWorkbenchFingerprintResponse> {
+	return apiPost<GitWorkbenchFingerprintResponse>(
+		'/api/v1/git/workbench/fingerprint',
+		{ project },
+		options,
 	);
 }
 

--- a/web/src/lib/components/git/GitFreshnessBanner.svelte
+++ b/web/src/lib/components/git/GitFreshnessBanner.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+	import AlertTriangle from '@lucide/svelte/icons/triangle-alert';
+
+	interface Props {
+		isRefreshing: boolean;
+		onRefresh: () => void | Promise<void>;
+	}
+
+	let { isRefreshing, onRefresh }: Props = $props();
+</script>
+
+<div class="flex items-center gap-2 border-b border-border bg-status-warning/10 px-3 py-2 text-xs text-foreground">
+	<AlertTriangle class="h-4 w-4 shrink-0 text-status-warning" />
+	<span class="min-w-0 flex-1">Refresh to see new changes.</span>
+	<button
+		type="button"
+		onclick={() => void onRefresh()}
+		disabled={isRefreshing}
+		class="inline-flex items-center gap-1 rounded border border-border bg-background px-2 py-1 text-xs hover:bg-muted disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+	>
+		<RefreshCw class="h-3.5 w-3.5 {isRefreshing ? 'animate-spin' : ''}" />
+		Refresh
+	</button>
+</div>

--- a/web/src/lib/components/git/GitPanel.svelte
+++ b/web/src/lib/components/git/GitPanel.svelte
@@ -11,6 +11,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import GitTopToolbar from './GitTopToolbar.svelte';
 	import GitWorkbench from './GitWorkbench.svelte';
+	import GitFreshnessBanner from './GitFreshnessBanner.svelte';
 	import GitHistoryView from './GitHistoryView.svelte';
 	import GitCommitModal from './GitCommitModal.svelte';
 	import NewBranchModal from './NewBranchModal.svelte';
@@ -19,9 +20,13 @@
 	import CommitMessageSettingsModal from './CommitMessageSettingsModal.svelte';
 	import GitRevertModal from './GitRevertModal.svelte';
 	import GitWorktreePanel from './GitWorktreePanel.svelte';
+	import { startGitFreshnessPolling } from './git-freshness-polling';
 	import { GitPanelStore } from '$lib/stores/git-panel.svelte.js';
 	import { GitWorkbenchStore, type GitWorkbenchTarget } from '$lib/stores/git-workbench.svelte.js';
-	import { getGitTargetCandidates, type GitTargetCandidate } from '$lib/api/git.js';
+	import {
+		getGitTargetCandidates,
+		type GitTargetCandidate,
+	} from '$lib/api/git.js';
 	import { getLocalSettings, getFileViewer, getRemoteSettings } from '$lib/context';
 
 	interface GitPanelProps {
@@ -217,6 +222,17 @@
 		}
 	});
 
+	$effect(() => {
+		const nextTarget = activeTarget ?? fallbackTarget;
+		if (!nextTarget) return;
+		return startGitFreshnessPolling({
+			projectPath: nextTarget.projectPath,
+			checkFreshness: (projectToCheck) => {
+				untrack(() => void wb.checkFreshness(projectToCheck));
+			},
+		});
+	});
+
 	// Fetch history when switching to the history tab.
 	$effect(() => {
 		if (activeProjectPath && store.activeView === 'history') {
@@ -235,6 +251,13 @@
 		store.refreshDeferredMetadata(activeProjectPath);
 		await wb.setTarget(nextTarget);
 		if (shouldRefreshExistingTarget) await wb.refresh({ reason: 'manual' });
+		if (projectPath) startTargetRefresh(projectPath, fallbackTarget);
+	}
+
+	async function handleStaleRefresh(): Promise<void> {
+		if (!activeProjectPath) return;
+		store.refreshDeferredMetadata(activeProjectPath);
+		await wb.refreshStaleWorkbench();
 		if (projectPath) startTargetRefresh(projectPath, fallbackTarget);
 	}
 
@@ -360,6 +383,13 @@
 					<X class="h-3.5 w-3.5" />
 				</button>
 			</div>
+		{/if}
+
+		{#if wb.isExternallyStale}
+			<GitFreshnessBanner
+				isRefreshing={wb.isLoadingTree}
+				onRefresh={handleStaleRefresh}
+			/>
 		{/if}
 
 		{#if store.activeView === 'changes'}

--- a/web/src/lib/components/git/GitWorkbench.svelte
+++ b/web/src/lib/components/git/GitWorkbench.svelte
@@ -453,7 +453,7 @@
 							activeTab={wb.activeTab}
 							fontSize={diffFontSize}
 							selectedLineKeys={wb.selectedLineKeys}
-							operationPending={wb.hasPendingOperation}
+							operationPending={wb.hasPendingOperation || wb.isExternallyStale}
 							scrollToRequest={wb.virtualReviewScrollRequest}
 							composerState={wb.commentComposer}
 							overscan={3}
@@ -490,7 +490,7 @@
 							onclick={() => {
 								if (activeProjectPath) wb.stageSelectedLines(activeProjectPath);
 							}}
-							disabled={wb.hasPendingOperation}
+								disabled={wb.hasPendingOperation || wb.isExternallyStale}
 							class="flex-1 px-2 py-1.5 text-xs rounded bg-git-added/20 text-git-added disabled:opacity-50"
 						>
 							Stage ({wb.selectedLineKeys.size})
@@ -500,7 +500,7 @@
 							onclick={() => {
 								if (activeProjectPath) wb.unstageSelectedLines(activeProjectPath);
 							}}
-							disabled={wb.hasPendingOperation}
+								disabled={wb.hasPendingOperation || wb.isExternallyStale}
 							class="flex-1 px-2 py-1.5 text-xs rounded bg-git-deleted/20 text-git-deleted disabled:opacity-50"
 						>
 							Unstage ({wb.selectedLineKeys.size})
@@ -626,7 +626,7 @@
 							activeTab={wb.activeTab}
 							fontSize={diffFontSize}
 							selectedLineKeys={wb.selectedLineKeys}
-							operationPending={wb.hasPendingOperation}
+							operationPending={wb.hasPendingOperation || wb.isExternallyStale}
 							scrollToRequest={wb.virtualReviewScrollRequest}
 							composerState={wb.commentComposer}
 							overscan={5}
@@ -661,7 +661,7 @@
 									onclick={() => {
 										if (activeProjectPath) wb.stageSelectedLines(activeProjectPath);
 									}}
-									disabled={wb.hasPendingOperation}
+									disabled={wb.hasPendingOperation || wb.isExternallyStale}
 									class="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-git-added/20 text-git-added hover:bg-git-added/30 transition-colors disabled:opacity-50"
 								>
 									<Plus class="w-4 h-4" />
@@ -673,7 +673,7 @@
 									onclick={() => {
 										if (activeProjectPath) wb.unstageSelectedLines(activeProjectPath);
 									}}
-									disabled={wb.hasPendingOperation}
+									disabled={wb.hasPendingOperation || wb.isExternallyStale}
 									class="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-git-deleted/20 text-git-deleted hover:bg-git-deleted/30 transition-colors disabled:opacity-50"
 								>
 									<Minus class="w-4 h-4" />

--- a/web/src/lib/components/git/__tests__/GitFreshnessBanner.test.ts
+++ b/web/src/lib/components/git/__tests__/GitFreshnessBanner.test.ts
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import GitFreshnessBanner from '../GitFreshnessBanner.svelte';
+
+describe('GitFreshnessBanner', () => {
+	it('shows the stale message and refreshes on click', async () => {
+		const onRefresh = vi.fn();
+
+		render(GitFreshnessBanner, {
+			props: {
+				isRefreshing: false,
+				onRefresh,
+			},
+		});
+
+		expect(screen.getByText('Refresh to see new changes.')).toBeTruthy();
+		await fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+		expect(onRefresh).toHaveBeenCalledOnce();
+	});
+
+	it('disables refresh while a refresh is already running', () => {
+		render(GitFreshnessBanner, {
+			props: {
+				isRefreshing: true,
+				onRefresh: vi.fn(),
+			},
+		});
+
+		expect((screen.getByRole('button', { name: 'Refresh' }) as HTMLButtonElement).disabled).toBe(true);
+	});
+});

--- a/web/src/lib/components/git/__tests__/git-freshness-polling.test.ts
+++ b/web/src/lib/components/git/__tests__/git-freshness-polling.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	canPollGitFreshness,
+	startGitFreshnessPolling,
+} from '../git-freshness-polling';
+
+function makeDocumentRef(initialVisibility: DocumentVisibilityState) {
+	const listeners = new Map<string, EventListener>();
+	return {
+		get visibilityState() {
+			return initialVisibility;
+		},
+		set visibilityState(value: DocumentVisibilityState) {
+			initialVisibility = value;
+		},
+		addEventListener: vi.fn((event: string, listener: EventListener) => {
+			listeners.set(event, listener);
+		}),
+		removeEventListener: vi.fn((event: string, listener: EventListener) => {
+			if (listeners.get(event) === listener) listeners.delete(event);
+		}),
+		dispatch(event: string) {
+			listeners.get(event)?.(new Event(event));
+		},
+		listeners,
+	};
+}
+
+describe('git freshness polling', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('polls on the configured interval without an immediate first tick', () => {
+		vi.useFakeTimers();
+		const checkFreshness = vi.fn();
+		const documentRef = makeDocumentRef('visible');
+
+		const cleanup = startGitFreshnessPolling({
+			projectPath: '/project',
+			checkFreshness,
+			documentRef,
+			intervalMs: 15_000,
+		});
+
+		expect(checkFreshness).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(14_999);
+		expect(checkFreshness).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(checkFreshness).toHaveBeenCalledWith('/project');
+
+		cleanup();
+	});
+
+	it('skips hidden intervals and checks once when the document becomes visible', () => {
+		vi.useFakeTimers();
+		const checkFreshness = vi.fn();
+		const documentRef = makeDocumentRef('hidden');
+
+		const cleanup = startGitFreshnessPolling({
+			projectPath: '/project',
+			checkFreshness,
+			documentRef,
+			intervalMs: 15_000,
+		});
+
+		vi.advanceTimersByTime(15_000);
+		expect(checkFreshness).not.toHaveBeenCalled();
+
+		documentRef.visibilityState = 'visible';
+		documentRef.dispatch('visibilitychange');
+		expect(checkFreshness).toHaveBeenCalledOnce();
+
+		cleanup();
+	});
+
+	it('removes visibility listeners and intervals on cleanup', () => {
+		vi.useFakeTimers();
+		const checkFreshness = vi.fn();
+		const documentRef = makeDocumentRef('visible');
+
+		const cleanup = startGitFreshnessPolling({
+			projectPath: '/project',
+			checkFreshness,
+			documentRef,
+			intervalMs: 15_000,
+		});
+		cleanup();
+
+		expect(documentRef.listeners.size).toBe(0);
+		vi.advanceTimersByTime(15_000);
+		expect(checkFreshness).not.toHaveBeenCalled();
+	});
+
+	it('reports polling availability from document visibility', () => {
+		expect(canPollGitFreshness(makeDocumentRef('visible'))).toBe(true);
+		expect(canPollGitFreshness(makeDocumentRef('hidden'))).toBe(false);
+	});
+});

--- a/web/src/lib/components/git/git-freshness-polling.ts
+++ b/web/src/lib/components/git/git-freshness-polling.ts
@@ -1,0 +1,49 @@
+import { GIT_FRESHNESS_POLL_MS } from '$lib/api/git.js';
+
+interface FreshnessPollingDocument {
+	visibilityState: DocumentVisibilityState;
+	addEventListener: Document['addEventListener'];
+	removeEventListener: Document['removeEventListener'];
+}
+
+interface GitFreshnessPollingOptions {
+	projectPath: string;
+	checkFreshness: (projectPath: string) => void;
+	documentRef?: FreshnessPollingDocument;
+	intervalMs?: number;
+	setIntervalFn?: typeof setInterval;
+	clearIntervalFn?: typeof clearInterval;
+}
+
+export function canPollGitFreshness(
+	documentRef: Pick<FreshnessPollingDocument, 'visibilityState'> | undefined = globalThis.document,
+): boolean {
+	return !documentRef || documentRef.visibilityState === 'visible';
+}
+
+export function startGitFreshnessPolling({
+	projectPath,
+	checkFreshness,
+	documentRef = globalThis.document,
+	intervalMs = GIT_FRESHNESS_POLL_MS,
+	setIntervalFn = globalThis.setInterval,
+	clearIntervalFn = globalThis.clearInterval,
+}: GitFreshnessPollingOptions): () => void {
+	function tick(): void {
+		if (!canPollGitFreshness(documentRef)) return;
+		checkFreshness(projectPath);
+	}
+
+	const intervalId = setIntervalFn(tick, intervalMs);
+
+	function handleVisibilityChange(): void {
+		tick();
+	}
+
+	documentRef?.addEventListener('visibilitychange', handleVisibilityChange);
+
+	return () => {
+		clearIntervalFn(intervalId);
+		documentRef?.removeEventListener('visibilitychange', handleVisibilityChange);
+	};
+}

--- a/web/src/lib/stores/__tests__/git-workbench.test.ts
+++ b/web/src/lib/stores/__tests__/git-workbench.test.ts
@@ -21,6 +21,7 @@ const mockDeps: GitWorkbenchDeps = {
 // Mock the git API module
 vi.mock('$lib/api/git.js', () => ({
 	getGitWorkbenchSnapshot: vi.fn(),
+	getGitWorkbenchFingerprint: vi.fn(),
 	getGitReviewFileBodies: vi.fn(),
 	getGitConflicts: vi.fn(),
 	getGitConflictDetails: vi.fn(),
@@ -189,6 +190,7 @@ function makeWorkbenchSnapshot({
 	summary,
 	selectedFile,
 	firstBodyCandidates = [],
+	workbenchFingerprint = 'v1:baseline',
 }: {
 	project?: string;
 	root?: GitTreeNode[];
@@ -196,6 +198,7 @@ function makeWorkbenchSnapshot({
 	summary?: GitReviewDocumentSummary;
 	selectedFile?: string | null;
 	firstBodyCandidates?: string[];
+	workbenchFingerprint?: string;
 } = {}): GitWorkbenchSnapshotResponse {
 	const filePaths = root
 		.filter((node) => node.kind === 'file')
@@ -221,6 +224,7 @@ function makeWorkbenchSnapshot({
 		selectedFile: selectedFile ?? reviewSummary.files[0]?.path ?? null,
 		firstBodyCandidates,
 		snapshotId: reviewSummary.documentId,
+		workbenchFingerprint,
 	};
 }
 
@@ -339,7 +343,157 @@ describe('GitWorkbenchStore', () => {
 				expect(wb.repositoryError).toBe('Git is not initialized in this directory.');
 				expect(wb.tree).toEqual([]);
 				expect(wb.virtualReviewRows).toEqual([]);
+				expect(wb.loadedWorkbenchFingerprint).toBeNull();
+				expect(wb.isExternallyStale).toBe(false);
 				expect(mockedApi.getGitReviewFileBodies).not.toHaveBeenCalled();
+			});
+
+			it('stores the ready snapshot fingerprint as the freshness baseline', async () => {
+				mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(makeWorkbenchSnapshot({
+					workbenchFingerprint: 'v1:loaded',
+				}));
+
+				await wb.setTarget({
+					projectPath: '/project',
+					repoRoot: '/project',
+					worktreePath: '/project',
+					label: 'project',
+					source: 'chat-project',
+				});
+
+				expect(wb.loadedWorkbenchFingerprint).toBe('v1:loaded');
+				expect(wb.latestWorkbenchFingerprint).toBe('v1:loaded');
+				expect(wb.isExternallyStale).toBe(false);
+			});
+
+			it('keeps the workbench fresh when the polled fingerprint matches', async () => {
+				mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(makeWorkbenchSnapshot({
+					workbenchFingerprint: 'v1:loaded',
+				}));
+				mockedApi.getGitWorkbenchFingerprint.mockResolvedValue({
+					status: 'ready',
+					project: '/project',
+					fingerprintVersion: 1,
+					fingerprint: 'v1:loaded',
+					changedPathCount: 1,
+				});
+
+				await wb.setTarget({
+					projectPath: '/project',
+					repoRoot: '/project',
+					worktreePath: '/project',
+					label: 'project',
+					source: 'chat-project',
+				});
+				await wb.checkFreshness('/project');
+
+				expect(wb.latestWorkbenchFingerprint).toBe('v1:loaded');
+				expect(wb.isExternallyStale).toBe(false);
+			});
+
+			it('marks the workbench stale when the polled fingerprint changes', async () => {
+				mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(makeWorkbenchSnapshot({
+					workbenchFingerprint: 'v1:loaded',
+				}));
+				mockedApi.getGitWorkbenchFingerprint.mockResolvedValue({
+					status: 'ready',
+					project: '/project',
+					fingerprintVersion: 1,
+					fingerprint: 'v1:changed',
+					changedPathCount: 1,
+				});
+
+				await wb.setTarget({
+					projectPath: '/project',
+					repoRoot: '/project',
+					worktreePath: '/project',
+					label: 'project',
+					source: 'chat-project',
+				});
+				await wb.checkFreshness('/project');
+
+				expect(wb.latestWorkbenchFingerprint).toBe('v1:changed');
+				expect(wb.isExternallyStale).toBe(true);
+			});
+
+			it('ignores stale freshness responses after target changes', async () => {
+				const staleFingerprint = deferred<Awaited<ReturnType<typeof gitApi.getGitWorkbenchFingerprint>>>();
+				mockedApi.getGitWorkbenchSnapshot
+					.mockResolvedValueOnce(makeWorkbenchSnapshot({
+						project: '/project-a',
+						workbenchFingerprint: 'v1:a',
+					}))
+					.mockResolvedValueOnce(makeWorkbenchSnapshot({
+						project: '/project-b',
+						workbenchFingerprint: 'v1:b',
+					}));
+				mockedApi.getGitWorkbenchFingerprint.mockReturnValueOnce(staleFingerprint.promise);
+
+				await wb.setTarget({
+					projectPath: '/project-a',
+					repoRoot: '/repo',
+					worktreePath: '/project-a',
+					label: 'a',
+					source: 'worktree',
+				});
+				const staleCheck = wb.checkFreshness('/project-a');
+				await wb.setTarget({
+					projectPath: '/project-b',
+					repoRoot: '/repo',
+					worktreePath: '/project-b',
+					label: 'b',
+					source: 'worktree',
+				});
+
+				staleFingerprint.resolve({
+					status: 'ready',
+					project: '/project-a',
+					fingerprintVersion: 1,
+					fingerprint: 'v1:stale-response',
+					changedPathCount: 1,
+				});
+				await staleCheck;
+
+				expect(wb.target?.projectPath).toBe('/project-b');
+				expect(wb.loadedWorkbenchFingerprint).toBe('v1:b');
+				expect(wb.latestWorkbenchFingerprint).toBe('v1:b');
+				expect(wb.isExternallyStale).toBe(false);
+			});
+
+			it('refreshes stale workbench data while preserving the selected file', async () => {
+				mockedApi.getGitWorkbenchSnapshot
+					.mockResolvedValueOnce(makeWorkbenchSnapshot({
+						root: [makeTreeFile('a.ts')],
+						workbenchFingerprint: 'v1:old',
+					}))
+					.mockResolvedValueOnce(makeWorkbenchSnapshot({
+						root: [makeTreeFile('a.ts')],
+						workbenchFingerprint: 'v1:new',
+					}));
+
+				await wb.setTarget({
+					projectPath: '/project',
+					repoRoot: '/project',
+					worktreePath: '/project',
+					label: 'project',
+					source: 'chat-project',
+				});
+				wb.markExternallyStale();
+				mockedApi.getGitWorkbenchSnapshot.mockClear();
+
+				await wb.refreshStaleWorkbench();
+
+				expect(mockedApi.getGitWorkbenchSnapshot).toHaveBeenCalledWith(
+					'/project',
+					'unstaged',
+					5,
+					expect.objectContaining({
+						selectedFile: 'a.ts',
+						bodyCandidateCount: 8,
+					}),
+				);
+				expect(wb.loadedWorkbenchFingerprint).toBe('v1:new');
+				expect(wb.isExternallyStale).toBe(false);
 			});
 
 			it('surfaces unexpected snapshot load failures', async () => {
@@ -606,6 +760,28 @@ describe('GitWorkbenchStore', () => {
 				expect(result).toBe(true);
 				expect(wb.selectedLineKeys.size).toBe(0);
 				expect(mockedApi.getGitWorkbenchSnapshot).toHaveBeenCalled();
+			});
+
+			it('blocks diff-coordinate staging while the workbench is stale', async () => {
+				mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(makeWorkbenchSnapshot());
+				await wb.setTarget({
+					projectPath: '/project',
+					repoRoot: '/project',
+					worktreePath: '/project',
+					label: 'project',
+					source: 'chat-project',
+				});
+				wb.markExternallyStale();
+
+				const result = await wb.stageHunk(
+					'/project',
+					{ filePath: 'a.ts', tab: 'unstaged', mode: 'stage', contextLines: 5 },
+					0,
+				);
+
+				expect(result).toBe(false);
+				expect(mockedApi.gitStageHunk).not.toHaveBeenCalled();
+				expect(wb.lastError).toBe('Refresh the Git workbench before modifying changes.');
 			});
 
 			it('stages entire file for untracked files', async () => {

--- a/web/src/lib/stores/git-workbench.svelte.ts
+++ b/web/src/lib/stores/git-workbench.svelte.ts
@@ -1,4 +1,5 @@
 import {
+	getGitWorkbenchFingerprint,
 	getGitWorkbenchSnapshot,
 	type GitDiffTab,
 	type GitReviewCommentDraft,
@@ -98,6 +99,8 @@ export class GitWorkbenchStore {
 	private scheduledRefresh: ReturnType<typeof setTimeout> | null = null;
 	private refreshPromise: Promise<void> | null = null;
 	private snapshotLoadAbort: AbortController | null = null;
+	private freshnessGeneration = 0;
+	private freshnessAbort: AbortController | null = null;
 	private scrollPositions = new Map<string, number>();
 
 	private readonly treeState: GitTreeState;
@@ -116,6 +119,11 @@ export class GitWorkbenchStore {
 	private selectedFileValue = $state<string | null>(null);
 	private lastErrorValue = $state<string | null>(null);
 	private repositoryErrorValue = $state<string | null>(null);
+	loadedWorkbenchFingerprint = $state<string | null>(null);
+	latestWorkbenchFingerprint = $state<string | null>(null);
+	isExternallyStale = $state(false);
+	isCheckingFreshness = $state(false);
+	freshnessError = $state<string | null>(null);
 
 	constructor(deps?: GitWorkbenchDeps) {
 		const resolvedDeps =
@@ -145,6 +153,7 @@ export class GitWorkbenchStore {
 			composerState: () => this.commentComposer,
 			isFileViewed: (filePath) => this.isFileViewed(filePath),
 			surfaceError: (message) => this.surfaceError(message),
+			markExternallyStale: () => this.markExternallyStale(),
 		});
 		this.lineSelection = new GitLineSelectionState();
 		this.reviewProgress = new GitReviewProgress();
@@ -164,6 +173,7 @@ export class GitWorkbenchStore {
 			refreshAfterGitAction: (projectPath, options) =>
 				this.refreshAfterGitAction(projectPath, options),
 			surfaceError: (message) => this.surfaceError(message),
+			ensureFreshForGitMutation: () => this.ensureFreshForGitMutation(),
 		});
 		this.commitController = new GitCommitController({
 			...resolvedDeps,
@@ -194,6 +204,7 @@ export class GitWorkbenchStore {
 					preferSelectedFile: true,
 				}),
 			surfaceError: (message) => this.surfaceError(message),
+			ensureFreshForGitMutation: () => this.ensureFreshForGitMutation(),
 		});
 
 		this.loadTreePaneWidth();
@@ -634,6 +645,63 @@ export class GitWorkbenchStore {
 		}
 	}
 
+	async refreshStaleWorkbench(): Promise<void> {
+		if (!this.target) return;
+		await this.refresh({
+			reason: 'manual',
+			preserveDrafts: true,
+			preserveSelection: true,
+			preferSelectedFile: true,
+		});
+	}
+
+	async checkFreshness(projectPath: string): Promise<void> {
+		if (!projectPath || !this.loadedWorkbenchFingerprint || this.isExternallyStale) return;
+		if (this.refreshPromise || this.isCheckingFreshness) return;
+
+		const target = this.target;
+		if (!target || target.projectPath !== projectPath) return;
+
+		const requestTargetKey = targetKey(target);
+		const requestProjectPath = target.projectPath;
+		const generation = ++this.freshnessGeneration;
+		this.freshnessAbort?.abort();
+		const controller = new AbortController();
+		this.freshnessAbort = controller;
+		this.isCheckingFreshness = true;
+
+		try {
+			const result = await getGitWorkbenchFingerprint(projectPath, { signal: controller.signal });
+			if (!this.isCurrentFreshnessLoad(requestTargetKey, requestProjectPath, generation)) return;
+			if (result.status !== 'ready') {
+				this.freshnessError = result.status === 'unknown' ? result.message : null;
+				return;
+			}
+			this.freshnessError = null;
+			this.latestWorkbenchFingerprint = result.fingerprint;
+			this.isExternallyStale = result.fingerprint !== this.loadedWorkbenchFingerprint;
+		} catch (error) {
+			if (isAbortError(error) || !this.isCurrentFreshnessLoad(requestTargetKey, requestProjectPath, generation)) return;
+			this.freshnessError = error instanceof Error ? error.message : String(error);
+		} finally {
+			if (this.freshnessAbort === controller) this.freshnessAbort = null;
+			if (this.isCurrentFreshnessLoad(requestTargetKey, requestProjectPath, generation)) {
+				this.isCheckingFreshness = false;
+			}
+		}
+	}
+
+	markExternallyStale(): void {
+		if (!this.loadedWorkbenchFingerprint) return;
+		this.isExternallyStale = true;
+	}
+
+	ensureFreshForGitMutation(): boolean {
+		if (!this.isExternallyStale) return true;
+		this.surfaceError('Refresh the Git workbench before modifying changes.');
+		return false;
+	}
+
 	toggleDirCollapsed(dirPath: string): void {
 		this.treeState.toggleDirCollapsed(dirPath);
 	}
@@ -907,10 +975,12 @@ export class GitWorkbenchStore {
 	}
 
 	async commitIndex(projectPath: string): Promise<boolean> {
+		if (!this.ensureFreshForGitMutation()) return false;
 		return this.commitController.commitIndex(projectPath);
 	}
 
 	async createInitialCommit(projectPath: string): Promise<boolean> {
+		if (!this.ensureFreshForGitMutation()) return false;
 		return this.commitController.createInitialCommit(projectPath);
 	}
 
@@ -970,6 +1040,7 @@ export class GitWorkbenchStore {
 		projectPath: string,
 		strategy: 'revert' | 'reset-soft' = 'revert',
 	): Promise<boolean> {
+		if (!this.ensureFreshForGitMutation()) return false;
 		return this.commitController.revertLastCommit(projectPath, strategy);
 	}
 
@@ -1000,6 +1071,7 @@ export class GitWorkbenchStore {
 		const requestTab = this.activeTab;
 		const requestContext = this.contextLines;
 		const previousSelectedFile = this.selectedFile;
+		this.abortFreshnessCheck();
 		this.snapshotLoadAbort?.abort();
 		const controller = new AbortController();
 		this.snapshotLoadAbort = controller;
@@ -1051,6 +1123,7 @@ export class GitWorkbenchStore {
 		previousSelectedFile: string | null,
 	): void {
 		if (snapshot.status === 'not-git-repository') {
+			this.clearFreshnessState();
 			this.repositoryError = snapshot.message;
 			this.lastError = null;
 			this.treeState.applyTree([], true, 'loaded');
@@ -1061,6 +1134,10 @@ export class GitWorkbenchStore {
 			return;
 		}
 
+		this.loadedWorkbenchFingerprint = snapshot.workbenchFingerprint;
+		this.latestWorkbenchFingerprint = snapshot.workbenchFingerprint;
+		this.isExternallyStale = false;
+		this.freshnessError = null;
 		this.repositoryError = null;
 		this.treeState.applyTree(snapshot.tree.root, snapshot.tree.hasCommits, snapshot.tree.statsState);
 		this.virtualReview.applySummary(snapshot.reviewSummary);
@@ -1145,6 +1222,16 @@ export class GitWorkbenchStore {
 		return this.target?.projectPath === target.projectPath;
 	}
 
+	private isCurrentFreshnessLoad(
+		requestTargetKey: string,
+		projectPath: string,
+		generation: number,
+	): boolean {
+		if (generation !== this.freshnessGeneration) return false;
+		if (targetKey(this.target) !== requestTargetKey) return false;
+		return this.target?.projectPath === projectPath;
+	}
+
 	private selectFirstVisibleFileForActiveTab(): void {
 		if (this.selectedFile && this.preferredTabForFile(this.selectedFile) === this.activeTab) return;
 		this.selectedFile = this.visibleFilePaths[0] ?? null;
@@ -1182,6 +1269,7 @@ export class GitWorkbenchStore {
 	}
 
 	private resetForTargetChange(): void {
+		this.clearFreshnessState();
 		this.treeState.reset();
 		this.virtualReview.reset();
 		this.selectedFile = null;
@@ -1199,6 +1287,21 @@ export class GitWorkbenchStore {
 		this.snapshotLoadAbort?.abort();
 		this.snapshotLoadAbort = null;
 		this.refreshGeneration++;
+	}
+
+	private abortFreshnessCheck(): void {
+		this.freshnessGeneration += 1;
+		this.freshnessAbort?.abort();
+		this.freshnessAbort = null;
+		this.isCheckingFreshness = false;
+	}
+
+	private clearFreshnessState(): void {
+		this.abortFreshnessCheck();
+		this.loadedWorkbenchFingerprint = null;
+		this.latestWorkbenchFingerprint = null;
+		this.isExternallyStale = false;
+		this.freshnessError = null;
 	}
 }
 

--- a/web/src/lib/stores/git/git-porcelain.svelte.ts
+++ b/web/src/lib/stores/git/git-porcelain.svelte.ts
@@ -27,6 +27,7 @@ export interface GitPorcelainDeps {
 	selectedFile: () => string | null;
 	refreshAfterMutation: (projectPath: string) => Promise<void>;
 	surfaceError: (message: string) => void;
+	ensureFreshForGitMutation: () => boolean;
 }
 
 interface PorcelainLoadContext {
@@ -114,6 +115,7 @@ export class GitPorcelainState {
 	}
 
 	async acceptConflictSide(projectPath: string, filePath: string, side: 'ours' | 'theirs'): Promise<void> {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.cancelActiveLoad();
 		await this.withLoading('Failed to accept conflict side', async () => {
 			const result = await gitAcceptConflictSide(projectPath, filePath, side);
@@ -125,6 +127,7 @@ export class GitPorcelainState {
 	}
 
 	async markConflictResolved(projectPath: string, filePath: string): Promise<void> {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.cancelActiveLoad();
 		await this.withLoading('Failed to mark conflict resolved', async () => {
 			const result = await gitMarkConflictResolved(projectPath, filePath);
@@ -144,6 +147,7 @@ export class GitPorcelainState {
 	}
 
 	async createStash(projectPath: string): Promise<void> {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.cancelActiveLoad();
 		await this.withLoading('Failed to create stash', async () => {
 			const result = await gitCreateStash(
@@ -160,6 +164,7 @@ export class GitPorcelainState {
 	}
 
 	async applyStash(projectPath: string, stashRef: string): Promise<void> {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.cancelActiveLoad();
 		await this.withLoading('Failed to apply stash', async () => {
 			const result = await gitApplyStash(projectPath, stashRef);
@@ -168,6 +173,7 @@ export class GitPorcelainState {
 	}
 
 	async popStash(projectPath: string, stashRef: string): Promise<void> {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.cancelActiveLoad();
 		await this.withLoading('Failed to pop stash', async () => {
 			const result = await gitPopStash(projectPath, stashRef);
@@ -179,6 +185,7 @@ export class GitPorcelainState {
 	}
 
 	async dropStash(projectPath: string, stashRef: string): Promise<void> {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.cancelActiveLoad();
 		await this.withLoading('Failed to drop stash', async () => {
 			const result = await gitDropStash(projectPath, stashRef);

--- a/web/src/lib/stores/git/git-staging-actions.svelte.ts
+++ b/web/src/lib/stores/git/git-staging-actions.svelte.ts
@@ -40,6 +40,7 @@ export interface GitStagingActionsDeps {
 		options: GitWorkbenchRefreshOptions,
 	) => Promise<void>;
 	surfaceError: (message: string) => void;
+	ensureFreshForGitMutation: () => boolean;
 }
 
 export class GitStagingActions {
@@ -49,10 +50,12 @@ export class GitStagingActions {
 	constructor(private readonly deps: GitStagingActionsDeps) {}
 
 	async stageSelectedLines(projectPath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageGroupedSelectedLines(projectPath, 'stage');
 	}
 
 	async unstageSelectedLines(projectPath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageGroupedSelectedLines(projectPath, 'unstage');
 	}
 
@@ -61,6 +64,7 @@ export class GitStagingActions {
 		target: GitDiffActionTarget,
 		diffLineIndex: number,
 	): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageSelectionForTarget(projectPath, { ...target, mode: 'stage' }, [diffLineIndex]);
 	}
 
@@ -69,6 +73,7 @@ export class GitStagingActions {
 		target: GitDiffActionTarget,
 		diffLineIndex: number,
 	): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageSelectionForTarget(projectPath, { ...target, mode: 'unstage' }, [
 			diffLineIndex,
 		]);
@@ -79,6 +84,7 @@ export class GitStagingActions {
 		targetOrHunkIndex: GitDiffActionTarget | number,
 		maybeHunkIndex?: number,
 	): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		const target =
 			typeof targetOrHunkIndex === 'number'
 				? this.targetForSelectedFile('stage')
@@ -105,6 +111,7 @@ export class GitStagingActions {
 		targetOrHunkIndex: GitDiffActionTarget | number,
 		maybeHunkIndex?: number,
 	): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		const target =
 			typeof targetOrHunkIndex === 'number'
 				? this.targetForSelectedFile('unstage')
@@ -127,22 +134,27 @@ export class GitStagingActions {
 	}
 
 	async stageFile(projectPath: string, filePath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageFileWithMode(projectPath, filePath, 'stage', 'Stage file failed');
 	}
 
 	async unstageFile(projectPath: string, filePath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageFileWithMode(projectPath, filePath, 'unstage', 'Unstage file failed');
 	}
 
 	async stageDirectory(projectPath: string, dirPath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageDirectoryWithMode(projectPath, dirPath, 'stage', 'Stage directory failed');
 	}
 
 	async unstageDirectory(projectPath: string, dirPath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		return this.stageDirectoryWithMode(projectPath, dirPath, 'unstage', 'Unstage directory failed');
 	}
 
 	requestDiscard(filePath: string): void {
+		if (!this.deps.ensureFreshForGitMutation()) return;
 		this.pendingDiscardFile = filePath;
 	}
 
@@ -151,6 +163,7 @@ export class GitStagingActions {
 	}
 
 	async confirmDiscard(projectPath: string): Promise<boolean> {
+		if (!this.deps.ensureFreshForGitMutation()) return false;
 		const filePath = this.pendingDiscardFile;
 		if (!filePath) return false;
 		this.pendingDiscardFile = null;

--- a/web/src/lib/stores/git/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/stores/git/git-virtual-review-document.svelte.ts
@@ -92,6 +92,7 @@ export interface GitVirtualReviewDocumentDeps {
 	composerState: () => CommentComposerState;
 	isFileViewed: (filePath: string) => boolean;
 	surfaceError: (message: string) => void;
+	markExternallyStale: () => void;
 }
 
 export interface BuildVirtualRowsOptions {
@@ -341,7 +342,11 @@ export class GitVirtualReviewDocumentController {
 				for (const filePath of batch) {
 					const file = this.summaryForFile(filePath);
 					const body = result.files[filePath];
-					if (!file || !body || body.bodyFingerprint !== file.bodyFingerprint) continue;
+					if (!file || !body) continue;
+					if (body.bodyFingerprint !== file.bodyFingerprint) {
+						this.deps.markExternallyStale();
+						continue;
+					}
 					this.cacheSet(file, guard, body);
 					next[filePath] = body;
 				}


### PR DESCRIPTION
Introduce a new endpoint and service helper, `getWorkbenchFingerprint`, to quickly compute a hash of the current workspace state. Using this fingerprint, the client polls the repository's status at a regular interval and displays a warning banner when external changes make the current workbench state stale.
