### PR TITLE
feat(sidebar): add recent-activity sort toggle for chat list

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -863,6 +863,8 @@
 	"sidebar_chats_loading_chats": "Loading chats...",
 	"sidebar_chats_mark_all_read": "Mark all as read",
 	"sidebar_chats_sort_by_recent": "Sort by recent activity",
+	"sidebar_chats_sort_recent_active": "Recent activity",
+	"sidebar_chats_sort_recent_active_hint": "Sorted by recent activity. Click to use manual order.",
 	"sidebar_chats_move_to_bottom": "Move to bottom",
 	"sidebar_chats_move_to_top": "Move to top",
 	"sidebar_chats_new_chat": "New Chat",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -862,6 +862,7 @@
 	"sidebar_chats_loading": "Loading...",
 	"sidebar_chats_loading_chats": "Loading chats...",
 	"sidebar_chats_mark_all_read": "Mark all as read",
+	"sidebar_chats_sort_by_recent": "Sort by recent activity",
 	"sidebar_chats_move_to_bottom": "Move to bottom",
 	"sidebar_chats_move_to_top": "Move to top",
 	"sidebar_chats_new_chat": "New Chat",

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -103,6 +103,7 @@
 		groupByProject: localSettings.sidebarGroupByProject,
 		groupNestedProjectPaths: localSettings.sidebarGroupNestedProjectPaths,
 		compactChatItems: localSettings.sidebarCompactChatItems,
+		sortMode: localSettings.sidebarSortMode,
 	});
 
 	let visibleUnreadChatIds = $derived.by(() =>
@@ -344,6 +345,13 @@
 		localSettings.toggle('sidebarCompactChatItems');
 	}
 
+	function handleToggleSortByRecent(): void {
+		localSettings.set(
+			'sidebarSortMode',
+			localSettings.sidebarSortMode === 'recent' ? 'manual' : 'recent',
+		);
+	}
+
 	// Search dialog actions.
 
 	function handleSearchSelectChat(chatId: string) {
@@ -386,6 +394,7 @@
 			groupByProject={displayOptions.groupByProject}
 			groupNestedProjectPaths={displayOptions.groupNestedProjectPaths}
 			compactChatItems={displayOptions.compactChatItems}
+			sortByRecent={displayOptions.sortMode === 'recent'}
 			sidebarMenuSearches={sidebarSearch.sidebarMenuSearches}
 			sidebarPillSearches={sidebarSearch.sidebarPillSearches}
 			activeQuery={sidebarSearch.activeQuery}
@@ -397,6 +406,7 @@
 			onToggleGroupByProject={handleToggleGroupByProject}
 			onToggleGroupNestedProjectPaths={handleToggleGroupNestedProjectPaths}
 			onToggleCompactChatItems={handleToggleCompactChatItems}
+			onToggleSortByRecent={handleToggleSortByRecent}
 			onApplySidebarMenuSearch={handleApplySidebarMenuSearch}
 			onApplyPillSearch={handleApplySidebarPillSearch}
 			onClearActiveQuery={handleClearActiveQuery}

--- a/web/src/lib/components/sidebar/SidebarChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatList.svelte
@@ -15,6 +15,7 @@
 		DEFAULT_SIDEBAR_DISPLAY_OPTIONS,
 		type SidebarDisplayOptions,
 	} from './sidebar-display-options';
+	import { sortChatsByRecencyDesc } from './chat-recency-sort';
 	import type { SessionAgentId } from '$lib/types/app';
 	import type { ChatSessionRecord } from '$lib/types/chat-session';
 	import type { ChatOrderList, ReorderQuickTarget } from '$lib/api/chats.js';
@@ -84,7 +85,14 @@
 	}: SidebarChatListProps = $props();
 
 	let isFiltered = $derived(searchFilter.trim().length > 0);
-	let displayedChats = $derived(isFiltered ? filteredChats : chats);
+	let sortByRecent = $derived(displayOptions.sortMode === 'recent');
+	// Recent-activity sort ranks every chat newest-first within its pin/archive
+	// group; manual order defers to the server-persisted drag order. Filtered
+	// results are already recency-ordered upstream, so re-sorting is idempotent.
+	let displayedChats = $derived.by(() => {
+		const source = isFiltered ? filteredChats : chats;
+		return sortByRecent ? sortChatsByRecencyDesc(source) : source;
+	});
 	let showChats = $derived(!isLoading && chats.length > 0 && displayedChats.length > 0);
 	let hasPinnedChats = $derived(partitionSidebarChats(chats).hasPinned);
 	let baseOrders = $derived.by(() => buildSidebarChatOrderMap(displayedChats));

--- a/web/src/lib/components/sidebar/SidebarControlsRow.svelte
+++ b/web/src/lib/components/sidebar/SidebarControlsRow.svelte
@@ -15,6 +15,7 @@
 	import EllipsisVertical from '@lucide/svelte/icons/ellipsis-vertical';
 	import FolderTree from '@lucide/svelte/icons/folder-tree';
 	import ListCollapse from '@lucide/svelte/icons/list-collapse';
