### PR TITLE
fix(codex): harden goal lifecycle delivery

### DIFF
--- a/server/agents/__tests__/runtime-router-seed.test.js
+++ b/server/agents/__tests__/runtime-router-seed.test.js
@@ -115,6 +115,7 @@ describe('AgentRuntimeRouter seed branch', () => {
 
     // Composed command starts with the carried seed context verbatim.
     expect(request.command.startsWith(carryOverContext)).toBe(true);
+    expect(request.codexSeedContext).toBeUndefined();
 
     // The user command's @-mention is resolved: file body is inlined.
     expect(request.command).toContain('USER FILE BODY');
@@ -162,9 +163,10 @@ describe('AgentRuntimeRouter seed branch', () => {
 
     expect(startSession).toHaveBeenCalledTimes(1);
     const request = startSession.mock.calls[0][0];
-    expect(request.command).toContain('ship seeded work');
+    expect(request.command).toBe('ship seeded work');
     expect(request.command).not.toContain('/goal');
     expect(request.codexGoalCommand).toEqual({ kind: 'set', objective: 'ship seeded work' });
+    expect(request.codexSeedContext).toBe(carryOverContext);
   });
 
   it('preserves Codex goal lifecycle controls as controls on resumed turns', async () => {

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -830,6 +830,37 @@ describe('CodexAppServerRuntime', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  function createActiveGoalQueue(provider, codexGoalCommand, markFailed) {
+    return new QueueManager(
+      tmpDir,
+      {
+        runAgentTurn: async () => { throw new Error('must use active delivery'); },
+        submitActiveInput: (_chatId, command, options, beforeDelivery) => provider.submitActiveInput(makeRequest({
+          ...options,
+          agentSessionId: 'thread-1',
+          command,
+          codexGoalCommand,
+          nativePath: null,
+        }), beforeDelivery),
+        abortSession: async () => false,
+        isChatRunning: () => provider.isRunning('thread-1'),
+      },
+      {
+        register: async () => {},
+        discard: () => true,
+        markFailed,
+      },
+      { appendMessages: async () => ({ generationId: 'generation-1', messages: [] }) },
+      () => ({
+        model: 'gpt-5.4-codex',
+        permissionMode: 'default',
+        thinkingMode: 'medium',
+        claudeThinkingMode: 'off',
+        ampAgentMode: 'default',
+      }),
+    );
+  }
+
   it('starts a turn and waits for the app-server transcript path before resolving', async () => {
     const nativePath = path.join(tmpDir, 'thread.jsonl');
     const fake = new FakeClient({
@@ -1860,6 +1891,36 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.shutdown).not.toHaveBeenCalled();
   });
 
+  it('applies a restored goal snapshot before replaying newer buffered goal notifications', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => {
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'completed-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'complete'),
+          },
+        });
+        return { goal: makeGoal('thread-1', 'Ship the feature', 'active') };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'status' },
+      nativePath: null,
+    }));
+
+    expect(emitted.at(-1)?.content).toContain('Status: complete');
+    expect(fake.startTurn).not.toHaveBeenCalled();
+    expect(fake.steerTurn).not.toHaveBeenCalled();
+  });
+
   it('delivers accepted restart input after buffered notifications finish the restored turn', async () => {
     let fake;
     fake = new FakeClient({
@@ -2176,6 +2237,88 @@ describe('CodexAppServerRuntime', () => {
       clientUserMessageId: 'message-queue',
     }));
     expect(fake.resumeThread).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports accepted active goal RPC failures through the queue delivery contract', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      setThreadGoalStatus: async () => { throw new Error('goal status unavailable'); },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    const markFailed = mock(() => true);
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+    const queue = createActiveGoalQueue(provider, { kind: 'pause' }, markFailed);
+
+    await expect(queue.enqueueChat('chat-1', '/goal pause', {
+      clientRequestId: 'request-goal-failure',
+    })).rejects.toMatchObject({
+      deliveryAccepted: true,
+      retryable: false,
+      cause: expect.objectContaining({ message: 'goal status unavailable' }),
+    });
+
+    expect(markFailed).toHaveBeenCalledWith('chat-1', 'request-goal-failure');
+    expect(emitted.at(-1)?.content).toBe('Codex error: goal status unavailable');
+  });
+
+  it('reports accepted active goal cancellation through the queue delivery contract', async () => {
+    let statusRequested;
+    const statusRequest = new Promise((resolve) => { statusRequested = resolve; });
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      setThreadGoalStatus: async (threadId) => {
+        statusRequested();
+        return { goal: makeGoal(threadId, 'Long-running work', 'active') };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const markFailed = mock(() => true);
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn' }) },
+    });
+    const queue = createActiveGoalQueue(provider, { kind: 'resume' }, markFailed);
+
+    const delivery = queue.enqueueChat('chat-1', '/goal resume', {
+      clientRequestId: 'request-goal-cancelled',
+    });
+    await statusRequest;
+    await Promise.resolve();
+    provider.abort('thread-1');
+
+    await expect(delivery).rejects.toMatchObject({
+      deliveryAccepted: true,
+      retryable: false,
+      cause: expect.any(Error),
+    });
+    expect(markFailed).toHaveBeenCalledWith('chat-1', 'request-goal-cancelled');
   });
 
   it('declines active input without accepting its user row after the Codex session ends', async () => {

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -5,7 +5,7 @@ import os from 'os';
 import path from 'path';
 import { CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage, WaitToolUseMessage } from '../../../../../common/chat-types.js';
 import { buildApprovalResponse, createPendingApproval } from '../approvals.ts';
-import { CodexAppServerClient } from '../client.ts';
+import { CodexAppServerClient, CodexAppServerRpcError } from '../client.ts';
 import { convertCodexAppServerItem, convertCodexAppServerLiveItem, convertCodexRawCodeModeItem } from '../converter.ts';
 import { waitForMaterializedThread } from '../durability.ts';
 import { CodexAppServerRuntime } from '../runtime.ts';
@@ -95,14 +95,16 @@ class FakeClient extends EventEmitter {
       goal: makeGoal(threadId, params.objective ?? 'Ship the feature', params.status ?? 'active'),
     })));
     this.setThreadGoalStatus = mock(script.setThreadGoalStatus ?? (async (threadId, status) => ({ goal: makeGoal(threadId, 'Ship the feature', status) })));
-    this.getThreadGoal = mock(script.getThreadGoal ?? (async (threadId) => ({ goal: makeGoal(threadId, 'Ship the feature') })));
+    this.getThreadGoal = mock(script.getThreadGoal ?? (async () => ({ goal: null })));
     this.clearThreadGoal = mock(script.clearThreadGoal ?? (async () => ({ cleared: true })));
+    this.injectThreadItems = mock(script.injectThreadItems ?? (async () => ({})));
     this.listThreads = mock(script.listThreads ?? (async () => ({ data: [], nextCursor: null, backwardsCursor: null })));
     this.loadedThreads = mock(script.loadedThreads ?? (async () => ({ data: [] })));
     this.unsubscribeThread = mock(script.unsubscribeThread ?? (async () => ({ status: 'notSubscribed' })));
     this.startTurn = mock(script.startTurn ?? (async () => ({ turn: { id: 'turn-1', items: [], itemsView: 'full', status: 'inProgress', error: null, startedAt: 1_700_000_000_000, completedAt: null, durationMs: null } })));
     this.steerTurn = mock(script.steerTurn ?? (async ({ expectedTurnId }) => ({ turnId: expectedTurnId })));
     this.interruptTurn = mock(script.interruptTurn ?? (async () => ({})));
+    this.compactThread = mock(script.compactThread ?? (async () => ({})));
     this.connect = mock(script.connect ?? (async () => ({ userAgent: 'codex', codexHome: '/tmp', platformFamily: 'unix', platformOs: 'linux' })));
     this.respond = mock();
     this.reject = mock();
@@ -202,6 +204,7 @@ describe('CodexAppServerClient lifecycle RPCs', () => {
       }
       if (message.method === 'thread/goal/get') return { goal: makeGoal(message.params.threadId, 'Ship the feature') };
       if (message.method === 'thread/goal/clear') return { cleared: true };
+      if (message.method === 'thread/inject_items') return {};
       if (message.method === 'turn/steer') return { turnId: message.params.expectedTurnId };
       throw new Error(`Unexpected method ${message.method}`);
     });
@@ -220,6 +223,10 @@ describe('CodexAppServerClient lifecycle RPCs', () => {
       goal: { threadId: 'thread-1', objective: 'Ship the feature' },
     });
     await expect(client.clearThreadGoal('thread-1')).resolves.toEqual({ cleared: true });
