### PR TITLE
feat: expose agent/provider selector in existing-chat composer

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -181,6 +181,7 @@
 	"chat_notice_cannot_compact_draft": "Cannot compact a draft chat. Send a message first.",
 	"chat_notice_cannot_fork_draft": "Cannot fork a draft chat. Select an existing chat first.",
 	"chat_notice_cannot_fork_processing": "Cannot fork while chat is processing",
+	"chat_notice_cannot_switch_agent_mid_session": "Cannot switch to {agent} mid-conversation yet. Fork or start a new chat to use {agent}.",
 	"chat_notice_cannot_switch_model_mid_session": "Cannot switch to a {target} model mid-session. Start a new chat to use {model}.",
 	"chat_notice_failed_compact": "Failed to compact: {detail}",
 	"chat_notice_failed_deny_permission": "Failed to deny permission: {detail}",

--- a/web/src/lib/chat/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/__tests__/conversation-session-controller.test.ts
@@ -8,6 +8,7 @@ import {
 	runChat,
 	startChat,
 	stopChat,
+	updateChatModel,
 } from '$lib/api/chats.js';
 import { ConversationSessionController } from '../conversation-session-controller.svelte';
 import type { ChatRestoreResult } from '../state.svelte';
@@ -40,6 +41,7 @@ const mockRunChat = vi.mocked(runChat);
 const mockStartChat = vi.mocked(startChat);
 const mockEnqueueChatMessage = vi.mocked(enqueueChatMessage);
 const mockStopChat = vi.mocked(stopChat);
+const mockUpdateChatModel = vi.mocked(updateChatModel);
 
 function deferred<T>() {
 	let resolve!: (value: T) => void;
@@ -221,6 +223,7 @@ function createDeps(chat = createRunningChat()) {
 					modelProtocol: null,
 				})),
 				selectionValueFor: vi.fn((_provider, model) => model),
+				getAgentLabel: vi.fn((agentId: string) => agentId),
 				supportsFork: vi.fn(() => true),
 				supportsForkWhileRunning: vi.fn(() => true),
 			},
@@ -248,6 +251,8 @@ describe('ConversationSessionController', () => {
 		mockStartChat.mockReset();
 		mockEnqueueChatMessage.mockReset();
 		mockStopChat.mockReset();
+		mockUpdateChatModel.mockReset();
+		mockUpdateChatModel.mockResolvedValue({ success: true } as never);
 		mockGetChatQueue.mockResolvedValue({
 			success: true,
 			chatId: 'chat-1',
@@ -912,5 +917,48 @@ describe('ConversationSessionController', () => {
 		await controller.loadChat('chat-1');
 
 		expect(deps.chatState.pendingUserInputs).toEqual([pending]);
+	});
+
+	describe('handleModelSelectionChange', () => {
+		it('applies a same-agent selection through the model update path', () => {
+			const { deps } = createDeps(createRunningChat({ agentId: 'claude', model: 'sonnet' }));
+			deps.agentState.agentId = 'claude';
+			const controller = new ConversationSessionController(deps as never);
+
+			controller.handleModelSelectionChange({
+				agentId: 'claude',
+				modelValue: 'opus',
+				model: 'opus',
+				apiProviderId: null,
+				modelEndpointId: null,
+				modelProtocol: null,
+			});
+
+			expect(mockUpdateChatModel).toHaveBeenCalledWith(
+				expect.objectContaining({ chatId: 'chat-1', model: 'opus' }),
+			);
+			expect(deps.chatState.appendLocalNotice).not.toHaveBeenCalled();
+		});
+
+		it('refuses a cross-agent selection with a notice and no model update', () => {
+			const { deps } = createDeps(createRunningChat({ agentId: 'claude', model: 'sonnet' }));
+			deps.agentState.agentId = 'claude';
+			const controller = new ConversationSessionController(deps as never);
+
+			controller.handleModelSelectionChange({
+				agentId: 'codex',
+				modelValue: 'gpt-5.5',
+				model: 'gpt-5.5',
+				apiProviderId: null,
+				modelEndpointId: null,
+				modelProtocol: null,
+			});
+
+			expect(mockUpdateChatModel).not.toHaveBeenCalled();
+			expect(deps.chatState.appendLocalNotice).toHaveBeenCalledWith(
+				'error',
+				expect.stringContaining('codex'),
+			);
+		});
 	});
 });

--- a/web/src/lib/chat/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation-session-controller.svelte.ts
@@ -37,6 +37,7 @@ import type { ChatSessionRecord, ChatStartupConfig } from '$lib/types/chat-sessi
 import type { AppTab, SessionAgentId } from '$lib/types/app';
 import type { ApiProtocol } from '$shared/api-providers';
 import type { PermissionDecisionPayload } from '$shared/chat-command-contracts';
+import type { ModelSelectorChange } from '$lib/components/model-selector/model-selector-types';
 import * as m from '$lib/paraglide/messages.js';
 
 export interface SessionControllerDeps {
@@ -81,6 +82,7 @@ export interface SessionControllerDeps {
 			model: string,
 			modelEndpointId?: string | null,
 		) => string;
+		getAgentLabel: (agentId: SessionAgentId) => string;
 		supportsFork: (agentId: SessionAgentId) => boolean;
 		supportsForkWhileRunning: (agentId: SessionAgentId) => boolean;
 	};
@@ -919,6 +921,28 @@ export class ConversationSessionController {
 					m.chat_notice_failed_remove_queued_message({ detail: errorDetail(error) }),
 				);
 			});
