### PR TITLE
common/models: surface Fable 5 in the Claude model selector

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -12,7 +12,7 @@ export const CLAUDE_MODELS = {
     { value: 'opus', label: 'Opus', supportsImages: true },
     { value: 'sonnet', label: 'Sonnet', supportsImages: true },
     { value: 'haiku', label: 'Haiku', supportsImages: true },
-    { value: 'fable', label: 'Fable', supportsImages: true },
+    { value: 'fable', label: 'Fable 5', supportsImages: true },
   ] satisfies SharedModelOption[],
   DEFAULT: 'opus',
 };

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -572,6 +572,10 @@ describe('ModelCatalogStore', () => {
 		const claudeModels = store.getModels('claude');
 		expect(claudeModels[0]).toMatchObject({ value: 'opus', label: 'Opus', supportsImages: true });
 		expect(claudeModels.find((m) => m.value === 'sonnet')).toBeTruthy();
+		expect(claudeModels.find((m) => m.value === 'fable')).toMatchObject({
+			label: 'Fable 5',
+			supportsImages: true,
+		});
 	});
 
 	it('merges missing static models into catalog results', async () => {


### PR DESCRIPTION
**Problem**

Anthropic's newest and most capable model, Fable 5 (`claude-fable-5`), was not named in the built-in Claude model selector. A generic `fable` alias existed, but it was labeled simply "Fable", so users could not tell which concrete model it maps to and the newest tier was not clearly discoverable.

**Solution**

Label the Claude picker's Fable option as **Fable 5** so the model is named the way Anthropic and users refer to it. The underlying `fable` value is unchanged — the Claude CLI resolves it to the latest Fable model (`claude-fable-5`), verified via `claude --help` (`--model` accepts `'fable'` as an alias for the latest model).

**Changes**

- `common/models.ts`: `CLAUDE_MODELS.OPTIONS` — relabel the `fable` entry from "Fable" to "Fable 5" (single-line change; the single source of truth consumed by both the server model catalog and the frontend picker).

**Expected Impact**

Users see "Fable 5" in the Claude model dropdown and can select it; no change to routing, defaults (`opus` remains default), or the API contract. Verified end-to-end by dogfooding a local build: the `/api/v1/models` catalog returns the new label and the composer applies it on selection.

Dropdown listing Fable 5 alongside Opus/Sonnet/Haiku:

![Claude model dropdown showing Fable 5](https://raw.githubusercontent.com/cfal/garcon/4422e11b2ab32803ee1721225b994c59a6c80dcc/dropdown-fable5.png)

Composer with Fable 5 selected:

![Composer with Fable 5 selected](https://raw.githubusercontent.com/cfal/garcon/4422e11b2ab32803ee1721225b994c59a6c80dcc/composer-fable5-selected.png)