+    await expect(client.injectThreadItems({
+      threadId: 'thread-1',
+      items: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Earlier context' }] }],
+    })).resolves.toEqual({});
     await expect(client.steerTurn({
       threadId: 'thread-1',
       expectedTurnId: 'turn-1',
@@ -250,6 +257,13 @@ describe('CodexAppServerClient lifecycle RPCs', () => {
     expect(writes).toContainEqual(expect.objectContaining({
       method: 'thread/goal/clear',
       params: { threadId: 'thread-1' },
+    }));
+    expect(writes).toContainEqual(expect.objectContaining({
+      method: 'thread/inject_items',
+      params: {
+        threadId: 'thread-1',
+        items: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Earlier context' }] }],
+      },
     }));
     expect(writes).toContainEqual(expect.objectContaining({
       method: 'turn/steer',
@@ -1043,6 +1057,46 @@ describe('CodexAppServerRuntime', () => {
     expect(calls).toEqual(['get', 'goal:Ship the feature']);
   });
 
+  it('injects carried context before setting a seeded goal', async () => {
+    const nativePath = path.join(tmpDir, 'seeded-goal-thread.jsonl');
+    const calls = [];
+    let fake;
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      injectThreadItems: async (params) => { calls.push(['inject', params]); },
+      getThreadGoal: async () => { calls.push(['get']); return { goal: null }; },
+      setThreadGoal: async (threadId, params) => {
+        calls.push(['set', params.objective]);
+        await fs.writeFile(nativePath, '{}\n');
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+
+    await provider.startSession(makeRequest({
+      command: 'Ship seeded work',
+      codexGoalCommand: { kind: 'set', objective: 'Ship seeded work' },
+      codexSeedContext: '<carried-context>Earlier work</carried-context>',
+    }));
+
+    expect(calls).toEqual([
+      ['inject', {
+        threadId: 'thread-1',
+        items: [{
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: '<carried-context>Earlier work</carried-context>' }],
+        }],
+      }],
+      ['get'],
+      ['set', 'Ship seeded work'],
+    ]);
+  });
+
   it('rejects replacing an unfinished goal unless replacement is explicit', async () => {
     for (const status of ['active', 'paused', 'blocked', 'usageLimited', 'budgetLimited']) {
       const fake = new FakeClient({
@@ -1051,18 +1105,16 @@ describe('CodexAppServerRuntime', () => {
       const provider = new CodexAppServerRuntime({ createClient: () => fake });
       const emitted = [];
       provider.onMessages((_chatId, messages) => emitted.push(...messages));
-      const finished = new Promise((resolve) => provider.onFinished(resolve));
-
       await provider.runTurn(makeRequest({
         agentSessionId: 'thread-1',
         codexGoalCommand: { kind: 'set', objective: 'Replacement work' },
         nativePath: null,
       }));
-      await finished;
 
       expect(fake.setThreadGoal).not.toHaveBeenCalled();
       expect(fake.clearThreadGoal).not.toHaveBeenCalled();
       expect(emitted.at(-1)?.content).toContain('/goal replace <objective>');
+      expect(provider.isRunning('thread-1')).toBe(status === 'active');
     }
   });
 
@@ -1129,6 +1181,208 @@ describe('CodexAppServerRuntime', () => {
     });
   });
 
+  it('restores and reconciles the previous goal when replacement set fails', async () => {
+    const previous = { ...makeGoal('thread-1', 'Existing work', 'paused'), tokenBudget: 50_000 };
+    const calls = [];
+    const fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: previous }),
+      clearThreadGoal: async () => { calls.push('clear'); return { cleared: true }; },
+      setThreadGoal: async (threadId, params) => {
+        calls.push(params);
+        if (params.objective === 'Replacement work') throw new Error('replacement rejected');
+        return { goal: { ...previous, threadId, ...params } };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'replace', objective: 'Replacement work' },
+      nativePath: null,
+    }));
+
+    expect(calls).toEqual([
+      'clear',
+      { objective: 'Replacement work', status: 'active' },
+      { objective: 'Existing work', status: 'paused', tokenBudget: 50_000 },
+    ]);
+    expect(fake.getThreadGoal).toHaveBeenCalledTimes(2);
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(emitted.at(-1)?.content).toContain('replacement rejected');
+  });
+
+  it('keeps an active restored goal alive when replacement set fails', async () => {
+    const previous = makeGoal('thread-1', 'Existing work', 'active');
+    const fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: previous }),
+      clearThreadGoal: async () => ({ cleared: true }),
+      setThreadGoal: async (threadId, params) => {
+        if (params.objective === 'Replacement work') throw new Error('replacement rejected');
+        return { goal: { ...previous, threadId, ...params } };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'replace', objective: 'Replacement work' },
+      nativePath: null,
+    }));
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+    expect(fake.setThreadGoal).toHaveBeenLastCalledWith('thread-1', {
+      objective: 'Existing work',
+      status: 'active',
+      tokenBudget: null,
+    });
+
+    fake.emit('notification', {
+      method: 'thread/goal/cleared',
+      params: { threadId: 'thread-1' },
+    });
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('ignores a delayed replacement clear after the replacement goal starts', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async (threadId) => ({ goal: makeGoal(threadId, 'Existing work', 'blocked') }),
+      clearThreadGoal: async () => ({ cleared: true }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'replacement-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'replace', objective: 'Replacement work' },
+      nativePath: null,
+    }));
+    fake.emit('notification', {
+      method: 'thread/goal/cleared',
+      params: { threadId: 'thread-1' },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'replacement-turn' }) },
+    });
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('releases clear suppression immediately when replacement clear does not commit', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async (threadId) => ({ goal: makeGoal(threadId, 'Existing work', 'blocked') }),
+      clearThreadGoal: async () => ({ cleared: false }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'replacement-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'replace', objective: 'Replacement work' },
+      nativePath: null,
+    }));
+    fake.emit('notification', {
+      method: 'thread/goal/cleared',
+      params: { threadId: 'thread-1' },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'replacement-turn' }) },
+    });
+    await finished;
+
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores an active goal when replacement clear commits but its response is lost', async () => {
+    const previous = makeGoal('thread-1', 'Existing work', 'active');
+    let goal = previous;
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal }),
+      clearThreadGoal: async () => {
+        goal = null;
+        fake.emit('notification', {
+          method: 'thread/goal/cleared',
+          params: { threadId: 'thread-1' },
+        });
+        throw new Error('clear response lost');
+      },
+      setThreadGoal: async (threadId, params) => {
+        goal = { ...previous, threadId, ...params };
+        return { goal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'replace', objective: 'Replacement work' },
+      nativePath: null,
+    }));
+
+    expect(fake.getThreadGoal).toHaveBeenCalledTimes(2);
+    expect(fake.setThreadGoal).toHaveBeenCalledTimes(1);
+    expect(fake.setThreadGoal).toHaveBeenCalledWith('thread-1', {
+      objective: 'Existing work',
+      status: 'active',
+      tokenBudget: null,
+    });
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    goal = null;
+    fake.emit('notification', {
+      method: 'thread/goal/cleared',
+      params: { threadId: 'thread-1' },
+    });
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes cleanly when replacement and rollback both fail', async () => {
+    const previous = makeGoal('thread-1', 'Existing work', 'blocked');
+    let getCalls = 0;
+    const fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: getCalls++ === 0 ? previous : null }),
+      clearThreadGoal: async () => ({ cleared: true }),
+      setThreadGoal: async () => { throw new Error('goal set unavailable'); },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'replace', objective: 'Replacement work' },
+      nativePath: null,
+    }));
+
+    expect(fake.setThreadGoal).toHaveBeenCalledTimes(2);
+    expect(fake.getThreadGoal).toHaveBeenCalledTimes(2);
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
   it('reports the current Codex goal without starting a turn', async () => {
     const fake = new FakeClient({
       getThreadGoal: async (threadId) => ({
@@ -1138,7 +1392,6 @@ describe('CodexAppServerRuntime', () => {
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
     const emitted = [];
     provider.onMessages((_chatId, messages) => emitted.push(...messages));
-    const finished = new Promise((resolve) => provider.onFinished(resolve));
 
     await provider.runTurn(makeRequest({
       agentSessionId: 'thread-1',
@@ -1146,10 +1399,11 @@ describe('CodexAppServerRuntime', () => {
       codexGoalCommand: { kind: 'status' },
       nativePath: null,
     }));
-    await finished;
 
     expect(fake.getThreadGoal).toHaveBeenCalledWith('thread-1');
     expect(fake.startTurn).not.toHaveBeenCalled();
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
     expect(emitted.map((message) => message.content)).toEqual([
       'Goal\nStatus: active\nObjective: Ship the feature\nTime used: 0s\nTokens used: 0\n\nCommands: /goal edit <objective>, /goal pause, /goal clear',
     ]);
@@ -1235,6 +1489,465 @@ describe('CodexAppServerRuntime', () => {
     expect(provider.isRunning('thread-1')).toBe(true);
   });
 
+  it('finishes without waiting when resume returns a terminal goal status', async () => {
+    const fake = new FakeClient({
+      setThreadGoalStatus: async (threadId) => ({
+        goal: makeGoal(threadId, 'Ship the feature', 'budgetLimited'),
+      }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      command: '/goal resume',
+      codexGoalCommand: { kind: 'resume' },
+      nativePath: null,
+    }));
+    await finished;
+
+    expect(fake.startTurn).not.toHaveBeenCalled();
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(emitted.at(-1)?.content).toContain('Codex goal updated.');
+    expect(emitted.at(-1)?.content).toContain('Ship the feature');
+  });
+
+  it('replays continuation notifications received during thread resume', async () => {
+    let fake;
+    fake = new FakeClient({
+      resumeThread: async () => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: null,
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        }));
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'early-goal-turn', status: 'inProgress' }) },
+        }));
+        await Promise.resolve();
+        return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+      },
+      setThreadGoalStatus: async (threadId, status) => ({ goal: makeGoal(threadId, 'Ship the feature', status) }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'resume' },
+      nativePath: null,
+    }));
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('synchronizes a split-chunk active goal before gap pause and clear controls', async () => {
+    for (const control of ['pause', 'clear']) {
+      const calls = [];
+      const fake = new FakeClient({
+        resumeThread: async () => {
+          calls.push('resume');
+          return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+        },
+        getThreadGoal: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          calls.push('get');
+          return { goal: makeGoal('thread-1', 'Ship the feature', 'active') };
+        },
+        setThreadGoalStatus: async (threadId, status) => {
+          calls.push('pause');
+          return { goal: makeGoal(threadId, 'Ship the feature', status) };
+        },
+        clearThreadGoal: async () => {
+          calls.push('clear');
+          return { cleared: false };
+        },
+      });
+      const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+      await provider.runTurn(makeRequest({
+        agentSessionId: 'thread-1',
+        command: `/goal ${control}`,
+        codexGoalCommand: { kind: control },
+        nativePath: null,
+      }));
+
+      expect(calls).toEqual(['resume', 'get', control]);
+      expect(provider.isRunning('thread-1')).toBe(false);
+      expect(fake.shutdown).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('keeps a restored active turn through a pause response and its turn boundary', async () => {
+    let fake;
+    fake = new FakeClient({
+      resumeThread: async () => {
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+        });
+        return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+      },
+      getThreadGoal: async () => ({ goal: makeGoal('thread-1', 'Ship the feature', 'active') }),
+      setThreadGoalStatus: async (threadId, status) => ({
+        goal: makeGoal(threadId, 'Ship the feature', status),
+      }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'pause' },
+      nativePath: null,
+    }));
+
+    expect(emitted.at(-1)?.content).toContain('Codex goal paused.');
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'automatic-turn',
+        goal: makeGoal('thread-1', 'Ship the feature', 'paused'),
+      },
+    });
+    expect(provider.isRunning('thread-1')).toBe(true);
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn' }) },
+    });
+    await finished;
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a restored active turn through a clear response and its turn boundary', async () => {
+    let fake;
+    fake = new FakeClient({
+      resumeThread: async () => {
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+        });
+        return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+      },
+      getThreadGoal: async () => ({ goal: makeGoal('thread-1', 'Ship the feature', 'active') }),
+      clearThreadGoal: async () => ({ cleared: true }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'clear' },
+      nativePath: null,
+    }));
+
+    expect(emitted.at(-1)?.content).toBe('Codex goal cleared.');
+    expect(provider.isRunning('thread-1')).toBe(true);
+    fake.emit('notification', {
+      method: 'thread/goal/cleared',
+      params: { threadId: 'thread-1' },
+    });
+    expect(provider.isRunning('thread-1')).toBe(true);
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn' }) },
+    });
+    await finished;
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a resumed goal turn after buffered terminal replay defers the prior finish', async () => {
+    let fake;
+    fake = new FakeClient({
+      resumeThread: async () => {
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+        });
+        fake.emit('notification', {
+          method: 'turn/completed',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn' }) },
+        });
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'complete'),
+          },
+        });
+        return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+      },
+      setThreadGoalStatus: async (threadId) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'resumed-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, 'Ship the feature', 'active') };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'resume' },
+      nativePath: null,
+    }));
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('routes approvals that arrive after resume through the synchronized goal session', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => {
+        setTimeout(() => {
+          fake.emit('notification', {
+            method: 'thread/goal/updated',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'automatic-turn',
+              goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+            },
+          });
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+          });
+          fake.emit('serverRequest', {
+            id: 77,
+            method: 'item/commandExecution/requestApproval',
+            params: { threadId: 'thread-1', turnId: 'automatic-turn', itemId: 'cmd-1', command: 'bun test' },
+          });
+        }, 0);
+        return { goal: makeGoal('thread-1', 'Ship the feature', 'active') };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Continue after approval',
+      nativePath: null,
+    }));
+
+    const request = emitted.find((message) => message instanceof PermissionRequestMessage);
+    expect(request).toBeTruthy();
+    expect(fake.respond).not.toHaveBeenCalled();
+    expect(fake.getThreadGoal).toHaveBeenCalledWith('thread-1');
+    expect(fake.steerTurn).toHaveBeenCalledWith(expect.objectContaining({
+      expectedTurnId: 'automatic-turn',
+    }));
+    await provider.resolvePermission(request.permissionRequestId, { allow: true });
+    expect(fake.respond).toHaveBeenCalledWith(77, { decision: 'accept' });
+  });
+
+  it('waits for a restored active goal turn emitted after resume before steering ordinary input', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => {
+        setTimeout(() => {
+          fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+          });
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+          });
+        }, 0);
+        return { goal: makeGoal('thread-1', 'Ship the feature', 'active') };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Prioritize the restart failure',
+      clientMessageId: 'restart-message',
+      nativePath: null,
+    }));
+
+    expect(fake.steerTurn).toHaveBeenCalledTimes(1);
+    expect(fake.getThreadGoal).toHaveBeenCalledWith('thread-1');
+    expect(fake.steerTurn).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      expectedTurnId: 'automatic-turn',
+      clientUserMessageId: 'restart-message',
+      input: [{ type: 'text', text: 'Prioritize the restart failure', text_elements: [] }],
+    });
+    expect(fake.startTurn).not.toHaveBeenCalled();
+    expect(provider.isRunning('thread-1')).toBe(true);
+  });
+
+  it('keeps status read-only when resume restores an active goal continuation', async () => {
+    let fake;
+    fake = new FakeClient({
+      resumeThread: async () => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        }));
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+        }));
+        await Promise.resolve();
+        return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+      },
+      getThreadGoal: async () => ({ goal: makeGoal('thread-1', 'Ship the feature', 'active') }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'status' },
+      nativePath: null,
+    }));
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.startTurn).not.toHaveBeenCalled();
+    expect(fake.steerTurn).not.toHaveBeenCalled();
+    expect(fake.interruptTurn).not.toHaveBeenCalled();
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('delivers accepted restart input after buffered notifications finish the restored turn', async () => {
+    let fake;
+    fake = new FakeClient({
+      resumeThread: async () => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        }));
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn', status: 'inProgress' }) },
+        }));
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/completed',
+          params: { threadId: 'thread-1', turn: makeTurn({ id: 'automatic-turn' }) },
+        }));
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'automatic-turn',
+            goal: makeGoal('thread-1', 'Ship the feature', 'complete'),
+          },
+        }));
+        await Promise.resolve();
+        return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const processing = [];
+    provider.onProcessing((_chatId, value) => processing.push(value));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Do not dispatch after terminal replay',
+      nativePath: null,
+    }));
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(processing).toContain(true);
+    expect(fake.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: 'thread-1',
+      input: [{ type: 'text', text: 'Do not dispatch after terminal replay', text_elements: [] }],
+    }));
+    expect(fake.steerTurn).not.toHaveBeenCalled();
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('settles goal-turn waiters immediately when sessions terminate', async () => {
+    for (const termination of ['finish', 'abort', 'exit']) {
+      let setCalled;
+      const ready = new Promise((resolve) => { setCalled = resolve; });
+      const fake = new FakeClient({
+        getThreadGoal: async () => ({ goal: null }),
+        setThreadGoal: async (threadId, params) => {
+          setCalled();
+          return { goal: makeGoal(threadId, params.objective) };
+        },
+      });
+      const provider = new CodexAppServerRuntime({ createClient: () => fake });
+      const emitted = [];
+      provider.onMessages((_chatId, messages) => emitted.push(...messages));
+      const running = provider.runTurn(makeRequest({
+        agentSessionId: 'thread-1',
+        codexGoalCommand: { kind: 'set', objective: `Wait for ${termination}` },
+        nativePath: null,
+      }));
+      await ready;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      if (termination === 'finish') {
+        fake.emit('notification', { method: 'thread/goal/cleared', params: { threadId: 'thread-1' } });
+      } else if (termination === 'abort') {
+        expect(provider.abort('thread-1')).toBe(true);
+      } else {
+        fake.emit('exit', 7);
+      }
+      await running;
+
+      expect(provider.isRunning('thread-1')).toBe(false);
+      expect(emitted.some((message) => String(message.content).includes('timed out waiting'))).toBe(false);
+    }
+  });
+
   it('edits a paused goal while preserving its status and token budget', async () => {
     const existing = {
       ...makeGoal('thread-1', 'Old objective', 'paused'),
@@ -1265,6 +1978,32 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.startTurn).not.toHaveBeenCalled();
   });
 