+	import Clock from '@lucide/svelte/icons/clock';
 	import SquareCheck from '@lucide/svelte/icons/square-check';
 	import type { SavedChatSearch } from '$lib/api/settings';
 
@@ -25,6 +26,7 @@
 		groupByProject?: boolean;
 		groupNestedProjectPaths?: boolean;
 		compactChatItems?: boolean;
+		sortByRecent?: boolean;
 		sidebarMenuSearches?: SavedChatSearch[];
 		hasAdjacentSearchContext?: boolean;
 		onOpenSearchDialog: () => void;
@@ -33,6 +35,7 @@
 		onToggleGroupByProject?: () => void;
 		onToggleGroupNestedProjectPaths?: () => void;
 		onToggleCompactChatItems?: () => void;
+		onToggleSortByRecent?: () => void;
 		onApplySidebarMenuSearch?: (query: string) => void;
 		onShowSettings: () => void;
 	}
@@ -44,6 +47,7 @@
 		groupByProject = false,
 		groupNestedProjectPaths = false,
 		compactChatItems = false,
+		sortByRecent = false,
 		sidebarMenuSearches = [],
 		hasAdjacentSearchContext = false,
 		onOpenSearchDialog,
@@ -52,6 +56,7 @@
 		onToggleGroupByProject,
 		onToggleGroupNestedProjectPaths,
 		onToggleCompactChatItems,
+		onToggleSortByRecent,
 		onApplySidebarMenuSearch,
 		onShowSettings,
 	}: SidebarControlsRowProps = $props();
@@ -143,6 +148,13 @@
 					{m.sidebar_chats_mark_all_read()}
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
+				<DropdownMenuCheckboxItem
+					checked={sortByRecent}
+					onCheckedChange={() => onToggleSortByRecent?.()}
+				>
+					<Clock class="h-3.5 w-3.5" />
+					{m.sidebar_chats_sort_by_recent()}
+				</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem
 					checked={groupByProject}
 					onCheckedChange={() => onToggleGroupByProject?.()}

--- a/web/src/lib/components/sidebar/SidebarSearchDock.svelte
+++ b/web/src/lib/components/sidebar/SidebarSearchDock.svelte
@@ -10,6 +10,7 @@
 		groupByProject?: boolean;
 		groupNestedProjectPaths?: boolean;
 		compactChatItems?: boolean;
+		sortByRecent?: boolean;
 		sidebarMenuSearches?: SavedChatSearch[];
 		sidebarPillSearches: SavedChatSearch[];
 		activeQuery: string;
@@ -19,6 +20,7 @@
 		onToggleGroupByProject?: () => void;
 		onToggleGroupNestedProjectPaths?: () => void;
 		onToggleCompactChatItems?: () => void;
+		onToggleSortByRecent?: () => void;
 		onApplySidebarMenuSearch?: (query: string) => void;
 		onApplyPillSearch: (search: SavedChatSearch) => void;
 		onClearActiveQuery: () => void;
@@ -32,6 +34,7 @@
 		groupByProject = false,
 		groupNestedProjectPaths = false,
 		compactChatItems = false,
+		sortByRecent = false,
 		sidebarMenuSearches = [],
 		sidebarPillSearches,
 		activeQuery,
@@ -41,6 +44,7 @@
 		onToggleGroupByProject,
 		onToggleGroupNestedProjectPaths,
 		onToggleCompactChatItems,
+		onToggleSortByRecent,
 		onApplySidebarMenuSearch,
 		onApplyPillSearch,
 		onClearActiveQuery,
@@ -58,6 +62,7 @@
 		{groupByProject}
 		{groupNestedProjectPaths}
 		{compactChatItems}
+		{sortByRecent}
 		{sidebarMenuSearches}
 		hasAdjacentSearchContext={hasSearchContext}
 		{onOpenSearchDialog}
@@ -66,6 +71,7 @@
 		{onToggleGroupByProject}
 		{onToggleGroupNestedProjectPaths}
 		{onToggleCompactChatItems}
+		{onToggleSortByRecent}
 		{onApplySidebarMenuSearch}
 		{onShowSettings}
 	/>

--- a/web/src/lib/components/sidebar/SidebarSearchDock.svelte
+++ b/web/src/lib/components/sidebar/SidebarSearchDock.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import SidebarControlsRow from './SidebarControlsRow.svelte';
 	import SidebarSearchContext from './SidebarSearchContext.svelte';
+	import SidebarSortIndicator from './SidebarSortIndicator.svelte';
 	import type { SavedChatSearch } from '$lib/api/settings';
 
 	interface SidebarSearchDockProps {
@@ -52,6 +53,9 @@
 	}: SidebarSearchDockProps = $props();
 
 	let hasSearchContext = $derived(sidebarPillSearches.length > 0 || activeQuery.trim().length > 0);
+	// The controls row drops its own bottom border whenever another element
+	// (sort indicator or search context) renders directly beneath it.
+	let hasContentBelowControls = $derived(sortByRecent || hasSearchContext);
 </script>
 
 <div data-slot="sidebar-search-dock">
