### PR TITLE
web: support fork for slash commands

### DIFF
--- a/web/src/lib/chat/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/__tests__/conversation-session-controller.test.ts
@@ -215,6 +215,8 @@ function createDeps(chat = createRunningChat()) {
 					modelProtocol: null,
 				})),
 				selectionValueFor: vi.fn((_provider, model) => model),
+				supportsFork: vi.fn(() => true),
+				supportsForkWhileRunning: vi.fn(() => true),
 			},
 			readReceiptOutbox: {
 				enqueue: vi.fn(),
@@ -412,6 +414,72 @@ describe('ConversationSessionController', () => {
 		expect(deps.lifecycle.setCurrentChatId).toHaveBeenCalledWith('456');
 		expect(deps.sessions.setSelectedChatId).toHaveBeenCalledWith('456');
 		expect(deps.navigation.navigateToChat).toHaveBeenCalledWith('456');
+	});
+
+	it('rejects /fork when agent does not support fork', async () => {
+		const chat = createRunningChat({ id: '123', agentId: 'opencode' });
+		const { deps } = createDeps(chat);
+		deps.composerState.inputText = '/fork continue from here';
+		deps.modelCatalog.supportsFork = vi.fn(() => false);
+		mockRunChat.mockResolvedValue({
+			success: true,
+			commandType: 'run',
+			clientRequestId: 'req-1',
+			chatId: '123',
+			status: 'accepted',
+			acceptedAt: '2026-03-27T08:00:00.000Z',
+		});
+		const controller = new ConversationSessionController(deps as never);
+
+		await controller.submitForChat('123');
+
+		expect(mockForkRunChat).not.toHaveBeenCalled();
+		expect(mockForkChat).not.toHaveBeenCalled();
+		expect(mockRunChat).toHaveBeenCalledWith(
+			expect.objectContaining({
+				command: '/fork continue from here',
+			}),
+		);
+	});
+
+	it('rejects /fork when processing and agent does not support fork-while-running', async () => {
+		const chat = createRunningChat({ id: '123', isProcessing: true });
+		const { deps } = createDeps(chat);
+		deps.composerState.inputText = '/fork continue from here';
+		deps.modelCatalog.supportsForkWhileRunning = vi.fn(() => false);
+		const controller = new ConversationSessionController(deps as never);
+
+		await controller.submitForChat('123');
+
+		expect(mockForkRunChat).not.toHaveBeenCalled();
+		expect(mockForkChat).not.toHaveBeenCalled();
+		expect(deps.chatState.localNotices).toHaveLength(1);
+		expect(deps.chatState.localNotices[0]).toMatchObject({
+			noticeType: 'error',
+			content: 'Cannot fork while chat is processing',
+		});
+	});
+
+	it('allows /fork when processing and agent supports fork-while-running', async () => {
+		const chat = createRunningChat({ id: '123', isProcessing: true });
+		const { deps } = createDeps(chat);
+		deps.composerState.inputText = '/fork continue from here';
+		deps.modelCatalog.supportsForkWhileRunning = vi.fn(() => true);
+		deps.ws.sendMessage = vi.fn(() => true);
+		mockForkRunChat.mockResolvedValue({
+			success: true,
+			commandType: 'fork-run',
+			clientRequestId: 'req-1',
+			chatId: '456',
+			status: 'accepted',
+			acceptedAt: '2026-03-27T08:00:00.000Z',
+			sourceChatId: '123',
+		});
+		const controller = new ConversationSessionController(deps as never);
+
+		await controller.submitForChat('123');
+
+		expect(mockForkRunChat).toHaveBeenCalled();
 	});
 
 	it('submits in-chat fork actions with the clicked message sequence', async () => {

--- a/web/src/lib/chat/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation-session-controller.svelte.ts
@@ -80,6 +80,8 @@ export interface SessionControllerDeps {
 			model: string,
 			modelEndpointId?: string | null,
 		) => string;
+		supportsFork: (agentId: SessionAgentId) => boolean;
+		supportsForkWhileRunning: (agentId: SessionAgentId) => boolean;
 	};
 	appShell: {
 		openNewChatDialog: (opts: { prefill: string }) => void;
@@ -313,7 +315,6 @@ export class ConversationSessionController {
 		chatId: string,
 		messageOverride?: string,
 		imageOverride?: File[],
-		options: { allowForkCommand?: boolean } = {},
 	): Promise<void> {
 		const { deps } = this;
 		const selected = deps.sessions.byId[chatId];
@@ -328,9 +329,15 @@ export class ConversationSessionController {
 		const previousText = deps.composerState.inputText;
 		const previousImages = [...deps.composerState.images];
 
-		if (options.allowForkCommand !== false) {
+		const agentId = selected.agentId as SessionAgentId;
+		if (deps.modelCatalog.supportsFork(agentId)) {
 			const forkCommand = parseForkCommand(text);
 			if (forkCommand) {
+				const isProcessing = selected.status === 'running' && selected.isProcessing;
+				if (isProcessing && !deps.modelCatalog.supportsForkWhileRunning(agentId)) {
+					deps.chatState.appendLocalNotice('error', 'Cannot fork while chat is processing');
+					return;
+				}
 				await this.#submitForkCommand(
 					chatId,
 					selected,

--- a/web/src/lib/chat/slash-commands.ts
+++ b/web/src/lib/chat/slash-commands.ts
@@ -14,6 +14,11 @@ export const BUILTIN_SLASH_COMMANDS: readonly SlashCommand[] = [
 		source: 'command',
 		description: 'Summarize the conversation to free up context',
 	},
+	{
+		name: 'fork',
+		source: 'command',
+		description: 'Fork the conversation into a new chat',
+	},
 ];
 
 export interface SlashCommandTrigger {

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -326,6 +326,7 @@
 	}
 
 	const selectedIsProcessing = $derived(isChatProcessing(sessions.selectedChat));
+	const forkCapabilityAgentId = $derived(sessions.selectedChat?.agentId ?? agentState.agentId);
 	const isDraftStartupSubmitting = $derived(
 		composerState.isSubmitting && sessions.selectedChat?.status === 'draft',
 	);
@@ -599,7 +600,7 @@
 			chatId={sessions.selectedChatId}
 			isVisible={ui.showSlashMenu}
 			query={ui.slashQuery}
-			supportsFork={modelCatalog.supportsFork(agentState.agentId)}
+			supportsFork={modelCatalog.supportsFork(forkCapabilityAgentId)}
 			onSelect={insertSlashCommand}
 			onClose={() => ui.closeSlashMenu()}
 		/>

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -599,6 +599,7 @@
 			chatId={sessions.selectedChatId}
 			isVisible={ui.showSlashMenu}
 			query={ui.slashQuery}
+			supportsFork={modelCatalog.supportsFork(agentState.agentId)}
 			onSelect={insertSlashCommand}
 			onClose={() => ui.closeSlashMenu()}
 		/>

--- a/web/src/lib/components/chat/SlashCommandMenu.svelte
+++ b/web/src/lib/components/chat/SlashCommandMenu.svelte
@@ -14,6 +14,7 @@
 		chatId?: string | null;
 		isVisible: boolean;
 		query: string;
+		supportsFork: boolean;
 		onSelect: (name: string) => void;
 		onClose: () => void;
 		position?: { top: number; left: number };
@@ -25,6 +26,7 @@
 		chatId = null,
 		isVisible,
 		query,
+		supportsFork,
 		onSelect,
 		onClose,
 		position,
@@ -74,11 +76,16 @@
 
 	// Client-side built-ins are always available; agent-discovered commands are
 	// appended, skipping any whose name a built-in already covers so the richer
-	// built-in entry (with its description) wins.
+	// built-in entry (with its description) wins. Fork is filtered based on
+	// agent capability.
 	let mergedCommands = $derived.by(() => {
 		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => command.name));
 		const discovered = allCommands.filter((command) => !builtinNames.has(command.name));
-		return [...BUILTIN_SLASH_COMMANDS, ...discovered];
+		const merged = [...BUILTIN_SLASH_COMMANDS, ...discovered];
+		if (!supportsFork) {
+			return merged.filter((command) => command.name !== 'fork');
+		}
+		return merged;
 	});
 
 	// Filters commands by query (case-insensitive), capped at 10 results.

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -268,4 +268,19 @@ describe('PromptComposer focus', () => {
 
 		expect(textarea.value).toBe('after refocus');
 	});
+
+	it('hides /fork using the selected chat agent capability', async () => {
+		render(PromptComposerTestHost, {
+			selectedChatId: 'chat-1',
+			selectedAgentId: 'opencode',
+			selectedStatus: 'running',
+			isSubmitting: false,
+		});
+		const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+		await fireEvent.input(textarea, { target: { value: '/' } });
+
+		expect(await screen.findByText('/compact')).toBeTruthy();
+		expect(screen.queryByText('/fork')).toBeNull();
+	});
 });

--- a/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
@@ -19,6 +19,7 @@
 
 	interface Props {
 		selectedChatId?: string;
+		selectedAgentId?: ChatSessionRecord['agentId'];
 		selectedStatus?: ChatStatus;
 		selectedIsProcessing?: boolean;
 		isSubmitting?: boolean;
@@ -34,6 +35,7 @@
 
 	let {
 		selectedChatId = 'chat-1',
+		selectedAgentId = 'claude',
 		selectedStatus = 'running',
 		selectedIsProcessing = false,
 		isSubmitting = false,
@@ -57,7 +59,7 @@
 		id: selectedChatId,
 		projectPath: '/workspace/project',
 		title: selectedChatId,
-		agentId: 'claude',
+		agentId: selectedAgentId,
 		model: 'opus',
 		permissionMode: 'default',
 		thinkingMode: 'none',
@@ -123,7 +125,7 @@
 		getModelForSelection: (_agentId: string, model: string) =>
 			modelOptions.find((option) => option.value === model) ?? null,
 		supportsImages: () => true,
-		supportsFork: () => true,
+		supportsFork: (agentId: string) => agentId !== 'opencode',
 		supportsForkWhileRunning: () => true,
 		selectionFor: (_agentId: string, model: string) => ({
 			model,

--- a/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
@@ -123,6 +123,8 @@
 		getModelForSelection: (_agentId: string, model: string) =>
 			modelOptions.find((option) => option.value === model) ?? null,
 		supportsImages: () => true,
+		supportsFork: () => true,
+		supportsForkWhileRunning: () => true,
 		selectionFor: (_agentId: string, model: string) => ({
 			model,
 			apiProviderId: null,

--- a/web/src/lib/components/chat/__tests__/SlashCommandMenu.test.ts
+++ b/web/src/lib/components/chat/__tests__/SlashCommandMenu.test.ts
@@ -4,7 +4,7 @@ import SlashCommandMenu from '../SlashCommandMenu.svelte';
 
 // An empty projectPath skips agent discovery, so these cases exercise the
 // always-present built-in commands without hitting the network.
-const baseProps = { agent: 'claude', projectPath: '' };
+const baseProps = { agent: 'claude', projectPath: '', supportsFork: true };
 
 describe('SlashCommandMenu', () => {
 	it('lists the built-in compact command matching the query', () => {
@@ -18,6 +18,33 @@ describe('SlashCommandMenu', () => {
 
 		expect(screen.getByText('/compact')).toBeTruthy();
 		expect(screen.getByText('Summarize the conversation to free up context')).toBeTruthy();
+	});
+
+	it('lists the built-in fork command when supported', () => {
+		render(SlashCommandMenu, {
+			...baseProps,
+			supportsFork: true,
+			isVisible: true,
+			query: 'fork',
+			onSelect: vi.fn(),
+			onClose: vi.fn(),
+		});
+
+		expect(screen.getByText('/fork')).toBeTruthy();
+		expect(screen.getByText('Fork the conversation into a new chat')).toBeTruthy();
+	});
+
+	it('hides the fork command when not supported', () => {
+		render(SlashCommandMenu, {
+			...baseProps,
+			supportsFork: false,
+			isVisible: true,
+			query: '',
+			onSelect: vi.fn(),
+			onClose: vi.fn(),
+		});
+
+		expect(screen.queryByText('/fork')).toBeNull();
 	});
 
 	it('selects a command on click', async () => {


### PR DESCRIPTION
`/fork <prompt>` already worked but was not displayed in the slash commands popup and did not check supportsFork* flags