+  it('uses the returned goal status when an edited exhausted goal cannot continue', async () => {
+    const current = makeGoal('thread-1', 'Old objective', 'complete');
+    const fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: current }),
+      setThreadGoal: async (threadId, params) => ({
+        goal: { ...current, threadId, objective: params.objective, status: 'budgetLimited' },
+      }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'edit', objective: 'Better objective' },
+      nativePath: null,
+    }));
+    await finished;
+
+    expect(fake.setThreadGoal).toHaveBeenCalledWith('thread-1', {
+      objective: 'Better objective',
+      status: 'active',
+      tokenBudget: null,
+    });
+    expect(provider.isRunning('thread-1')).toBe(false);
+  });
+
   it('shows actionable usage for a bare goal edit', async () => {
     const fake = new FakeClient();
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
@@ -1281,7 +2020,7 @@ describe('CodexAppServerRuntime', () => {
     await finished;
 
     expect(emitted.at(-1)?.content).toBe('Usage: /goal edit <objective>');
-    expect(fake.getThreadGoal).not.toHaveBeenCalled();
+    expect(fake.getThreadGoal).toHaveBeenCalledTimes(1);
   });
 
   it('keeps one app-server session across automatic goal turns until completion', async () => {
@@ -1468,6 +2207,23 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.steerTurn).not.toHaveBeenCalled();
   });
 
+  it('keeps compact and other unmanaged turns on the persisted queue path', async () => {
+    const fake = new FakeClient();
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.compact(makeRequest({ agentSessionId: 'thread-1', nativePath: null }));
+    let accepted = false;
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'queue after compact',
+      nativePath: null,
+    }), async () => { accepted = true; })).resolves.toBe(false);
+
+    expect(accepted).toBe(false);
+    expect(fake.steerTurn).not.toHaveBeenCalled();
+    expect(fake.startTurn).not.toHaveBeenCalled();
+  });
+
   it('falls back to turn/start on the same client when a turn-boundary steer loses the race', async () => {
     let fake;
     fake = new FakeClient({
@@ -1547,6 +2303,233 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.steerTurn.mock.calls[1][0].input).toEqual([
       { type: 'text', text: 'Do this exactly once', text_elements: [] },
     ]);
+  });
+
+  it('adopts the server-reported rollover turn and retries steering exactly once', async () => {
+    const steeredTurnIds = [];
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async ({ expectedTurnId }) => {
+        steeredTurnIds.push(expectedTurnId);
+        if (expectedTurnId === 'old-turn') {
+          throw new Error('expected active turn id `old-turn` but found `new-turn`');
+        }
+        return { turnId: expectedTurnId };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Steer across rollover',
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(steeredTurnIds).toEqual(['old-turn', 'new-turn']);
+    expect(fake.startTurn).not.toHaveBeenCalled();
+  });
+
+  it('retains accepted input across non-steerable goal turns and delivers it to the next turn', async () => {
+    for (const turnKind of ['review', 'compact']) {
+      const steeredTurnIds = [];
+      let rejectedNonSteerable;
+      const nonSteerableRejected = new Promise((resolve) => { rejectedNonSteerable = resolve; });
+      let fake;
+      fake = new FakeClient({
+        getThreadGoal: async () => ({ goal: null }),
+        setThreadGoal: async (threadId, params) => {
+          queueMicrotask(() => fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+          }));
+          return { goal: makeGoal(threadId, params.objective) };
+        },
+        steerTurn: async ({ expectedTurnId }) => {
+          steeredTurnIds.push(expectedTurnId);
+          if (expectedTurnId === 'old-turn') {
+            throw new Error(`expected active turn id \`old-turn\` but found \`${turnKind}-turn\``);
+          }
+          if (expectedTurnId === `${turnKind}-turn`) {
+            rejectedNonSteerable();
+            throw new CodexAppServerRpcError(
+              `cannot steer a ${turnKind} turn`,
+              -32600,
+              {
+                message: `cannot steer a ${turnKind} turn`,
+                codexErrorInfo: { activeTurnNotSteerable: { turnKind } },
+                additionalDetails: null,
+              },
+            );
+          }
+          return { turnId: expectedTurnId };
+        },
+      });
+      const provider = new CodexAppServerRuntime({ createClient: () => fake });
+      await provider.runTurn(makeRequest({
+        agentSessionId: 'thread-1',
+        codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+        nativePath: null,
+      }));
+      let accepted = false;
+
+      const delivery = provider.submitActiveInput(makeRequest({
+        agentSessionId: 'thread-1',
+        command: `Deliver after ${turnKind}`,
+        nativePath: null,
+      }), async () => { accepted = true; });
+      await nonSteerableRejected;
+      expect(accepted).toBe(true);
+      fake.emit('notification', {
+        method: 'turn/completed',
+        params: { threadId: 'thread-1', turn: makeTurn({ id: `${turnKind}-turn` }) },
+      });
+      fake.emit('notification', {
+        method: 'turn/started',
+        params: { threadId: 'thread-1', turn: makeTurn({ id: 'next-turn', status: 'inProgress' }) },
+      });
+
+      await expect(delivery).resolves.toBe(true);
+      expect(steeredTurnIds).toEqual(['old-turn', `${turnKind}-turn`, 'next-turn']);
+      expect(fake.startTurn).not.toHaveBeenCalled();
+      expect(provider.isRunning('thread-1')).toBe(true);
+    }
+  });
+
+  it('falls back to turn start when a mismatch retry finds no active turn', async () => {
+    const steeredTurnIds = [];
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async ({ expectedTurnId }) => {
+        steeredTurnIds.push(expectedTurnId);
+        if (expectedTurnId === 'old-turn') {
+          throw new Error('expected active turn id `old-turn` but found `boundary-turn`');
+        }
+        throw new Error('no active turn to steer');
+      },
+      startTurn: async () => ({ turn: makeTurn({ id: 'user-turn', status: 'inProgress' }) }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Start after the boundary',
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(steeredTurnIds).toEqual(['old-turn', 'boundary-turn']);
+    expect(fake.startTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('adopts a newly started turn after a mismatch retry finds no active turn', async () => {
+    const steeredTurnIds = [];
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async ({ expectedTurnId }) => {
+        steeredTurnIds.push(expectedTurnId);
+        if (expectedTurnId === 'old-turn') {
+          throw new Error('expected active turn id `old-turn` but found `boundary-turn`');
+        }
+        if (expectedTurnId === 'boundary-turn') {
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'fresh-turn', status: 'inProgress' }) },
+          });
+          throw new Error('no active turn to steer');
+        }
+        return { turnId: expectedTurnId };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Steer the fresh turn',
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(steeredTurnIds).toEqual(['old-turn', 'boundary-turn', 'fresh-turn']);
+    expect(fake.startTurn).not.toHaveBeenCalled();
+  });
+
+  it('declines active delivery before acceptance when a terminal finish is pending', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    const first = provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'First input',
+      nativePath: null,
+    }), async () => {
+      fake.emit('notification', {
+        method: 'error',
+        params: { threadId: 'thread-1', error: { message: 'terminal failure' } },
+      });
+    });
+    await expect(first).rejects.toThrow('terminal failure');
+    let accepted = false;
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Must fall back',
+      nativePath: null,
+    }), async () => { accepted = true; })).resolves.toBe(false);
+
+    expect(accepted).toBe(false);
+    expect(fake.steerTurn).not.toHaveBeenCalled();
+    expect(provider.isRunning('thread-1')).toBe(false);
   });
 
   it('executes goal controls immediately on the active client and waits for the turn boundary', async () => {
@@ -1629,6 +2612,81 @@ describe('CodexAppServerRuntime', () => {
       params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn' }) },
     });
     await finished;
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes a paused active goal immediately between automatic turns', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      setThreadGoalStatus: async (threadId, status) => ({
+        goal: makeGoal(threadId, 'Long-running work', status),
+      }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn' }) },
+    });
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: '/goal pause',
+      codexGoalCommand: { kind: 'pause' },
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes a no-op clear immediately between automatic turns', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      clearThreadGoal: async () => ({ cleared: false }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn' }) },
+    });
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: '/goal clear',
+      codexGoalCommand: { kind: 'clear' },
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(emitted.at(-1)?.content).toBe('No Codex goal was set.');
+    expect(provider.isRunning('thread-1')).toBe(false);
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
   });
 