@@ -64,7 +68,7 @@
 		{compactChatItems}
 		{sortByRecent}
 		{sidebarMenuSearches}
-		hasAdjacentSearchContext={hasSearchContext}
+		hasAdjacentSearchContext={hasContentBelowControls}
 		{onOpenSearchDialog}
 		{onCreateChat}
 		{onMarkAllRead}
@@ -75,6 +79,7 @@
 		{onApplySidebarMenuSearch}
 		{onShowSettings}
 	/>
+	<SidebarSortIndicator active={sortByRecent} onDisable={() => onToggleSortByRecent?.()} />
 	<SidebarSearchContext
 		hasAdjacentControlsRow={true}
 		{sidebarPillSearches}

--- a/web/src/lib/components/sidebar/SidebarSortIndicator.svelte
+++ b/web/src/lib/components/sidebar/SidebarSortIndicator.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import Clock from '@lucide/svelte/icons/clock';
+	import X from '@lucide/svelte/icons/x';
+	import * as m from '$lib/paraglide/messages.js';
+
+	interface SidebarSortIndicatorProps {
+		active: boolean;
+		onDisable: () => void;
+	}
+
+	let { active, onDisable }: SidebarSortIndicatorProps = $props();
+</script>
+
+{#if active}
+	<div
+		data-slot="sidebar-sort-indicator"
+		class="flex-shrink-0 border-b border-border/60 bg-card px-2 pb-2"
+	>
+		<button
+			type="button"
+			class="group flex w-full items-center gap-1.5 rounded-lg border border-border bg-muted/40 px-2.5 py-1.5 text-left transition-colors hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			onclick={onDisable}
+			title={m.sidebar_chats_sort_recent_active_hint()}
+			aria-label={m.sidebar_chats_sort_recent_active_hint()}
+		>
+			<Clock class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+			<span class="flex-1 truncate text-xs font-medium text-foreground"
+				>{m.sidebar_chats_sort_recent_active()}</span
+			>
+			<X class="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-60 group-hover:opacity-100" />
+		</button>
+	</div>
+{/if}

--- a/web/src/lib/components/sidebar/SidebarVirtualSortableChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarVirtualSortableChatList.svelte
@@ -135,7 +135,9 @@
 	} | null = null;
 	let separatorPixelRatio = $state(1);
 	let bottomPadding = $derived(isMobile ? mobileBottomPadding : desktopBottomPadding);
-	let dragEnabled = $derived(!isMultiSelectMode);
+	// Manual drag/quick-move only applies to the manual sort order; the
+	// recent-activity sort is derived, so reordering is disabled there.
+	let dragEnabled = $derived(!isMultiSelectMode && displayOptions.sortMode === 'manual');
 	let separatorLineHeight = $derived(1 / Math.max(separatorPixelRatio, 1));
 
 	type SidebarPointDropContext =
@@ -900,7 +902,7 @@
 	}
 
 	function getMoveToTop(row: SidebarVirtualChatRow): (() => void) | undefined {
-		if (isMultiSelectMode) return undefined;
+		if (!dragEnabled) return undefined;
 		const order = row.reorderScopeIds;
 		const index = order.indexOf(row.chat.id);
 		if (index <= 0) return undefined;
@@ -908,7 +910,7 @@
 	}
 
 	function getMoveToBottom(row: SidebarVirtualChatRow): (() => void) | undefined {
-		if (isMultiSelectMode) return undefined;
+		if (!dragEnabled) return undefined;
 		const order = row.reorderScopeIds;
 		const index = order.indexOf(row.chat.id);
 		if (index < 0 || index >= order.length - 1) return undefined;

--- a/web/src/lib/components/sidebar/__tests__/SidebarChatItemHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarChatItemHost.svelte
@@ -35,6 +35,7 @@
 			groupByProject: false,
 			groupNestedProjectPaths: false,
 			compactChatItems: false,
+			sortMode: 'manual',
 		},
 		onTagClick,
 		onManageTags,

--- a/web/src/lib/components/sidebar/__tests__/SidebarChatListHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarChatListHost.svelte
@@ -33,6 +33,7 @@
 			groupByProject: false,
 			groupNestedProjectPaths: false,
 			compactChatItems: false,
+			sortMode: 'manual',
 		},
 		collapsedProjectKeys = new Set<string>(),
 		onToggleProjectCollapsed,

--- a/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
@@ -199,6 +199,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 		});
 
@@ -224,6 +225,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 			collapsedProjectKeys: new Set([sidebarProjectKey('/tmp/project-a')]),
 		});
@@ -250,6 +252,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 		});
 
@@ -271,6 +274,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: true,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 		});
 
@@ -294,6 +298,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: true,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 		});
 
@@ -320,6 +325,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 		});
 
@@ -365,6 +371,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: false,
 				groupNestedProjectPaths: false,
 				compactChatItems: true,
+				sortMode: 'manual',
 			},
 		});
 
@@ -597,6 +604,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 			onPersistReorder: persist,
 		});
