### PR TITLE
fix: keep queue dispatch controls visible behind composer cap

### DIFF
--- a/web/src/lib/chat/__tests__/composer-cap-layout.test.ts
+++ b/web/src/lib/chat/__tests__/composer-cap-layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { composerCapReservation } from '../composer-cap-layout';
+
+describe('composerCapReservation', () => {
+	it('reserves nothing when no cap is shown', () => {
+		expect(composerCapReservation(false, false)).toEqual({ feed: false, queue: false });
+		expect(composerCapReservation(false, true)).toEqual({ feed: false, queue: false });
+	});
+
+	it('reserves on the feed when a cap is shown without a visible queue', () => {
+		expect(composerCapReservation(true, false)).toEqual({ feed: true, queue: false });
+	});
+
+	it('reserves on the queue panel when a cap is shown with a visible queue', () => {
+		expect(composerCapReservation(true, true)).toEqual({ feed: false, queue: true });
+	});
+});

--- a/web/src/lib/chat/composer-cap-layout.ts
+++ b/web/src/lib/chat/composer-cap-layout.ts
@@ -1,0 +1,23 @@
+// The composer renders an absolutely positioned cap directly above itself: the
+// agent status tray while a turn is processing, or the git quick-commit tray
+// otherwise. Because the cap is out of flow, it floats up over whichever element
+// sits immediately above the composer, so that element must reserve vertical
+// space or the cap overlaps it. When inputs are queued the queue panel is the
+// element directly above the composer; otherwise the message feed is. Reserving
+// space in exactly the right place keeps the queue's dispatch controls visible
+// and clickable while a cap is shown.
+
+export interface ComposerCapReservation {
+	feed: boolean;
+	queue: boolean;
+}
+
+// Decides which element reserves space for the composer cap. At most one slot is
+// active: the queue panel when queued inputs are visible, otherwise the feed.
+export function composerCapReservation(
+	capVisible: boolean,
+	queueVisible: boolean,
+): ComposerCapReservation {
+	if (!capVisible) return { feed: false, queue: false };
+	return { feed: !queueVisible, queue: queueVisible };
+}

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -36,6 +36,7 @@
 	import { QuickCommitDialogState } from '$lib/stores/git/quick-commit-dialog-state.svelte';
 	import { gitProjectInvalidations } from '$lib/stores/git-project-invalidation.svelte';
 	import { isChatProcessing } from '$lib/chat/chat-processing';
+	import { composerCapReservation } from '$lib/chat/composer-cap-layout';
 	import { buildSubagentManagementModel } from '$lib/chat/subagent-management';
 	import {
 		getChatSessions,
@@ -192,6 +193,11 @@
 		!selectedIsProcessing && localSettings.showQuickCommitTray && quickGit.canShowTrayFor(projectPath),
 	);
 	const reserveComposerTraySpace = $derived(selectedIsProcessing || quickGitTrayVisible);
+	const queueVisible = $derived((activeQueue?.entries.length ?? 0) > 0);
+	// The composer cap floats over whatever sits directly above the composer.
+	// Reserve its space on the queue panel when inputs are queued, otherwise on
+	// the feed, so the queue's dispatch controls stay clickable behind the cap.
+	const composerCapSpace = $derived(composerCapReservation(reserveComposerTraySpace, queueVisible));
 	const subagentModel = $derived(
 		buildSubagentManagementModel(chatState.displayMessages, {
 			rootTitle: sessions.selectedChat?.title || 'Root',
@@ -530,7 +536,7 @@
 						const chatId = sessions.selectedChatId;
 						if (chatId) void controller.forkChat(chatId, upToSeq);
 					}}
-					{reserveComposerTraySpace}
+					reserveComposerTraySpace={composerCapSpace.feed}
 					{isPreparingInitialScroll}
 					isProcessing={selectedIsProcessing}
 					{textScale}
@@ -563,7 +569,7 @@
 			{/if}
 		</div>
 
-		<div bind:this={queueControlsContainer}>
+		<div bind:this={queueControlsContainer} class={cn(composerCapSpace.queue && 'pb-14')}>
 			<QueueControls
 				queue={activeQueue}
 				onResume={() => controller.handleQueueResume()}


### PR DESCRIPTION
**Problem**

While the agent is running (or the git quick-commit tray is showing), a queued input cannot be dispatched. The queue panel sits directly above the composer, but the "Thinking..." status tray and the git quick-commit tray are absolutely positioned caps that float up over the composer. When inputs are queued, that cap overlaps the bottom of the queue panel and covers its Resume/Pause dispatch controls, so the paused queue can't be resumed. The existing `reserveComposerTraySpace` padding only reserves room inside the message feed, which no longer sits directly above the composer once the queue panel is present.

**Solution**

Reserve the composer cap's vertical space on whichever element is directly above the composer. When queued inputs are visible, reserve it on the queue panel so its dispatch controls always clear the cap; otherwise keep reserving it on the feed as before. The decision is a small pure helper so the invariant (exactly one reservation slot, correctly placed) is explicit and unit-tested.

**Changes**

- Add `composerCapReservation` helper in `web/src/lib/chat/composer-cap-layout.ts` deciding whether the feed or the queue panel reserves cap space.
- Wire it into `ConversationWorkspace.svelte`: derive `queueVisible`, pass `composerCapSpace.feed` to the feed's `reserveComposerTraySpace`, and apply `pb-14` to the queue container when `composerCapSpace.queue` is set.
- Add unit tests for the helper.

**Expected Impact**

Queued inputs can always be dispatched: the Resume/Pause controls stay visible and clickable behind the status and git trays. No behavior change when no inputs are queued.

**Before / After**

| Before (dispatch covered) | After (dispatch always visible) |
| --- | --- |
| ![before](https://files.catbox.moe/obnfwr.png) | ![after](https://files.catbox.moe/ca5qwh.png) |