--- a/server/agents/codex/app-server/client.ts
+++ b/server/agents/codex/app-server/client.ts
@@ -12,6 +12,8 @@ import type {
   ThreadGoalClearResponse,
   ThreadGoalGetResponse,
   ThreadGoalSetResponse,
+  ThreadInjectItemsParams,
+  ThreadInjectItemsResponse,
   ThreadLoadedListResponse,
   ThreadResumeResponse,
   ThreadStartResponse,
@@ -188,6 +190,10 @@ export class CodexAppServerClient extends EventEmitter {
 
   clearThreadGoal(threadId: string): Promise<ThreadGoalClearResponse> {
     return this.request<ThreadGoalClearResponse>('thread/goal/clear', { threadId });
+  }
+
+  injectThreadItems(params: ThreadInjectItemsParams): Promise<ThreadInjectItemsResponse> {
+    return this.request<ThreadInjectItemsResponse>('thread/inject_items', params);
   }
 
   listThreads(params: Record<string, unknown>): Promise<ThreadListResponse> {

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -167,6 +167,11 @@ export interface ThreadGoalGetResponse {
 export interface ThreadGoalClearResponse {
   cleared: boolean;
 }
+export interface ThreadInjectItemsParams {
+  threadId: string;
+  items: Array<Record<string, unknown>>;
+}
+export type ThreadInjectItemsResponse = Record<string, never>;
 export interface ThreadGoalUpdatedNotification {
   threadId: string;
   turnId: string | null;

--- a/server/agents/codex/app-server/request-builders.ts
+++ b/server/agents/codex/app-server/request-builders.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import type { AgentCommandImage, CodexProviderConfig, PermissionMode, StartSessionRequest, ThinkingMode } from "../../session-types.js";
 import type { CodexSkillRef } from '../slash-command-discovery.js';
+import type { ThreadInjectItemsParams } from './protocol.js';
 import { attachmentMimeType, isImageAttachment, parseAttachmentDataUrl } from '../../shared/attachments.js';
 
 // Matches a leading "/<name>" skill token with optional trailing arguments,
@@ -90,6 +91,14 @@ export function buildThreadStartParams(request: StartSessionRequest): Record<str
   return appendCommonThreadParams({
     ephemeral: false,
   }, request);
+}
+
+export function buildInjectedContextItems(context: string): ThreadInjectItemsParams['items'] {
+  return [{
+    type: 'message',
+    role: 'user',
+    content: [{ type: 'input_text', text: context }],
+  }];
 }
 
 export function buildThreadResumeParams(request: {

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -45,6 +45,11 @@ import { cleanupMaterializedGoalDraft, materializeGoalDraft } from './goal-files
 
 type RunningStatus = 'running' | 'completing' | 'completed' | 'failed' | 'aborted';
 type FinishSessionOptions = { failedMessage?: string; aborted?: boolean };
+type GoalCommandOptions = {
+  keepSession: boolean;
+  goalSynchronized?: boolean;
+  propagateDeliveryFailure?: boolean;
+};
 const GOAL_TURN_START_TIMEOUT_MS = 30_000;
 const MAX_ACTIVE_INPUT_DELIVERY_TRANSITIONS = 8;
 
@@ -145,7 +150,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           items: buildInjectedContextItems(request.codexSeedContext),
         });
       }
-      await this.#handleGoalCommand(client, session, request.codexGoalCommand, request, false);
+      await this.#handleGoalCommand(client, session, request.codexGoalCommand, request, { keepSession: false });
       return;
     }
 
@@ -173,9 +178,13 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     session: RunningCodexSession,
     command: CodexGoalCommand,
     request: StartSessionRequest | ResumeTurnRequest,
-    keepSession: boolean,
-    goalSynchronized = false,
+    options: GoalCommandOptions,
   ): Promise<void> {
+    const {
+      keepSession,
+      goalSynchronized = false,
+      propagateDeliveryFailure = false,
+    } = options;
     try {
       switch (command.kind) {
         case 'set':
@@ -307,11 +316,15 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           return;
       }
     } catch (error) {
-      if (error instanceof TurnStartWaitCancelledError) return;
+      if (error instanceof TurnStartWaitCancelledError) {
+        if (propagateDeliveryFailure) throw error;
+        return;
+      }
       this.emitMessages(session.chatId, [new ErrorMessage(new Date().toISOString(), humanizeCodexAppServerError(error))]);
       if (!hasActiveGoalContinuation(session)) {
         this.#finishSession(session);
       }
+      if (propagateDeliveryFailure) throw error;
       return;
     }
   }
@@ -356,7 +369,10 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
 
   async #deliverReservedActiveInput(session: RunningCodexSession, request: ResumeTurnRequest): Promise<void> {
     if (request.codexGoalCommand) {
-      await this.#handleGoalCommand(session.client, session, request.codexGoalCommand, request, true);
+      await this.#handleGoalCommand(session.client, session, request.codexGoalCommand, request, {
+        keepSession: true,
+        propagateDeliveryFailure: true,
+      });
       return;
     }
 
@@ -511,11 +527,11 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       activeSession = session;
       session.activeDeliveryReservations += 1;
       try {
-        this.#releaseBufferedClientEvents(client);
         if (this.#sessions.get(session.threadId) !== session) {
           throw new Error('Codex session ended while resuming the thread');
         }
         await this.#synchronizeRestoredGoal(client, session);
+        this.#releaseBufferedClientEvents(client);
         if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
           throw new TurnStartWaitCancelledError('Codex session ended while synchronizing the restored goal');
         }
@@ -532,8 +548,10 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
             session,
             request.codexGoalCommand,
             request,
