### PR TITLE
fix(chat): surface humanized failure reason instead of blanket 'The process died.'

### DIFF
--- a/server/chats/__tests__/chat-native-reload.test.js
+++ b/server/chats/__tests__/chat-native-reload.test.js
@@ -49,6 +49,28 @@ describe('ChatNativeReloader', () => {
     expect(warmPage.messages[2].message).toBeInstanceOf(ErrorMessage);
   });
 
+  it('process-error reload persists the humanized failure reason when provided', async () => {
+    const views = new ChatViewStore(() => false);
+    const nativeSource = { loadNativeMessages: mock(async () => [assistant('native response')]) };
+    const reloader = new ChatNativeReloader(views, nativeSource, () => false);
+
+    const reason = 'Codex rate limit exceeded. Please wait a moment and try again.';
+    const reload = await reloader.reloadFromNative('chat-1', 'process-error', reason);
+
+    expect(contents(reload)).toEqual(['native response', reason]);
+    expect(reload.messages[1].message).toBeInstanceOf(ErrorMessage);
+  });
+
+  it('process-error reload falls back to the death notice for a blank reason', async () => {
+    const views = new ChatViewStore(() => false);
+    const nativeSource = { loadNativeMessages: mock(async () => [assistant('native response')]) };
+    const reloader = new ChatNativeReloader(views, nativeSource, () => false);
+
+    const reload = await reloader.reloadFromNative('chat-1', 'process-error', '   ');
+
+    expect(contents(reload)).toEqual(['native response', 'The process died.']);
+  });
+
   it('rejects manual reload for running chats', async () => {
     const nativeSource = { loadNativeMessages: mock(async () => [assistant('native')]) };
     const reloader = new ChatNativeReloader(new ChatViewStore(() => true), nativeSource, () => true);

--- a/server/chats/__tests__/chat-view-store.test.js
+++ b/server/chats/__tests__/chat-view-store.test.js
@@ -145,13 +145,13 @@ describe('ChatViewStore', () => {
     });
   });
 
