### PR TITLE
fix(chat): focus split pane composer immediately

### DIFF
--- a/web/src/lib/components/layout/WorkspaceView.svelte
+++ b/web/src/lib/components/layout/WorkspaceView.svelte
@@ -3,6 +3,7 @@
 	import { untrack } from 'svelte';
 	import {
 		getChatSessions,
+		getAppShell,
 		getLocalSettings,
 		getModelCatalog,
 		getSplitLayout,
@@ -75,6 +76,7 @@
 	}: MainContentProps = $props();
 
 	const sessions = getChatSessions();
+	const appShell = getAppShell();
 	const localSettings = getLocalSettings();
 	const modelCatalog = getModelCatalog();
 	const splitLayout = getSplitLayout();
@@ -168,6 +170,7 @@
 		splitLayout.focusPane(paneId);
 		const pane = splitLayout.panes.find((p) => p.id === paneId);
 		if (pane) sessions.setSelectedChatId(pane.chatId);
+		appShell.requestComposerFocus();
 	}
 
 	function handleSplitClosePane(paneId: string) {

--- a/web/src/lib/components/layout/__tests__/SplitContainerStub.svelte
+++ b/web/src/lib/components/layout/__tests__/SplitContainerStub.svelte
@@ -3,12 +3,20 @@
 
 	interface SplitContainerStubProps {
 		node: LayoutNode;
+		focusedPaneId?: string | null;
 		previewStore?: unknown;
 		textScale?: number;
+		onFocusPane?: (paneId: string) => void;
 		onMaximizePane?: (paneId: string) => void;
 	}
 
-	let { node, textScale = 1, onMaximizePane }: SplitContainerStubProps = $props();
+	let {
+		node,
+		focusedPaneId = null,
+		textScale = 1,
+		onFocusPane,
+		onMaximizePane,
+	}: SplitContainerStubProps = $props();
 
 	function collectPanes(nodeToRead: LayoutNode): PaneNode[] {
 		if (nodeToRead.type === 'pane') return [nodeToRead];
@@ -21,8 +29,15 @@
 <div data-testid="split-container-stub" data-text-scale={String(textScale)}>
 	{#each panes as pane (pane.id)}
 		<div data-pane-id={pane.id}>
-			<div data-pane-body>
+			<div data-pane-body data-focused={focusedPaneId === pane.id ? 'true' : 'false'}>
 				{pane.chatId}
+				<button
+					type="button"
+					aria-label={`Focus pane showing ${pane.chatId}`}
+					onclick={() => onFocusPane?.(pane.id)}
+				>
+					Focus
+				</button>
 				<button
 					type="button"
 					aria-label={`Maximize pane showing ${pane.chatId}`}

--- a/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
+++ b/web/src/lib/components/layout/__tests__/WorkspaceView.test.ts
@@ -266,6 +266,66 @@ describe('WorkspaceView header visibility', () => {
 		expect(screen.getByRole('button', { name: 'Git' }).getAttribute('aria-pressed')).toBe('true');
 	});
 
+	it('requests composer focus immediately when switching split panes', async () => {
+		const focusPane = vi.fn();
+		const setSelectedChatId = vi.fn();
+		const requestComposerFocus = vi.fn();
+		const root = {
+			type: 'split',
+			direction: 'horizontal',
+			ratio: 0.5,
+			children: [
+				{ type: 'pane', id: 'pane-left', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-right', chatId: 'chat-2' },
+			],
+		};
+		const splitLayout = {
+			isEnabled: true,
+			root,
+			focusedPaneId: 'pane-left',
+			draggedChatId: null,
+			draggedPaneId: null,
+			paneCount: 2,
+			panes: [
+				{ type: 'pane', id: 'pane-left', chatId: 'chat-1' },
+				{ type: 'pane', id: 'pane-right', chatId: 'chat-2' },
+			],
+			focusedChatId: 'chat-1',
+			focusPane,
+			replacePaneChat: vi.fn(),
+			swapPanes: vi.fn(),
+			closePane: vi.fn(),
+			addChatToZone: vi.fn(),
+			endDrag: vi.fn(),
+			setRatioByPath: vi.fn(),
+			disable: vi.fn(),
+			enableWithChat: vi.fn(),
+			setGrid: vi.fn(),
+			splitPane: vi.fn(),
+		};
+
+		render(WorkspaceViewTestHost, {
+			activeTab: 'chat',
+			isMobile: false,
+			splitLayout,
+			onRequestComposerFocus: requestComposerFocus,
+			chatSessions: makeChatSessions({
+				selectedChat: { id: 'chat-1', title: 'Header Test Chat', projectPath: '/tmp/header-test' },
+				byId: {
+					'chat-1': { id: 'chat-1', title: 'Header Test Chat', projectPath: '/tmp/header-test' },
+					'chat-2': { id: 'chat-2', title: 'Right Pane Chat', projectPath: '/tmp/header-test' },
+				},
+				setSelectedChatId,
+			}),
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Focus pane showing chat-2' }));
+
+		expect(focusPane).toHaveBeenCalledWith('pane-right');
+		expect(setSelectedChatId).toHaveBeenCalledWith('chat-2');
+		expect(requestComposerFocus).toHaveBeenCalledOnce();
+	});
+
 	it('maximizes a split pane by exiting split view and selecting that chat', async () => {
 		const disable = vi.fn();
 		const setSelectedChatId = vi.fn();

--- a/web/src/lib/components/layout/__tests__/WorkspaceViewTestHost.svelte
+++ b/web/src/lib/components/layout/__tests__/WorkspaceViewTestHost.svelte
@@ -31,6 +31,7 @@
 		chatActions?: WorkspaceChatActions;
 		supportsFork?: boolean;
 		supportsForkWhileRunning?: boolean;
+		onRequestComposerFocus?: () => void;
 	}
 
 	let {
@@ -43,6 +44,7 @@
 		chatActions,
 		supportsFork = true,
 		supportsForkWhileRunning = false,
+		onRequestComposerFocus = () => {},
 	}: WorkspaceViewTestHostProps = $props();
 
 	const defaultChatActions: WorkspaceChatActions = {
@@ -127,6 +129,9 @@
 
 	setAppShell({
 		openNewChatDialog() {},
+		requestComposerFocus() {
+			onRequestComposerFocus();
+		},
 	} as never);
 
 	setWs({

--- a/web/src/lib/components/layout/split-drop-controller.svelte.ts
+++ b/web/src/lib/components/layout/split-drop-controller.svelte.ts
@@ -132,7 +132,6 @@ export class SplitDropController {
 			const update = () => {
 				paneEl = root.querySelector<HTMLElement>(`[data-pane-id="${focusedId}"] [data-pane-body]`);
 				if (!paneEl) {
-					this.focusedOverlayRect = null;
 					return;
 				}
 				const rootRect = root.getBoundingClientRect();

--- a/web/src/lib/components/split/ChatPane.svelte
+++ b/web/src/lib/components/split/ChatPane.svelte
@@ -14,6 +14,7 @@
 	import ConversationTranscript from '$lib/components/chat/ConversationTranscript.svelte';
 	import { Scrollbar } from '$lib/components/ui/scroll-area';
 	import { ScrollArea as ScrollAreaPrimitive } from 'bits-ui';
+	import SplitPaneComposerBar from './SplitPaneComposerBar.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import X from '@lucide/svelte/icons/x';
 	import Maximize2 from '@lucide/svelte/icons/maximize-2';
@@ -82,6 +83,7 @@
 	// hasn't acknowledged -- lets the user see at a glance which pane
 	// needs attention across a 4-up split.
 	const needsAttention = $derived(!isProcessing && !isFocused && (chatRecord?.isUnread ?? false));
+	let lastPointerFocusAt = 0;
 
 	// Grabbing the header starts a pane drag; the workspace-level drop layer
 	// (which covers every pane during a drag) resolves the target and swap.
@@ -123,8 +125,35 @@
 	}
 
 	function handlePreviewClick(event: MouseEvent): void {
-		if (isInteractiveTarget(event.target, event.currentTarget)) return;
+		if (consumePointerFocusClick()) return;
+		if (isFocused || isInteractiveTarget(event.target, event.currentTarget)) return;
 		onFocus();
+	}
+
+	function handlePanePointerDown(event: PointerEvent): void {
+		if (isFocused || isInteractiveTarget(event.target, event.currentTarget)) return;
+		event.preventDefault();
+		lastPointerFocusAt = performance.now();
+		onFocus();
+	}
+
+	function handlePaneHeaderPointerDown(event: PointerEvent): void {
+		if (isFocused || isInteractiveTarget(event.target, event.currentTarget)) return;
+		lastPointerFocusAt = performance.now();
+		onFocus();
+	}
+
+	function handlePaneHeaderClick(event: MouseEvent): void {
+		if (consumePointerFocusClick()) return;
+		if (isFocused || isInteractiveTarget(event.target, event.currentTarget)) return;
+		onFocus();
+	}
+
+	function consumePointerFocusClick(): boolean {
+		if (lastPointerFocusAt === 0) return false;
+		const ageMs = performance.now() - lastPointerFocusAt;
+		lastPointerFocusAt = 0;
+		return ageMs < 750;
 	}
 </script>
 
@@ -150,7 +179,8 @@
 				: 'bg-muted/20 border-border/30 hover:bg-muted/40',
 		)}
 		draggable={true}
-		onclick={onFocus}
+		onpointerdown={handlePaneHeaderPointerDown}
+		onclick={handlePaneHeaderClick}
 		onkeydown={(e) => {
 			if (e.key === 'Enter') onFocus();
 		}}
@@ -237,6 +267,7 @@
 				'bg-background/40 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
 				'transition-colors',
 			)}
+			onpointerdown={handlePanePointerDown}
 			onclick={handlePreviewClick}
 			onkeydown={(e) => {
 				if (isInteractiveTarget(e.target, e.currentTarget)) return;
@@ -280,6 +311,7 @@
 				<Scrollbar orientation="vertical" class="w-1.5" />
 				<ScrollAreaPrimitive.Corner />
 			</ScrollAreaPrimitive.Root>
+			<SplitPaneComposerBar chatId={chatId} title={chatTitle} onFocus={onFocus} />
 		</div>
 	{/if}
 

--- a/web/src/lib/components/split/SplitPaneComposerBar.svelte
+++ b/web/src/lib/components/split/SplitPaneComposerBar.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import SendHorizontal from '@lucide/svelte/icons/send-horizontal';
+	import * as m from '$lib/paraglide/messages.js';
+	import {
+		chatDraftStorageKey,
+		getLocalStorageItem,
+		removeLocalStorageItem,
+		setLocalStorageItem,
+	} from '$lib/utils/local-persistence';
+
+	interface SplitPaneComposerBarProps {
+		chatId: string;
+		title: string;
+		onFocus: () => void;
+	}
+
+	let { chatId, title, onFocus }: SplitPaneComposerBarProps = $props();
+
+	let draftText = $state('');
+	let focusTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function loadDraft(id: string): void {
+		draftText = getLocalStorageItem(chatDraftStorageKey(id)) ?? '';
+	}
+
+	$effect(() => {
+		loadDraft(chatId);
+	});
+
+	function persistDraft(): void {
+		const key = chatDraftStorageKey(chatId);
+		if (draftText.trim()) {
+			setLocalStorageItem(key, draftText);
+		} else {
+			removeLocalStorageItem(key);
+		}
+	}
+
+	function clearFocusTimer(): void {
+		if (!focusTimer) return;
+		clearTimeout(focusTimer);
+		focusTimer = null;
+	}
+
+	function promoteFocus(): void {
+		clearFocusTimer();
+		onFocus();
+	}
+
+	function scheduleFocusPromotion(): void {
+		clearFocusTimer();
+		focusTimer = setTimeout(() => {
+			focusTimer = null;
+			onFocus();
+		}, 100);
+	}
+
+	function handleInput(event: Event): void {
+		draftText = (event.currentTarget as HTMLTextAreaElement).value;
+		persistDraft();
+		promoteFocus();
+	}
+
+	onDestroy(clearFocusTimer);
+</script>
+
+<div class="flex-shrink-0 border-t border-border/40 bg-background/95 p-2">
+	<div class="rounded-xl border border-border bg-card shadow-sm">
+		<textarea
+			bind:value={draftText}
+			rows="1"
+			class="block w-full resize-none bg-transparent px-3 py-2 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground/80"
+			placeholder={m.chat_composer_reply_placeholder()}
+			aria-label={m.chat_pane_focus_composer({ title })}
+			onpointerdown={(event) => event.stopPropagation()}
+			onclick={(event) => event.stopPropagation()}
+			onfocus={scheduleFocusPromotion}
+			oninput={handleInput}
+			onkeydown={(event) => {
+				if (event.key === 'Escape') {
+					(event.currentTarget as HTMLTextAreaElement).blur();
+				}
+			}}
+		></textarea>
+		<div class="flex items-center justify-end border-t border-border/40 px-2 py-1.5">
+			<div
+				class="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/70"
+				aria-hidden="true"
+			>
+				<SendHorizontal class="h-3.5 w-3.5" />
+			</div>
+		</div>
+	</div>
+</div>

--- a/web/src/lib/components/split/__tests__/ChatPane.test.ts
+++ b/web/src/lib/components/split/__tests__/ChatPane.test.ts
@@ -2,6 +2,7 @@
 	import { fireEvent, render, screen } from '@testing-library/svelte';
 	import ChatPaneTestHost from './ChatPaneTestHost.svelte';
 	import { AssistantMessage, BashToolUseMessage, UserMessage } from '$shared/chat-types';
+	import { chatDraftStorageKey } from '$lib/utils/local-persistence';
 
 vi.mock('$lib/api/chats.js', () => ({
 	getChatMessages: vi.fn(() =>
@@ -41,7 +42,7 @@ vi.mock('$lib/api/chats.js', () => ({
 }));
 
 describe('ChatPane', () => {
-	it('shows chat history without a fake composer when unfocused', async () => {
+	it('shows chat history with a pane-local composer when unfocused', async () => {
 		const onFocus = vi.fn();
 		render(ChatPaneTestHost, { isFocused: false, onFocus });
 
@@ -55,8 +56,58 @@ describe('ChatPane', () => {
 		expect(await screen.findByText('2 commands')).toBeTruthy();
 		expect(await screen.findByText('pwd')).toBeTruthy();
 		expect(await screen.findByText('rg split')).toBeTruthy();
-		expect(screen.queryByText('Reply...')).toBeNull();
+		expect(screen.getByRole('textbox', { name: 'Focus chat composer for Pane Test Chat' })).toBeTruthy();
 
+		await fireEvent.click(focusTarget);
+
+		expect(onFocus).toHaveBeenCalledTimes(1);
+	});
+
+	it('persists pane-local composer input as the chat draft before focusing', async () => {
+		vi.useFakeTimers();
+		const onFocus = vi.fn();
+		const draftKey = chatDraftStorageKey('chat-1');
+		localStorage.removeItem(draftKey);
+		const { unmount } = render(ChatPaneTestHost, { isFocused: false, onFocus });
+
+		try {
+			const composer = screen.getByRole('textbox', {
+				name: 'Focus chat composer for Pane Test Chat',
+			});
+			await fireEvent.focus(composer);
+			expect(onFocus).not.toHaveBeenCalled();
+
+			await fireEvent.input(composer, { target: { value: 'draft from inactive pane' } });
+
+			expect(localStorage.getItem(draftKey)).toBe('draft from inactive pane');
+			expect(onFocus).toHaveBeenCalledTimes(1);
+		} finally {
+			unmount();
+			localStorage.removeItem(draftKey);
+			vi.useRealTimers();
+		}
+	});
+
+	it('focuses a pane on pointer down so the composer can accept typing immediately', async () => {
+		const onFocus = vi.fn();
+		render(ChatPaneTestHost, { isFocused: false, onFocus });
+
+		const focusTarget = screen.getByRole('button', {
+			name: 'Focus chat composer for Pane Test Chat',
+		});
+		await fireEvent.pointerDown(focusTarget);
+
+		expect(onFocus).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not focus twice for a full pointer click sequence', async () => {
+		const onFocus = vi.fn();
+		render(ChatPaneTestHost, { isFocused: false, onFocus });
+
+		const focusTarget = screen.getByRole('button', {
+			name: 'Focus chat composer for Pane Test Chat',
+		});
+		await fireEvent.pointerDown(focusTarget);
 		await fireEvent.click(focusTarget);
 
 		expect(onFocus).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Before

Switching between split panes relied on the click path to focus the pane, then on the selected-chat update to eventually move focus into the composer. During the switch the focused overlay could also clear for a frame while the new pane body was being measured, which made the composer feel late to appear.

```mermaid
flowchart LR
  A[Click non-focused pane] --> B[Focus pane]
  B --> C[Select pane chat]
  C --> D[Composer focus follows later]
  B --> E[Overlay may clear during remeasure]
```

## After

Non-focused split panes now promote focus on pointer-down, and every preview pane renders a lightweight pane-local chat bar. The full `ConversationWorkspace` stays single-mounted for the focused pane, while preview bars persist typed text into the same per-chat draft storage that the real composer restores after focus changes.

```mermaid
flowchart LR
  A[Pointer down or type in non-focused pane] --> B[Focus pane immediately]
  A --> C[Preview bar saves draft by chat id]
  B --> D[Select pane chat]
  D --> E[Request composer focus]
  C --> F[Focused composer restores draft]
  E --> G[Typing can continue right away]
```

## Screenshots

![Split view with chat bars in both panes](https://litter.catbox.moe/tthnib.png)

![Right pane active with immediate composer typing](https://litter.catbox.moe/skiw4c.png)

## Files

- `web/src/lib/components/split/SplitPaneComposerBar.svelte` adds the lightweight preview-pane chat bar and draft handoff.
- `web/src/lib/components/split/ChatPane.svelte` renders the pane-local bar for non-focused previews and keeps pointer-down focus promotion idempotent.
- `web/src/lib/components/layout/WorkspaceView.svelte` requests composer focus immediately after split pane focus selects the pane chat.
- `web/src/lib/components/layout/split-drop-controller.svelte.ts` keeps the focused overlay rect during a transient measurement gap.
- Split-pane component tests cover pointer-down focus, duplicate click suppression, pane-local bar rendering, draft persistence, and immediate composer-focus requests.

## Tests

- `bun run --cwd web test src/lib/components/split/__tests__/ChatPane.test.ts src/lib/components/layout/__tests__/WorkspaceView.test.ts` (39 tests passed)
- `bun run --cwd web check` (0 errors, 0 warnings)
- `bun run test` (server suite passed; web suite 169 files / 1578 tests passed)
- `timeout 40s bun run start --port 0` (build completed and server listened on a random port; timeout sent SIGTERM)

Prompted by: yk (@chiayong)
