### PR TITLE
feat(fork): fork chats mid-stream with an in-chat Fork button

### DIFF
--- a/common/agents.ts
+++ b/common/agents.ts
@@ -28,6 +28,10 @@ export type AgentId = BuiltinAgentId | (string & {});
 
 export interface AgentCapabilities {
   supportsFork: boolean;
+  // Whether a chat may be forked while its agent session is still processing a
+  // turn. Only safe for agents whose fork snapshots the transcript up to the
+  // last completed turn (e.g. Claude's JSONL copy).
+  supportsForkWhileRunning: boolean;
   supportsImages: boolean;
   acceptsApiProviderEndpoints: boolean;
   supportedProtocols: ApiProtocol[];
@@ -51,6 +55,7 @@ export interface AgentCatalogEntry {
   description?: string;
   kind: 'agent';
   supportsFork: boolean;
+  supportsForkWhileRunning: boolean;
   supportsImages: boolean;
   acceptsApiProviderEndpoints: boolean;
   supportedProtocols: ApiProtocol[];
@@ -67,6 +72,7 @@ export interface AgentCatalog {
 export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilities> = {
   claude: {
     supportsFork: true,
+    supportsForkWhileRunning: true,
     supportsImages: true,
     acceptsApiProviderEndpoints: true,
     supportedProtocols: ['anthropic-messages'],
@@ -74,6 +80,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   codex: {
     supportsFork: true,
+    supportsForkWhileRunning: false,
     supportsImages: true,
     acceptsApiProviderEndpoints: true,
     supportedProtocols: ['openai-compatible'],
@@ -81,6 +88,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   cursor: {
     supportsFork: true,
+    supportsForkWhileRunning: false,
     supportsImages: false,
     acceptsApiProviderEndpoints: false,
     supportedProtocols: [],
@@ -88,6 +96,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   opencode: {
     supportsFork: false,
+    supportsForkWhileRunning: false,
     supportsImages: false,
     acceptsApiProviderEndpoints: false,
     supportedProtocols: [],
@@ -95,6 +104,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   amp: {
     supportsFork: false,
+    supportsForkWhileRunning: false,
     supportsImages: false,
     acceptsApiProviderEndpoints: false,
     supportedProtocols: [],
@@ -102,6 +112,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   factory: {
     supportsFork: false,
+    supportsForkWhileRunning: false,
     supportsImages: false,
     acceptsApiProviderEndpoints: false,
     supportedProtocols: [],
@@ -109,6 +120,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   pi: {
     supportsFork: true,
+    supportsForkWhileRunning: false,
     supportsImages: false,
     acceptsApiProviderEndpoints: false,
     supportedProtocols: [],
@@ -116,6 +128,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   [DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID]: {
     supportsFork: false,
+    supportsForkWhileRunning: false,
     supportsImages: true,
     acceptsApiProviderEndpoints: true,
     supportedProtocols: ['openai-compatible'],
@@ -123,6 +136,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   [DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID]: {
     supportsFork: false,
+    supportsForkWhileRunning: false,
     supportsImages: true,
     acceptsApiProviderEndpoints: true,
     supportedProtocols: ['openai-compatible'],
@@ -130,6 +144,7 @@ export const BUILTIN_AGENT_CAPABILITIES: Record<BuiltinAgentId, AgentCapabilitie
   },
   [DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID]: {
     supportsFork: false,
+    supportsForkWhileRunning: false,
     supportsImages: true,
     acceptsApiProviderEndpoints: true,
     supportedProtocols: ['anthropic-messages'],
@@ -174,6 +189,13 @@ export function isEndpointOnlyAgentId(value: string): value is EndpointOnlyAgent
 export function supportsFork(agentId: AgentId): boolean {
   if (agentId in BUILTIN_AGENT_CAPABILITIES) {
     return BUILTIN_AGENT_CAPABILITIES[agentId as BuiltinAgentId].supportsFork;
+  }
+  return false;
+}
+
+export function supportsForkWhileRunning(agentId: AgentId): boolean {
+  if (agentId in BUILTIN_AGENT_CAPABILITIES) {
+    return BUILTIN_AGENT_CAPABILITIES[agentId as BuiltinAgentId].supportsForkWhileRunning;
   }
   return false;
 }

--- a/server/agents/__tests__/capabilities.test.js
+++ b/server/agents/__tests__/capabilities.test.js
@@ -5,6 +5,7 @@ describe('createAgentCapabilities', () => {
   test('defaults optional flags to false and protocol lists to empty', () => {
     expect(createAgentCapabilities()).toEqual({
       supportsFork: false,
+      supportsForkWhileRunning: false,
       supportsImages: false,
       acceptsApiProviderEndpoints: false,
       supportedProtocols: [],

--- a/server/agents/capabilities.ts
+++ b/server/agents/capabilities.ts
@@ -2,6 +2,7 @@ import type { AgentCapabilities, SupportedAgentProtocol } from './types.js';
 
 export interface CreateAgentCapabilitiesInput {
   supportsFork?: boolean;
+  supportsForkWhileRunning?: boolean;
   supportsImages?: boolean;
   acceptsApiProviderEndpoints?: boolean;
   supportedProtocols?: SupportedAgentProtocol[];
@@ -12,6 +13,7 @@ export interface CreateAgentCapabilitiesInput {
 export function createAgentCapabilities(input: CreateAgentCapabilitiesInput = {}): AgentCapabilities {
   return {
     supportsFork: input.supportsFork ?? false,
+    supportsForkWhileRunning: input.supportsForkWhileRunning ?? false,
     supportsImages: input.supportsImages ?? false,
     acceptsApiProviderEndpoints: input.acceptsApiProviderEndpoints ?? false,
     supportedProtocols: input.supportedProtocols ?? [],

--- a/server/agents/catalog-service.ts
+++ b/server/agents/catalog-service.ts
@@ -98,6 +98,7 @@ export class AgentCatalogService {
       label: agent.label,
       kind: 'agent',
       supportsFork: agent.capabilities.supportsFork,
+      supportsForkWhileRunning: agent.capabilities.supportsForkWhileRunning,
       supportsImages: agent.capabilities.supportsImages,
       acceptsApiProviderEndpoints: agent.capabilities.acceptsApiProviderEndpoints,
       supportedProtocols: agent.capabilities.supportedProtocols,

--- a/server/agents/claude/index.ts
+++ b/server/agents/claude/index.ts
@@ -117,6 +117,7 @@ export function createClaudeAgent(claude: ClaudeCliRuntime): Agent {
     },
     capabilities: createAgentCapabilities({
       supportsFork: true,
+      supportsForkWhileRunning: true,
       supportsImages: true,
       acceptsApiProviderEndpoints: true,
       supportedProtocols: ['anthropic-messages'],

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -35,6 +35,7 @@ import { AgentSessionSettingsService } from './session-settings-service.js';
 export interface AgentRegistryServiceContract {
   hasAgent(agentId: string): boolean;
   supportsFork(agentId: string): boolean;
+  supportsForkWhileRunning(agentId: string): boolean;
   supportsImages(agentId: string): boolean;
   isAgentSessionRunning(agentId: string, agentSessionId: string | null | undefined): boolean;
   getRunningSessions(): Record<string, Array<{ id: string; [key: string]: unknown }>>;
@@ -124,6 +125,10 @@ export class AgentRegistry implements AgentRegistryServiceContract {
 
   supportsFork(agentId: string): boolean {
     return this.#directory.get(agentId)?.capabilities.supportsFork ?? false;
+  }
+
+  supportsForkWhileRunning(agentId: string): boolean {
+    return this.#directory.get(agentId)?.capabilities.supportsForkWhileRunning ?? false;
   }
 
   supportsImages(agentId: string): boolean {

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -72,6 +72,9 @@ export interface AgentModelDiscoveryError extends Error {
 export interface AgentCapabilities {
   getModels?(query?: AgentModelQuery): Promise<AgentModelOption[]>;
   supportsFork: boolean;
+  // Whether forking is permitted while the source session is mid-turn. Requires
+  // a fork implementation that snapshots the last completed turn safely.
+  supportsForkWhileRunning: boolean;
   supportsImages: boolean;
   acceptsApiProviderEndpoints: boolean;
   supportedProtocols: SupportedAgentProtocol[];

--- a/server/chats/__tests__/fork-chat.test.js
+++ b/server/chats/__tests__/fork-chat.test.js
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
-import { replaceUuidBounded, assertJsonlValid, forkChatFileCopy } from '../fork-chat.js';
+import {
+  replaceUuidBounded,
+  assertJsonlValid,
+  sanitizeForkJsonl,
+  forkChatFileCopy,
+} from '../fork-chat.js';
 
 let tmpDir;
 
@@ -134,7 +139,65 @@ describe('assertJsonlValid', () => {
   });
 });
 
+describe('sanitizeForkJsonl', () => {
+  it('keeps fully valid JSONL untouched', () => {
+    const content = '{"a":1}\n{"b":2}\n';
+    expect(sanitizeForkJsonl(content, '/tmp/test.jsonl')).toBe(content);
+  });
+
+  it('drops a trailing incomplete line from an in-flight write', () => {
+    const content = '{"a":1}\n{"b":2}\n{"c":';
+    const result = sanitizeForkJsonl(content, '/tmp/test.jsonl');
+    expect(result).toBe('{"a":1}\n{"b":2}');
+    expect(() => assertJsonlValid(result, '/tmp/test.jsonl')).not.toThrow();
+  });
+
+  it('throws when a malformed line is followed by more content', () => {
+    const content = '{"a":1}\n{bad}\n{"c":3}\n';
+    expect(() => sanitizeForkJsonl(content, '/tmp/test.jsonl')).toThrow(/Invalid JSONL/);
+  });
+});
+
 describe('forkChatFileCopy', () => {
+  it('snapshots up to the last completed turn when the source is mid-write', async () => {
+    const agentSessionId = '44444444-4444-4444-4444-444444444444';
+    const nativePath = path.join(tmpDir, `${agentSessionId}.jsonl`);
+    const partial = [
+      JSON.stringify({ type: 'session', session_id: agentSessionId }),
+      JSON.stringify({ type: 'message', session_id: agentSessionId, text: 'done' }),
+      '{"type":"message","session_id":"' + agentSessionId + '","text":"in-fli',
+    ].join('\n');
+    await fs.writeFile(nativePath, partial, 'utf8');
+
+    const registry = createRegistry({
+      '400': {
+        agentId: 'claude',
+        model: 'sonnet',
+        projectPath: '/proj',
+        nativePath,
+        tags: [],
+        agentSessionId,
+      },
+    });
+    const settings = createSettings({ '400': 'Live turn' });
+    const metadata = createMetadata({ '400': { firstMessage: 'Live prompt' } });
+
+    const result = await forkChatFileCopy({
+      sourceSession: registry.getChat('400'),
+      sourceChatId: '400',
+      targetChatId: '401',
+      registry,
+      settings,
+      metadata,
+    });
+
+    const forked = await fs.readFile(result.nativePath, 'utf8');
+    expect(() => assertJsonlValid(forked, result.nativePath)).not.toThrow();
+    expect(forked).not.toContain('in-fli');
+    expect(forked).toContain('"text":"done"');
+  });
+
+
   it('defaults to the first fork ordinal when the source chat has no counter', async () => {
     const sourceNativePath = await createSourceNativeFile('11111111-1111-1111-1111-111111111111');
     const registry = createRegistry({

--- a/server/chats/fork-chat.ts
+++ b/server/chats/fork-chat.ts
@@ -68,6 +68,33 @@ export function assertJsonlValid(content: string, targetPath: string): void {
   }
 }
 
+// Drops a trailing incomplete JSON line left by an in-flight write so a fork
+// captured mid-turn snapshots the last completed turn instead of failing.
+// Throws when a malformed line is followed by more content, which signals real
+// corruption rather than a partial tail.
+export function sanitizeForkJsonl(content: string, targetPath: string): string {
+  const lines = content.split('\n');
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (!raw.trim()) {
+      kept.push(raw);
+      continue;
+    }
+    try {
+      JSON.parse(raw.trim());
+      kept.push(raw);
+    } catch (error) {
+      const hasMoreContent = lines.slice(i + 1).some((rest) => rest.trim().length > 0);
+      if (hasMoreContent) {
+        throw new Error(`Invalid JSONL at ${targetPath}:${i + 1}: ${errorMessage(error)}`);
+      }
+      break;
+    }
+  }
+  return kept.join('\n');
+}
+
 function buildForkDestination(sourcePath: string, newAgentSessionId: string): string {
   const dir = path.dirname(sourcePath);
   return path.join(dir, `${newAgentSessionId}.jsonl`);
@@ -140,9 +167,10 @@ export async function forkChatFileCopy({
       .map((line) => replaceUuidBounded(line, sourceAgentSessionId, generatedAgentSessionId))
       .join('\n');
 
-    assertJsonlValid(rewritten, destinationNativePath);
+    const sanitized = sanitizeForkJsonl(rewritten, destinationNativePath);
+    assertJsonlValid(sanitized, destinationNativePath);
 
-    await fs.writeFile(destinationNativePath, rewritten, 'utf8');
+    await fs.writeFile(destinationNativePath, sanitized, 'utf8');
     ownsDestinationFile = true;
   }
 

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -60,6 +60,7 @@ function makeService() {
     startSession: mock(() => Promise.resolve(undefined)),
     resolvePermission: mock(() => undefined),
     supportsFork: mock(() => true),
+    supportsForkWhileRunning: mock(() => false),
     isAgentSessionRunning: mock(() => false),
     forkAgentSession: mock(() => Promise.resolve(null)),
     getAgentAuthStatusMap: mock(() => ({})),
@@ -194,6 +195,16 @@ describe('ChatCommandService', () => {
     });
 
     expect(forkChatFileCopy).not.toHaveBeenCalled();
+  });
+
+  it('forks a running source when the agent supports fork-while-running', async () => {
+    const { service, agents, forkChatFileCopy } = makeService();
+    agents.isAgentSessionRunning.mockReturnValue(true);
+    agents.supportsForkWhileRunning.mockReturnValue(true);
+
+    await service.forkChat({ sourceChatId: '1', chatId: '2' });
+
+    expect(forkChatFileCopy).toHaveBeenCalledTimes(1);
   });
 
   it('forwards structured permission decision responses to agents', async () => {

--- a/server/commands/chat-command-service.ts
+++ b/server/commands/chat-command-service.ts
@@ -73,6 +73,7 @@ type AgentRegistryDep = Pick<
   | 'getAgentCatalogEntries'
   | 'runSingleQuery'
   | 'supportsFork'
+  | 'supportsForkWhileRunning'
   | 'isAgentSessionRunning'
   | 'forkAgentSession'
 >;
@@ -638,7 +639,10 @@ export class ChatCommandService {
     if (!this.deps.agents.supportsFork(sourceSession.agentId)) {
       throw new CommandValidationError('UNSUPPORTED_AGENT', `Fork unsupported for agent: ${sourceSession.agentId}`, 422);
     }
-    if (this.deps.agents.isAgentSessionRunning(sourceSession.agentId, sourceSession.agentSessionId)) {
+    if (
+      this.deps.agents.isAgentSessionRunning(sourceSession.agentId, sourceSession.agentSessionId)
+      && !this.deps.agents.supportsForkWhileRunning(sourceSession.agentId)
+    ) {
       throw new CommandValidationError('SESSION_BUSY', 'Cannot fork a chat while it is processing', 409, true);
     }
     if (this.deps.chats.getChat(targetChatId)) {

--- a/server/routes/__tests__/chats-command-routes.test.js
+++ b/server/routes/__tests__/chats-command-routes.test.js
@@ -121,6 +121,7 @@ function createRouteAgent(sessionOverrides = {}) {
   const agents = {
     hasAgent: mock(() => true),
     supportsFork: mock(() => true),
+    supportsForkWhileRunning: mock(() => false),
     supportsImages: mock(() => true),
     isAgentSessionRunning: mock(() => false),
     getRunningSessions: mock(() => ({ claude: [{ id: '123' }] })),

--- a/server/routes/__tests__/chats-fork.test.js
+++ b/server/routes/__tests__/chats-fork.test.js
@@ -61,6 +61,7 @@ const chatViews = {
 const agents = {
   startSession: mock(() => undefined),
   supportsFork: mock(() => true),
+  supportsForkWhileRunning: mock(() => false),
   isAgentSessionRunning: mock(() => false),
 };
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -74,6 +74,7 @@
 	"chat_message_delivery_sending": "Sending",
 	"chat_message_delivery_sent": "Sent",
 	"chat_message_copy_text": "Copy Text",
+	"chat_message_fork": "Fork",
 	"chat_message_render_failed": "Failed to render message",
 	"chat_message_send_to_new_session": "Send to New Session",
 	"chat_message_thinking": "Thinking",

--- a/web/src/lib/chat/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation-session-controller.svelte.ts
@@ -572,6 +572,35 @@ export class ConversationSessionController {
 		}
 	}
 
+	// Forks a chat without sending a new message, then selects the fork. Backs
+	// both the in-chat Fork button and the bare `/fork` command. For agents that
+	// support it the server snapshots the transcript up to the last completed
+	// turn, so this works while the source chat is still processing.
+	async forkChat(sourceChatId: string): Promise<void> {
+		const { deps } = this;
+		const sourceChat = deps.sessions.byId[sourceChatId];
+		if (!sourceChat || sourceChat.status === 'draft') {
+			deps.chatState.appendLocalNotice('error', 'Cannot fork a draft chat. Select an existing chat first.');
+			return;
+		}
+		try {
+			await this.#performForkOnly(sourceChatId);
+		} catch (error) {
+			deps.chatState.appendLocalNotice('error',
+				`Failed to fork chat: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	async #performForkOnly(sourceChatId: string): Promise<void> {
+		const { deps } = this;
+		const result = await forkChat({ sourceChatId, chatId: createClientChatId() });
+		await deps.sessions.quietRefreshChats();
+		deps.lifecycle.setCurrentChatId(result.chatId);
+		deps.sessions.setSelectedChatId(result.chatId);
+		deps.navigation.navigateToChat?.(result.chatId);
+	}
+
 	async #submitForkOnlyCommand(
 		sourceChatId: string,
 		previousText: string,
@@ -579,14 +608,8 @@ export class ConversationSessionController {
 		restoreComposer: boolean,
 	): Promise<void> {
 		const { deps } = this;
-		const forkChatId = createClientChatId();
-
 		try {
-			const result = await forkChat({ sourceChatId, chatId: forkChatId });
-			await deps.sessions.quietRefreshChats();
-			deps.lifecycle.setCurrentChatId(result.chatId);
-			deps.sessions.setSelectedChatId(result.chatId);
-			deps.navigation.navigateToChat?.(result.chatId);
+			await this.#performForkOnly(sourceChatId);
 		} catch (error) {
 			if (restoreComposer) {
 				deps.composerState.inputText = previousText;

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -2,7 +2,13 @@
 	import ConversationTranscript from './ConversationTranscript.svelte';
 	import type { PendingPermissionRequest } from '$lib/types/chat';
 	import type { PermissionDecisionPayload } from '$shared/chat-command-contracts';
-	import { getChatState, getAgentState, getLocalSettings, getAppShell } from '$lib/context';
+	import {
+		getChatState,
+		getAgentState,
+		getLocalSettings,
+		getAppShell,
+		getModelCatalog,
+	} from '$lib/context';
 	import * as m from '$lib/paraglide/messages.js';
 	import {
 		CHAT_MAX_WIDTH_FEED_CONTENT_CLASS,
@@ -26,6 +32,7 @@
 		onRetry?: () => void;
 		reserveLoadingStatusSpace?: boolean;
 		textScale?: number;
+		onForkChat?: () => void;
 	}
 
 	let {
@@ -37,12 +44,16 @@
 		onRetry,
 		reserveLoadingStatusSpace = false,
 		textScale = 1,
+		onForkChat,
 	}: Props = $props();
 
 	const chatState = getChatState();
 	const agentState = getAgentState();
 	const localSettings = getLocalSettings();
 	const appShell = getAppShell();
+	const modelCatalog = getModelCatalog();
+
+	const canFork = $derived(modelCatalog.supportsFork(agentState.agentId));
 
 	function handleMessagePaneFocusIntent() {
 		appShell.requestSidebarRecenterToSelected();
@@ -156,6 +167,7 @@
 					{pendingPermissionRequests}
 					{onPermissionDecision}
 					{onExitPlanMode}
+					onForkChat={canFork ? onForkChat : undefined}
 			/>
 		{/if}
 	{/snippet}

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -25,7 +25,9 @@
 	import { Check, ChevronRight, CircleAlert, LoaderCircle } from '@lucide/svelte';
 	import EllipsisVertical from '@lucide/svelte/icons/ellipsis-vertical';
 	import Copy from '@lucide/svelte/icons/copy';
+	import GitFork from '@lucide/svelte/icons/git-fork';
 	import SquareArrowOutUpRight from '@lucide/svelte/icons/square-arrow-out-up-right';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { getChatSessions, getFileViewer, getAppShell, getLocalSettings } from '$lib/context';
 	import Markdown from './Markdown.svelte';
 	import type { MarkdownLinkNavigateEvent } from './Markdown.svelte';
@@ -62,6 +64,8 @@
 		agentId: SessionAgentId | string;
 		showThinking?: boolean;
 		chatContext?: ConversationMessageChatContext | null;
+		/** Forks the current chat from the in-chat action. Omitted when the agent cannot fork. */
+		onForkChat?: () => void;
 	}
 
 	let {
@@ -75,6 +79,7 @@
 		agentId,
 		showThinking = true,
 		chatContext = null,
+		onForkChat,
 	}: Props = $props();
 
 	const sessions = getChatSessions();
@@ -194,6 +199,11 @@
 		appShell.openNewChatDialog({
 			prefill: messageMenuText,
 		});
+	}
+
+	function handleFork(e: MouseEvent) {
+		e.stopPropagation();
+		onForkChat?.();
 	}
 
 	/** Routes a file-like markdown link to the viewer overlay. */
@@ -392,8 +402,25 @@
 										/>
 									</div>
 									<div
-										class="message-menu-actions mt-1 flex justify-end opacity-100 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/message:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within/message:opacity-100"
+										class="message-menu-actions mt-1 flex justify-end gap-1 opacity-100 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/message:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within/message:opacity-100"
 									>
+										{#if onForkChat}
+											<Tooltip.Provider delayDuration={150} skipDelayDuration={100}>
+												<Tooltip.Root>
+													<Tooltip.Trigger
+														type="button"
+														onclick={handleFork}
+														aria-label={m.chat_message_fork()}
+														class="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+													>
+														<GitFork class="size-4" />
+													</Tooltip.Trigger>
+													<Tooltip.Content side="top" sideOffset={6}>
+														{m.chat_message_fork()}
+													</Tooltip.Content>
+												</Tooltip.Root>
+											</Tooltip.Provider>
+										{/if}
 										<button
 											type="button"
 											class="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"

--- a/web/src/lib/components/chat/ConversationTranscript.svelte
+++ b/web/src/lib/components/chat/ConversationTranscript.svelte
@@ -29,6 +29,8 @@
 		textScale?: number;
 		onPermissionDecision?: (permissionRequestId: string, decision: PermissionDecision) => void;
 		onExitPlanMode?: (permissionRequestId: string, choice: string, plan: string) => void;
+		/** Forks the current chat from the in-chat action. Omitted when the agent cannot fork. */
+		onForkChat?: () => void;
 	}
 
 	let {
@@ -40,6 +42,7 @@
 		textScale = 1,
 		onPermissionDecision,
 		onExitPlanMode,
+		onForkChat,
 	}: Props = $props();
 
 	const sessions = getChatSessions();
@@ -129,6 +132,7 @@
 					{agentId}
 					{showThinking}
 					{chatContext}
+					{onForkChat}
 				/>
 				{#snippet failed(error)}
 					<MessageRenderFallback {error} />

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -345,6 +345,10 @@
 						const chatId = sessions.selectedChatId;
 						if (chatId) controller.loadChat(chatId);
 					}}
+					onForkChat={() => {
+						const chatId = sessions.selectedChatId;
+						if (chatId) void controller.forkChat(chatId);
+					}}
 					reserveLoadingStatusSpace={selectedIsProcessing}
 					{textScale}
 				/>

--- a/web/src/lib/stores/model-catalog.svelte.ts
+++ b/web/src/lib/stores/model-catalog.svelte.ts
@@ -47,6 +47,7 @@ export interface AgentMetadata {
 	label: string;
 	description?: string;
 	supportsFork: boolean;
+	supportsForkWhileRunning: boolean;
 	supportsImages: boolean;
 	acceptsApiProviderEndpoints: boolean;
 	supportedProtocols: ApiProtocol[];
@@ -348,6 +349,7 @@ function parseCatalogResponse(data: unknown): {
 			label: typeof entry.label === 'string' ? entry.label : id,
 			description: typeof entry.description === 'string' ? entry.description : undefined,
 			supportsFork: Boolean(entry.supportsFork),
+			supportsForkWhileRunning: Boolean(entry.supportsForkWhileRunning),
 			supportsImages: Boolean(entry.supportsImages),
 			acceptsApiProviderEndpoints: Boolean(entry.acceptsApiProviderEndpoints),
 			supportedProtocols: normalizeProtocols(entry.supportedProtocols),
@@ -526,6 +528,11 @@ export class ModelCatalogStore {
 	supportsFork(agentId: SessionAgentId): boolean {
 		if (!isVisibleAgentId(agentId)) return false;
 		return this.agentMetadata[agentId]?.supportsFork ?? false;
+	}
+
+	supportsForkWhileRunning(agentId: SessionAgentId): boolean {
+		if (!isVisibleAgentId(agentId)) return false;
+		return this.agentMetadata[agentId]?.supportsForkWhileRunning ?? false;
 	}
 
 	supportsImages(


### PR DESCRIPTION
**Problem**

Forking a chat was only reachable from the sidebar dropdown or the `/fork` command, and the server hard-rejected any fork while the source chat was still processing (`SESSION_BUSY`, HTTP 409). To branch a conversation you had to wait for the in-flight turn to finish and hunt for the menu item. Codex-style mid-stream forking from the conversation itself was not possible.

**Solution**

Allow forking while a turn is in flight for agents that can do it safely, and surface a dedicated Fork button (with tooltip) directly on each assistant turn.

A new `supportsForkWhileRunning` agent capability gates the behavior. Only Claude sets it, because Claude forks by copying the transcript JSONL, which is now sanitized to drop an incomplete trailing line so the fork snapshots up to the last completed turn. Agents with native fork (Codex, Pi) keep the previous guard until their fork-while-running semantics are verified.

**Changes**

- **Capability contract**: add `supportsForkWhileRunning` to `AgentCapabilities` and `AgentCatalogEntry` in `common/agents.ts` (+ helper), server `types.ts`/`capabilities.ts`/`registry.ts`/`catalog-service.ts`, and the web `model-catalog` store. Claude = true, all others = false.
- **Validation**: `chat-command-service` only throws `SESSION_BUSY` when the session is running and the agent does not support fork-while-running.
- **Mid-stream safety**: `fork-chat.ts` adds `sanitizeForkJsonl`, dropping an in-flight trailing line (real corruption mid-file still throws).
- **In-chat Fork button**: `ConversationMessage` renders a `GitFork` icon button with a "Fork" tooltip in the assistant footer; threaded via `onForkChat` through `ConversationFeed` (gated by `canFork`) and `ConversationWorkspace` to a new `ConversationSessionController.forkChat()` (shared fork-only path). New `chat_message_fork` message key.
- **Tests**: capability default shape, fork-while-running allowed when capable, and `sanitizeForkJsonl` / mid-write snapshot coverage; fork mocks updated.

**Migration note**

API/behavior change: forking a Claude chat is now permitted while it is processing (previously always 409). The shared agent catalog payload gains a `supportsForkWhileRunning` field; clients default it to `false` for unknown agents.

**Validation**

`bun run --cwd web check` (0 errors), `bun run --cwd web lint`, web tests (1195) and server tests (1025) all pass. Startup smoke on a throwaway port OK. (Pre-existing unrelated `server typecheck` error in `agents/claude/claude-cli.ts` is present on `main` and untouched here; it is not part of the `check` gate.)

**Dogfood evidence**

Driven in a real browser against an isolated workspace.

Fork button + tooltip on the assistant turn:

![Fork tooltip](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-fork-while-running/screenshots/fork-tooltip.png)

Fork buttons in the conversation footer:

![Fork buttons](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-fork-while-running/screenshots/fork-buttons.png)

After clicking Fork — a new "… (1)" fork is created and opened with the copied transcript:

![After fork](https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-fork-while-running/screenshots/after-fork.png)

Repro video: https://raw.githubusercontent.com/0xSolarPunk/garcon/assets-fork-while-running/screenshots/fork-repro.webm

**Expected Impact**

One-click branching of a Claude conversation at any point, including mid-turn, without losing the original. Other agents are unchanged. No new tech debt: the behavior is gated by an explicit, tested capability rather than a special case.
