### PR TITLE
fix(composer): align processing status bar with composer box

### DIFF
--- a/web/src/lib/components/chat/LoadingStatus.svelte
+++ b/web/src/lib/components/chat/LoadingStatus.svelte
@@ -108,9 +108,9 @@
 				(quickCommitSummary.additions > 0 || quickCommitSummary.deletions > 0),
 		),
 	);
-	const statusTrayClass = cn(
-		'absolute bottom-full left-[13px] right-[13px] z-10 md:left-3 md:right-3',
-	);
+	// Flush with the composer surface below (both span the shared frame edge to
+	// edge) so the status tray's left/right edges line up with the composer box.
+	const statusTrayClass = cn('absolute bottom-full left-0 right-0 z-10');
 	const statusPanelClass = cn(
 		'pointer-events-auto flex min-h-10 items-center justify-between gap-3 rounded-t-2xl bg-chat-thinking px-3 py-2 shadow-sm sm:px-4',
 	);


### PR DESCRIPTION
**Problem** — The "Processing…" status bar sat inset ~12–13px on each side relative to the composer box directly below it, so their left/right edges (and rounded top corners) didn't line up.

**Solution** — The status tray and the composer surface share the same `.relative` frame; the composer surface spans it edge to edge while the tray was hard-inset. Drop the tray's lateral inset so it spans the frame flush with the composer box.

**Changes** — `web/src/lib/components/chat/LoadingStatus.svelte`: `statusTrayClass` from `absolute bottom-full left-[13px] right-[13px] z-10 md:left-3 md:right-3` to `absolute bottom-full left-0 right-0 z-10`.

**Expected Impact** — Status bar edges align with the composer box. Purely visual; no behavior change.

**Before**

![before](https://raw.githubusercontent.com/cfal/garcon/pr-assets/composer-align/before.png)

**After**

![after](https://raw.githubusercontent.com/cfal/garcon/pr-assets/composer-align/after.png)
