### PR TITLE
fix: prevent cross-provider model mismatch in generated-title config

### DIFF
--- a/server/settings/__tests__/generation-effective.test.js
+++ b/server/settings/__tests__/generation-effective.test.js
@@ -198,6 +198,81 @@ describe('resolveEffectiveGenerationConfig', () => {
     });
   });
 
+  it('discards a persisted model that belongs to a different provider when the agent falls back', () => {
+    const result = resolveEffectiveGenerationConfig({
+      persisted: {
+        enabled: true,
+        // agentId is absent (e.g. dropped as invalid on normalize) but a Codex model persists.
+        model: 'gpt-5.3-codex-spark',
+        modelProtocol: 'openai-compatible',
+      },
+      authByAgent: { claude: { authenticated: true } },
+      modelsByAgent: {
+        claude: [{ value: 'haiku', label: 'Claude Haiku' }],
+        codex: [{ value: 'gpt-5.3-codex-spark', label: 'gpt-5.3-codex-spark' }],
+      },
+    });
+
+    expect(result).toEqual({
+      enabled: true,
+      agentId: 'claude',
+      model: 'haiku',
+      apiProviderId: null,
+      modelEndpointId: null,
+      modelProtocol: null,
+      source: 'manual',
+    });
+  });
+
+  it('discards a persisted model that does not belong to the explicitly persisted agent', () => {
+    const result = resolveEffectiveGenerationConfig({
+      persisted: { enabled: true, agentId: 'claude', model: 'gpt-5.3-codex-spark' },
+      authByAgent: { claude: { authenticated: true } },
+      modelsByAgent: {
+        claude: [{ value: 'haiku', label: 'Claude Haiku' }],
+      },
+    });
+
+    expect(result).toEqual({
+      enabled: true,
+      agentId: 'claude',
+      model: 'haiku',
+      apiProviderId: null,
+      modelEndpointId: null,
+      modelProtocol: null,
+      source: 'manual',
+    });
+  });
+
+  it('keeps a persisted model that matches the resolved agent by rawModel', () => {
+    const result = resolveEffectiveGenerationConfig({
+      persisted: {
+        enabled: true,
+        agentId: 'direct-openai-compatible',
+        model: 'zai_openai:glm-5.1',
+        apiProviderId: 'zai_openai',
+        modelEndpointId: 'zai_openai',
+        modelProtocol: 'openai-compatible',
+      },
+      authByAgent: {},
+      modelsByAgent: {
+        'direct-openai-compatible': [
+          { value: 'zai_openai:glm-5.1', label: 'Z.AI: GLM-5.1', rawModel: 'glm-5.1' },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      enabled: true,
+      agentId: 'direct-openai-compatible',
+      model: 'zai_openai:glm-5.1',
+      apiProviderId: 'zai_openai',
+      modelEndpointId: 'zai_openai',
+      modelProtocol: 'openai-compatible',
+      source: 'manual',
+    });
+  });
+
   it('uses dynamic agent model defaults from catalog-shaped model maps', () => {
     const result = resolveEffectiveGenerationConfig({
       persisted: { enabled: true, agentId: 'direct-openai-compatible' },

--- a/server/settings/generation-effective.ts
+++ b/server/settings/generation-effective.ts
@@ -72,6 +72,22 @@ function pickDefaultModel(agentId: string, modelsByAgent: GenerationModelMap): s
   return generationModelDefaults[agentId] || modelsByAgent?.[agentId]?.[0]?.value || '';
 }
 
+// Guards against cross-provider mismatches (e.g. a Codex model paired with the Claude
+// agent after the persisted agentId is dropped or falls back). A persisted model is only
+// trusted when it is that agent's known default or appears in the agent's catalog models.
+// When no model list is available the model cannot be validated, so it is kept as-is to
+// avoid discarding legitimate selections while the catalog is loading.
+function modelBelongsToAgent(
+  agentId: string,
+  model: string,
+  modelsByAgent: GenerationModelMap,
+): boolean {
+  if (generationModelDefaults[agentId] === model) return true;
+  const models = modelsByAgent?.[agentId];
+  if (!Array.isArray(models) || models.length === 0) return true;
+  return models.some((option) => option?.value === model || option?.rawModel === model);
+}
+
 export function resolveEffectiveGenerationConfig({
   persisted,
   authByAgent,
@@ -90,16 +106,22 @@ export function resolveEffectiveGenerationConfig({
 
   const autoAgent = pickAutoAgent(authByAgent, readinessByAgent ?? {}, modelsByAgent);
   const selectedAgent = persistedAgent || autoAgent || 'claude';
-  const selectedModel = persistedModel || pickDefaultModel(selectedAgent, modelsByAgent);
+  const persistedModelValid =
+    persistedModel !== '' && modelBelongsToAgent(selectedAgent, persistedModel, modelsByAgent);
+  const selectedModel = persistedModelValid
+    ? persistedModel
+    : pickDefaultModel(selectedAgent, modelsByAgent);
   const selectedEnabled = persistedEnabled ?? Boolean(autoAgent);
 
   return {
     enabled: selectedEnabled,
     agentId: selectedAgent,
     model: selectedModel,
-    apiProviderId: persistedApiProviderId,
-    modelEndpointId: persistedEndpointId,
-    modelProtocol: persistedProtocol,
+    // The endpoint/provider/protocol describe the persisted model, so they are dropped
+    // alongside a mismatched model to avoid carrying stale provider metadata forward.
+    apiProviderId: persistedModelValid ? persistedApiProviderId : null,
+    modelEndpointId: persistedModelValid ? persistedEndpointId : null,
+    modelProtocol: persistedModelValid ? persistedProtocol : null,
     source: persistedEnabled === null && !persistedAgent && !persistedModel ? 'auto' : 'manual',
   };
 }


### PR DESCRIPTION
**Problem**

The Remote Settings "Title model" selector could display a provider paired with a model that belongs to a different provider -- e.g. the **Claude** provider showing the Codex model `gpt-5.3-codex-spark`. `resolveEffectiveGenerationConfig` resolves the agent and the model independently: when the persisted `agentId` is missing or invalid (normalization drops an invalid `agentId` but keeps `model`), the agent falls back to `claude` while a stale model from another provider is carried through unchecked.

| Before (bug) | After (fix) |
| --- | --- |
| ![before](https://files.catbox.moe/ywg7zk.png) | ![after](https://files.catbox.moe/zuigk9.png) |
| `Claude OAuth / gpt-5.3-codex-spark` | `Claude OAuth / Haiku` |

**Solution**

Validate the persisted model against the resolved agent. If the model does not belong to the agent, fall back to the agent's default model and drop the now-stale provider/endpoint/protocol metadata. When no model list is available (catalog still loading), the persisted model is kept as-is to avoid discarding legitimate selections.

**Changes**

- `server/settings/generation-effective.ts`: add `modelBelongsToAgent` guard and apply it when resolving the effective model, clearing `apiProviderId`/`modelEndpointId`/`modelProtocol` for mismatched models.
- `server/settings/__tests__/generation-effective.test.js`: add coverage for provider/model mismatch (fallback agent and explicit agent) and for preserving a valid `rawModel` match.

**Expected Impact**

The title/commit-message model selectors can no longer surface a cross-provider mismatch; a stale model is transparently replaced by the resolved provider's default. No behavior change for valid selections or when the catalog is unavailable.