@@ -641,6 +649,7 @@ describe('SidebarVirtualSortableChatList', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 			onPersistReorder: persist,
 		});

--- a/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatListHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatListHost.svelte
@@ -30,6 +30,7 @@
 			groupByProject: false,
 			groupNestedProjectPaths: false,
 			compactChatItems: false,
+			sortMode: 'manual',
 		},
 		rowHeight,
 		onRegisterRecenter,

--- a/web/src/lib/components/sidebar/__tests__/chat-recency-sort.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/chat-recency-sort.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatSessionRecord } from '$lib/types/chat-session';
+import { sortChatsByRecencyDesc } from '../chat-recency-sort';
+
+function makeChat(id: string, activity: Partial<ChatSessionRecord>): ChatSessionRecord {
+	return {
+		id,
+		projectPath: '/tmp/project',
+		title: id,
+		agentId: 'claude',
+		model: 'claude',
+		apiProviderId: null,
+		modelEndpointId: null,
+		modelProtocol: null,
+		permissionMode: 'default',
+		thinkingMode: 'off',
+		claudeThinkingMode: 'off',
+		ampAgentMode: 'default',
+		createdAt: null,
+		lastActivityAt: null,
+		lastReadAt: null,
+		isPinned: false,
+		isArchived: false,
+		isProcessing: false,
+		isUnread: false,
+		status: 'running',
+		tags: [],
+		...activity,
+	} as ChatSessionRecord;
+}
+
+describe('sortChatsByRecencyDesc', () => {
+	it('orders chats newest-first by last activity', () => {
+		const chats = [
+			makeChat('old', { lastActivityAt: '2026-01-01T00:00:00.000Z' }),
+			makeChat('new', { lastActivityAt: '2026-03-01T00:00:00.000Z' }),
+			makeChat('mid', { lastActivityAt: '2026-02-01T00:00:00.000Z' }),
+		];
+
+		expect(sortChatsByRecencyDesc(chats).map((c) => c.id)).toEqual(['new', 'mid', 'old']);
+	});
+
+	it('falls back to creation time when activity is missing', () => {
+		const chats = [
+			makeChat('created-first', { createdAt: '2026-01-01T00:00:00.000Z' }),
+			makeChat('active', { lastActivityAt: '2026-02-15T00:00:00.000Z' }),
+			makeChat('created-later', { createdAt: '2026-02-01T00:00:00.000Z' }),
+		];
+
+		expect(sortChatsByRecencyDesc(chats).map((c) => c.id)).toEqual([
+			'active',
+			'created-later',
+			'created-first',
+		]);
+	});
+
+	it('does not mutate the source array', () => {
+		const chats = [
+			makeChat('a', { lastActivityAt: '2026-01-01T00:00:00.000Z' }),
+			makeChat('b', { lastActivityAt: '2026-02-01T00:00:00.000Z' }),
+		];
+		const originalOrder = chats.map((c) => c.id);
+
+		sortChatsByRecencyDesc(chats);
+
+		expect(chats.map((c) => c.id)).toEqual(originalOrder);
+	});
+});

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -133,6 +133,7 @@ describe('shared sidebar chat row', () => {
 				groupByProject: false,
 				groupNestedProjectPaths: false,
 				compactChatItems: true,
+				sortMode: 'manual',
 			},
 		});
 
@@ -150,6 +151,7 @@ describe('shared sidebar chat row', () => {
 				groupByProject: true,
 				groupNestedProjectPaths: false,
 				compactChatItems: false,
+				sortMode: 'manual',
 			},
 		});
 

--- a/web/src/lib/components/sidebar/__tests__/sidebar-search-interactions.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-search-interactions.test.ts
@@ -328,15 +328,19 @@ describe('sidebar search interactions', () => {
 		expect(items[0]?.textContent).toContain('Unread');
 		expect(items[1]?.textContent).toContain('Active');
 		expect(items[2]?.textContent).toContain('Mark all as read');
+		expect(
+			screen.getByRole('menuitemcheckbox', { name: 'Sort by recent activity' }),
+		).toBeTruthy();
+		expect(items[3]?.textContent).toContain('Sort by recent activity');
 		expect(screen.getByRole('menuitemcheckbox', { name: 'Group chats by project' })).toBeTruthy();
-		expect(items[3]?.textContent).toContain('Group chats by project');
+		expect(items[4]?.textContent).toContain('Group chats by project');
 		expect(
 			screen.getByRole('menuitemcheckbox', { name: 'Group nested project paths' }),
 		).toBeTruthy();
-		expect(items[4]?.textContent).toContain('Group nested project paths');
+		expect(items[5]?.textContent).toContain('Group nested project paths');
 		expect(screen.getByRole('menuitemcheckbox', { name: 'Compact chat items' })).toBeTruthy();
-		expect(items[5]?.textContent).toContain('Compact chat items');
-		expect(items[6]?.textContent).toContain('Settings');
+		expect(items[6]?.textContent).toContain('Compact chat items');
+		expect(items[7]?.textContent).toContain('Settings');
 		expect(document.querySelectorAll('[data-slot="dropdown-menu-separator"]')).toHaveLength(3);
 	});
 