-            session.managesGoalLifecycle,
-            true,
+            {
+              keepSession: session.managesGoalLifecycle,
+              goalSynchronized: true,
+            },
           );
         }
         if (session.activeTurnId && !hasTerminalPendingFinish(session)) {
@@ -546,6 +564,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     } catch (error) {
       const message = humanizeCodexAppServerError(error);
       if (activeSession) {
+        this.#discardBufferedClientEvents(client);
         this.#finishSession(activeSession, { failedMessage: message });
       } else {
         this.#discardBufferedClientEvents(client);

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -29,6 +29,7 @@ import type {
 } from './protocol.js';
 import {
   buildCodexEnv,
+  buildInjectedContextItems,
   buildThreadForkParams,
   buildThreadResumeParams,
   buildThreadStartParams,
@@ -45,6 +46,18 @@ import { cleanupMaterializedGoalDraft, materializeGoalDraft } from './goal-files
 type RunningStatus = 'running' | 'completing' | 'completed' | 'failed' | 'aborted';
 type FinishSessionOptions = { failedMessage?: string; aborted?: boolean };
 const GOAL_TURN_START_TIMEOUT_MS = 30_000;
+const MAX_ACTIVE_INPUT_DELIVERY_TRANSITIONS = 8;
+
+interface TurnStartWaiter {
+  resolve: (turnId: string) => void;
+  reject: (error: Error) => void;
+}
+
+class TurnStartWaitCancelledError extends Error {}
+
+type BufferedClientEvent =
+  | { type: 'notification'; notification: JsonRpcNotification }
+  | { type: 'serverRequest'; request: JsonRpcServerRequest };
 
 interface RunningCodexSession {
   chatId: string;
@@ -60,7 +73,7 @@ interface RunningCodexSession {
   // contextCompaction item is labeled 'manual' rather than 'auto'.
   manualCompactionPending?: boolean;
   cleanupAttachments?: () => Promise<void>;
-  turnStartWaiters: Set<(turnId: string) => void>;
+  turnStartWaiters: Set<TurnStartWaiter>;
   goal: CodexThreadGoal | null;
   managesGoalLifecycle: boolean;
   completedGoalTurn: boolean;
@@ -85,6 +98,8 @@ export interface CodexAppServerRuntimeOptions {
 export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #sessions = new Map<string, RunningCodexSession>();
   #pendingApprovals = new Map<string, CodexPendingApproval & { client: CodexAppServerClient }>();
+  #bufferingClients = new Set<CodexAppServerClient>();
+  #bufferedClientEvents = new Map<CodexAppServerClient, BufferedClientEvent[]>();
   #utilityClient: CodexAppServerClient | null = null;
   #utilityQueue: Promise<unknown> = Promise.resolve();
   #threadListCaches = new Map<boolean, Promise<Map<string, CodexThread>>>();
@@ -124,6 +139,12 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     request: StartSessionRequest | ResumeTurnRequest,
   ): Promise<void> {
     if (request.codexGoalCommand) {
+      if ('codexSeedContext' in request && request.codexSeedContext) {
+        await client.injectThreadItems({
+          threadId: session.threadId,
+          items: buildInjectedContextItems(request.codexSeedContext),
+        });
+      }
       await this.#handleGoalCommand(client, session, request.codexGoalCommand, request, false);
       return;
     }
@@ -153,12 +174,15 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     command: CodexGoalCommand,
     request: StartSessionRequest | ResumeTurnRequest,
     keepSession: boolean,
+    goalSynchronized = false,
   ): Promise<void> {
     try {
       switch (command.kind) {
         case 'set':
         case 'replace': {
-          const current = await client.getThreadGoal(session.threadId);
+          const current = goalSynchronized
+            ? { goal: session.goal }
+            : await client.getThreadGoal(session.threadId);
           if (command.kind === 'set' && current.goal && current.goal.status !== 'complete') {
             this.emitMessages(session.chatId, [new ErrorMessage(
               new Date().toISOString(),
@@ -170,12 +194,9 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           const draft = await materializeGoalDraft(session.codexHome, command.objective, request.images);
           let response: ThreadGoalSetResponse;
           try {
-            if (current.goal) await this.#clearGoalForReplacement(client, session);
-            session.managesGoalLifecycle = true;
-            response = await client.setThreadGoal(session.threadId, {
-              objective: draft.objective,
-              status: 'active',
-            });
+            response = current.goal
+              ? await this.#replaceThreadGoal(client, session, current.goal, draft.objective)
+              : await this.#setNewThreadGoal(client, session, draft.objective);
           } catch (error) {
             await cleanupMaterializedGoalDraft(draft.outputDir);
             throw error;
@@ -185,18 +206,22 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           return;
         }
         case 'status': {
-          const response = await client.getThreadGoal(session.threadId);
+          const response = goalSynchronized
+            ? { goal: session.goal }
+            : await client.getThreadGoal(session.threadId);
+          session.goal = response.goal;
+          if (response.goal?.status === 'active') session.managesGoalLifecycle = true;
           this.emitMessages(session.chatId, [
             new AssistantMessage(new Date().toISOString(), formatGoalStatusMessage(response.goal)),
           ]);
-          if (!keepSession) this.#finishSession(session);
+          if (!keepSession && !hasActiveGoalContinuation(session)) this.#finishSession(session);
           return;
         }
         case 'clear': {
           const response = await client.clearThreadGoal(session.threadId);
           const message = response.cleared ? 'Codex goal cleared.' : 'No Codex goal was set.';
           this.emitMessages(session.chatId, [new AssistantMessage(new Date().toISOString(), message)]);
-          if (!keepSession) this.#finishSession(session);
+          if (!keepSession || !session.activeTurnId) this.#finishSession(session);
           return;
         }
         case 'pause': {
@@ -209,10 +234,19 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           return;
         }
         case 'resume': {
-          session.managesGoalLifecycle = true;
+          const previouslyManaged = session.managesGoalLifecycle;
           const response = await client.setThreadGoalStatus(session.threadId, 'active');
           session.goal = response.goal;
-          await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
+          if (response.goal.status === 'active') {
+            session.managesGoalLifecycle = true;
+            await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
+          } else {
+            session.managesGoalLifecycle = previouslyManaged;
+            this.emitMessages(session.chatId, [
+              new AssistantMessage(new Date().toISOString(), formatGoalUpdatedMessage('updated', response.goal)),
+            ]);
+            if (!hasActiveGoalContinuation(session)) this.#finishSession(session);
+          }
           return;
         }
         case 'edit': {
@@ -224,7 +258,9 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
             if (!keepSession) this.#finishSession(session);
             return;
           }
-          const current = (await client.getThreadGoal(session.threadId)).goal;
+          const current = goalSynchronized
+            ? session.goal
+            : (await client.getThreadGoal(session.threadId)).goal;
           if (!current) {
             this.emitMessages(session.chatId, [new ErrorMessage(
               new Date().toISOString(),
@@ -236,7 +272,9 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           const status = editedGoalStatus(current.status);
           const draft = await materializeGoalDraft(session.codexHome, command.objective, request.images);
           let response: ThreadGoalSetResponse;
+          const previouslyManaged = session.managesGoalLifecycle;
           try {
+            if (status === 'active') session.managesGoalLifecycle = true;
             response = await client.setThreadGoal(session.threadId, {
               objective: draft.objective,
               status,
@@ -247,10 +285,10 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
             throw error;
           }
           session.goal = response.goal;
-          if (status === 'active') {
-            session.managesGoalLifecycle = true;
+          if (response.goal.status === 'active') {
             await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
           } else {
+            session.managesGoalLifecycle = previouslyManaged;
             this.emitMessages(session.chatId, [
               new AssistantMessage(new Date().toISOString(), formatGoalUpdatedMessage('updated', response.goal)),
             ]);
@@ -269,8 +307,11 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           return;
       }
     } catch (error) {
+      if (error instanceof TurnStartWaitCancelledError) return;
       this.emitMessages(session.chatId, [new ErrorMessage(new Date().toISOString(), humanizeCodexAppServerError(error))]);
-      if (!keepSession) this.#finishSession(session);
+      if (!hasActiveGoalContinuation(session)) {
+        this.#finishSession(session);
+      }
       return;
     }
   }
@@ -283,12 +324,23 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (!session || session.status === 'completed' || session.status === 'failed' || session.status === 'aborted') {
       return false;
     }
+    if (!session.managesGoalLifecycle) return false;
     const operation = session.activeInputChain.then(async () => {
       if (this.#sessions.get(request.agentSessionId) !== session) return false;
+      if (
+        !session.managesGoalLifecycle
+        || session.status === 'failed'
+        || session.status === 'aborted'
+        || session.status === 'completed'
+        || hasTerminalPendingFinish(session)
+      ) return false;
       session.activeDeliveryReservations += 1;
       try {
         await beforeDelivery();
-        await this.#submitActiveInputNow(session, request);
+        if (hasTerminalPendingFinish(session) || isTerminalSessionStatus(session.status)) {
+          throw new Error(session.pendingFinish?.failedMessage ?? 'Codex session ended before active input delivery');
+        }
+        await this.#deliverReservedActiveInput(session, request);
         if (session.activeTurnId && session.pendingFinish && !session.pendingFinish.failedMessage && !session.pendingFinish.aborted) {
           session.pendingFinish = null;
         }
@@ -302,7 +354,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     return operation;
   }
 
-  async #submitActiveInputNow(session: RunningCodexSession, request: ResumeTurnRequest): Promise<void> {
+  async #deliverReservedActiveInput(session: RunningCodexSession, request: ResumeTurnRequest): Promise<void> {
     if (request.codexGoalCommand) {
       await this.#handleGoalCommand(session.client, session, request.codexGoalCommand, request, true);
       return;
@@ -312,21 +364,6 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     this.#retainAttachmentCleanup(session, attachments.cleanup);
     const command = goalObjectiveWithAttachmentPaths(request.command, [], attachments.filePaths);
     const input = buildUserInput(command, attachments.imagePaths);
-    const staleTurnId = session.activeTurnId;
-    if (staleTurnId) {
-      try {
-        await session.client.steerTurn({
-          threadId: session.threadId,
-          expectedTurnId: staleTurnId,
-          input,
-          ...(request.clientMessageId ? { clientUserMessageId: request.clientMessageId } : {}),
-        });
-        return;
-      } catch (error) {
-        if (!isNoActiveTurnError(error)) throw error;
-      }
-    }
-
     const startParams = buildTurnStartParams({
       threadId: session.threadId,
       command,
@@ -337,19 +374,73 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       thinkingMode: request.thinkingMode,
       clientMessageId: request.clientMessageId,
     });
-    try {
-      const turn = await session.client.startTurn(startParams);
-      session.activeTurnId = turn.turn.id;
-    } catch (error) {
-      if (!isActiveTurnConflictError(error)) throw error;
-      const nextTurnId = await this.#waitForDifferentTurnStart(session, staleTurnId, GOAL_TURN_START_TIMEOUT_MS);
-      await session.client.steerTurn({
-        threadId: session.threadId,
-        expectedTurnId: nextTurnId,
-        input,
-        ...(request.clientMessageId ? { clientUserMessageId: request.clientMessageId } : {}),
-      });
+    let turnId = session.activeTurnId;
+    let transitions = 0;
+
+    if (!turnId && session.goal?.status === 'active') {
+      turnId = await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
     }
+
+    while (transitions < MAX_ACTIVE_INPUT_DELIVERY_TRANSITIONS) {
+      if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
+        throw new TurnStartWaitCancelledError('Codex session ended before active input delivery');
+      }
+      if (!turnId && session.activeTurnId) turnId = session.activeTurnId;
+
+      if (!turnId) {
+        const previousTurnId = session.activeTurnId;
+        try {
+          const turn = await session.client.startTurn(startParams);
+          session.activeTurnId = turn.turn.id;
+          return;
+        } catch (error) {
+          if (!isActiveTurnConflictError(error) && !isActiveTurnNotSteerableError(error)) throw error;
+          turnId = await this.#waitForDifferentTurnStart(
+            session,
+            previousTurnId,
+            GOAL_TURN_START_TIMEOUT_MS,
+          );
+          transitions += 1;
+          continue;
+        }
+      }
+
+      try {
+        await session.client.steerTurn({
+          threadId: session.threadId,
+          expectedTurnId: turnId,
+          input,
+          ...(request.clientMessageId ? { clientUserMessageId: request.clientMessageId } : {}),
+        });
+        return;
+      } catch (error) {
+        const actualTurnId = actualTurnIdFromSteerMismatch(error);
+        if (actualTurnId && actualTurnId !== turnId) {
+          session.activeTurnId = actualTurnId;
+          turnId = actualTurnId;
+          transitions += 1;
+          continue;
+        }
+        if (actualTurnId) throw error;
+        if (isActiveTurnNotSteerableError(error)) {
+          turnId = await this.#waitForDifferentTurnStart(
+            session,
+            turnId,
+            GOAL_TURN_START_TIMEOUT_MS,
+          );
+          transitions += 1;
+          continue;
+        }
+        if (isNoActiveTurnError(error)) {
+          if (session.activeTurnId === turnId) session.activeTurnId = null;
+          turnId = null;
+          transitions += 1;
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error('Codex active input delivery exceeded the turn transition limit');
   }
 
   #retainAttachmentCleanup(session: RunningCodexSession, cleanup: () => Promise<void>): void {
@@ -360,7 +451,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   }
 
   async startSession(request: StartSessionRequest): Promise<StartedAgentSession> {
-    const client = this.#newClient(request);
+    const client = this.#newClient(request, true);
     let activeSession: RunningCodexSession | null = null;
 
     try {
@@ -376,6 +467,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         permissionMode: request.permissionMode,
       });
       activeSession = session;
+      session.managesGoalLifecycle = Boolean(request.codexGoalCommand);
+      this.#releaseBufferedClientEvents(client);
       this.emitProcessing(request.chatId, true);
       this.emitSessionCreated(request.chatId);
       await this.#startRequestedTurn(client, session, request);
@@ -391,6 +484,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       if (activeSession) {
         this.#finishSession(activeSession, { failedMessage: message });
       } else {
+        this.#discardBufferedClientEvents(client);
         client.shutdown();
         this.emitProcessing(request.chatId, false);
         this.emitFailed(request.chatId, message);
@@ -400,7 +494,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   }
 
   async runTurn(request: ResumeTurnRequest): Promise<void> {
-    const client = this.#newClient(request);
+    const client = this.#newClient(request, true);
     let activeSession: RunningCodexSession | null = null;
 
     try {
@@ -415,13 +509,46 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         permissionMode: request.permissionMode,
       });
       activeSession = session;
-      this.emitProcessing(request.chatId, true);
-      await this.#startRequestedTurn(client, session, request);
+      session.activeDeliveryReservations += 1;
+      try {
+        this.#releaseBufferedClientEvents(client);
+        if (this.#sessions.get(session.threadId) !== session) {
+          throw new Error('Codex session ended while resuming the thread');
+        }
+        await this.#synchronizeRestoredGoal(client, session);
+        if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
+          throw new TurnStartWaitCancelledError('Codex session ended while synchronizing the restored goal');
+        }
+        this.emitProcessing(request.chatId, true);
+        if (!request.codexGoalCommand) {
+          if (session.managesGoalLifecycle) {
+            await this.#deliverReservedActiveInput(session, request);
+          } else {
+            await this.#startRequestedTurn(client, session, request);
+          }
+        } else {
+          await this.#handleGoalCommand(
+            client,
+            session,
+            request.codexGoalCommand,
+            request,
+            session.managesGoalLifecycle,
+            true,
+          );
+        }
+        if (session.activeTurnId && !hasTerminalPendingFinish(session)) {
+          session.pendingFinish = null;
+        }
+      } finally {
+        session.activeDeliveryReservations -= 1;
+        this.#flushPendingFinish(session);
+      }
     } catch (error) {
       const message = humanizeCodexAppServerError(error);
       if (activeSession) {
         this.#finishSession(activeSession, { failedMessage: message });
       } else {
+        this.#discardBufferedClientEvents(client);
         client.shutdown();
         this.emitProcessing(request.chatId, false);
         this.emitFailed(request.chatId, message);
@@ -440,7 +567,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       throw new Error('Cannot compact while a Codex turn is active');
     }
 
-    const client = this.#newClient(request);
+    const client = this.#newClient(request, true);
     let activeSession: RunningCodexSession | null = null;
 
     try {
@@ -456,6 +583,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       });
       session.manualCompactionPending = true;
       activeSession = session;
+      this.#releaseBufferedClientEvents(client);
       this.emitProcessing(request.chatId, true);
       await client.compactThread(resumed.thread.id);
     } catch (error) {
@@ -463,6 +591,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       if (activeSession) {
         this.#finishSession(activeSession, { failedMessage: message });
       } else {
+        this.#discardBufferedClientEvents(client);
         client.shutdown();
         this.emitProcessing(request.chatId, false);
         this.emitFailed(request.chatId, message);
@@ -475,6 +604,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     const session = this.#sessions.get(agentSessionId);
     if (!session) return false;
     session.status = 'aborted';
+    this.#cancelTurnStartWaiters(session, 'Codex session aborted');
 
     const interrupt = session.activeTurnId
       ? session.client.interruptTurn(session.threadId, session.activeTurnId).catch((error: Error) => {
@@ -578,6 +708,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   shutdown(): void {
     this.#idlePurger.stop();
     for (const session of this.#sessions.values()) {
+      this.#cancelTurnStartWaiters(session, 'Codex runtime shut down');
       void session.cleanupAttachments?.();
       session.client.shutdown();
     }
@@ -586,10 +717,16 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     this.#utilityClient = null;
     this.#utilityQueue = Promise.resolve();
     this.#threadListCaches.clear();
+    this.#bufferingClients.clear();
+    this.#bufferedClientEvents.clear();
   }
 
-  #newClient(request: Pick<StartSessionRequest, 'envOverrides' | 'codexConfig'>): CodexAppServerClient {
+  #newClient(
+    request: Pick<StartSessionRequest, 'envOverrides' | 'codexConfig'>,
+    bufferNotifications = false,
+  ): CodexAppServerClient {
     const client = this.#createClient({ env: buildCodexEnv(request.envOverrides, request.codexConfig) });
+    if (bufferNotifications) this.#bufferingClients.add(client);
     this.#wireClient(client);
     return client;
   }
@@ -735,12 +872,57 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   }
 
   #wireClient(client: CodexAppServerClient): void {
-    client.on('notification', (notification: JsonRpcNotification) => this.#handleNotification(client, notification));
-    client.on('serverRequest', (request: JsonRpcServerRequest) => this.#handleServerRequest(client, request));
+    client.on('notification', (notification: JsonRpcNotification) => {
+      if (this.#bufferingClients.has(client)) {
+        this.#bufferClientEvent(client, { type: 'notification', notification });
+        return;
+      }
+      this.#handleNotification(client, notification);
+    });
+    client.on('serverRequest', (request: JsonRpcServerRequest) => {
+      if (this.#bufferingClients.has(client)) {
+        this.#bufferClientEvent(client, { type: 'serverRequest', request });
+        return;
+      }
+      this.#handleServerRequest(client, request);
+    });
     client.on('stderr', (line: string) => logger.warn('codex app-server:', line));
     client.on('warning', (message: string) => logger.warn(message));
     client.on('metric', (metric: unknown) => this.emit('metric', metric));
     client.on('exit', (code: number) => this.#handleClientExit(client, code));
+  }
+
+  #bufferClientEvent(client: CodexAppServerClient, event: BufferedClientEvent): void {
+    const buffered = this.#bufferedClientEvents.get(client) ?? [];
+    buffered.push(event);
+    this.#bufferedClientEvents.set(client, buffered);
+  }
+
+  #releaseBufferedClientEvents(client: CodexAppServerClient): void {
+    this.#bufferingClients.delete(client);
+    const events = this.#bufferedClientEvents.get(client) ?? [];
+    this.#bufferedClientEvents.delete(client);
+    for (const event of events) {
+      if (event.type === 'notification') {
+        this.#handleNotification(client, event.notification);
+      } else {
+        this.#handleServerRequest(client, event.request);
+      }
+    }
+  }
+
+  #discardBufferedClientEvents(client: CodexAppServerClient): void {
+    this.#bufferingClients.delete(client);
+    this.#bufferedClientEvents.delete(client);
+  }
+
+  async #synchronizeRestoredGoal(
+    client: CodexAppServerClient,
+    session: RunningCodexSession,
+  ): Promise<void> {
+    const response = await client.getThreadGoal(session.threadId);
+    session.goal = response.goal;
+    session.managesGoalLifecycle = response.goal?.status === 'active';
   }
 
   #handleNotification(client: CodexAppServerClient, notification: JsonRpcNotification): void {
@@ -774,14 +956,14 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (!session) return;
     session.activeTurnId = params.turn.id;
     session.status = 'running';
-    for (const resolve of session.turnStartWaiters) resolve(params.turn.id);
-    session.turnStartWaiters.clear();
+    for (const waiter of session.turnStartWaiters) waiter.resolve(params.turn.id);
   }
 
   #handleGoalUpdated(params: ThreadGoalUpdatedNotification): void {
     const session = this.#sessions.get(params.threadId);
     if (!session) return;
     session.goal = params.goal;
+    if (params.goal.status === 'active') session.managesGoalLifecycle = true;
     if (
       session.managesGoalLifecycle
       && params.goal.status !== 'active'
@@ -803,10 +985,85 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (session.managesGoalLifecycle && !session.activeTurnId) this.#finishSession(session);
   }
 
-  async #clearGoalForReplacement(client: CodexAppServerClient, session: RunningCodexSession): Promise<void> {
+  async #clearGoalForReplacement(client: CodexAppServerClient, session: RunningCodexSession): Promise<boolean> {
     session.ignoredGoalClears += 1;
     const response = await client.clearThreadGoal(session.threadId);
-    if (!response.cleared) session.ignoredGoalClears -= 1;
+    if (!response.cleared) this.#releaseIgnoredGoalClear(session);
+    return response.cleared;
+  }
+
+  async #setNewThreadGoal(
+    client: CodexAppServerClient,
+    session: RunningCodexSession,
+    objective: string,
+  ): Promise<ThreadGoalSetResponse> {
+    session.managesGoalLifecycle = true;
+    return client.setThreadGoal(session.threadId, { objective, status: 'active' });
+  }
+
+  async #replaceThreadGoal(
+    client: CodexAppServerClient,
+    session: RunningCodexSession,
+    previousGoal: CodexThreadGoal,
+    objective: string,
+  ): Promise<ThreadGoalSetResponse> {
+    const previouslyManaged = session.managesGoalLifecycle;
+    let cleared: boolean;
+    try {
+      cleared = await this.#clearGoalForReplacement(client, session);
+    } catch (clearError) {
+      let reconciled = false;
+      let clearCommitted = false;
+      try {
+        session.goal = (await client.getThreadGoal(session.threadId)).goal;
+        reconciled = true;
+        clearCommitted = !session.goal;
+      } catch (reconcileError) {
+        logger.warn('codex: failed to reconcile goal after replacement clear failure:', (reconcileError as Error).message);
+      }
+      if (clearCommitted) {
+        try {
+          session.goal = (await client.setThreadGoal(session.threadId, {
+            objective: previousGoal.objective,
+            status: previousGoal.status,
+            tokenBudget: previousGoal.tokenBudget,
+          })).goal;
+        } catch (rollbackError) {
+          logger.warn('codex: failed to restore goal after replacement clear failure:', (rollbackError as Error).message);
+        }
+      }
+      if (reconciled && !clearCommitted) this.#releaseIgnoredGoalClear(session);
+      session.managesGoalLifecycle = previouslyManaged || session.goal?.status === 'active';
+      throw clearError;
+    }
+    session.managesGoalLifecycle = true;
+    try {
+      return await client.setThreadGoal(session.threadId, { objective, status: 'active' });
+    } catch (replacementError) {
+      if (cleared) {
+        try {
+          session.goal = (await client.setThreadGoal(session.threadId, {
+            objective: previousGoal.objective,
+            status: previousGoal.status,
+            tokenBudget: previousGoal.tokenBudget,
+          })).goal;
+        } catch (rollbackError) {
+          logger.warn('codex: failed to restore goal after replacement failure:', (rollbackError as Error).message);
+        }
+      }
+      try {
+        session.goal = (await client.getThreadGoal(session.threadId)).goal;
+      } catch (reconcileError) {
+        session.goal = null;
+        logger.warn('codex: failed to reconcile goal after replacement failure:', (reconcileError as Error).message);
+      }
+      session.managesGoalLifecycle = previouslyManaged || session.goal?.status === 'active';
+      throw replacementError;
+    }
+  }
+
+  #releaseIgnoredGoalClear(session: RunningCodexSession): void {
+    if (session.ignoredGoalClears > 0) session.ignoredGoalClears -= 1;
   }
 
   #handleItemCompleted(params: ItemCompletedNotification): void {
@@ -909,12 +1166,13 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
 
   #handleClientExit(client: CodexAppServerClient, code: number): void {
     const session = this.#sessionForClient(client);
-    if (!session || session.status !== 'running') return;
+    if (!session || (session.status !== 'running' && session.status !== 'completing')) return;
     this.#finishSession(session, { failedMessage: `Codex app-server exited with code ${code}` });
   }
 
   #finishSession(session: RunningCodexSession, opts: FinishSessionOptions = {}): void {
     if (!this.#sessions.has(session.threadId)) return;
+    this.#cancelTurnStartWaiters(session, 'Codex session finished');
     if (session.activeDeliveryReservations > 0) {
       session.pendingFinish = mergeFinishOptions(session.pendingFinish, opts);
       return;
@@ -945,19 +1203,12 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
 
   #waitForTurnStart(session: RunningCodexSession, timeoutMs: number): Promise<string> {
     if (session.activeTurnId) return Promise.resolve(session.activeTurnId);
-
-    return new Promise((resolve, reject) => {
-      const resolveWaiter = (turnId: string) => {
-        clearTimeout(timeout);
-        session.turnStartWaiters.delete(resolveWaiter);
-        resolve(turnId);
-      };
-      const timeout = setTimeout(() => {
-        session.turnStartWaiters.delete(resolveWaiter);
-        reject(new Error(`timed out waiting for Codex goal turn to start after ${Math.round(timeoutMs / 1000)} seconds`));
-      }, timeoutMs);
-      session.turnStartWaiters.add(resolveWaiter);
-    });
+    return this.#registerTurnStartWaiter(
+      session,
+      timeoutMs,
+      () => true,
+      `timed out waiting for Codex goal turn to start after ${Math.round(timeoutMs / 1000)} seconds`,
+    );
   }
 
   #waitForDifferentTurnStart(
@@ -968,19 +1219,44 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (session.activeTurnId && session.activeTurnId !== previousTurnId) {
       return Promise.resolve(session.activeTurnId);
     }
+    return this.#registerTurnStartWaiter(
+      session,
+      timeoutMs,
+      (turnId) => turnId !== previousTurnId,
+      `timed out waiting for the next Codex turn after ${Math.round(timeoutMs / 1000)} seconds`,
+    );
+  }
+
+  #registerTurnStartWaiter(
+    session: RunningCodexSession,
+    timeoutMs: number,
+    accepts: (turnId: string) => boolean,
+    timeoutMessage: string,
+  ): Promise<string> {
+    if (this.#sessions.get(session.threadId) !== session) {
+      return Promise.reject(new TurnStartWaitCancelledError('Codex session is no longer active'));
+    }
     return new Promise((resolve, reject) => {
-      const resolveWaiter = (turnId: string) => {
-        if (turnId === previousTurnId) return;
+      let timeout: ReturnType<typeof setTimeout>;
+      const settle = (action: () => void) => {
         clearTimeout(timeout);
-        session.turnStartWaiters.delete(resolveWaiter);
-        resolve(turnId);
+        session.turnStartWaiters.delete(waiter);
+        action();
       };
-      const timeout = setTimeout(() => {
-        session.turnStartWaiters.delete(resolveWaiter);
-        reject(new Error(`timed out waiting for the next Codex turn after ${Math.round(timeoutMs / 1000)} seconds`));
-      }, timeoutMs);
-      session.turnStartWaiters.add(resolveWaiter);
+      const waiter: TurnStartWaiter = {
+        resolve: (turnId) => {
+          if (accepts(turnId)) settle(() => resolve(turnId));
+        },
+        reject: (error) => settle(() => reject(error)),
+      };
+      timeout = setTimeout(() => waiter.reject(new Error(timeoutMessage)), timeoutMs);
+      session.turnStartWaiters.add(waiter);
     });
+  }
+
+  #cancelTurnStartWaiters(session: RunningCodexSession, message: string): void {
+    const error = new TurnStartWaitCancelledError(message);
+    for (const waiter of [...session.turnStartWaiters]) waiter.reject(error);
   }
 
   #cancelPendingApprovals(chatId: string, reason: 'cancelled' | 'session-complete' | 'aborted'): void {
@@ -1126,6 +1402,26 @@ function isNoActiveTurnError(error: unknown): boolean {
   return /no active turn|expected turn.*(?:not active|mismatch|active turn)|active turn.*not found/i.test(message);
 }
 
+function isActiveTurnNotSteerableError(error: unknown): boolean {
+  if (error instanceof CodexAppServerRpcError) {
+    const data = error.data && typeof error.data === 'object'
+      ? error.data as Record<string, unknown>
+      : null;
+    const codexErrorInfo = data?.codexErrorInfo;
+    if (codexErrorInfo && typeof codexErrorInfo === 'object' && 'activeTurnNotSteerable' in codexErrorInfo) {
+      return true;
+    }
+  }
+  const message = String((error as Error)?.message || error || '');
+  return /cannot steer (?:a )?(?:review|compact) turn/i.test(message);
+}
+
+function actualTurnIdFromSteerMismatch(error: unknown): string | null {
+  const message = String((error as Error)?.message || error || '');
+  const match = /^expected active turn id `[^`]+` but found `([^`]+)`$/.exec(message);
+  return match?.[1] ?? null;
+}
+
 function isActiveTurnConflictError(error: unknown): boolean {
   const message = String((error as Error)?.message || error || '');
   return /turn already active|active turn.*(?:exists|in progress)|cannot start.*active turn/i.test(message);
@@ -1139,6 +1435,19 @@ function mergeFinishOptions(
     failedMessage: next.failedMessage ?? current?.failedMessage,
     aborted: Boolean(next.aborted || current?.aborted),
   };
+}
+
+function hasTerminalPendingFinish(session: RunningCodexSession): boolean {
+  return Boolean(session.pendingFinish?.failedMessage || session.pendingFinish?.aborted);
+}
+
+function isTerminalSessionStatus(status: RunningStatus): boolean {
+  return status === 'completed' || status === 'failed' || status === 'aborted';
+}
+
+function hasActiveGoalContinuation(session: RunningCodexSession): boolean {
+  return session.managesGoalLifecycle
+    && Boolean(session.activeTurnId || session.goal?.status === 'active');
 }
 
 function delay(ms: number): Promise<void> {

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -102,6 +102,7 @@ export class AgentRuntimeRouter {
     clientMessageId?: string;
     turnId?: string;
     codexGoalCommand?: CodexGoalCommand;
+    codexSeedContext?: string;
     // Skips @-mention resolution when the command is already resolved (e.g. a
     // seeded cross-agent continuation, whose historical text must stay opaque).
     skipFileMentions?: boolean;
@@ -138,6 +139,7 @@ export class AgentRuntimeRouter {
       command: resolvedCommand,
       codexGoalCommand: opts.codexGoalCommand
         ?? withResolvedGoalObjective(prepared.codexGoalCommand, resolvedCommand),
+      codexSeedContext: opts.codexSeedContext,
       projectPath: entry.projectPath,
       model: selection.model,
       permissionMode: entry.permissionMode,
@@ -197,7 +199,11 @@ export class AgentRuntimeRouter {
         // transcript text and must stay opaque so it cannot re-inject file
         // contents into the fresh session.
         const resolvedCommand = await resolveFileMentionsInCommand(prepared.command, rawEntry.projectPath);
-        const seededCommand = `${rawEntry.carryOverContext}\n\n${resolvedCommand}`;
+        const codexGoalCommand = withResolvedGoalObjective(prepared.codexGoalCommand, resolvedCommand);
+        const injectCodexSeed = agentId === 'codex' && Boolean(codexGoalCommand);
+        const seededCommand = injectCodexSeed
+          ? resolvedCommand
+          : `${rawEntry.carryOverContext}\n\n${resolvedCommand}`;
         await this.startSession(chatId, seededCommand, {
           images: opts.images,
           model: opts.model,
@@ -208,7 +214,8 @@ export class AgentRuntimeRouter {
           clientRequestId: opts.clientRequestId,
           clientMessageId: opts.clientMessageId,
           turnId: opts.turnId,
-          codexGoalCommand: withResolvedGoalObjective(prepared.codexGoalCommand, resolvedCommand),
+          codexGoalCommand,
+          codexSeedContext: injectCodexSeed ? rawEntry.carryOverContext : undefined,
           skipFileMentions: true,
         });
         await this.#registry.updateChat(chatId, { carryOverContext: null }, { flush: true });

--- a/server/agents/session-types.ts
+++ b/server/agents/session-types.ts
@@ -82,6 +82,7 @@ export class UnsupportedAgentSettingError extends Error {
 export interface StartSessionRequest extends AgentExecutionConfig {
   command: string;
   codexGoalCommand?: CodexGoalCommand;
+  codexSeedContext?: string;
   images?: AgentCommandImage[];
   envOverrides?: Record<string, string>;
   codexConfig?: CodexProviderConfig;

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -9,6 +9,11 @@ import { CommandLedger } from '../command-ledger.ts';
 import { UserMessage } from '../../../common/chat-types.js';
 import { attachNativeMessageSource } from '../../agents/shared/native-message-source.js';
 import { ChatIdAllocator } from '../../chats/chat-id-allocator.js';
+import {
+  ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+  ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+  ActiveInputDeliveryError,
+} from '../../lib/domain-error.js';
 
 let workspaceDir;
 let projectBaseDir;
@@ -656,14 +661,14 @@ describe('ChatCommandService', () => {
     expect(records.at(-1)?.status).toBe('finished');
   });
 
-  it('marks active delivery failures retryable without poisoning the request id', async () => {
+  it('reopens pre-accept active delivery failures for the same request id', async () => {
     let attempts = 0;
     const { service, queue } = makeService({
       queue: {
         readChatQueue: mock(() => Promise.resolve({ entries: [], paused: false, version: 0 })),
         enqueueChat: mock(async () => {
           attempts += 1;
-          if (attempts === 1) throw new Error('live steer failed');
+          if (attempts === 1) throw new ActiveInputDeliveryError(new Error('live registration failed'), false);
           return {
             entry: { id: 'queued-retry' },
             queue: {
@@ -677,7 +682,12 @@ describe('ChatCommandService', () => {
     });
 
     const input = { chatId: SOURCE_CHAT_ID, content: 'retry me', clientRequestId: 'request-retry' };
-    await expect(service.submitQueueEnqueue(input)).rejects.toThrow('live steer failed');
+    await expect(service.submitQueueEnqueue(input)).rejects.toMatchObject({
+      message: ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+      cause: expect.objectContaining({ message: 'live registration failed' }),
+      deliveryAccepted: false,
+      retryable: true,
+    });
     let records = await readLedgerRecords();
     expect(records.at(-1)).toEqual(expect.objectContaining({
       status: 'failed',
@@ -749,6 +759,43 @@ describe('ChatCommandService', () => {
     expect(outcome).toEqual({ type: 'skipped-busy', chatId: SOURCE_CHAT_ID });
     expect(queue.enqueueChat).not.toHaveBeenCalled();
     expect(queue.registerPendingUserInput).not.toHaveBeenCalled();
+  });
+
+  it('does not replay post-accept active delivery failures for the same request id', async () => {
+    const { service, queue } = makeService({
+      queue: {
+        readChatQueue: mock(() => Promise.resolve({ entries: [], paused: false, version: 0 })),
+        enqueueChat: mock(async () => {
+          throw new ActiveInputDeliveryError(new Error('live steer failed after acceptance'), true);
+        }),
+      },
+    });
+    const input = {
+      chatId: SOURCE_CHAT_ID,
+      content: 'deliver once',
+      clientRequestId: 'request-accepted',
+    };
+
+    await expect(service.submitQueueEnqueue(input)).rejects.toMatchObject({
+      message: ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+      cause: expect.objectContaining({ message: 'live steer failed after acceptance' }),
+      deliveryAccepted: true,
+      retryable: false,
+    });
+    let records = await readLedgerRecords();
+    expect(records.at(-1)).toEqual(expect.objectContaining({
+      status: 'failed',
+      error: ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+    }));
+    expect(records.at(-1)?.errorCode).toBeUndefined();
+
+    await expect(service.submitQueueEnqueue(input)).resolves.toEqual(expect.objectContaining({
+      status: 'duplicate',
+      clientRequestId: 'request-accepted',
+    }));
+    records = await readLedgerRecords();
+    expect(records.at(-1)?.status).toBe('failed');
+    expect(queue.enqueueChat).toHaveBeenCalledTimes(1);
   });
 
   it('strips internal sending entries from mutate (dequeue) responses', async () => {

--- a/server/commands/chat-command-service.ts
+++ b/server/commands/chat-command-service.ts
@@ -42,6 +42,7 @@ import { getNativeMessageSource } from '../agents/shared/native-message-source.j
 import { createLogger } from '../lib/log.js';
 import { AttachmentValidationError, validateCommandAttachments } from '../attachments/validation.js';
 import type { ChatIdAllocator } from '../chats/chat-id-allocator.js';
+import { ActiveInputDeliveryError } from '../lib/domain-error.js';
 
 const logger = createLogger('commands:chat-command-service');
 
@@ -636,10 +637,11 @@ export class ChatCommandService {
         activeInputPolicy,
       });
     } catch (error) {
+      const deliveryAccepted = error instanceof ActiveInputDeliveryError && error.deliveryAccepted;
       await this.deps.ledger.update(ledger.record.key, {
         status: 'failed',
         error: error instanceof Error ? error.message : String(error),
-        errorCode: PRE_SCHEDULE_FAILURE_ERROR_CODE,
+        errorCode: deliveryAccepted ? undefined : PRE_SCHEDULE_FAILURE_ERROR_CODE,
       });
       throw error;
     }

--- a/server/lib/__tests__/http-error.test.js
+++ b/server/lib/__tests__/http-error.test.js
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
 import { jsonError, jsonErrorFromUnknown } from '../http-error.ts';
+import {
+  ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+  ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+  ActiveInputDeliveryError,
+} from '../domain-error.ts';
 
 describe('jsonError', () => {
   it('emits the shared HTTP error envelope', async () => {
@@ -41,5 +46,36 @@ describe('jsonErrorFromUnknown', () => {
     expect(response.status).toBe(400);
     expect(body.error).toBe('name is required');
     expect(body.errorCode).toBe('VALIDATION_FAILED');
+  });
+
+  it('sanitizes active-input delivery errors while preserving retry safety', async () => {
+    const preAcceptCause = new Error('/secret/workspace/chat.jsonl could not be appended');
+    const postAcceptCause = new Error('Codex RPC turn/steer rejected internal request 987');
+    const preAcceptError = new ActiveInputDeliveryError(preAcceptCause, false);
+    const postAcceptError = new ActiveInputDeliveryError(postAcceptCause, true);
+
+    const [preAcceptResponse, postAcceptResponse] = [
+      jsonErrorFromUnknown(preAcceptError),
+      jsonErrorFromUnknown(postAcceptError),
+    ];
+    const [preAcceptBody, postAcceptBody] = await Promise.all([
+      preAcceptResponse.json(),
+      postAcceptResponse.json(),
+    ]);
+
+    expect(preAcceptError.cause).toBe(preAcceptCause);
+    expect(postAcceptError.cause).toBe(postAcceptCause);
+    expect(preAcceptBody).toMatchObject({
+      error: ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+      errorCode: 'INTERNAL_ERROR',
+      retryable: true,
+    });
+    expect(postAcceptBody).toMatchObject({
+      error: ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+      errorCode: 'INTERNAL_ERROR',
+      retryable: false,
+    });
+    expect(JSON.stringify([preAcceptBody, postAcceptBody])).not.toContain('/secret/workspace');
+    expect(JSON.stringify([preAcceptBody, postAcceptBody])).not.toContain('turn/steer');
   });
 });

--- a/server/lib/domain-error.ts
+++ b/server/lib/domain-error.ts
@@ -3,8 +3,8 @@ export class DomainError extends Error {
   readonly status: number;
   readonly retryable: boolean;
 
-  constructor(code: string, message: string, status = 400, retryable = false) {
-    super(message);
+  constructor(code: string, message: string, status = 400, retryable = false, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'DomainError';
     this.code = code;
     this.status = status;
@@ -16,6 +16,26 @@ export class ValidationDomainError extends DomainError {
   constructor(message: string) {
     super('VALIDATION_FAILED', message, 400);
     this.name = 'ValidationDomainError';
+  }
+}
+
+export const ACTIVE_INPUT_NOT_DELIVERED_MESSAGE = 'Active input was not delivered. Retry the request.';
+export const ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE =
+  'Active input delivery could not be confirmed after acceptance. Check the chat before sending it again.';
+
+export class ActiveInputDeliveryError extends DomainError {
+  readonly deliveryAccepted: boolean;
+
+  constructor(error: unknown, deliveryAccepted: boolean) {
+    super(
+      'INTERNAL_ERROR',
+      deliveryAccepted ? ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE : ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+      500,
+      !deliveryAccepted,
+      { cause: error },
+    );
+    this.name = 'ActiveInputDeliveryError';
+    this.deliveryAccepted = deliveryAccepted;
   }
 }
 

--- a/server/queue.ts
+++ b/server/queue.ts
@@ -15,6 +15,7 @@ import type { IChatRegistry } from './chats/store.js';
 import { writeJsonFileAtomic } from './lib/json-file-store.js';
 import { KeyedPromiseLock } from './lib/keyed-lock.js';
 import { createLogger } from './lib/log.js';
+import { ActiveInputDeliveryError } from './lib/domain-error.js';
 
 const logger = createLogger('queue');
 
@@ -258,18 +259,30 @@ export class QueueManager extends EventEmitter implements ChatQueueService {
     options: EnqueueChatOptions = {},
   ): Promise<{ entry: QueueEntry; queue: QueueState; handledActive?: boolean }> {
     const { activeInputPolicy = 'allow-active-input', ...turnOptions } = options;
-    if (
-      activeInputPolicy === 'allow-active-input'
+    return this.#withLock(
+      `enqueue:${chatId}`,
+      () => this.#enqueueChatLocked(chatId, content, turnOptions, activeInputPolicy),
+    );
+  }
+
+  async #enqueueChatLocked(
+    chatId: string,
+    content: string,
+    options: RunAgentTurnOptions,
+    activeInputPolicy: ActiveInputPolicy,
+  ): Promise<{ entry: QueueEntry; queue: QueueState; handledActive?: boolean }> {
+    const supportsActiveInput = activeInputPolicy === 'allow-active-input'
       && this.#turnRunner.isChatRunning(chatId)
-      && this.#turnRunner.submitActiveInput
-    ) {
+      && typeof this.#turnRunner.submitActiveInput === 'function';
+    const currentQueue = supportsActiveInput ? await this.readChatQueue(chatId) : null;
+    if (supportsActiveInput && currentQueue?.entries.length === 0) {
       const activeOptions = ensureTurnIdentifiers({
         ...this.#getDrainOptions(chatId),
-        ...turnOptions,
+        ...options,
       });
       let accepted = false;
       try {
-        const handled = await this.#turnRunner.submitActiveInput(
+        const handled = await this.#turnRunner.submitActiveInput!(
           chatId,
           content,
           activeOptions,
@@ -295,7 +308,7 @@ export class QueueManager extends EventEmitter implements ChatQueueService {
         }
       } catch (error) {
         if (accepted) this.#pendingInputs.markFailed(chatId, activeOptions.clientRequestId!);
-        throw error;
+        throw new ActiveInputDeliveryError(error, accepted);
       }
     }
     return this.#withLock(`chat:${chatId}`, async () => {

--- a/server/queue/__tests__/queue.test.js
+++ b/server/queue/__tests__/queue.test.js
@@ -4,6 +4,10 @@ import os from 'os';
 import { promises as fs } from 'fs';
 import { randomUUID } from 'crypto';
 import { QueueManager } from '../../queue.js';
+import {
+  ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+  ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+} from '../../lib/domain-error.js';
 
 let workspaceDir = '';
 let queue;
@@ -409,6 +413,19 @@ describe('orchestration', () => {
       }), expect.any(Function));
     });
 
+    it('preserves the active-input runner receiver', async () => {
+      mockAgents.isChatRunning.mockReturnValue(true);
+      mockAgents.submitActiveInput = mock(async function (_chatId, _content, _options, beforeDelivery) {
+        expect(this).toBe(mockAgents);
+        await beforeDelivery();
+        return true;
+      });
+
+      await expect(orchQueue.enqueueChat('c1', 'receiver-safe')).resolves.toMatchObject({
+        handledActive: true,
+      });
+    });
+
     it('persists input for running agents without active-input support', async () => {
       mockAgents.isChatRunning.mockReturnValue(true);
 
@@ -432,6 +449,65 @@ describe('orchestration', () => {
       expect(mockPendingInputs.markFailed).not.toHaveBeenCalled();
     });
 
+    it('persists behind an older queued entry instead of overtaking it live', async () => {
+      await orchQueue.enqueueChat('c1', 'older queued input');
+      mockAgents.isChatRunning.mockReturnValue(true);
+      mockAgents.submitActiveInput = mock(async () => true);
+
+      const result = await orchQueue.enqueueChat('c1', 'newer input');
+
+      expect(mockAgents.submitActiveInput).not.toHaveBeenCalled();
+      expect(result.handledActive).toBeUndefined();
+      expect(result.queue.entries).toHaveLength(1);
+      expect(result.queue.entries[0]).toMatchObject({
+        status: 'queued',
+        content: 'older queued input\nnewer input',
+      });
+    });
+
+    it('persists behind an older sending entry instead of overtaking it live', async () => {
+      const older = await orchQueue.enqueueChat('c1', 'older sending input');
+      await orchQueue.popNextChat('c1');
+      mockAgents.isChatRunning.mockReturnValue(true);
+      mockAgents.submitActiveInput = mock(async () => true);
+
+      const result = await orchQueue.enqueueChat('c1', 'newer input');
+
+      expect(mockAgents.submitActiveInput).not.toHaveBeenCalled();
+      expect(result.handledActive).toBeUndefined();
+      expect(result.queue.entries).toEqual([
+        expect.objectContaining({ id: older.entry.id, status: 'sending', content: 'older sending input' }),
+        expect.objectContaining({ status: 'queued', content: 'newer input' }),
+      ]);
+    });
+
+    it('serializes concurrent active-delivery fallback before later enqueue arbitration', async () => {
+      let enteredFirst;
+      let releaseFirst;
+      const firstEntered = new Promise((resolve) => { enteredFirst = resolve; });
+      const firstReleased = new Promise((resolve) => { releaseFirst = resolve; });
+      mockAgents.isChatRunning.mockReturnValue(true);
+      mockAgents.submitActiveInput = mock(async () => {
+        enteredFirst();
+        await firstReleased;
+        return false;
+      });
+
+      const older = orchQueue.enqueueChat('c1', 'older input');
+      await firstEntered;
+      const newer = orchQueue.enqueueChat('c1', 'newer input');
+      await Promise.resolve();
+
+      expect(mockAgents.submitActiveInput).toHaveBeenCalledTimes(1);
+      releaseFirst();
+      await Promise.all([older, newer]);
+
+      expect(mockAgents.submitActiveInput).toHaveBeenCalledTimes(1);
+      expect((await orchQueue.readChatQueue('c1')).entries).toEqual([
+        expect.objectContaining({ status: 'queued', content: 'older input\nnewer input' }),
+      ]);
+    });
+
     it('marks accepted input failed when live delivery throws', async () => {
       mockAgents.isChatRunning.mockReturnValue(true);
       mockAgents.submitActiveInput = mock(async (_chatId, _content, _options, beforeDelivery) => {
@@ -441,7 +517,12 @@ describe('orchestration', () => {
 
       await expect(orchQueue.enqueueChat('c1', 'accepted then failed', {
         clientRequestId: 'request-failed',
-      })).rejects.toThrow('steer failed');
+      })).rejects.toMatchObject({
+        message: ACTIVE_INPUT_OUTCOME_UNKNOWN_MESSAGE,
+        cause: expect.objectContaining({ message: 'steer failed' }),
+        deliveryAccepted: true,
+        retryable: false,
+      });
 
       expect(mockPendingInputs.register).toHaveBeenCalledTimes(1);
       expect(mockPendingInputs.markFailed).toHaveBeenCalledWith('c1', 'request-failed');
@@ -461,7 +542,12 @@ describe('orchestration', () => {
 
       await expect(orchQueue.enqueueChat('c1', 'must not deliver', {
         clientRequestId: 'request-append-failed',
-      })).rejects.toThrow('chat append failed');
+      })).rejects.toMatchObject({
+        message: ACTIVE_INPUT_NOT_DELIVERED_MESSAGE,
+        cause: expect.objectContaining({ message: 'chat append failed' }),
+        deliveryAccepted: false,
+        retryable: true,
+      });
 
       expect(delivered).toBe(false);
       expect(mockPendingInputs.discard).toHaveBeenCalledWith('c1', 'request-append-failed');

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -27,7 +27,7 @@ import { CHAT_MESSAGES_MAX_LIMIT, parsePagination } from '../lib/pagination.js';
 import { assertRealWithinProjectBase, isProjectBoundaryError } from '../lib/path-boundary.js';
 import { extractFirstLine } from '../lib/text.js';
 import { jsonError, jsonErrorFromUnknown } from '../lib/http-error.js';
-import { ValidationDomainError } from '../lib/domain-error.js';
+import { ActiveInputDeliveryError, ValidationDomainError } from '../lib/domain-error.js';
 import type { ReorderResult } from '../settings/types.js';
 import type { RouteMap } from '../lib/http-route-types.js';
 import {
@@ -756,6 +756,9 @@ export default function createChatRoutes({
     } catch (error: unknown) {
       if (error instanceof CommandValidationError) {
         return jsonError(error.message, error.status, error.code, error.retryable);
+      }
+      if (error instanceof ActiveInputDeliveryError) {
+        logger.error('queue: active input delivery failed:', error.cause);
       }
       return jsonErrorFromUnknown(error);
     }


### PR DESCRIPTION
## Summary

- preserve seeded goal context and canonical stale-turn handling across continuation and rollover
- make pause, clear, edit, replace, resume, and queued steering transactional and retry-safe
- cancel goal waiters at lifecycle boundaries and prevent accepted input from being overtaken or replayed
- sanitize active-delivery failures at the HTTP boundary while retaining internal diagnostics

## Validation

- full server test suite
- 190 web test files / 1,761 tests
- bun run check
- executable build and startup smoke
- focused final regression set: 92 tests
- git diff --check

Follow-up to #267, which was merged while the review fixes were being finalized.