### PR TITLE
fix: surface busy agent switch errors

### DIFF
--- a/server/agents/__tests__/agent-switch-service.test.js
+++ b/server/agents/__tests__/agent-switch-service.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test';
 
-import { AgentSwitchService } from '../agent-switch-service.ts';
+import { AgentSwitchError, AgentSwitchService } from '../agent-switch-service.ts';
 import { KeyedPromiseLock } from '../../lib/keyed-lock.ts';
 import { UserMessage } from '../../../common/chat-types.js';
 
@@ -113,9 +113,16 @@ describe('AgentSwitchService', () => {
   it('refuses to switch while the outgoing turn is running', async () => {
     const { service, registry, carryOver } = makeService({ isRunning: mock(() => true) });
 
-    await expect(
-      service.switchAgentModel({ chatId: '1', agentId: 'codex', model: 'gpt-5' }),
-    ).rejects.toThrow('Stop the current turn before switching agents.');
+    let error;
+    try {
+      await service.switchAgentModel({ chatId: '1', agentId: 'codex', model: 'gpt-5' });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(AgentSwitchError);
+    expect(error.message).toBe('Stop the current turn before switching agents.');
+    expect(error.status).toBe(409);
+    expect(error.code).toBe('SESSION_BUSY');
 
     // A running turn short-circuits before any mutation or snapshot.
     expect(registry.updateChat).not.toHaveBeenCalled();

--- a/server/agents/agent-switch-service.ts
+++ b/server/agents/agent-switch-service.ts
@@ -21,6 +21,20 @@ import type { AgentDirectory } from './directory.js';
 import { permissionModeForAgent } from './permission-modes.js';
 import { renderTranscriptSeed } from './shared/transcript-seed.js';
 
+export type AgentSwitchErrorCode = 'SESSION_BUSY';
+
+export class AgentSwitchError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: AgentSwitchErrorCode,
+    readonly retryable = false,
+  ) {
+    super(message);
+    this.name = 'AgentSwitchError';
+  }
+}
+
 export class AgentSwitchService {
   readonly #registry: IChatRegistry;
   readonly #directory: AgentDirectory;
@@ -57,7 +71,11 @@ export class AgentSwitchService {
 
     const fromAgent = this.#directory.get(entry.agentId);
     if (entry.agentSessionId && fromAgent?.runtime.isRunning(entry.agentSessionId)) {
-      throw new Error('Stop the current turn before switching agents.');
+      throw new AgentSwitchError(
+        'Stop the current turn before switching agents.',
+        409,
+        'SESSION_BUSY',
+      );
     }
 
     const messages = entry.agentSessionId

--- a/server/routes/__tests__/chats-command-routes.test.js
+++ b/server/routes/__tests__/chats-command-routes.test.js
@@ -34,6 +34,7 @@ import createChatRoutes from '../chats.js';
 import { parseJsonBody } from '../../lib/http-request.js';
 import { forkChatFileCopy } from '../../chats/fork-chat.js';
 import { ModelSelectionError } from '../../api-providers/endpoint-resolver.js';
+import { AgentSwitchError } from '../../agents/agent-switch-service.js';
 import { createRouteCommandLedger, createRouteCommandService, createRoutePendingInputs } from './chat-routes-test-utils.js';
 
 function createSession(overrides = {}) {
@@ -135,6 +136,19 @@ function createRouteAgent(sessionOverrides = {}) {
     prepareProjectPathUpdate: mock(() => Promise.resolve(undefined)),
     updateSessionSettings: mock((chatId, patch) => Promise.resolve(registry.updateChat(chatId, patch))),
   };
+  const agentSwitch = {
+    switchAgentModel: mock((req) => Promise.resolve(registry.updateChat(req.chatId, {
+      agentId: req.agentId,
+      model: req.model,
+      apiProviderId: req.apiProviderId ?? null,
+      modelEndpointId: req.modelEndpointId ?? null,
+      modelProtocol: req.modelProtocol ?? null,
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      claudeThinkingMode: 'auto',
+      ampAgentMode: 'smart',
+    }))),
+  };
   const commandLedger = createRouteCommandLedger('chats-command-routes');
   const pendingInputs = createRoutePendingInputs();
   const routes = createChatRoutes({
@@ -146,6 +160,7 @@ function createRouteAgent(sessionOverrides = {}) {
     chatViews,
     agents,
     pendingInputs,
+    agentSwitch,
     commandService: createRouteCommandService({
       registry,
       queue,
@@ -156,7 +171,7 @@ function createRouteAgent(sessionOverrides = {}) {
       pendingInputs,
     }),
   });
-  return { sessions, registry, settings, queue, pathCache, metadata, chatViews, agents, routes };
+  return { sessions, registry, settings, queue, pathCache, metadata, chatViews, agents, agentSwitch, routes };
 }
 
 async function callJson(handler, body, method = 'POST') {
@@ -516,8 +531,8 @@ describe('REST chat command routes', () => {
     expect(body.error).toBe('model is required');
   });
 
-	  it('PATCH /model maps model selection failures to 422', async () => {
-	    const agent = createRouteAgent();
+  it('PATCH /model maps model selection failures to 422', async () => {
+    const agent = createRouteAgent();
     agent.agents.updateSessionSettings.mockRejectedValueOnce(
       new ModelSelectionError('Endpoint not found', 'ENDPOINT_NOT_FOUND'),
     );
@@ -531,6 +546,24 @@ describe('REST chat command routes', () => {
     expect(response.status).toBe(422);
     expect(body.errorCode).toBe('MODEL_SELECTION_ERROR');
     expect(body.error).toBe('Endpoint not found');
+  });
+
+  it('PATCH /agent-model maps active-turn switch conflicts to 409', async () => {
+    const agent = createRouteAgent();
+    agent.agentSwitch.switchAgentModel.mockRejectedValueOnce(
+      new AgentSwitchError('Stop the current turn before switching agents.', 409, 'SESSION_BUSY'),
+    );
+
+    const { response, body } = await callJson(
+      agent.routes['/api/v1/chats/agent-model'].PATCH,
+      { chatId: '123', agentId: 'codex', model: 'gpt-5' },
+      'PATCH',
+    );
+
+    expect(response.status).toBe(409);
+    expect(body.errorCode).toBe('SESSION_BUSY');
+    expect(body.error).toBe('Stop the current turn before switching agents.');
+    expect(body.retryable).toBe(false);
   });
 
   it('PATCH /project-path validates, prepares the agent, and patches the registry', async () => {

--- a/server/routes/__tests__/shares.test.js
+++ b/server/routes/__tests__/shares.test.js
@@ -135,7 +135,6 @@ describe('shared chat page route', () => {
     expect(body).toContain('<title>Investigate flaky share rendering · Garcon - Work</title>');
     expect(body).toContain('<meta property="og:site_name" content="Garcon - Work" />');
     expect(body).toContain('<meta name="apple-mobile-web-app-title" content="Garcon - Work" />');
-    expect(body).toContain('__GARCON_APP_TITLE__');
   });
 
   it('HTML-escapes snapshot content to prevent markup injection', async () => {

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -38,7 +38,7 @@ import type { ChatViewPageReader } from '../chats/chat-message-reader.js';
 import type { ChatMetadata } from '../chats/metadata-store.js';
 import type { PendingUserInputServiceContract } from '../chats/pending-user-input-service.js';
 import type { AgentRegistryServiceContract } from '../agents/registry.js';
-import type { AgentSwitchService } from '../agents/agent-switch-service.js';
+import { AgentSwitchError, type AgentSwitchService } from '../agents/agent-switch-service.js';
 import { createLogger } from '../lib/log.js';
 
 const logger = createLogger('routes:chats');
@@ -153,6 +153,9 @@ function optionalStringOrNull(value: unknown): string | null | undefined {
 }
 
 function chatSettingsPatchErrorResponse(error: unknown): Response {
+  if (error instanceof AgentSwitchError) {
+    return jsonError(error.message, error.status, error.code, error.retryable);
+  }
   if (error instanceof ModelSelectionError) {
     return jsonError(error.message, 422, 'MODEL_SELECTION_ERROR');
   }

--- a/web/src/lib/components/chat/LoadingStatus.svelte
+++ b/web/src/lib/components/chat/LoadingStatus.svelte
@@ -5,11 +5,12 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { cn } from '$lib/utils/cn';
 	import type { GitQuickSummaryReady } from '$lib/api/git.js';
+	import type { LoadingStatus as ChatLoadingStatus } from '$lib/stores/chat-lifecycle.svelte';
 	import { GitCommitHorizontal, Square } from '@lucide/svelte';
 
 	interface Props {
 		isVisible: boolean;
-		status: { text?: string; can_interrupt?: boolean } | null;
+		status: ChatLoadingStatus | null;
 		agentId: string;
 		onAbort: (() => void) | null;
 		spinnerSelectionKey?: string | null;


### PR DESCRIPTION
## Summary
- classify expected cross-agent switch busy failures with `AgentSwitchError`
- return `409 SESSION_BUSY` from `/api/v1/chats/agent-model` instead of a generic 500
- add service and route coverage for switching agents during an active turn
- align adjacent validation drift after rebasing onto current `main`

## Root Cause
When an agent switch is requested while the current turn is still running, `AgentSwitchService` throws `Stop the current turn before switching agents.`. The chat route previously treated that expected conflict as an unknown exception, so `jsonErrorFromUnknown` masked it as `Internal server error`.

## Tests
- `bunx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide` from `web/`
- `bun run check`
- `bun run test`
- startup smoke: `bun run start --port 0` reached listening state before the timeout stopped it