### PR TITLE
fix(composer): merge status caps into the composer as one seamless card

### DIFF
--- a/web/src/lib/components/chat/GitQuickStatusTray.svelte
+++ b/web/src/lib/components/chat/GitQuickStatusTray.svelte
@@ -29,9 +29,9 @@
 		onCommit,
 	}: Props = $props();
 
-	const trayClass = cn(
-		'absolute bottom-full left-[13px] right-[13px] z-30 md:left-3 md:right-3',
-	);
+	// Flush with the composer surface below so the cap's left/right edges line up
+	// with the composer box, matching LoadingStatus.
+	const trayClass = cn('absolute bottom-full left-0 right-0 z-30');
 	const panelClass = cn(
 		'pointer-events-auto flex min-h-10 items-center justify-between gap-3 rounded-t-2xl border border-b-0 border-border bg-card px-3 py-2 shadow-sm sm:px-4',
 	);

--- a/web/src/lib/components/chat/LoadingStatus.svelte
+++ b/web/src/lib/components/chat/LoadingStatus.svelte
@@ -111,8 +111,10 @@
 	// Flush with the composer surface below (both span the shared frame edge to
 	// edge) so the status tray's left/right edges line up with the composer box.
 	const statusTrayClass = cn('absolute bottom-full left-0 right-0 z-10');
+	// Border on top and sides (no bottom) so the cap merges into the composer
+	// surface below as one continuous card, matching GitQuickStatusTray.
 	const statusPanelClass = cn(
-		'pointer-events-auto flex min-h-10 items-center justify-between gap-3 rounded-t-2xl bg-chat-thinking px-3 py-2 shadow-sm sm:px-4',
+		'pointer-events-auto flex min-h-10 items-center justify-between gap-3 rounded-t-2xl border border-b-0 border-border bg-chat-thinking px-3 py-2 shadow-sm sm:px-4',
 	);
 </script>
 

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -356,7 +356,15 @@
 		cn('w-full', CHAT_MAX_WIDTH_COMPOSER_FRAME_CLASS[localSettings.chatMaxWidth]),
 	);
 	const composerSurfaceClass = $derived(
-		cn('relative z-20 bg-card overflow-hidden rounded-2xl border border-border shadow-sm'),
+		cn(
+			'relative z-20 bg-card overflow-hidden border border-border shadow-sm',
+			// Square the top only while a status cap is attached above (processing or
+			// quick-commit), so the two form one continuous card instead of two
+			// fighting corner radii.
+			selectedIsProcessing || quickCommitTrayVisible
+				? 'rounded-b-2xl rounded-t-none'
+				: 'rounded-2xl',
+		),
 	);
 	const imageListClass = $derived(cn('p-2 bg-muted/40 rounded-lg mx-2 mt-2'));
 	const textareaClass = $derived(


### PR DESCRIPTION
**Problem** — Now that the status caps sit flush with the composer (from #234), a second issue shows: each cap (processing indicator and the quick-commit tray) has a flat bottom, but the composer still has rounded top corners. Where they meet, a small triangular gap of background shows at each top corner. The quick-commit cap was also still inset (`left-[13px]`), unlike the processing cap.

**Solution** — Treat a cap and the composer as one continuous card. Square the composer's top corners while a cap is attached so the cap's flat bottom meets the composer's flat top on a single clean seam; align the quick-commit cap flush like the processing cap; and give the processing cap the same top/side border the quick-commit cap already had.

**Changes**
- `PromptComposer.svelte`: composer surface squares its top (`rounded-t-none rounded-b-2xl`) while `selectedIsProcessing || quickCommitTrayVisible`, else stays `rounded-2xl`.
- `LoadingStatus.svelte`: panel gains `border border-b-0 border-border`.
- `GitQuickStatusTray.svelte`: tray `left-[13px] right-[13px] md:left-3 md:right-3` to `left-0 right-0`.

**Expected Impact** — A cap and the composer render as one seamless card; no triangular corner gap; both caps align consistently. Purely visual; no behavior change.

**Top-left corner, zoomed** (the seam)

Before | After
:--:|:--:
![corner before](https://raw.githubusercontent.com/cfal/garcon/524386a9b212957c3129306c047edcf54b764964/corner-before.png) | ![corner after](https://raw.githubusercontent.com/cfal/garcon/524386a9b212957c3129306c047edcf54b764964/corner-after.png)

**Full composer**

Before (flush caps, rounded composer top)

![before](https://raw.githubusercontent.com/cfal/garcon/524386a9b212957c3129306c047edcf54b764964/before.png)

After (one seamless card)

![after](https://raw.githubusercontent.com/cfal/garcon/524386a9b212957c3129306c047edcf54b764964/after.png)
