### PR TITLE
Revert "Revert "fix: stop leaking internal 'sending' queue state to clients""

### DIFF
--- a/common/queue-state.ts
+++ b/common/queue-state.ts
@@ -25,6 +25,24 @@ function normalizeQueueEntry(value: unknown): QueueEntry | null {
   return { id, content, status, createdAt };
 }
 
+// Projects a queue to its client-facing form. The 'sending' status is an
+// internal dispatch marker: the entry stays in the queue for the duration of
+// its turn so a failed turn can be re-queued and a crashed turn recovered, but
+// the message has already been written to the transcript as a pending user
+// input. Exposing the 'sending' entry to clients duplicates that transcript
+// message and desyncs the pending-count badge, so it is stripped at every
+// boundary that crosses to the client. A 'sending' entry only exists while its
+// turn is actively running (recoverStaleChatQueues resets any left by a crash
+// before the server accepts connections), so hiding it never conceals a stuck
+// chat. Returns the same reference when nothing is stripped to avoid needless
+// version churn; otherwise normalizeQueueState re-applies the shared invariants
+// (e.g. paused is false when no entries remain) so they live in one place.
+export function toClientQueueState(queue: QueueState): QueueState {
+  const entries = queue.entries.filter((entry) => entry.status === 'queued');
+  if (entries.length === queue.entries.length) return queue;
+  return normalizeQueueState({ ...queue, entries });
+}
+
 // Normalizes untrusted queue payloads from transport boundaries.
 // Invalid entries are dropped; paused is forced false when no entries remain.
 export function normalizeQueueState(value: unknown): QueueState {

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -42,6 +42,7 @@ function makeService(overrides = {}) {
     registerPendingUserInput: mock(() => Promise.resolve(undefined)),
     discardPendingUserInput: mock(() => true),
     runAcceptedTurn: mock(() => Promise.resolve(undefined)),
+    ...overrides.queue,
   };
   const settings = {
     getUiSettings: mock(() => null),
@@ -328,5 +329,53 @@ describe('ChatCommandService', () => {
     await expect(service.submitCompact({ chatId: '1', clientRequestId: 'req-compact-2' }))
       .rejects.toThrow(/Cannot compact while a turn is running/);
     expect(agents.compactSession).not.toHaveBeenCalled();
+  });
+
+  it('strips internal sending entries from the enqueue response queue', async () => {
+    // Enqueuing while a previous entry is mid-dispatch ('sending') must not leak
+    // that entry to the client: it already lives in the transcript.
+    const postEnqueue = {
+      entries: [
+        { id: 's1', content: 'in flight', status: 'sending', createdAt: '2026-02-27T00:00:00.000Z' },
+        { id: 'q1', content: 'still waiting', status: 'queued', createdAt: '2026-02-27T00:00:01.000Z' },
+      ],
+      paused: false,
+      version: 7,
+    };
+    const { service } = makeService({
+      queue: {
+        readChatQueue: mock(() => Promise.resolve({ entries: [], paused: false })),
+        enqueueChat: mock(() => Promise.resolve({ entry: { id: 'q1' }, queue: postEnqueue })),
+        triggerDrain: mock(() => Promise.resolve(undefined)),
+      },
+    });
+
+    const result = await service.submitQueueEnqueue({
+      chatId: '1',
+      content: 'still waiting',
+      clientRequestId: 'req-enqueue-1',
+    });
+
+    expect(result.queue.entries.map((e) => e.id)).toEqual(['q1']);
+    expect(result.queue.entries.every((e) => e.status === 'queued')).toBe(true);
+  });
+
+  it('strips internal sending entries from mutate (dequeue) responses', async () => {
+    const afterDequeue = {
+      entries: [
+        { id: 's1', content: 'in flight', status: 'sending', createdAt: '2026-02-27T00:00:00.000Z' },
+      ],
+      paused: false,
+      version: 9,
+    };
+    const { service } = makeService({
+      queue: {
+        dequeueChat: mock(() => Promise.resolve(afterDequeue)),
+      },
+    });
+
+    const result = await service.mutateQueue({ chatId: '1', action: 'dequeue', entryId: 'q1' });
+
+    expect(result.queue.entries).toEqual([]);
   });
 });