+	}
+
+	// Entry point for the composer model selector. Same-agent selections keep the
+	// existing model-switch behavior; cross-agent selections are refused for now,
+	// since continuing a live runtime session under a different agent can replay
+	// agent-specific transcript artifacts (e.g. thinking-block signatures) that
+	// are invalid across backends. Actual cross-agent continuation is a follow-up.
+	handleModelSelectionChange(next: ModelSelectorChange): void {
+		const { deps } = this;
+		const chatId = deps.sessions.selectedChatId;
+		if (!chatId) return;
+		const currentAgentId = deps.sessions.selectedChat?.agentId ?? deps.agentState.agentId;
+		if (next.agentId !== currentAgentId) {
+			deps.chatState.appendLocalNotice(
+				'error',
+				m.chat_notice_cannot_switch_agent_mid_session({
+					agent: deps.modelCatalog.getAgentLabel(next.agentId),
+				}),
+			);
+			return;
+		}
+		this.handleModelChange(next.modelValue);
 	}
 
 	handleModelChange(model: string): void {

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -584,7 +584,7 @@
 		<PromptComposer
 			{isVisible}
 			onsubmit={onSubmit}
-			onModelChange={(m) => controller.handleModelChange(m)}
+			onModelChange={(next) => controller.handleModelSelectionChange(next)}
 			onPermissionModeChange={(m) => controller.handlePermissionModeChange(m)}
 			onThinkingModeChange={(m) => controller.handleThinkingModeChange(m)}
 			onAbort={() => controller.handleAbort()}

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -46,11 +46,15 @@
 	import type { GitQuickSummaryReady } from '$lib/api/git.js';
 	import type { GitQuickBranchSelectorControls } from './git-quick-status-tray-types.js';
 	import ComposerModelSelector from '$lib/components/model-selector/ComposerModelSelector.svelte';
-	import type { ModelSelectorMode } from '$lib/components/model-selector/model-selector-types';
+	import { composerModelSelectorMode } from '$lib/components/model-selector/composer-model-selector-mode';
+	import type {
+		ModelSelectorChange,
+		ModelSelectorMode,
+	} from '$lib/components/model-selector/model-selector-types';
 
 	interface Props {
 		onsubmit: () => void;
-		onModelChange?: (model: string) => void;
+		onModelChange?: (selection: ModelSelectorChange) => void;
 		onPermissionModeChange?: (mode: PermissionMode) => void;
 		onThinkingModeChange?: (mode: ThinkingMode) => void;
 		onAbort?: (() => void) | null;
@@ -349,11 +353,17 @@
 			localSettings.showQuickCommitTray &&
 			Boolean(onQuickCommit && quickCommitSummary && quickCommitSummary.changedFiles > 0),
 	);
-	const modelSelectorMode: ModelSelectorMode = {
-		agent: 'fixed',
-		source: 'hidden',
-		surface: 'composer',
-	};
+	// Existing (already-started) chats expose the full agent/source picker so a
+	// conversation can move between configured providers and models. Drafts keep
+	// the compact trigger; the new-chat form owns agent selection before start.
+	const isActiveModelSelection = $derived(
+		Boolean(sessions.selectedChat) && sessions.selectedChat?.status !== 'draft',
+	);
+	const modelSelectorMode: ModelSelectorMode = $derived(
+		isActiveModelSelection
+			? composerModelSelectorMode(modelCatalog, agentState.agentId)
+			: { agent: 'fixed', source: 'hidden', surface: 'composer' },
+	);
 	const modelSelectorValue = $derived({
 		agentId: agentState.agentId,
 		model: agentState.model,
@@ -579,7 +589,7 @@
 					<ComposerModelSelector
 						value={modelSelectorValue}
 						mode={modelSelectorMode}
-						onChange={(next) => onModelChange?.(next.modelValue)}
+						onChange={(next) => onModelChange?.(next)}
 						align="end"
 						side="top"
 					/>

--- a/web/src/lib/components/model-selector/__tests__/composer-model-selector-mode.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/composer-model-selector-mode.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelCatalogStore, ModelOption } from '$lib/stores/model-catalog.svelte';
+import { composerModelSelectorMode } from '../composer-model-selector-mode';
+
+function makeCatalog(input: {
+	agents: string[];
+	models: Record<string, ModelOption[]>;
+	labels?: Record<string, string>;
+}): ModelCatalogStore {
+	return {
+		getSelectableAgents: () => input.agents,
+		getModels: (id: string) => input.models[id] ?? [],
+		getAgentLabel: (id: string) => input.labels?.[id] ?? id,
+		findEndpoint: () => null,
+	} as unknown as ModelCatalogStore;
+}
+
+describe('composerModelSelectorMode', () => {
+	it('exposes agent and source selection when multiple agents are configured', () => {
+		const catalog = makeCatalog({
+			agents: ['claude', 'codex'],
+			models: {
+				claude: [{ value: 'opus', label: 'Opus' }],
+				codex: [{ value: 'gpt-5.5', label: 'GPT-5.5' }],
+			},
+		});
+
+		expect(composerModelSelectorMode(catalog, 'claude')).toEqual({
+			agent: 'select',
+			source: 'select',
+			surface: 'composer',
+		});
+	});
+
+	it('stays compact when a single agent has a single source', () => {
+		const catalog = makeCatalog({
+			agents: ['claude'],
+			models: { claude: [{ value: 'opus', label: 'Opus' }] },
+			labels: { claude: 'Claude' },
+		});
+
+		expect(composerModelSelectorMode(catalog, 'claude')).toEqual({
+			agent: 'fixed',
+			source: 'hidden',
+			surface: 'composer',
+		});
+	});
+
+	it('offers source selection for a single agent that has multiple sources', () => {
+		const catalog = makeCatalog({
+			agents: ['claude'],
+			models: {
+				claude: [
+					{ value: 'opus', label: 'Opus' },
+					{
+						value: 'acme-anthropic:acme-sonnet',
+						label: 'Acme: Sonnet',
+						rawModel: 'acme-sonnet',
+						apiProviderId: 'acme',
+						endpointId: 'acme-anthropic',
+						protocol: 'anthropic-messages',
+					},
+				],
+			},
+			labels: { claude: 'Claude' },
+		});
+
+		expect(composerModelSelectorMode(catalog, 'claude')).toEqual({
+			agent: 'fixed',
+			source: 'select',
+			surface: 'composer',
+		});
+	});
+});

--- a/web/src/lib/components/model-selector/composer-model-selector-mode.ts
+++ b/web/src/lib/components/model-selector/composer-model-selector-mode.ts
@@ -1,0 +1,25 @@
+import type { SessionAgentId } from '$lib/types/app';
+import type { ModelCatalogStore } from '$lib/stores/model-catalog.svelte';
+import { buildModelSources } from './model-selector-options';
+import type { ModelSelectorMode } from './model-selector-types';
+
+// Resolves the model-selector configuration for the active chat composer.
+// Existing chats expand to agent/source selection so a conversation can move
+// between configured agents and providers, and collapse back to the compact
+// single-model trigger when only one agent and one source are available.
+export function composerModelSelectorMode(
+	modelCatalog: ModelCatalogStore,
+	agentId: SessionAgentId,
+): ModelSelectorMode {
+	const canSelectAgent = modelCatalog.getSelectableAgents().length > 1;
+	// Different agents can expose different sources, so keep source selection
+	// available whenever the agent can change. Otherwise only offer it when the
+	// current agent genuinely has more than one source to choose between.
+	const canSelectSource =
+		canSelectAgent || buildModelSources(modelCatalog, agentId).length > 1;
+	return {
+		agent: canSelectAgent ? 'select' : 'fixed',
+		source: canSelectSource ? 'select' : 'hidden',
+		surface: 'composer',
+	};
+}


### PR DESCRIPTION
Implements the minimal viable version from #251.

**Problem**

In an existing chat, the composer model selector was hard-locked to the current agent with the provider/source picker hidden, so a conversation could not switch providers/models mid-chat (e.g. Codex to Claude). The composer also forwarded only the model string, dropping agent/provider metadata.

**Solution**

Expose the full agent/source selector in active (non-draft) chats when more than one agent or source is configured, and carry the full `ModelSelectorChange` through the composer to the controller. Same-agent model/provider switches use the existing model-update path. Cross-agent switches are refused with a clear, actionable notice, since continuing a live runtime session under a different agent can replay agent-specific transcript artifacts (e.g. thinking-block signatures); real cross-agent continuation is deferred to a follow-up PR. No backend change is needed: the existing `/api/v1/chats/model` endpoint cannot change the agent and already rejects models not exposed by the current agent, so the guard lives in the controller where it can surface a useful message instead of adding a reject-only endpoint.

**Changes**

- `PromptComposer.svelte`: derive selector mode via new `composerModelSelectorMode` (expands to agent/source select for multi-agent or multi-source active chats, stays compact otherwise); `onModelChange` now carries the full `ModelSelectorChange`.
- `composer-model-selector-mode.ts` (new) + unit test: pure mode resolver.
- `ConversationWorkspace.svelte`: forward the full selection to the controller.
- `conversation-session-controller.svelte.ts`: add `handleModelSelectionChange` (same-agent delegates to existing `handleModelChange`; cross-agent surfaces a notice) + tests.
- `en.json`: add `chat_notice_cannot_switch_agent_mid_session`.

**Expected Impact**

Existing chats can switch model/provider within the same agent from the composer. Cross-agent selections are visible but clearly declined with guidance to fork or start a new chat, with no silent reuse of an incompatible native session. Single-agent, single-source deployments keep the current compact selector unchanged. Behavior note: the existing-chat composer now shows the agent/source picker where it previously showed a single-model trigger, only when multiple agents or sources are configured.

**Dogfood**

Built this branch and ran it against a Claude + Codex configuration. In an existing Codex chat, the composer model selector now opens the full Agent / Provider / model picker:

![Agent/Provider/model picker in an existing chat](https://raw.githubusercontent.com/0xSolarPunk/garcon/cdf20959d979b1e844ef1f6b9f2a7aad6598f0f4/existing-chat-model-selector.png)

Selecting a different agent (Claude) is refused with a clear notice, so no incompatible native session is silently reused:

![Cross-agent switch refused](https://raw.githubusercontent.com/0xSolarPunk/garcon/cdf20959d979b1e844ef1f6b9f2a7aad6598f0f4/cross-agent-switch-notice.png)
