### PR TITLE
Add provider-agnostic ExecToolUseMessage and exec tool visualization

### DIFF
--- a/common/chat-types.ts
+++ b/common/chat-types.ts
@@ -77,6 +77,17 @@ export class BashToolUseMessage {
   ) {}
 }
 
+export class ExecToolUseMessage {
+  readonly type = 'exec-tool-use' as const;
+
+  constructor(
+    public timestamp: string,
+    public toolId: string,
+    public code: string,
+    public language: string,
+  ) {}
+}
+
 export class ReadToolUseMessage {
   readonly type = 'read-tool-use' as const;
 
@@ -594,6 +605,7 @@ export class AgentSwitchMessage {
 // Union of all explicit tool-use message classes.
 export type ToolUseChatMessage =
   | BashToolUseMessage
+  | ExecToolUseMessage
   | ReadToolUseMessage
   | ListToolUseMessage
   | EditToolUseMessage
@@ -889,6 +901,15 @@ const TOOL_USE_MESSAGE_PARSERS = {
     return new BashToolUseMessage(
       str(data.timestamp), str(data.toolId),
       command, asOptionalString(data.description));
+  },
+
+  'exec-tool-use': (data) => {
+    const code = asOptionalString(data.code);
+    const language = asOptionalString(data.language);
+    if (code === undefined || language === undefined) return null;
+    return new ExecToolUseMessage(
+      str(data.timestamp), str(data.toolId),
+      code, language);
   },
 
   'read-tool-use': (data) => {

--- a/server/agents/codex/__tests__/history-loader.test.js
+++ b/server/agents/codex/__tests__/history-loader.test.js
@@ -17,6 +17,45 @@ async function withTempJsonl(lines, fn) {
 }
 
 describe('loadCodexChatMessages', () => {
+	it('loads Exec calls and paired outputs from native history', async () => {
+	  const code = '// @exec: {"yield_time_ms": 1000}\ntext("ok")';
+	  const lines = [
+	    JSON.stringify({
+	      type: 'response_item',
+	      timestamp: '2026-07-10T21:34:09.149Z',
+	      payload: {
+	        type: 'custom_tool_call',
+	        name: 'exec',
+	        call_id: 'call_exec',
+	        input: code,
+	      },
+	    }),
+	    JSON.stringify({
+	      type: 'response_item',
+	      timestamp: '2026-07-10T21:34:09.150Z',
+	      payload: {
+	        type: 'custom_tool_call_output',
+	        call_id: 'call_exec',
+	        output: 'Script completed',
+	      },
+	    }),
+	  ];
+
+	  const messages = await withTempJsonl(lines, (filePath) => loadCodexChatMessages(filePath));
+
+	  expect(messages.map((message) => message.type)).toEqual(['exec-tool-use', 'tool-result']);
+	  expect(messages[0]).toMatchObject({
+	    toolId: 'call_exec',
+	    code,
+	    language: 'javascript',
+	  });
+	  expect(messages[1]).toMatchObject({
+	    toolId: 'call_exec',
+	    content: { raw: 'Script completed' },
+	    isError: false,
+	  });
+	});
+
   it('loads only the first value from a concatenated physical line', async () => {
     const first = {
       type: 'event_msg',

--- a/server/agents/codex/__tests__/history-normalizer.test.js
+++ b/server/agents/codex/__tests__/history-normalizer.test.js
@@ -4,7 +4,7 @@ import {
   extractTextContent,
   parseApplyPatch,
 } from '../history-normalizer.js';
-import { BashToolUseMessage, EditToolUseMessage, UnknownToolUseMessage } from '../../../../common/chat-types.js';
+import { BashToolUseMessage, EditToolUseMessage, ExecToolUseMessage, ToolResultMessage, UnknownToolUseMessage } from '../../../../common/chat-types.js';
 
 describe('extractTextContent', () => {
   it('returns string content directly', () => {
@@ -370,6 +370,42 @@ describe('normalizeCodexJsonlEntry', () => {
   });
 
   describe('response_item custom_tool_call', () => {
+	  it('pairs Exec input and output through the shared tool contracts', () => {
+	    const code = '// @exec: {"yield_time_ms": 1000}\ntext("ok")';
+	    const input = normalizeCodexJsonlEntry({
+	      type: 'response_item',
+	      timestamp: ts,
+	      payload: {
+	        type: 'custom_tool_call',
+	        name: 'exec',
+	        call_id: 'call_exec',
+	        input: code,
+	      },
+	    });
+	    const output = normalizeCodexJsonlEntry({
+	      type: 'response_item',
+	      timestamp: ts,
+	      payload: {
+	        type: 'custom_tool_call_output',
+	        call_id: 'call_exec',
+	        output: [{ type: 'input_text', text: 'ok' }],
+	      },
+	    });
+
+	    expect(input.canonical[0]).toBeInstanceOf(ExecToolUseMessage);
+	    expect(input.canonical[0]).toMatchObject({
+	      toolId: 'call_exec',
+	      code,
+	      language: 'javascript',
+	    });
+	    expect(output.canonical[0]).toBeInstanceOf(ToolResultMessage);
+	    expect(output.canonical[0]).toMatchObject({
+	      toolId: 'call_exec',
+	      content: { items: [{ type: 'input_text', text: 'ok' }] },
+	      isError: false,
+	    });
+	  });
+
     it('normalizes apply_patch to EditToolUseMessage with parsed diff', () => {
       const patchInput = [
         '*** Begin Patch',

--- a/server/agents/codex/__tests__/jsonl-tool-use-converter.test.js
+++ b/server/agents/codex/__tests__/jsonl-tool-use-converter.test.js
@@ -4,6 +4,7 @@ import {
   BashToolUseMessage,
   CodexSubagentToolUseMessage,
   EditToolUseMessage,
+  ExecToolUseMessage,
   WriteStdinToolUseMessage,
   UpdatePlanToolUseMessage,
   UnknownToolUseMessage,
@@ -178,6 +179,35 @@ describe('convertCodexCustomToolCall', () => {
     expect(msg.filePath).toBe('/project/file.js');
     expect(msg.oldString).toBe('old line');
     expect(msg.newString).toBe('new line');
+  });
+
+  it('maps exec source to provider-agnostic ExecToolUseMessage', () => {
+    const code = '// @exec: {"yield_time_ms": 1000}\nconst value = 1; text(value);';
+    const msg = convertCodexCustomToolCall(TS, {
+      name: 'exec',
+      input: code,
+      call_id: 'call-exec',
+    }, mockParseApplyPatch);
+
+    expect(msg).toBeInstanceOf(ExecToolUseMessage);
+    expect(msg).toEqual({
+      type: 'exec-tool-use',
+      timestamp: TS,
+      toolId: 'call-exec',
+      code,
+      language: 'javascript',
+    });
+  });
+
+  it('preserves malformed exec input through the unknown fallback', () => {
+    const msg = convertCodexCustomToolCall(TS, {
+      name: 'exec',
+      input: { code: 'text("ok")' },
+      call_id: 'call-exec-invalid',
+    }, mockParseApplyPatch);
+
+    expect(msg).toBeInstanceOf(UnknownToolUseMessage);
+    expect(msg.rawName).toBe('exec');
   });
 
   it('passes through non-apply_patch custom tools as Unknown', () => {

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -3,10 +3,10 @@ import { EventEmitter } from 'events';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { CodexSubagentToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage } from '../../../../../common/chat-types.js';
+import { CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage } from '../../../../../common/chat-types.js';
 import { buildApprovalResponse, createPendingApproval } from '../approvals.ts';
 import { CodexAppServerClient } from '../client.ts';
-import { convertCodexAppServerItem, convertCodexAppServerLiveItem } from '../converter.ts';
+import { convertCodexAppServerItem, convertCodexAppServerLiveItem, convertCodexRawExecItem } from '../converter.ts';
 import { waitForMaterializedThread } from '../durability.ts';
 import { CodexAppServerRuntime } from '../runtime.ts';
 import { QueueManager } from '../../../../queue.ts';
@@ -453,6 +453,88 @@ describe('Codex app-server durability', () => {
 });
 
 describe('Codex app-server converter', () => {
+  it('normalizes only tracked raw Exec calls and outputs', () => {
+    const activeExecCallIds = new Set();
+    const code = '// @exec: {"yield_time_ms": 1000}\ntext("ok")';
+
+    expect(convertCodexRawExecItem({
+      type: 'custom_tool_call',
+      name: 'other',
+      call_id: 'call-other',
+      input: code,
+    }, '2026-07-10T21:34:09.149Z', activeExecCallIds)).toEqual([]);
+    expect(convertCodexRawExecItem({
+      type: 'custom_tool_call_output',
+      call_id: 'call-other',
+      output: 'ignored',
+    }, '2026-07-10T21:34:09.149Z', activeExecCallIds)).toEqual([]);
+
+    const input = convertCodexRawExecItem({
+      type: 'custom_tool_call',
+      name: 'exec',
+      call_id: 'call-exec',
+      input: code,
+    }, '2026-07-10T21:34:09.149Z', activeExecCallIds);
+    expect(input).toHaveLength(1);
+    expect(input[0]).toBeInstanceOf(ExecToolUseMessage);
+    expect(input[0]).toMatchObject({
+      toolId: 'call-exec',
+      code,
+      language: 'javascript',
+    });
+    expect(activeExecCallIds.has('call-exec')).toBe(true);
+
+    expect(convertCodexRawExecItem({
+      type: 'custom_tool_call',
+      name: 'exec',
+      call_id: 'call-exec',
+      input: code,
+    }, '2026-07-10T21:34:09.149Z', activeExecCallIds)).toEqual([]);
+
+    const output = convertCodexRawExecItem({
+      type: 'custom_tool_call_output',
+      call_id: 'call-exec',
+      output: [{ type: 'input_text', text: 'ok' }],
+    }, '2026-07-10T21:34:09.150Z', activeExecCallIds);
+    expect(output).toHaveLength(1);
+    expect(output[0]).toBeInstanceOf(ToolResultMessage);
+    expect(output[0]).toMatchObject({
+      toolId: 'call-exec',
+      content: { items: [{ type: 'input_text', text: 'ok' }] },
+      isError: false,
+    });
+    expect(activeExecCallIds.has('call-exec')).toBe(false);
+    expect(convertCodexRawExecItem({
+      type: 'custom_tool_call_output',
+      call_id: 'call-exec',
+      output: 'duplicate',
+    }, '2026-07-10T21:34:09.151Z', activeExecCallIds)).toEqual([]);
+
+    convertCodexRawExecItem({
+      type: 'custom_tool_call',
+      name: 'exec',
+      call_id: 'call-exec-string',
+      input: 'text("done")',
+    }, '2026-07-10T21:34:09.152Z', activeExecCallIds);
+    expect(convertCodexRawExecItem({
+      type: 'custom_tool_call_output',
+      call_id: 'call-exec-string',
+      output: 'Script completed',
+    }, '2026-07-10T21:34:09.153Z', activeExecCallIds)[0]).toMatchObject({
+      content: { raw: 'Script completed' },
+    });
+  });
+
+  it('ignores malformed raw Exec calls', () => {
+    const activeExecCallIds = new Set();
+    expect(convertCodexRawExecItem({
+      type: 'custom_tool_call',
+      name: 'exec',
+      call_id: 'call-exec',
+    }, '2026-07-10T21:34:09.149Z', activeExecCallIds)).toEqual([]);
+    expect(activeExecCallIds.size).toBe(0);
+  });
+
   it('converts app-server live item families to shared chat messages', () => {
     const items = [
       { type: 'userMessage', id: 'u1', content: [{ type: 'text', text: 'Hi', text_elements: [] }] },
@@ -706,6 +788,136 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.startThread).toHaveBeenCalledTimes(1);
     expect(fake.startTurn).toHaveBeenCalledTimes(1);
     expect(provider.isRunning('thread-1')).toBe(true);
+  });
+
+  it('streams raw Exec calls and their paired outputs through the shared contract', async () => {
+    const nativePath = path.join(tmpDir, 'live-exec-thread.jsonl');
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ id: 'thread-1', path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    await provider.startSession(makeRequest());
+
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call-exec-1',
+          input: 'const value = 1; text(value);',
+        },
+      },
+    });
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call-unrelated',
+          output: 'ignored',
+        },
+      },
+    });
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call-exec-1',
+          output: [{ type: 'input_text', text: '1' }],
+        },
+      },
+    });
+
+    expect(emitted.map((message) => message.type)).toEqual(['exec-tool-use', 'tool-result']);
+    expect(emitted[0]).toMatchObject({
+      toolId: 'call-exec-1',
+      code: 'const value = 1; text(value);',
+      language: 'javascript',
+    });
+    expect(emitted[1]).toMatchObject({
+      toolId: 'call-exec-1',
+      content: { items: [{ type: 'input_text', text: '1' }] },
+      isError: false,
+    });
+  });
+
+  it('clears unmatched raw Exec calls at an automatic goal turn boundary', async () => {
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Keep the session active' },
+      nativePath: null,
+    }));
+
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'goal-turn',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call-stale',
+          input: 'text("waiting")',
+        },
+      },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn' }) },
+    });
+    expect(provider.isRunning('thread-1')).toBe(true);
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'goal-turn',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call-stale',
+          output: 'late output',
+        },
+      },
+    });
+
+    expect(emitted.map((message) => message.type)).toEqual(['exec-tool-use']);
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'goal-turn',
+        goal: makeGoal('thread-1', 'Keep the session active', 'complete'),
+      },
+    });
+    await finished;
   });
 
   it('sets a new native goal and waits for its automatic turn without starting a user turn', async () => {

--- a/server/agents/codex/app-server/converter.ts
+++ b/server/agents/codex/app-server/converter.ts
@@ -4,6 +4,7 @@ import {
   CompactionMessage,
   EditToolUseMessage,
   ErrorMessage,
+  ExecToolUseMessage,
   ExternalToolUseMessage,
   GlobToolUseMessage,
   GrepToolUseMessage,
@@ -25,7 +26,7 @@ import {
 import { stripResolvedFileMentionContext } from "../../shared/file-mention-context.js";
 import { normalizeTodoItems, normalizeToolInput, normalizeToolResultContent } from "../../shared/normalize-util.js";
 import { convertCodexSubagentToolUse } from '../subagent-tool-use.js';
-import type { CodexThreadItem, CodexUserInput, CodexWebSearchAction } from './protocol.js';
+import type { CodexRawResponseItem, CodexThreadItem, CodexUserInput, CodexWebSearchAction } from './protocol.js';
 
 export interface ConvertCodexAppServerItemOptions {
   includeUserMessages?: boolean;
@@ -85,6 +86,40 @@ export function convertCodexAppServerItem(
     default:
       return [];
   }
+}
+
+export function convertCodexRawExecItem(
+  item: CodexRawResponseItem,
+  timestamp: string,
+  activeExecCallIds: Set<string>,
+): ChatMessage[] {
+  if (
+    item.type === 'custom_tool_call'
+    && item.name === 'exec'
+    && typeof item.call_id === 'string'
+    && typeof item.input === 'string'
+  ) {
+    if (activeExecCallIds.has(item.call_id)) return [];
+    activeExecCallIds.add(item.call_id);
+    return [new ExecToolUseMessage(timestamp, item.call_id, item.input, 'javascript')];
+  }
+
+  if (
+    item.type === 'custom_tool_call_output'
+    && typeof item.call_id === 'string'
+    && activeExecCallIds.delete(item.call_id)
+  ) {
+    return [
+      new ToolResultMessage(
+        timestamp,
+        item.call_id,
+        normalizeToolResultContent(item.output),
+        false,
+      ),
+    ];
+  }
+
+  return [];
 }
 
 function convertCommandExecution(item: Extract<CodexThreadItem, { type: 'commandExecution' }>, timestamp: string): ChatMessage[] {

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -206,6 +206,20 @@ export interface ItemCompletedNotification {
   item: CodexThreadItem;
 }
 
+export interface CodexRawResponseItem {
+  type: string;
+  call_id?: string;
+  name?: string;
+  input?: string;
+  output?: unknown;
+}
+
+export interface RawResponseItemCompletedNotification {
+  threadId: string;
+  turnId: string;
+  item: CodexRawResponseItem;
+}
+
 export interface ErrorNotification {
   threadId?: string;
   turnId?: string;

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -6,7 +6,7 @@ import type { AgentChatEntry, AgentSessionSettingsPatch, PermissionMode, ResumeT
 import type { AgentTranscriptPage } from '../../types.js';
 import { buildApprovalMessage, buildApprovalResponse, createPendingApproval, isApprovalRequest, type CodexPendingApproval } from './approvals.js';
 import { CodexAppServerClient, CodexAppServerRpcError, type CodexAppServerClientOptions, type CodexAppServerMetric } from './client.js';
-import { convertCodexAppServerLiveItem } from './converter.js';
+import { convertCodexAppServerLiveItem, convertCodexRawExecItem } from './converter.js';
 import { waitForMaterializedThread } from './durability.js';
 import { createLogger } from '../../../lib/log.js';
 import { IdleSessionPurger } from '../../shared/idle-session-purger.js';
@@ -23,6 +23,7 @@ import type {
   ThreadGoalClearedNotification,
   ThreadGoalUpdatedNotification,
   ThreadGoalSetResponse,
+  RawResponseItemCompletedNotification,
   TurnCompletedNotification,
   TurnStartedNotification,
 } from './protocol.js';
@@ -67,6 +68,7 @@ interface RunningCodexSession {
   activeInputChain: Promise<void>;
   activeDeliveryReservations: number;
   pendingFinish: FinishSessionOptions | null;
+  liveExecCallIds: Set<string>;
 }
 
 interface CodexForkSessionRequest {
@@ -726,6 +728,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       activeInputChain: Promise.resolve(),
       activeDeliveryReservations: 0,
       pendingFinish: null,
+      liveExecCallIds: new Set(),
     };
     this.#sessions.set(args.threadId, session);
     return session;
@@ -747,6 +750,9 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         break;
       case 'item/completed':
         this.#handleItemCompleted(notification.params as ItemCompletedNotification);
+        break;
+      case 'rawResponseItem/completed':
+        this.#handleRawResponseItemCompleted(notification.params as RawResponseItemCompletedNotification);
         break;
       case 'turn/completed':
         this.#handleTurnCompleted(notification.params as TurnCompletedNotification);
@@ -817,6 +823,17 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (messages.length) this.emitMessages(session.chatId, messages);
   }
 
+  #handleRawResponseItemCompleted(params: RawResponseItemCompletedNotification): void {
+    const session = this.#sessions.get(params.threadId);
+    if (!session) return;
+    const messages = convertCodexRawExecItem(
+      params.item,
+      new Date().toISOString(),
+      session.liveExecCallIds,
+    );
+    if (messages.length) this.emitMessages(session.chatId, messages);
+  }
+
   #handleTurnCompleted(params: TurnCompletedNotification): void {
     void this.#completeTurn(params).catch((error) => {
       const session = this.#sessions.get(params.threadId);
@@ -828,6 +845,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   async #completeTurn(params: TurnCompletedNotification): Promise<void> {
     const session = this.#sessions.get(params.threadId);
     if (!session) return;
+    session.liveExecCallIds.clear();
     if (params.turn.status === 'failed') {
       if (session.managesGoalLifecycle && session.goal && session.goal.status !== 'active') {
         session.activeTurnId = null;

--- a/server/agents/codex/jsonl-tool-use-converter.ts
+++ b/server/agents/codex/jsonl-tool-use-converter.ts
@@ -5,6 +5,7 @@
 import {
   BashToolUseMessage,
   EditToolUseMessage,
+  ExecToolUseMessage,
   WriteStdinToolUseMessage,
   UpdatePlanToolUseMessage,
   UnknownToolUseMessage,
@@ -86,6 +87,10 @@ export function convertCodexCustomToolCall(
   const rawName = typeof rawPayload.name === 'string' ? rawPayload.name : 'custom_tool';
   const callId = typeof rawPayload.call_id === 'string' ? rawPayload.call_id : '';
   const rawInput = rawPayload.input;
+
+  if (rawName === 'exec' && typeof rawInput === 'string') {
+    return new ExecToolUseMessage(ts, callId, rawInput, 'javascript');
+  }
 
   if (rawName === 'apply_patch') {
     const parsed = parseApplyPatch(typeof rawInput === 'string' ? rawInput : '');

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -668,73 +668,73 @@
 		font-size: inherit;
 	}
 
-	.markdown-body .markdown-code-block {
+	.markdown-code-block {
 		background-color: hsl(var(--markdown-code-background));
 		border-color: hsl(var(--markdown-code-border));
 		color: hsl(var(--markdown-code-foreground));
 	}
 
-	.markdown-body .markdown-code-block pre {
+	.markdown-code-block pre {
 		margin: 0;
 	}
 
-	.markdown-body .markdown-code-block code {
+	.markdown-code-block code {
 		overflow-wrap: normal;
 		white-space: inherit;
 		word-break: normal;
 	}
 
-	.markdown-body .markdown-code-block[data-wrap='true'] code {
+	.markdown-code-block[data-wrap='true'] code {
 		overflow-wrap: anywhere;
 		white-space: inherit;
 		word-break: break-word;
 	}
 
-	.markdown-body .cm-code {
+	.markdown-code-block .cm-code {
 		background-color: hsl(var(--markdown-code-background));
 		color: hsl(var(--markdown-code-foreground));
 		display: block;
 	}
 
-	.markdown-body .cm-code-keyword {
+	.markdown-code-block .cm-code-keyword {
 		color: hsl(var(--markdown-code-keyword));
 	}
 
-	.markdown-body .cm-code-title {
+	.markdown-code-block .cm-code-title {
 		color: hsl(var(--markdown-code-title));
 	}
 
-	.markdown-body .cm-code-meta,
-	.markdown-body .cm-code-invalid {
+	.markdown-code-block .cm-code-meta,
+	.markdown-code-block .cm-code-invalid {
 		color: hsl(var(--markdown-code-meta));
 	}
 
-	.markdown-body .cm-code-string {
+	.markdown-code-block .cm-code-string {
 		color: hsl(var(--markdown-code-string));
 	}
 
-	.markdown-body .cm-code-symbol {
+	.markdown-code-block .cm-code-symbol {
 		color: hsl(var(--markdown-code-symbol));
 	}
 
-	.markdown-body .cm-code-comment {
+	.markdown-code-block .cm-code-comment {
 		color: hsl(var(--markdown-code-comment));
 	}
 
-	.markdown-body .cm-code-name {
+	.markdown-code-block .cm-code-name {
 		color: hsl(var(--markdown-code-name));
 	}
 
-	.markdown-body .cm-code-section {
+	.markdown-code-block .cm-code-section {
 		color: hsl(var(--markdown-code-section));
 	}
 
-	.markdown-body .cm-code-addition {
+	.markdown-code-block .cm-code-addition {
 		background-color: hsl(var(--markdown-code-addition-bg));
 		color: hsl(var(--markdown-code-addition-fg));
 	}
 
-	.markdown-body .cm-code-deletion {
+	.markdown-code-block .cm-code-deletion {
 		background-color: hsl(var(--markdown-code-deletion-bg));
 		color: hsl(var(--markdown-code-deletion-fg));
 	}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -696,45 +696,56 @@
 		display: block;
 	}
 
-	.markdown-code-block .cm-code-keyword {
+	.markdown-code-block .cm-code-keyword,
+	.code-highlight .cm-code-keyword {
 		color: hsl(var(--markdown-code-keyword));
 	}
 
-	.markdown-code-block .cm-code-title {
+	.markdown-code-block .cm-code-title,
+	.code-highlight .cm-code-title {
 		color: hsl(var(--markdown-code-title));
 	}
 
 	.markdown-code-block .cm-code-meta,
-	.markdown-code-block .cm-code-invalid {
+	.markdown-code-block .cm-code-invalid,
+	.code-highlight .cm-code-meta,
+	.code-highlight .cm-code-invalid {
 		color: hsl(var(--markdown-code-meta));
 	}
 
-	.markdown-code-block .cm-code-string {
+	.markdown-code-block .cm-code-string,
+	.code-highlight .cm-code-string {
 		color: hsl(var(--markdown-code-string));
 	}
 
-	.markdown-code-block .cm-code-symbol {
+	.markdown-code-block .cm-code-symbol,
+	.code-highlight .cm-code-symbol {
 		color: hsl(var(--markdown-code-symbol));
 	}
 
-	.markdown-code-block .cm-code-comment {
+	.markdown-code-block .cm-code-comment,
+	.code-highlight .cm-code-comment {
 		color: hsl(var(--markdown-code-comment));
 	}
 
-	.markdown-code-block .cm-code-name {
+	.markdown-code-block .cm-code-name,
+	.code-highlight .cm-code-name {
 		color: hsl(var(--markdown-code-name));
 	}
 
-	.markdown-code-block .cm-code-section {
+	.markdown-code-block .cm-code-section,
+	.code-highlight .cm-code-section {
 		color: hsl(var(--markdown-code-section));
 	}
 
-	.markdown-code-block .cm-code-addition {
+	.markdown-code-block .cm-code-addition,
+	.code-highlight .cm-code-addition {
 		background-color: hsl(var(--markdown-code-addition-bg));
 		color: hsl(var(--markdown-code-addition-fg));
 	}
 
-	.markdown-code-block .cm-code-deletion {
+	.markdown-code-block .cm-code-deletion,
+	.code-highlight .cm-code-deletion {
 		background-color: hsl(var(--markdown-code-deletion-bg));
 		color: hsl(var(--markdown-code-deletion-fg));
 	}

--- a/web/src/lib/chat/__tests__/conversation-feed-items.test.ts
+++ b/web/src/lib/chat/__tests__/conversation-feed-items.test.ts
@@ -3,6 +3,7 @@ import {
 	AssistantMessage,
 	AskUserQuestionToolUseMessage,
 	BashToolUseMessage,
+	ExecToolUseMessage,
 	PermissionCancelledMessage,
 	PermissionRequestMessage,
 	PermissionResolvedMessage,
@@ -217,6 +218,16 @@ describe('buildConversationFeedRenderItems', () => {
 			state: 'cancelled',
 			reason: 'cancelled',
 		});
+	});
+
+	it('indexes Exec results without rendering them as standalone rows', () => {
+		const tool = new ExecToolUseMessage(TS, 'exec-1', 'text("ok")', 'javascript');
+		const result = new ToolResultMessage(TS, 'exec-1', { raw: 'ok' }, false);
+		const model = buildConversationFeedRenderModel(rows([tool, result]));
+
+		expect(model.items).toHaveLength(1);
+		expect(model.items[0]).toMatchObject({ kind: 'message', message: tool });
+		expect(model.toolResultIndex.get('exec-1')).toBe(result);
 	});
 
 	it('keeps local notices as their own render items and breaks assistant grouping', () => {

--- a/web/src/lib/chat/__tests__/tool-display-registry.test.ts
+++ b/web/src/lib/chat/__tests__/tool-display-registry.test.ts
@@ -11,6 +11,7 @@ import {
 	AmpFinderToolUseMessage,
 	AmpOracleToolUseMessage,
 	BashToolUseMessage,
+	ExecToolUseMessage,
 	CodexSubagentToolUseMessage,
 	ExternalToolUseMessage,
 	ExitPlanModeToolUseMessage,
@@ -27,6 +28,7 @@ describe('TOOL_DISPLAY_REGISTRY', () => {
 	it('contains entries for explicit tool-use message types', () => {
 		const expected = [
 			'bash-tool-use',
+			'exec-tool-use',
 			'read-tool-use',
 			'list-tool-use',
 			'edit-tool-use',
@@ -72,6 +74,29 @@ describe('TOOL_DISPLAY_REGISTRY', () => {
 		expect(TOOL_DISPLAY_REGISTRY['list-tool-use'].input.mode).toBe('inline');
 		expect(TOOL_DISPLAY_REGISTRY['edit-tool-use'].input.mode).toBe('collapsible');
 		expect(TOOL_DISPLAY_REGISTRY['write-stdin-tool-use'].input.mode).toBe('hidden');
+	});
+
+	it('renders Exec as collapsed language-aware code with a special result', () => {
+		const rule = TOOL_DISPLAY_REGISTRY['exec-tool-use'];
+		expect(rule.input).toMatchObject({
+			mode: 'collapsible',
+			label: 'Exec',
+			title: 'Code',
+			defaultOpen: false,
+			contentKind: 'code',
+		});
+		expect(
+			rule.input.getContentProps?.(
+				new ExecToolUseMessage('', 'exec-1', 'const value = 1;', 'javascript') as unknown as Record<
+					string,
+					unknown
+				>,
+			),
+		).toEqual({
+			content: 'const value = 1;',
+			language: 'javascript',
+		});
+		expect(rule.result).toEqual({ mode: 'special' });
 	});
 
 	it('uses canonical type keys for Amp-specific tools', () => {

--- a/web/src/lib/chat/__tests__/tool-display-registry.test.ts
+++ b/web/src/lib/chat/__tests__/tool-display-registry.test.ts
@@ -17,6 +17,7 @@ import {
 	ExitPlanModeToolUseMessage,
 	ListToolUseMessage,
 	McpToolUseMessage,
+	UnknownToolUseMessage,
 } from '$shared/chat-types';
 
 describe('TOOL_DISPLAY_REGISTRY', () => {
@@ -70,10 +71,25 @@ describe('TOOL_DISPLAY_REGISTRY', () => {
 
 	it('uses canonical type keys for core tools', () => {
 		expect(TOOL_DISPLAY_REGISTRY['bash-tool-use'].input.mode).toBe('inline');
+		expect(TOOL_DISPLAY_REGISTRY['bash-tool-use'].input.language).toBe('bash');
 		expect(TOOL_DISPLAY_REGISTRY['read-tool-use'].input.mode).toBe('inline');
 		expect(TOOL_DISPLAY_REGISTRY['list-tool-use'].input.mode).toBe('inline');
 		expect(TOOL_DISPLAY_REGISTRY['edit-tool-use'].input.mode).toBe('collapsible');
 		expect(TOOL_DISPLAY_REGISTRY['write-stdin-tool-use'].input.mode).toBe('hidden');
+	});
+
+	it('renders unknown tool inputs as highlighted JSON', () => {
+		const rule = TOOL_DISPLAY_REGISTRY['unknown-tool-use'];
+		const message = new UnknownToolUseMessage('', 'unknown-1', 'custom_tool', {
+			path: '/tmp/example',
+		});
+
+		expect(
+			rule.input.getContentProps?.(message as unknown as Record<string, unknown>),
+		).toMatchObject({
+			format: 'code',
+			language: 'json',
+		});
 	});
 
 	it('renders Exec as collapsed language-aware code with a special result', () => {

--- a/web/src/lib/chat/__tests__/tool-roundtrip.test.ts
+++ b/web/src/lib/chat/__tests__/tool-roundtrip.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
 	BashToolUseMessage,
+	ExecToolUseMessage,
 	ReadToolUseMessage,
 	ListToolUseMessage,
 	EditToolUseMessage,
@@ -60,6 +61,15 @@ describe('tool-use serialization round-trip', () => {
 		expect(parsed.command).toBe('ls -la');
 		expect(parsed.description).toBe('List files');
 		expect(parsed.type).toBe('bash-tool-use');
+	});
+
+	it('ExecToolUseMessage preserves code and language', () => {
+		const code = '// @exec: {"yield_time_ms": 1000}\nconst value = 1;';
+		const msg = new ExecToolUseMessage(TS, 'id-exec', code, 'javascript');
+		const parsed = roundTrip(msg);
+		expect(parsed.code).toBe(code);
+		expect(parsed.language).toBe('javascript');
+		expect(parsed.type).toBe('exec-tool-use');
 	});
 
 	it('ReadToolUseMessage preserves filePath and range fields', () => {
@@ -587,6 +597,25 @@ describe('malformed known-type payloads return null', () => {
 			toolId: 'id-bad',
 		});
 		expect(msg).toBeNull();
+	});
+
+	it('exec-tool-use without code or language returns null', () => {
+		expect(
+			parseChatMessage({
+				type: 'exec-tool-use',
+				timestamp: TS,
+				toolId: 'id-bad',
+				language: 'javascript',
+			}),
+		).toBeNull();
+		expect(
+			parseChatMessage({
+				type: 'exec-tool-use',
+				timestamp: TS,
+				toolId: 'id-bad',
+				code: 'text("ok")',
+			}),
+		).toBeNull();
 	});
 
 	it('read-tool-use without filePath returns null', () => {

--- a/web/src/lib/chat/tool-display-contract.ts
+++ b/web/src/lib/chat/tool-display-contract.ts
@@ -9,6 +9,7 @@ export type ToolDisplayMode = 'inline' | 'collapsible' | 'hidden';
 export type ToolInlineAction = 'copyValue' | 'openFile' | 'jumpToResult' | 'none';
 
 export type ToolContentKind =
+	| 'code'
 	| 'diff'
 	| 'markdown'
 	| 'fileList'

--- a/web/src/lib/chat/tool-display-contract.ts
+++ b/web/src/lib/chat/tool-display-contract.ts
@@ -26,6 +26,7 @@ export interface ToolInputDisplayRule {
 	action?: ToolInlineAction;
 	style?: string;
 	wrapText?: boolean;
+	language?: string;
 	colorScheme?: {
 		primary?: string;
 		secondary?: string;

--- a/web/src/lib/chat/tool-display-registry.ts
+++ b/web/src/lib/chat/tool-display-registry.ts
@@ -35,6 +35,7 @@ function asFiniteNumber(value: unknown): number | undefined {
 
 const DISPLAY_NAME_BY_TYPE: Record<string, string> = {
 	'bash-tool-use': 'Bash',
+	'exec-tool-use': 'Exec',
 	'read-tool-use': 'Read',
 	'list-tool-use': 'List',
 	'edit-tool-use': 'Edit',
@@ -250,6 +251,23 @@ export const TOOL_DISPLAY_REGISTRY: ToolDisplayRegistry = {
 		},
 		result: {
 			hideOnSuccess: true,
+			mode: 'special',
+		},
+	},
+
+	'exec-tool-use': {
+		input: {
+			mode: 'collapsible',
+			label: 'Exec',
+			title: 'Code',
+			defaultOpen: false,
+			contentKind: 'code',
+			getContentProps: (input) => ({
+				content: String(input.code ?? ''),
+				language: String(input.language ?? ''),
+			}),
+		},
+		result: {
 			mode: 'special',
 		},
 	},

--- a/web/src/lib/chat/tool-display-registry.ts
+++ b/web/src/lib/chat/tool-display-registry.ts
@@ -242,6 +242,7 @@ export const TOOL_DISPLAY_REGISTRY: ToolDisplayRegistry = {
 			action: 'copyValue',
 			style: 'terminal',
 			wrapText: true,
+			language: 'bash',
 			colorScheme: {
 				primary: 'text-foreground font-mono',
 				secondary: 'text-muted-foreground',
@@ -969,6 +970,7 @@ export const TOOL_DISPLAY_REGISTRY: ToolDisplayRegistry = {
 			getContentProps: (input) => ({
 				content: typeof input === 'string' ? input : JSON.stringify(input, null, 2),
 				format: 'code',
+				language: 'json',
 			}),
 		},
 		result: {

--- a/web/src/lib/components/chat/CodeBlock.svelte
+++ b/web/src/lib/components/chat/CodeBlock.svelte
@@ -5,28 +5,13 @@ The highlighter loads on demand and the raw source remains visible while
 language packages are fetched.
 -->
 <script module lang="ts">
-	import {
-		shouldAttemptCodeFenceHighlight,
-		shouldWrapCodeFenceLanguage,
-	} from '$lib/highlighting/code-language-aliases';
-	import {
-		plainCodeSegments,
-		type CodeHighlightSegment,
-	} from '$lib/highlighting/code-highlight-types';
-
-	type HighlighterModule = typeof import('$lib/highlighting/code-fence-highlighter');
-
-	let highlighterPromise: Promise<HighlighterModule> | null = null;
-
-	function loadHighlighter(): Promise<HighlighterModule> {
-		highlighterPromise ??= import('$lib/highlighting/code-fence-highlighter');
-		return highlighterPromise;
-	}
+	import { shouldWrapCodeFenceLanguage } from '$lib/highlighting/code-language-aliases';
 </script>
 
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import HighlightedCodeText from './HighlightedCodeText.svelte';
 
 	interface Props {
 		lang?: string;
@@ -35,37 +20,12 @@ language packages are fetched.
 
 	let { lang = '', text = '' }: Props = $props();
 
-	const plainSegments = $derived(plainCodeSegments(text));
-	let asyncSegments = $state<CodeHighlightSegment[] | null>(null);
-	const segments = $derived(asyncSegments ?? plainSegments);
 	const wrapsCodeBlock = $derived(shouldWrapCodeFenceLanguage(lang));
 	const preClass = $derived(
 		wrapsCodeBlock
 			? 'm-0 overflow-x-hidden whitespace-pre-wrap break-words px-3 pb-3 pt-1 text-xs font-mono'
 			: 'm-0 overflow-x-auto whitespace-pre px-3 pb-3 pt-1 text-xs font-mono',
 	);
-	let highlightToken = 0;
-
-	// Highlights asynchronously while preserving immediate plain-text rendering.
-	$effect(() => {
-		const currentText = text;
-		const currentLang = lang;
-		const token = ++highlightToken;
-
-		asyncSegments = null;
-		if (!currentText || !shouldAttemptCodeFenceHighlight(currentLang)) return;
-
-		void (async () => {
-			try {
-				const { highlightCodeFence } = await loadHighlighter();
-				const nextSegments = await highlightCodeFence(currentText, currentLang);
-				if (token === highlightToken) asyncSegments = nextSegments;
-			} catch {
-				if (token === highlightToken) asyncSegments = null;
-			}
-		})();
-	});
-
 	let copied = $state(false);
 	async function handleCopy() {
 		const didCopy = await copyToClipboard(text);
@@ -75,10 +35,10 @@ language packages are fetched.
 	}
 </script>
 
-	<div
-		class="markdown-code-block not-prose group relative my-2 overflow-hidden rounded-md border"
-		data-wrap={wrapsCodeBlock ? 'true' : 'false'}
-	>
+<div
+	class="markdown-code-block not-prose group relative my-2 overflow-hidden rounded-md border"
+	data-wrap={wrapsCodeBlock ? 'true' : 'false'}
+>
 	<div class="flex items-center gap-2 px-3 pt-2 pb-0.5 text-[11px] leading-none">
 		<span class="shrink-0 font-medium text-muted-foreground tracking-wide">{lang || 'text'}</span>
 		<button
@@ -114,5 +74,6 @@ language packages are fetched.
 			{/if}
 		</button>
 	</div>
-		<pre class={preClass}><code class="cm-code">{#each segments as segment, index (index)}{#if segment.className}<span class={segment.className}>{segment.text}</span>{:else}{segment.text}{/if}{/each}</code></pre>
-	</div>
+	<pre class={preClass}><code class="cm-code"><HighlightedCodeText {text} language={lang} /></code
+		></pre>
+</div>

--- a/web/src/lib/components/chat/HighlightedCodeText.svelte
+++ b/web/src/lib/components/chat/HighlightedCodeText.svelte
@@ -1,0 +1,62 @@
+<!--
+@component
+Renders highlighted token spans without adding layout or presentation wrappers.
+The raw source remains visible while the language package loads.
+-->
+<script module lang="ts">
+	import {
+		plainCodeSegments,
+		type CodeHighlightSegment,
+	} from '$lib/highlighting/code-highlight-types';
+	import { shouldAttemptCodeFenceHighlight } from '$lib/highlighting/code-language-aliases';
+
+	type HighlighterModule = typeof import('$lib/highlighting/code-fence-highlighter');
+
+	let highlighterPromise: Promise<HighlighterModule> | null = null;
+
+	function loadHighlighter(): Promise<HighlighterModule> {
+		highlighterPromise ??= import('$lib/highlighting/code-fence-highlighter');
+		return highlighterPromise;
+	}
+</script>
+
+<script lang="ts">
+	interface Props {
+		language?: string;
+		text?: string;
+	}
+
+	let { language = '', text = '' }: Props = $props();
+
+	const plainSegments = $derived(plainCodeSegments(text));
+	let asyncSegments = $state<CodeHighlightSegment[] | null>(null);
+	const segments = $derived(asyncSegments ?? plainSegments);
+
+	// Highlights asynchronously while preserving immediate plain-text rendering.
+	$effect(() => {
+		const currentText = text;
+		const currentLanguage = language;
+		let cancelled = false;
+
+		asyncSegments = null;
+		if (!currentText || !shouldAttemptCodeFenceHighlight(currentLanguage)) return;
+
+		void (async () => {
+			try {
+				const { highlightCodeFence } = await loadHighlighter();
+				const nextSegments = await highlightCodeFence(currentText, currentLanguage);
+				if (!cancelled) asyncSegments = nextSegments;
+			} catch {
+				if (!cancelled) asyncSegments = null;
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	});
+</script>
+
+{#each segments as segment, index (index)}{#if segment.className}<span class={segment.className}
+			>{segment.text}</span
+		>{:else}{segment.text}{/if}{/each}

--- a/web/src/lib/components/chat/__tests__/CodeBlock.test.ts
+++ b/web/src/lib/components/chat/__tests__/CodeBlock.test.ts
@@ -16,6 +16,8 @@ describe('CodeBlock', () => {
 	it('scopes syntax colors to the reusable code block instead of Markdown parents', () => {
 		expect(appCss).toContain('.markdown-code-block .cm-code-keyword');
 		expect(appCss).toContain('.markdown-code-block .cm-code-string');
+		expect(appCss).toContain('.code-highlight .cm-code-keyword');
+		expect(appCss).toContain('.code-highlight .cm-code-string');
 		expect(appCss).not.toContain('.markdown-body .cm-code-keyword');
 	});
 

--- a/web/src/lib/components/chat/__tests__/CodeBlock.test.ts
+++ b/web/src/lib/components/chat/__tests__/CodeBlock.test.ts
@@ -1,15 +1,24 @@
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { copyToClipboard } from '$lib/utils/clipboard';
 
 import CodeBlock from '../CodeBlock.svelte';
 
+const appCss = readFileSync('src/app.css', 'utf8');
+
 vi.mock('$lib/utils/clipboard', () => ({
 	copyToClipboard: vi.fn(),
 }));
 
 describe('CodeBlock', () => {
+	it('scopes syntax colors to the reusable code block instead of Markdown parents', () => {
+		expect(appCss).toContain('.markdown-code-block .cm-code-keyword');
+		expect(appCss).toContain('.markdown-code-block .cm-code-string');
+		expect(appCss).not.toContain('.markdown-body .cm-code-keyword');
+	});
+
 	beforeEach(() => {
 		vi.mocked(copyToClipboard).mockReset();
 	});

--- a/web/src/lib/components/chat/tools/ChatBashToolGroup.svelte
+++ b/web/src/lib/components/chat/tools/ChatBashToolGroup.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { BashToolUseMessage } from '$shared/chat-types';
+	import HighlightedCodeText from '../HighlightedCodeText.svelte';
 	import ChatEventCard from '../rows/ChatEventCard.svelte';
 	import { buildBashToolGroupRenderItems } from '$lib/chat/bash-tool-group-items';
 	import { copyToClipboard } from '$lib/utils/clipboard';
@@ -55,8 +56,10 @@
 				{#each renderItems as item (item.key)}
 					{@const message = item.message}
 					<div class="py-1 first:pt-0 last:pb-0">
-						<code class="block whitespace-pre-wrap break-all text-xs text-foreground font-mono">
-							{message.command}
+						<code
+							class="code-highlight block whitespace-pre-wrap break-all text-xs text-foreground font-mono"
+						>
+							<HighlightedCodeText text={message.command} language="bash" />
 						</code>
 						{#if message.description}
 							<div class="mt-0.5 text-[11px] text-muted-foreground italic">

--- a/web/src/lib/components/chat/tools/ChatToolEventRenderer.svelte
+++ b/web/src/lib/components/chat/tools/ChatToolEventRenderer.svelte
@@ -199,6 +199,7 @@
 				onAction={handleAction}
 				style={cfg.style}
 				wrapText={cfg.wrapText}
+				language={cfg.language}
 				colorScheme={cfg.colorScheme}
 				resultId={mode === 'input' ? `tool-result-${toolId}` : undefined}
 			/>
@@ -266,6 +267,7 @@
 							<ChatToolPlainTextView
 								content={(contentProps.content as string) || ''}
 								format={(contentProps.format as 'plain' | 'json' | 'code') || 'plain'}
+								language={contentProps.language as string | undefined}
 							/>
 						{:else if displayConfig.contentKind === 'successMessage'}
 							<div class="flex items-center gap-1.5 text-xs text-status-success-foreground">
@@ -325,6 +327,7 @@
 					<ChatToolPlainTextView
 						content={(resultContentProps.content as string) || ''}
 						format={(resultContentProps.format as 'plain' | 'json' | 'code') || 'plain'}
+						language={resultContentProps.language as string | undefined}
 					/>
 				{:else if resultConfig.contentKind === 'successMessage'}
 					<div class="flex items-center gap-1.5 text-xs text-status-success-foreground">

--- a/web/src/lib/components/chat/tools/ChatToolEventRenderer.svelte
+++ b/web/src/lib/components/chat/tools/ChatToolEventRenderer.svelte
@@ -17,6 +17,7 @@
 	import ChatToolFileListView from './content/ChatToolFileListView.svelte';
 	import ChatToolPlainTextView from './content/ChatToolPlainTextView.svelte';
 	import ChatToolTodoListView from './content/ChatToolTodoListView.svelte';
+	import CodeBlock from '../CodeBlock.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface ToolRendererProps {
@@ -223,7 +224,12 @@
 					onTitleClick={handleTitleClick}
 				>
 					{#snippet children()}
-						{#if displayConfig.contentKind === 'diff'}
+						{#if displayConfig.contentKind === 'code'}
+							<CodeBlock
+								text={(contentProps.content as string) || ''}
+								lang={(contentProps.language as string) || ''}
+							/>
+						{:else if displayConfig.contentKind === 'diff'}
 							{#if contentProps.diffUnavailable}
 								<ChatToolFileListView
 									files={(contentProps.files as string[]) || []}
@@ -297,7 +303,12 @@
 			defaultOpen={resultDefaultOpen}
 		>
 				{#snippet children()}
-					{#if resultConfig.contentKind === 'markdown'}
+					{#if resultConfig.contentKind === 'code'}
+						<CodeBlock
+							text={(resultContentProps.content as string) || ''}
+							lang={(resultContentProps.language as string) || ''}
+						/>
+					{:else if resultConfig.contentKind === 'markdown'}
 						<ChatToolRichTextView
 							content={(resultContentProps.content as string) || ''}
 							{projectBasePath}

--- a/web/src/lib/components/chat/tools/ChatToolInlineEvent.svelte
+++ b/web/src/lib/components/chat/tools/ChatToolInlineEvent.svelte
@@ -3,6 +3,7 @@
 	// Renders as a card surface instead of a rail/border-l treatment.
 
 	import ChatEventCard from '../rows/ChatEventCard.svelte';
+	import HighlightedCodeText from '../HighlightedCodeText.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import type { ToolInlineAction } from '$lib/chat/tool-display-contract';
@@ -16,6 +17,7 @@
 		onAction?: () => void;
 		style?: string;
 		wrapText?: boolean;
+		language?: string;
 		colorScheme?: {
 			primary?: string;
 			secondary?: string;
@@ -43,6 +45,7 @@
 		onAction,
 		style,
 		wrapText = false,
+		language,
 		colorScheme = DEFAULT_SCHEME,
 		resultId,
 		toolResult,
@@ -119,11 +122,11 @@
 					{/if}
 				</div>
 				<code
-					class="text-xs text-foreground font-mono {wrapText
+					class="code-highlight text-xs text-foreground font-mono {wrapText
 						? 'whitespace-pre-wrap break-all'
 						: 'block truncate'}"
 				>
-					{value}
+					<HighlightedCodeText text={value} {language} />
 				</code>
 				{#if secondary}
 					<div class="mt-0.5">

--- a/web/src/lib/components/chat/tools/__tests__/ChatBashToolGroup.test.ts
+++ b/web/src/lib/components/chat/tools/__tests__/ChatBashToolGroup.test.ts
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { BashToolUseMessage } from '$shared/chat-types';
+import ChatBashToolGroup from '../ChatBashToolGroup.svelte';
+
+const TS = '2026-07-10T00:00:00.000Z';
+
+describe('ChatBashToolGroup', () => {
+	it('highlights every command without changing the grouped row layout', async () => {
+		const commands = [
+			'if true; then echo "ready"; fi',
+			'for item in one two; do echo "$item"; done',
+		];
+		const { container } = render(ChatBashToolGroup, {
+			messages: commands.map(
+				(command, index) => new BashToolUseMessage(TS, `bash-${index}`, command),
+			),
+		});
+
+		expect(screen.getByText('2 commands')).toBeTruthy();
+		const codeRows = Array.from(container.querySelectorAll('code.code-highlight'));
+		expect(codeRows).toHaveLength(2);
+		expect(codeRows.map((row) => row.textContent)).toEqual(commands);
+		expect(container.querySelector('.markdown-code-block')).toBeNull();
+		expect(container.querySelector('pre')).toBeNull();
+
+		for (const row of codeRows) {
+			expect(row.classList.contains('block')).toBe(true);
+			expect(row.classList.contains('whitespace-pre-wrap')).toBe(true);
+			expect(row.classList.contains('break-all')).toBe(true);
+		}
+
+		await waitFor(
+			() => {
+				for (const row of codeRows) {
+					expect(row.querySelector('.cm-code-keyword')).toBeTruthy();
+					expect(row.querySelector('.cm-code-string')).toBeTruthy();
+				}
+			},
+			{ timeout: 5_000 },
+		);
+		expect(codeRows.map((row) => row.textContent)).toEqual(commands);
+	});
+});

--- a/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
+++ b/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import ChatToolEventRenderer from '../ChatToolEventRenderer.svelte';
 import {
@@ -7,6 +7,7 @@ import {
 	AmpTaskListToolUseMessage,
 	CodexSubagentToolUseMessage,
 	EditToolUseMessage,
+	ExecToolUseMessage,
 	ExitPlanModeToolUseMessage,
 	GlobToolUseMessage,
 	GrepToolUseMessage,
@@ -200,6 +201,38 @@ describe('ChatToolEventRenderer', () => {
 		expect(screen.queryByText('WriteStdin')).toBeNull();
 		expect(screen.queryByText('123')).toBeNull();
 		expect(container.childElementCount).toBe(0);
+	});
+
+	it('renders Exec source through the JavaScript CodeMirror code block', async () => {
+		const code = 'const value = 1 < 2;';
+		const { container } = render(ChatToolEventRenderer, {
+			toolMessage: new ExecToolUseMessage('', 'exec-1', code, 'javascript'),
+			mode: 'input',
+			autoExpandTools: true,
+		});
+
+		expect(screen.getByText('Exec')).toBeTruthy();
+		expect(screen.getByText('Code')).toBeTruthy();
+		expect(container.querySelector('.markdown-code-block')).toBeTruthy();
+		expect(container.querySelector('code')?.textContent).toBe(code);
+		await waitFor(
+			() => {
+				expect(container.querySelector('.cm-code-keyword')).toBeTruthy();
+			},
+			{ timeout: 5_000 },
+		);
+	});
+
+	it('does not render a generic result card for Exec special results', () => {
+		const { container } = render(ChatToolEventRenderer, {
+			toolMessage: new ExecToolUseMessage('', 'exec-2', 'text("ok")', 'javascript'),
+			toolResult: { content: { raw: 'ok' }, isError: false },
+			mode: 'input',
+			autoExpandTools: false,
+		});
+
+		expect(container.querySelector('#tool-result-exec-2')).toBeNull();
+		expect(screen.queryByText('ok')).toBeNull();
 	});
 });
 

--- a/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
+++ b/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
@@ -5,12 +5,14 @@ import {
 	AmpFinderToolUseMessage,
 	AmpOracleToolUseMessage,
 	AmpTaskListToolUseMessage,
+	BashToolUseMessage,
 	CodexSubagentToolUseMessage,
 	EditToolUseMessage,
 	ExecToolUseMessage,
 	ExitPlanModeToolUseMessage,
 	GlobToolUseMessage,
 	GrepToolUseMessage,
+	UnknownToolUseMessage,
 	WebFetchToolUseMessage,
 	WriteStdinToolUseMessage,
 } from '$shared/chat-types';
@@ -201,6 +203,55 @@ describe('ChatToolEventRenderer', () => {
 		expect(screen.queryByText('WriteStdin')).toBeNull();
 		expect(screen.queryByText('123')).toBeNull();
 		expect(container.childElementCount).toBe(0);
+	});
+
+	it('highlights Bash in place without adding code-block layout', async () => {
+		const command = 'if true; then echo "ready"; fi';
+		const { container } = render(ChatToolEventRenderer, {
+			toolMessage: new BashToolUseMessage('', 'bash-1', command),
+			mode: 'input',
+		});
+
+		const code = container.querySelector('code.code-highlight');
+		expect(code?.textContent).toBe(command);
+		expect(code?.classList.contains('text-xs')).toBe(true);
+		expect(code?.classList.contains('font-mono')).toBe(true);
+		expect(code?.classList.contains('whitespace-pre-wrap')).toBe(true);
+		expect(code?.classList.contains('break-all')).toBe(true);
+		expect(container.querySelector('.markdown-code-block')).toBeNull();
+		expect(container.querySelector('pre')).toBeNull();
+
+		await waitFor(
+			() => {
+				expect(code?.querySelector('.cm-code-keyword')).toBeTruthy();
+				expect(code?.querySelector('.cm-code-string')).toBeTruthy();
+			},
+			{ timeout: 5_000 },
+		);
+		expect(code?.textContent).toBe(command);
+	});
+
+	it('highlights unknown tool inputs as JSON within the existing details view', async () => {
+		const { container } = render(ChatToolEventRenderer, {
+			toolMessage: new UnknownToolUseMessage('', 'unknown-1', 'custom_tool', {
+				path: '/tmp/example',
+				recursive: true,
+			}),
+			mode: 'input',
+			autoExpandTools: true,
+		});
+
+		const code = container.querySelector('pre.code-highlight');
+		expect(code?.textContent).toContain('"path": "/tmp/example"');
+		expect(code?.classList.contains('p-2')).toBe(true);
+		expect(code?.classList.contains('whitespace-pre-wrap')).toBe(true);
+
+		await waitFor(
+			() => {
+				expect(code?.querySelector('.cm-code-string')).toBeTruthy();
+			},
+			{ timeout: 5_000 },
+		);
 	});
 
 	it('renders Exec source through the JavaScript CodeMirror code block', async () => {

--- a/web/src/lib/components/chat/tools/content/ChatToolPlainTextView.svelte
+++ b/web/src/lib/components/chat/tools/content/ChatToolPlainTextView.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
 	// Renders plain text, JSON, or code content for tool output.
+	import HighlightedCodeText from '../../HighlightedCodeText.svelte';
 
 	interface TextContentProps {
 		content: string;
 		format?: 'plain' | 'json' | 'code';
+		language?: string;
 		class?: string;
 	}
 
-	let { content, format = 'plain', class: className = '' }: TextContentProps = $props();
+	let {
+		content,
+		format = 'plain',
+		language = '',
+		class: className = '',
+	}: TextContentProps = $props();
 
 	let formattedContent = $derived.by(() => {
 		if (format !== 'json') return content;
@@ -24,7 +31,10 @@
 		class="mt-1 text-xs bg-muted border border-border text-foreground p-2.5 rounded overflow-x-auto font-mono {className}">{formattedContent}</pre>
 {:else if format === 'code'}
 	<pre
-		class="mt-1 text-xs bg-muted/40 border border-border p-2 rounded whitespace-pre-wrap break-words overflow-hidden text-foreground/85 font-mono {className}">{content}</pre>
+		class="code-highlight mt-1 text-xs bg-muted/40 border border-border p-2 rounded whitespace-pre-wrap break-words overflow-hidden text-foreground/85 font-mono {className}"><HighlightedCodeText
+			text={content}
+			{language}
+		/></pre>
 {:else}
 	<div class="mt-1 text-sm text-foreground/85 whitespace-pre-wrap {className}">
 		{content}


### PR DESCRIPTION
Introduce 'exec-tool-use' to standard chat types to support execution of arbitrary code. Integrate raw Codex custom tool call parser into history loading, normalization, and the live application server client. Expose a collapsible language-aware code editor in the web interface specifically for showing Exec payloads.