--- a/server/commands/chat-command-service.ts
+++ b/server/commands/chat-command-service.ts
@@ -17,7 +17,7 @@ import {
   normalizeThinkingMode,
 } from '../../common/chat-modes.js';
 import type { AgentRunCommandRequest, ForkRunCommandRequest } from '../../common/chat-command-contracts.js';
-import { normalizeQueueState } from '../../common/queue-state.js';
+import { normalizeQueueState, toClientQueueState } from '../../common/queue-state.js';
 import type { QueueState } from '../../common/queue-state.js';
 import type { ChatRegistryEntry, IChatRegistry } from '../chats/store.js';
 import type { ChatMessage } from '../../common/chat-types.js';
@@ -419,7 +419,7 @@ export class ChatCommandService {
         ...commandResultFromRecord(ledger.record, 'duplicate'),
         entryId: ledger.record.entryId ?? '',
         merged: false,
-        queue: state,
+        queue: toClientQueueState(state),
       };
     }
 
@@ -438,7 +438,7 @@ export class ChatCommandService {
       ...commandResultFromRecord(updated ?? ledger.record),
       entryId: result.entry.id,
       merged,
-      queue: state,
+      queue: toClientQueueState(state),
     };
   }
 
@@ -452,7 +452,7 @@ export class ChatCommandService {
       success: true,
       chatId: input.chatId,
       entryId: result.entry.id,
-      queue: normalizeQueueState(result.queue),
+      queue: toClientQueueState(normalizeQueueState(result.queue)),
     };
   }
 
@@ -474,7 +474,7 @@ export class ChatCommandService {
         logger.error('queue: resume drain error:', err.message);
       });
     }