-  it('adds process-death notice as a normal in-memory message', async () => {
+  it('appends the given process-error notice as a normal in-memory message', async () => {
     const store = new ChatViewStore(() => false);
     const page = await store.replaceFromNative('chat-1', async () => [assistant('native')], {
-      appendProcessDiedNotice: true,
+      processErrorNotice: 'Codex rate limit exceeded. Please wait a moment and try again.',
     });
 
-    expect(contents(page)).toEqual(['native', 'The process died.']);
+    expect(contents(page)).toEqual(['native', 'Codex rate limit exceeded. Please wait a moment and try again.']);
     expect(page.messages[1].message).toBeInstanceOf(ErrorMessage);
   });
 

--- a/server/chats/chat-native-reload.ts
+++ b/server/chats/chat-native-reload.ts
@@ -6,6 +6,9 @@ import { ChatRunningError } from './errors.js';
 
 const logger = createLogger('chat-native-reload');
 
+// Fallback notice when a process-error reload has no humanized failure reason.
+export const PROCESS_DIED_MESSAGE = 'The process died.';
+
 interface NativeHistorySource {
   loadNativeMessages(chatId: string): Promise<ChatMessage[]>;
 }
@@ -36,14 +39,18 @@ export class ChatNativeReloader {
     return this.#source.loadNativeMessages(chatId);
   }
 
-  async reloadFromNative(chatId: string, mode: NativeReloadMode): Promise<NativeReloadResult> {
+  async reloadFromNative(
+    chatId: string,
+    mode: NativeReloadMode,
+    processErrorReason?: string,
+  ): Promise<NativeReloadResult> {
     if (mode !== 'process-error' && this.#isChatRunning(chatId)) {
       throw new ChatRunningError(chatId);
     }
     const key = `${chatId}:${mode}`;
     const pending = this.#inFlight.get(key);
     if (pending) return pending;
-    const run = this.#run(chatId, mode);
+    const run = this.#run(chatId, mode, processErrorReason);
     this.#inFlight.set(key, run);
     try {
       return await run;
@@ -52,11 +59,21 @@ export class ChatNativeReloader {
     }
   }
 
-  async #run(chatId: string, mode: NativeReloadMode): Promise<NativeReloadResult> {
+  async #run(
+    chatId: string,
+    mode: NativeReloadMode,
+    processErrorReason?: string,
+  ): Promise<NativeReloadResult> {
+    // Persist the humanized failure reason (e.g. "Codex rate limit exceeded")
+    // so the chat surfaces the real cause instead of the blanket process-death
+    // label; fall back only when no reason is available.
+    const processErrorNotice = mode === 'process-error'
+      ? processErrorReason?.trim() || PROCESS_DIED_MESSAGE
+      : undefined;
     const page = await this.#views.replaceFromNative(
       chatId,
       () => this.#source.loadNativeMessages(chatId),
-      { appendProcessDiedNotice: mode === 'process-error' },
+      { processErrorNotice },
     );
     logger.info(`reload complete mode=${mode} chat=${chatId} messages=${page.lastSeq}`);
     return { ...page, mode };

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -34,7 +34,6 @@ interface ChatView {
 const REPLAY_LIMIT = 2048;
 const CACHE_LIMIT = 100;
 const STALE_NON_ACTIVE_MS = 10 * 60 * 1000;
-const PROCESS_DIED_MESSAGE = 'The process died.';
 
 export class ChatViewStore {
   #views = new Map<string, ChatView>();
@@ -108,13 +107,13 @@ export class ChatViewStore {
   async replaceFromNative(
     chatId: string,
     loadNativeMessages: () => Promise<ChatMessage[]>,
-    options: { appendProcessDiedNotice?: boolean } = {},
+    options: { processErrorNotice?: string } = {},
   ): Promise<ChatViewPage> {
     return this.#withChat(chatId, async () => {
       const nativeMessages = await loadNativeMessages();
       const view = this.#createGeneration(chatId, nativeMessages);
-      if (options.appendProcessDiedNotice) {
-        this.#appendToView(view, [new ErrorMessage(new Date().toISOString(), PROCESS_DIED_MESSAGE)]);
+      if (options.processErrorNotice) {
+        this.#appendToView(view, [new ErrorMessage(new Date().toISOString(), options.processErrorNotice)]);
       }
       this.#views.set(chatId, view);
       this.#pruneIfNeeded();

--- a/server/server-event-wiring.ts
+++ b/server/server-event-wiring.ts
@@ -129,7 +129,7 @@ export function wireServerEvents({
     markProcessFailure(chatId, turnMetadata);
     chatViews.invalidateFence(chatId);
     try {
-      const reload = await chatNativeReloader.reloadFromNative(chatId, 'process-error');
+      const reload = await chatNativeReloader.reloadFromNative(chatId, 'process-error', message);
       pendingInputs.discardChat(chatId);
       broadcast(new ChatGenerationResetMessage(
         chatId,


### PR DESCRIPTION
**Problem**

When any agent turn fails (for example a Codex `429` rate-limit from the codex-lb pool), garcon reloads the chat from native history and appends a fixed `The process died.` row. This is misleading: the server never crashed, and the real, already-humanized reason ("Codex rate limit exceeded. Please wait a moment and try again.") was only sent as a transient `agent-run-failed` message, so the persisted chat row hides the actual cause.

**Solution**

Thread the humanized failure reason through the process-error reload path so the persisted error row shows what actually happened, falling back to `The process died.` only when no reason is available.

**Changes**

- `reloadAfterProcessError` now passes the failure `message` into `reloadFromNative`.
- `ChatNativeReloader.reloadFromNative` accepts an optional reason and resolves the notice text (reason, else the `PROCESS_DIED_MESSAGE` fallback), which now lives with the reloader that owns the process-error semantics.
- `ChatViewStore.replaceFromNative` takes an explicit `processErrorNotice` string instead of the `appendProcessDiedNotice` boolean flag, so the store just appends the text it is given.
- Tests updated/added: notice carries the given reason, and blank/absent reasons still fall back.

**Expected Impact**

Failed turns (rate limits, auth errors, network issues, real process exits) surface the actionable cause directly in the transcript. No behavior change when a reason is unavailable. Server-only; no protocol or client changes.