@@ -344,12 +348,14 @@ describe('sidebar search interactions', () => {
 		const onToggleGroupByProject = vi.fn();
 		const onToggleGroupNestedProjectPaths = vi.fn();
 		const onToggleCompactChatItems = vi.fn();
+		const onToggleSortByRecent = vi.fn();
 		render(SidebarControlsRow, {
 			isLoading: false,
 			visibleUnreadCount: 1,
 			groupByProject: true,
 			groupNestedProjectPaths: true,
 			compactChatItems: true,
+			sortByRecent: false,
 			sidebarMenuSearches: [],
 			onOpenSearchDialog: vi.fn(),
 			onCreateChat: vi.fn(),
@@ -357,6 +363,7 @@ describe('sidebar search interactions', () => {
 			onToggleGroupByProject,
 			onToggleGroupNestedProjectPaths,
 			onToggleCompactChatItems,
+			onToggleSortByRecent,
 			onShowSettings: vi.fn(),
 		});
 
@@ -368,31 +375,64 @@ describe('sidebar search interactions', () => {
 			document.querySelectorAll<HTMLElement>('[role="menuitem"], [role="menuitemcheckbox"]'),
 		);
 		expect(items[0]?.textContent).toContain('Mark all as read');
+		const sortByRecent = screen.getByRole('menuitemcheckbox', {
+			name: 'Sort by recent activity',
+		});
+		expect(items[1]?.textContent).toContain('Sort by recent activity');
 		const groupByProject = screen.getByRole('menuitemcheckbox', {
 			name: 'Group chats by project',
 		});
 		expect(groupByProject.getAttribute('aria-checked')).toBe('true');
-		expect(items[1]?.textContent).toContain('Group chats by project');
+		expect(items[2]?.textContent).toContain('Group chats by project');
 		const groupNestedProjectPaths = screen.getByRole('menuitemcheckbox', {
 			name: 'Group nested project paths',
 		});
 		expect(groupNestedProjectPaths.getAttribute('aria-checked')).toBe('true');
-		expect(items[2]?.textContent).toContain('Group nested project paths');
+		expect(items[3]?.textContent).toContain('Group nested project paths');
 		const compactChatItems = screen.getByRole('menuitemcheckbox', {
 			name: 'Compact chat items',
 		});
 		expect(compactChatItems.getAttribute('aria-checked')).toBe('true');
-		expect(items[3]?.textContent).toContain('Compact chat items');
-		expect(items[4]?.textContent).toContain('Settings');
+		expect(items[4]?.textContent).toContain('Compact chat items');
+		expect(items[5]?.textContent).toContain('Settings');
+		expect(sortByRecent.getAttribute('aria-checked')).toBe('false');
 		expect(document.querySelectorAll('[data-slot="dropdown-menu-separator"]')).toHaveLength(2);
 		expect(groupByProject.querySelector('span')?.className ?? '').toContain('end-2');
 		expect(groupByProject.className).toContain('pe-8');
 		expect(groupByProject.className).not.toContain('ps-8');
 
+		expect(sortByRecent).toBeTruthy();
+
 		await fireEvent.click(compactChatItems);
 		expect(onToggleCompactChatItems).toHaveBeenCalledOnce();
 		expect(onToggleGroupByProject).not.toHaveBeenCalled();
 		expect(onToggleGroupNestedProjectPaths).not.toHaveBeenCalled();
+	});
+
+	it('invokes the sort-by-recent toggle when the menu item is selected', async () => {
+		const onToggleSortByRecent = vi.fn();
+		render(SidebarControlsRow, {
+			isLoading: false,
+			visibleUnreadCount: 0,
+			sortByRecent: false,
+			sidebarMenuSearches: [],
+			onOpenSearchDialog: vi.fn(),
+			onCreateChat: vi.fn(),
+			onApplySidebarMenuSearch: vi.fn(),
+			onToggleSortByRecent,
+			onShowSettings: vi.fn(),
+		});
+
+		const [mobileTrigger] = screen.getAllByRole('button', { name: 'More actions' });
+		await fireEvent.click(mobileTrigger);
+
+		const sortByRecent = await screen.findByRole('menuitemcheckbox', {
+			name: 'Sort by recent activity',
+		});
+		expect(sortByRecent.getAttribute('aria-checked')).toBe('false');
+
+		await fireEvent.click(sortByRecent);
+		expect(onToggleSortByRecent).toHaveBeenCalledOnce();
 	});
 
 	it('disables nested project grouping when project grouping is off', async () => {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-search-interactions.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-search-interactions.test.ts
@@ -611,6 +611,77 @@ describe('sidebar search interactions', () => {
 		expect(topChildSlots).toEqual(['sidebar-controls-row', 'sidebar-search-context']);
 	});
 
+	it('shows a recent-activity indicator below the controls row when recent sort is active', () => {
+		render(SidebarSearchDock, {
+			isLoading: false,
+			visibleUnreadCount: 0,
+			sortByRecent: true,
+			sidebarMenuSearches: [],
+			sidebarPillSearches: [],
+			activeQuery: '',
+			onOpenSearchDialog: vi.fn(),
+			onCreateChat: vi.fn(),
+			onApplySidebarMenuSearch: vi.fn(),
+			onApplyPillSearch: vi.fn(),
+			onClearActiveQuery: vi.fn(),
+			onToggleSortByRecent: vi.fn(),
+			onShowSettings: vi.fn(),
+		});
+
+		const topDock = document.querySelector('[data-slot="sidebar-search-dock"]');
+		const topChildSlots = Array.from(topDock?.children ?? []).map((element) =>
+			element.getAttribute('data-slot'),
+		);
+		expect(topChildSlots).toEqual(['sidebar-controls-row', 'sidebar-sort-indicator']);
+		expect(screen.getByText('Recent activity')).toBeTruthy();
+	});
+
+	it('hides the recent-activity indicator when recent sort is off', () => {
+		render(SidebarSearchDock, {
+			isLoading: false,
+			visibleUnreadCount: 0,
+			sortByRecent: false,
+			sidebarMenuSearches: [],
+			sidebarPillSearches: [],
+			activeQuery: '',
+			onOpenSearchDialog: vi.fn(),
+			onCreateChat: vi.fn(),
+			onApplySidebarMenuSearch: vi.fn(),
+			onApplyPillSearch: vi.fn(),
+			onClearActiveQuery: vi.fn(),
+			onToggleSortByRecent: vi.fn(),
+			onShowSettings: vi.fn(),
+		});
+
+		expect(document.querySelector('[data-slot="sidebar-sort-indicator"]')).toBeNull();
+	});
+
+	it('disables recent sort when the indicator is clicked', async () => {
+		const onToggleSortByRecent = vi.fn();
+		render(SidebarSearchDock, {
+			isLoading: false,
+			visibleUnreadCount: 0,
+			sortByRecent: true,
+			sidebarMenuSearches: [],
+			sidebarPillSearches: [],
+			activeQuery: '',
+			onOpenSearchDialog: vi.fn(),
+			onCreateChat: vi.fn(),
+			onApplySidebarMenuSearch: vi.fn(),
+			onApplyPillSearch: vi.fn(),
+			onClearActiveQuery: vi.fn(),
+			onToggleSortByRecent,
+			onShowSettings: vi.fn(),
+		});
+
+		const indicator = document.querySelector<HTMLButtonElement>(
+			'[data-slot="sidebar-sort-indicator"] button',
+		);
+		expect(indicator).toBeTruthy();
+		await fireEvent.click(indicator!);
+		expect(onToggleSortByRecent).toHaveBeenCalledOnce();
+	});
+
 	it('supports button-based reordering for saved searches', async () => {
 		const onReorder = vi.fn();
 

--- a/web/src/lib/components/sidebar/chat-recency-sort.ts
+++ b/web/src/lib/components/sidebar/chat-recency-sort.ts
@@ -1,0 +1,21 @@
+// Shared recency ordering for sidebar chat lists. Ranks chats by most recent
+// activity, falling back to creation time so chats without activity still order
+// deterministically.
+
+import type { ChatSessionRecord } from '$lib/types/chat-session';
+
+function recencyValue(chat: ChatSessionRecord): number {
+	if (chat.lastActivityAt) return new Date(chat.lastActivityAt).getTime();
+	if (chat.createdAt) return new Date(chat.createdAt).getTime();
+	return 0;
+}
+
+/** Comparator ordering chats newest-first by activity, then creation time. */
+export function compareChatsByRecencyDesc(a: ChatSessionRecord, b: ChatSessionRecord): number {
+	return recencyValue(b) - recencyValue(a);
+}
+
+/** Returns a new array of chats ordered newest-first. */
+export function sortChatsByRecencyDesc(chats: ChatSessionRecord[]): ChatSessionRecord[] {
+	return [...chats].sort(compareChatsByRecencyDesc);
+}

--- a/web/src/lib/components/sidebar/sidebar-display-options.ts
+++ b/web/src/lib/components/sidebar/sidebar-display-options.ts
@@ -1,11 +1,15 @@
+import type { SidebarSortMode } from '$lib/stores/local-settings.svelte';
+
 export interface SidebarDisplayOptions {
 	groupByProject: boolean;
 	groupNestedProjectPaths: boolean;
 	compactChatItems: boolean;
+	sortMode: SidebarSortMode;
 }
 
 export const DEFAULT_SIDEBAR_DISPLAY_OPTIONS: SidebarDisplayOptions = {
 	groupByProject: true,
 	groupNestedProjectPaths: false,
 	compactChatItems: false,
+	sortMode: 'manual',
 };

--- a/web/src/lib/components/sidebar/sidebar-filter-state.svelte.ts
+++ b/web/src/lib/components/sidebar/sidebar-filter-state.svelte.ts
@@ -12,6 +12,7 @@ import {
 	isEmptyFilter,
 	type ChatFilterSpec,
 } from './sidebar-search';
+import { compareChatsByRecencyDesc } from './chat-recency-sort';
 
 export type SystemFolderId = 'all' | 'active' | 'unread';
 
@@ -108,19 +109,7 @@ export class SidebarFilterState {
 		const result = isEmptyFilter(filter)
 			? [...chats]
 			: chats.filter((chat) => matchesChatFilter(chat, filter));
-		return result.sort((a, b) => {
-			const aTime = a.lastActivityAt
-				? new Date(a.lastActivityAt).getTime()
-				: a.createdAt
-					? new Date(a.createdAt).getTime()
-					: 0;
-			const bTime = b.lastActivityAt
-				? new Date(b.lastActivityAt).getTime()
-				: b.createdAt
-					? new Date(b.createdAt).getTime()
-					: 0;
-			return bTime - aTime;
-		});
+		return result.sort(compareChatsByRecencyDesc);
 	}
 
 	get allKnownTags(): string[] {

--- a/web/src/lib/stores/__tests__/local-settings.test.ts
+++ b/web/src/lib/stores/__tests__/local-settings.test.ts
@@ -14,7 +14,36 @@ describe('LocalSettingsStore', () => {
 		expect(store.sidebarGroupByProject).toBe(true);
 		expect(store.sidebarGroupNestedProjectPaths).toBe(false);
 		expect(store.sidebarCompactChatItems).toBe(false);
+		expect(store.sidebarSortMode).toBe('manual');
 		expect(store.showQuickCommitTray).toBe(true);
+
+		store.destroy();
+	});
+
+	it('persists and restores the sidebar sort mode', () => {
+		const store = createLocalSettingsStore();
+		store.set('sidebarSortMode', 'recent');
+
+		expect(
+			JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.localSettings) ?? '{}'),
+		).toMatchObject({ sidebarSortMode: 'recent' });
+
+		const restored = createLocalSettingsStore();
+		expect(restored.sidebarSortMode).toBe('recent');
+
+		store.destroy();
+		restored.destroy();
+	});
+
+	it('falls back to manual for invalid sidebar sort mode', () => {
+		localStorage.setItem(
+			LOCAL_STORAGE_KEYS.localSettings,
+			JSON.stringify({ sidebarSortMode: 'chronological' }),
+		);
+
+		const store = createLocalSettingsStore();
+
+		expect(store.sidebarSortMode).toBe('manual');
 
 		store.destroy();
 	});

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -10,6 +10,8 @@ import {
 export type ThemeMode = 'dark' | 'light' | 'system';
 export const CHAT_MAX_WIDTH_VALUES = ['none', 'large', 'medium', 'small'] as const;
 export type ChatMaxWidth = (typeof CHAT_MAX_WIDTH_VALUES)[number];
+export const SIDEBAR_SORT_MODE_VALUES = ['manual', 'recent'] as const;
+export type SidebarSortMode = (typeof SIDEBAR_SORT_MODE_VALUES)[number];
 
 export interface LocalSettingsSnapshot {
 	theme: ThemeMode;
@@ -26,6 +28,7 @@ export interface LocalSettingsSnapshot {
 	sidebarGroupByProject: boolean;
 	sidebarGroupNestedProjectPaths: boolean;
 	sidebarCompactChatItems: boolean;
+	sidebarSortMode: SidebarSortMode;
 	codeEditorTheme: string;
 	codeEditorWordWrap: boolean;
 	codeEditorLineNumbers: boolean;
@@ -65,6 +68,7 @@ const DEFAULTS: LocalSettingsSnapshot = {
 	sidebarGroupByProject: true,
 	sidebarGroupNestedProjectPaths: false,
 	sidebarCompactChatItems: false,
+	sidebarSortMode: 'manual',
 	codeEditorTheme: 'auto',
 	codeEditorWordWrap: false,
 	codeEditorLineNumbers: true,
@@ -102,6 +106,12 @@ function parseSidebarWidth(value: unknown): number {
 	return DEFAULTS.sidebarWidth;
 }
 
+function parseSidebarSortMode(value: unknown): SidebarSortMode {
+	return typeof value === 'string' && SIDEBAR_SORT_MODE_VALUES.includes(value as SidebarSortMode)
+		? (value as SidebarSortMode)
+		: DEFAULTS.sidebarSortMode;
+}
+
 function parseFromRaw(parsed: Record<string, unknown>): LocalSettingsSnapshot {
 	return {
 		theme: parseTheme(parsed.theme),
@@ -130,6 +140,7 @@ function parseFromRaw(parsed: Record<string, unknown>): LocalSettingsSnapshot {
 			parsed.sidebarCompactChatItems,
 			DEFAULTS.sidebarCompactChatItems,
 		),
+		sidebarSortMode: parseSidebarSortMode(parsed.sidebarSortMode),
 		codeEditorTheme: parseString(parsed.codeEditorTheme, DEFAULTS.codeEditorTheme),
 		codeEditorWordWrap: parseBoolean(parsed.codeEditorWordWrap, DEFAULTS.codeEditorWordWrap),
 		codeEditorLineNumbers: parseBoolean(
@@ -181,6 +192,7 @@ export class LocalSettingsStore {
 	sidebarGroupByProject = $state(DEFAULTS.sidebarGroupByProject);
 	sidebarGroupNestedProjectPaths = $state(DEFAULTS.sidebarGroupNestedProjectPaths);
 	sidebarCompactChatItems = $state(DEFAULTS.sidebarCompactChatItems);
+	sidebarSortMode = $state<SidebarSortMode>(DEFAULTS.sidebarSortMode);
 	codeEditorTheme = $state(DEFAULTS.codeEditorTheme);
 	codeEditorWordWrap = $state(DEFAULTS.codeEditorWordWrap);
 	codeEditorLineNumbers = $state(DEFAULTS.codeEditorLineNumbers);
@@ -233,6 +245,7 @@ export class LocalSettingsStore {
 			sidebarGroupByProject: this.sidebarGroupByProject,
 			sidebarGroupNestedProjectPaths: this.sidebarGroupNestedProjectPaths,
 			sidebarCompactChatItems: this.sidebarCompactChatItems,
+			sidebarSortMode: this.sidebarSortMode,
 			codeEditorTheme: this.codeEditorTheme,
 			codeEditorWordWrap: this.codeEditorWordWrap,
 			codeEditorLineNumbers: this.codeEditorLineNumbers,
@@ -258,6 +271,7 @@ export class LocalSettingsStore {
 		this.sidebarGroupByProject = snap.sidebarGroupByProject;
 		this.sidebarGroupNestedProjectPaths = snap.sidebarGroupNestedProjectPaths;
 		this.sidebarCompactChatItems = snap.sidebarCompactChatItems;
+		this.sidebarSortMode = snap.sidebarSortMode;
 		this.codeEditorTheme = snap.codeEditorTheme;
 		this.codeEditorWordWrap = snap.codeEditorWordWrap;
 		this.codeEditorLineNumbers = snap.codeEditorLineNumbers;


### PR DESCRIPTION
**Problem**

The chat sidebar renders in a manual, drag-persisted order, so the most recently active chat is not reliably at the top. Users had no way to keep the latest chat up without manually dragging it. (Filtered/search results were already recency-sorted, but the default list was not.)

**Solution**

Add a **Sort by recent activity** toggle to the sidebar overflow menu. When enabled, chats order newest-first by `lastActivityAt` (falling back to `createdAt`) within each pin/archive group, so the latest chat is always on top. The default remains the existing manual order; enabling recent sort disables manual drag/quick-move since the order is derived. The preference persists in local settings. While active, a **"Recent activity"** chip is shown below the controls row so the non-default ordering is visible without opening the menu; clicking it returns to manual order.

**Changes**

- New `chat-recency-sort.ts` shared comparator; `sidebar-filter-state` now reuses it (removes duplicated sort logic).
- `sidebarSortMode` (`'manual' | 'recent'`, default `'manual'`) added to local settings and `SidebarDisplayOptions`.
- `SidebarChatList` sorts the displayed chats when in recent mode; `SidebarVirtualSortableChatList` gates drag and move-to-top/bottom on manual mode.
- New menu item wired through `SidebarControlsRow` / `SidebarSearchDock` / `Sidebar`, plus `sidebar_chats_sort_by_recent` message.
- New `SidebarSortIndicator` chip shown while recent sort is active (click to return to manual).
- Unit tests for the comparator, the sort-mode setting, and the indicator; updated sidebar menu/fixture tests.

**Expected Impact**

Opt-in behavior only; the default order is unchanged. Users who enable the toggle get a time-sorted list with the latest chat always on top, with a clear on-screen indicator of the active mode. `bun run check` and `bun run test` pass (176 files, 1668 tests). Dogfooded on a real build: toggle, persistence across reload, reorder-gating, pin/unpin, mobile, and the indicator all verified with no console errors.

## Screenshots

New menu toggle (default off):

![menu](https://raw.githubusercontent.com/0xSolarPunk/garcon/b787535678bd8caadd52734d0be198a3bf5f94f8/01-menu.png)

Active-sort indicator chip (click to return to manual):

![indicator](https://raw.githubusercontent.com/0xSolarPunk/garcon/b787535678bd8caadd52734d0be198a3bf5f94f8/05-recent-indicator.png)

Before — manual order (not time-sorted):

![before](https://raw.githubusercontent.com/0xSolarPunk/garcon/b787535678bd8caadd52734d0be198a3bf5f94f8/02-before-manual.png)

After — sort by recent activity, latest always on top:

![after](https://raw.githubusercontent.com/0xSolarPunk/garcon/b787535678bd8caadd52734d0be198a3bf5f94f8/03-after-recent.png)

Recent sort also applies within project groups:

![grouped](https://raw.githubusercontent.com/0xSolarPunk/garcon/b787535678bd8caadd52734d0be198a3bf5f94f8/04-after-recent-grouped.png)