-    return { success: true, chatId: input.chatId, queue: normalizeQueueState(state) };
+    return { success: true, chatId: input.chatId, queue: toClientQueueState(normalizeQueueState(state)) };
   }
 
   async submitPermissionDecision(input: PermissionDecisionInput): Promise<CommandAcceptedResponse> {

--- a/server/queue/__tests__/client-queue-state.test.js
+++ b/server/queue/__tests__/client-queue-state.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'bun:test';
+import { toClientQueueState } from '../../../common/queue-state.js';
+
+function entry(id, status) {
+  return { id, content: `c-${id}`, status, createdAt: '2026-02-27T00:00:00.000Z' };
+}
+
+describe('toClientQueueState', () => {
+  it('strips sending entries that already live in the transcript', () => {
+    const result = toClientQueueState({
+      entries: [entry('s1', 'sending'), entry('q1', 'queued')],
+      paused: false,
+      version: 4,
+    });
+
+    expect(result.entries.map((e) => e.id)).toEqual(['q1']);
+    expect(result.version).toBe(4);
+  });
+
+  it('collapses to an empty queue while the only entry is sending', () => {
+    const result = toClientQueueState({
+      entries: [entry('s1', 'sending')],
+      paused: false,
+      version: 2,
+    });
+
+    expect(result.entries).toEqual([]);
+  });
+
+  it('returns the same reference when there is nothing to strip', () => {
+    const queue = { entries: [entry('q1', 'queued')], paused: true, version: 1 };
+    expect(toClientQueueState(queue)).toBe(queue);
+  });
+
+  it('forces paused false when stripping leaves no entries', () => {
+    const result = toClientQueueState({
+      entries: [entry('s1', 'sending')],
+      paused: true,
+      version: 3,
+    });
+
+    expect(result.entries).toEqual([]);
+    expect(result.paused).toBe(false);
+  });
+});

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -15,7 +15,7 @@ import { ModelSelectionError } from "../api-providers/endpoint-resolver.js";
 import type { AgentSessionSettingsPatch, RunAgentTurnOptions } from "../agents/session-types.js";
 import { CommandValidationError, runOptionsFromCommandRequest } from '../commands/chat-command-service.js';
 import type { ChatCommandService } from '../commands/chat-command-service.js';
-import { normalizeQueueState } from '../../common/queue-state.ts';
+import { normalizeQueueState, toClientQueueState } from '../../common/queue-state.ts';
 import { normalizeTags } from '../../common/tags.ts';
 import type {
   ChatListEntry,
@@ -753,7 +753,7 @@ export default function createChatRoutes({
     const chatId = url.searchParams.get('chatId');
     if (!chatId) return jsonError('chatId query parameter is required', 400);
     if (!registry.getChat(chatId)) return jsonError('Session not found', 404, 'SESSION_NOT_FOUND');
-    const state = normalizeQueueState(await queue.readChatQueue(chatId));
+    const state = toClientQueueState(normalizeQueueState(await queue.readChatQueue(chatId)));
     return Response.json({ success: true, chatId, queue: state });
   }
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -13,6 +13,7 @@ import { init as initAuthStore } from './auth/store.js';
 import { forkChatFileCopy } from './chats/fork-chat.js';
 import { ErrorMessage, parseChatMessages } from '../common/chat-types.js';
 import { isChatListInvalidationReason } from '../common/ws-events.ts';
+import { toClientQueueState } from '../common/queue-state.ts';
 
 // Classes
 import { ChatRegistry } from './chats/store.js';
@@ -536,9 +537,11 @@ export async function startServer(): Promise<void> {
       broadcast(new ChatReadUpdatedV1Message(chatId, lastReadAt));
     });
 
-    // Wire queue events to broadcast.
+    // Wire queue events to broadcast. The 'sending' status is internal dispatch
+    // state; toClientQueueState strips it so clients never see an entry that is
+    // already represented in the transcript as a pending user message.
     queue.onQueueUpdated((chatId, queueState) => {
-      broadcast(new QueueStateUpdatedMessage(chatId, queueState));
+      broadcast(new QueueStateUpdatedMessage(chatId, toClientQueueState(queueState)));
     });
     queue.onSessionStopRequested((chatId) => {
       expectedUserAborts.mark(chatId);

--- a/web/src/lib/components/chat/QueueControls.svelte
+++ b/web/src/lib/components/chat/QueueControls.svelte
@@ -16,22 +16,21 @@
 	const VISIBLE_ENTRY_LIMIT = 3;
 	const PREVIEW_CHAR_LIMIT = 180;
 
-	const queueEntries = $derived(queue?.entries ?? []);
-	const queuedEntryCount = $derived(
-		queueEntries.filter((entry) => entry.status === 'queued').length,
+	// Only queued entries belong in this panel. Once an entry is 'sending' it has
+	// been dispatched into the transcript as a pending user message, so showing it
+	// here too would duplicate it and leave a stale row while the badge reads zero.
+	const queuedEntries = $derived(
+		(queue?.entries ?? []).filter((entry) => entry.status === 'queued'),
 	);
-	const visibleEntries = $derived(queueEntries.slice(0, VISIBLE_ENTRY_LIMIT));
-	const hiddenEntryCount = $derived(Math.max(0, queueEntries.length - visibleEntries.length));
-	const hasEntries = $derived(queueEntries.length > 0);
+	const queuedEntryCount = $derived(queuedEntries.length);
+	const visibleEntries = $derived(queuedEntries.slice(0, VISIBLE_ENTRY_LIMIT));
+	const hiddenEntryCount = $derived(Math.max(0, queuedEntries.length - visibleEntries.length));
+	const hasEntries = $derived(queuedEntries.length > 0);
 	const visible = $derived(hasEntries);
 
 	function previewContent(content: string): string {
 		if (content.length <= PREVIEW_CHAR_LIMIT) return content;
 		return `${content.slice(0, PREVIEW_CHAR_LIMIT).trimEnd()}...`;
-	}
-
-	function entryStatusLabel(status: 'queued' | 'sending'): string {
-		return status === 'sending' ? m.chat_queue_sending() : m.chat_queue_pending_inputs();
 	}
 </script>
 
@@ -54,11 +53,6 @@
 			{#each visibleEntries as entry (entry.id)}
 				<div class="flex items-start gap-2 border-l-2 border-queue-entry-border pl-2">
 					<div class="min-w-0 flex-1">
-						<div
-							class="mb-0.5 text-[11px] font-medium uppercase tracking-normal text-queue-foreground/75"
-						>
-							{entryStatusLabel(entry.status)}
-						</div>
 						<span
 							class={cn(
 								'block text-sm leading-5 text-queue-foreground whitespace-pre-wrap break-words',
@@ -68,17 +62,15 @@
 							{previewContent(entry.content)}
 						</span>
 					</div>
-					{#if entry.status === 'queued'}
-						<button
-							type="button"
-							onclick={() => onDequeue(entry.id)}
-							class="shrink-0 rounded p-1 text-queue-foreground hover:bg-queue-action-hover-bg focus-visible:ring-2 focus-visible:ring-ring"
-							title={m.chat_queue_remove_from_queue()}
-							aria-label={m.chat_queue_remove_from_queue()}
-						>
-							<X class="h-3.5 w-3.5" />
-						</button>
-					{/if}
+					<button
+						type="button"
+						onclick={() => onDequeue(entry.id)}
+						class="shrink-0 rounded p-1 text-queue-foreground hover:bg-queue-action-hover-bg focus-visible:ring-2 focus-visible:ring-ring"
+						title={m.chat_queue_remove_from_queue()}
+						aria-label={m.chat_queue_remove_from_queue()}
+					>
+						<X class="h-3.5 w-3.5" />
+					</button>
 				</div>
 			{/each}
 		</div>

--- a/web/src/lib/components/chat/__tests__/QueueControls.test.ts
+++ b/web/src/lib/components/chat/__tests__/QueueControls.test.ts
@@ -127,8 +127,8 @@ describe('QueueControls', () => {
 		expect(content?.textContent).toBe(`${'x'.repeat(180)}...`);
 	});
 
-	it('shows sending entries without offering the queued remove action', () => {
-		render(QueueControls, {
+	it('hides sending entries since they already appear in the transcript', () => {
+		const { container } = render(QueueControls, {
 			queue: {
 				paused: false,
 				entries: [
@@ -145,8 +145,38 @@ describe('QueueControls', () => {
 			onDequeue: vi.fn(),
 		});
 
-		expect(screen.getByText(m.chat_queue_sending())).toBeTruthy();
-		expect(screen.queryByRole('button', { name: m.chat_queue_remove_from_queue() })).toBeNull();
-		expect(screen.getByText(m.chat_queue_pending_count({ count: 0 }))).toBeTruthy();
+		// The panel collapses entirely when only sending entries remain, so the
+		// stale "0 queued" row never appears.
+		expect(container.textContent?.trim() || '').toBe('');
+		expect(screen.queryByText('dispatching now')).toBeNull();
+	});
+
+	it('counts and renders only queued entries when sending and queued mix', () => {
+		render(QueueControls, {
+			queue: {
+				paused: false,
+				entries: [
+					{
+						id: 's1',
+						content: 'currently sending',
+						status: 'sending',
+						createdAt: '2026-02-27T00:00:00.000Z',
+					},
+					{
+						id: 'q1',
+						content: 'still waiting',
+						status: 'queued',
+						createdAt: '2026-02-27T00:00:01.000Z',
+					},
+				],
+			},
+			onResume: vi.fn(),
+			onPause: vi.fn(),
+			onDequeue: vi.fn(),
+		});
+
+		expect(screen.getByText(m.chat_queue_pending_count({ count: 1 }))).toBeTruthy();
+		expect(screen.getByText('still waiting')).toBeTruthy();
+		expect(screen.queryByText('currently sending')).toBeNull();
 	});
 });


### PR DESCRIPTION
Reverts cfal/garcon#218