### PR TITLE
Add GPT-5.6 Codex model options

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -20,6 +20,9 @@ export const CLAUDE_MODELS = {
 export const CODEX_MODELS = {
   OPTIONS: [
     { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
+    { value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol', supportsImages: true },
+    { value: 'gpt-5.6-terra', label: 'GPT-5.6-Terra', supportsImages: true },
+    { value: 'gpt-5.6-luna', label: 'GPT-5.6-Luna', supportsImages: true },
     { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: true },
     { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: false },

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -34,6 +34,11 @@ const agentCatalogEntries = [
     defaultModel: 'gpt-5.5',
     models: [
       { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
+      { value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol', supportsImages: true },
+      { value: 'gpt-5.6-terra', label: 'GPT-5.6-Terra', supportsImages: true },
+      { value: 'gpt-5.6-luna', label: 'GPT-5.6-Luna', supportsImages: true },
+      { value: 'gpt-5.4', label: 'GPT-5.4', supportsImages: true },
+      { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: true },
       { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', supportsImages: false },
     ],
   },
@@ -238,8 +243,8 @@ describe('GET /api/v1/models', () => {
         {
           ...agentCatalogEntries[1],
           models: [
-            { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
-            { value: 'gpt-5.5', label: 'GPT-5.5' },
+            { value: 'gpt-5.6-luna', label: 'GPT-5.6-Luna' },
+            { value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
           ],
         },
       ])
@@ -247,8 +252,8 @@ describe('GET /api/v1/models', () => {
         {
           ...agentCatalogEntries[1],
           models: [
-            { value: 'gpt-5.5', label: 'GPT-5.5' },
-            { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+            { value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
+            { value: 'gpt-5.6-luna', label: 'GPT-5.6-Luna' },
           ],
         },
         {
@@ -294,7 +299,21 @@ describe('GET /api/v1/models', () => {
     expect(codex.defaultModel).toBe('gpt-5.5');
     expect(codex.models[0]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true });
     const codexModelValues = codex.models.map((model) => model.value);
-    expect(codexModelValues).toContain('gpt-5.3-codex-spark');
+    expect(codexModelValues).toEqual([
+      'gpt-5.5',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.4',
+      'gpt-5.3-codex',
+      'gpt-5.3-codex-spark',
+    ]);
+    expect(codex.models.find((model) => model.value === 'gpt-5.5')).toMatchObject({ supportsImages: true });
+    expect(codex.models.find((model) => model.value === 'gpt-5.6-sol')).toMatchObject({ supportsImages: true });
+    expect(codex.models.find((model) => model.value === 'gpt-5.6-terra')).toMatchObject({ supportsImages: true });
+    expect(codex.models.find((model) => model.value === 'gpt-5.6-luna')).toMatchObject({ supportsImages: true });
+    expect(codex.models.find((model) => model.value === 'gpt-5.4')).toMatchObject({ supportsImages: true });
+    expect(codex.models.find((model) => model.value === 'gpt-5.3-codex')).toMatchObject({ supportsImages: true });
     expect(codex.models.find((model) => model.value === 'gpt-5.3-codex-spark')).toMatchObject({ supportsImages: false });
     expect(codexModelValues).not.toContain('gpt-5.2');
     expect(codexModelValues).not.toContain('gpt-5.2-codex');

--- a/web/src/lib/stores/__tests__/model-catalog.test.ts
+++ b/web/src/lib/stores/__tests__/model-catalog.test.ts
@@ -50,6 +50,21 @@ function piAgent(models: unknown[], defaultModel = ''): unknown {
 	};
 }
 
+function codexMetadata(defaultModel = 'gpt-5.5'): Record<string, unknown> {
+	return {
+		id: 'codex',
+		label: 'Codex',
+		supportsFork: true,
+		supportsForkAtMessage: true,
+		supportsForkWhileRunning: true,
+		supportsUpdateProjectPath: true,
+		supportsImages: true,
+		acceptsApiProviderEndpoints: true,
+		supportedProtocols: ['openai-compatible'],
+		defaultModel,
+	};
+}
+
 describe('ModelCatalogStore', () => {
 	beforeEach(() => {
 		localStorage.clear();
@@ -81,7 +96,21 @@ describe('ModelCatalogStore', () => {
 			supportsImages: true,
 		});
 		const codexModelValues = store.getModels('codex').map((model) => model.value);
-		expect(codexModelValues).toContain('gpt-5.3-codex-spark');
+		expect(codexModelValues).toEqual([
+			'gpt-5.5',
+			'gpt-5.6-sol',
+			'gpt-5.6-terra',
+			'gpt-5.6-luna',
+			'gpt-5.4',
+			'gpt-5.3-codex',
+			'gpt-5.3-codex-spark',
+		]);
+		expect(store.supportsImages('codex', 'gpt-5.5')).toBe(true);
+		expect(store.supportsImages('codex', 'gpt-5.6-sol')).toBe(true);
+		expect(store.supportsImages('codex', 'gpt-5.6-terra')).toBe(true);
+		expect(store.supportsImages('codex', 'gpt-5.6-luna')).toBe(true);
+		expect(store.supportsImages('codex', 'gpt-5.4')).toBe(true);
+		expect(store.supportsImages('codex', 'gpt-5.3-codex')).toBe(true);
 		expect(store.supportsImages('codex', 'gpt-5.3-codex-spark')).toBe(false);
 		expect(codexModelValues).not.toContain('gpt-5.2');
 		expect(codexModelValues).not.toContain('gpt-5.2-codex');
@@ -266,13 +295,8 @@ describe('ModelCatalogStore', () => {
 						defaultModel: 'opus',
 					},
 					codex: {
-						id: 'codex',
-						label: 'Codex',
-						supportsFork: true,
+						...codexMetadata(),
 						supportsImages: false,
-						acceptsApiProviderEndpoints: true,
-						supportedProtocols: ['openai-compatible'],
-						defaultModel: 'gpt-5.5',
 					},
 				},
 				lastFetchedAt: Date.now(),
@@ -509,8 +533,8 @@ describe('ModelCatalogStore', () => {
 							supportsImages: false,
 							acceptsApiProviderEndpoints: true,
 							supportedProtocols: ['openai-compatible'],
-							defaultModel: 'gpt-5.3-codex',
-							models: [{ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex', supportsImages: false }],
+							defaultModel: 'gpt-5.6-sol',
+							models: [{ value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol', supportsImages: true }],
 						},
 						{
 							id: 'factory',
@@ -578,7 +602,7 @@ describe('ModelCatalogStore', () => {
 		});
 	});
 
-	it('merges missing static models into catalog results', async () => {
+	it('merges missing static Codex models into Codex catalog results', async () => {
 		vi.mocked(clientApi.apiFetch).mockResolvedValue({
 			ok: true,
 			json: async () => ({
@@ -592,8 +616,8 @@ describe('ModelCatalogStore', () => {
 							supportsImages: false,
 							acceptsApiProviderEndpoints: true,
 							supportedProtocols: ['openai-compatible'],
-							defaultModel: 'gpt-5.3-codex',
-							models: [{ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' }],
+							defaultModel: 'gpt-5.6-terra',
+							models: [{ value: 'gpt-5.6-terra', label: 'GPT-5.6-Terra' }],
 						},
 					],
 					apiProviders: [],
@@ -605,8 +629,16 @@ describe('ModelCatalogStore', () => {
 		await store.forceRefresh();
 
 		const codexModels = store.getModels('codex');
-		expect(codexModels[0]).toMatchObject({ value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' });
+		expect(codexModels[0]).toMatchObject({ value: 'gpt-5.6-terra', label: 'GPT-5.6-Terra' });
 		expect(codexModels.find((m) => m.value === 'gpt-5.5')).toBeTruthy();
+		expect(codexModels.find((m) => m.value === 'gpt-5.6-sol')).toBeTruthy();
+		expect(codexModels.find((m) => m.value === 'gpt-5.6-terra')).toBeTruthy();
+		expect(codexModels.find((m) => m.value === 'gpt-5.6-luna')).toBeTruthy();
+		expect(codexModels.find((m) => m.value === 'gpt-5.4')).toBeTruthy();
+		expect(codexModels.find((m) => m.value === 'gpt-5.3-codex')).toBeTruthy();
+		expect(codexModels.find((m) => m.value === 'gpt-5.3-codex-spark')).toMatchObject({
+			supportsImages: false,
+		});
 		expect(codexModels.length).toBeGreaterThan(1);
 		expect(store.supportsForkAtMessage('codex')).toBe(false);
 	});

--- a/web/src/lib/stores/model-catalog.svelte.ts
+++ b/web/src/lib/stores/model-catalog.svelte.ts
@@ -462,13 +462,15 @@ function applyCatalogResult(
 	currentMetadata: AgentMetadataMap,
 	catalogResult: NonNullable<ReturnType<typeof parseCatalogResponse>>,
 ): CatalogApplyResult {
+	const agentModels = mergeWithFallbacks(catalogResult.agentModels);
+	const agentMetadata = filterVisibleAgentMetadata({
+		...STATIC_AGENT_METADATA,
+		...currentMetadata,
+		...catalogResult.agentMetadata,
+	});
 	return {
-		agentModels: mergeWithFallbacks(catalogResult.agentModels),
-		agentMetadata: filterVisibleAgentMetadata({
-			...STATIC_AGENT_METADATA,
-			...currentMetadata,
-			...catalogResult.agentMetadata,
-		}),
+		agentModels,
+		agentMetadata,
 		apiProviderCatalog: catalogResult.apiProviderCatalog,
 		requiresStrictPiValidation: hasExplicitEmptyPiModels(catalogResult.agentModels),
 	};


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol, Terra, and Luna to the built-in Codex model catalog with labels aligned to upstream Codex
- keep `gpt-5.5` as the Codex default model
- preserve the existing Codex options, including `gpt-5.4`, `gpt-5.3-codex`, and `gpt-5.3-codex-spark`
- keep frontend Codex catalog hydration additive by merging remote/cached entries with static fallbacks instead of pruning older native models

## References
- OpenAI docs: https://help.openai.com/en/articles/20001325-a-preview-of-gpt-56-sol-terra-and-luna
- openai/codex model update: https://github.com/openai/codex/pull/31684

## Validation
- `bun test server/routes/__tests__/models.test.js server/settings/__tests__/generation-effective.test.js server/routes/__tests__/app.test.js server/chats/__tests__/title-generator.test.js`
- `bun run --cwd web test src/lib/stores/__tests__/model-catalog.test.ts`
- `bun run check`
- `bun run test`
- `bun run start --port 0` startup smoke after production build; server reached a random local port before timeout stopped it
- GitHub checks passed: `server-tests`, `web-tests`, `build-exe`; release job skipped