### PR TITLE
fix(claude): cancel abort force-kill timer so interrupt+resend doesn't die with code 143

### DIFF
--- a/server/agents/claude/__tests__/abort-timer.test.js
+++ b/server/agents/claude/__tests__/abort-timer.test.js
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
+let versionProbe = () => Promise.resolve(false);
+
 // The version probe would otherwise consume the mocked Bun.spawn used to fake
 // the CLI process; stub it so spawn only ever produces the controllable proc.
 mock.module('../cli-version.js', () => ({
-  claudeCliSupportsLegacyThinkingFlag: () => Promise.resolve(false),
+  claudeCliSupportsLegacyThinkingFlag: () => versionProbe(),
 }));
 
 import { ClaudeCliRuntime } from '../claude-cli.js';
@@ -23,11 +25,12 @@ function createControllableProc() {
   let resolveExit;
   const exited = new Promise((resolve) => { resolveExit = resolve; });
   const encoder = new TextEncoder();
+  const writes = [];
 
   const proc = {
     stdout,
     stderr,
-    stdin: { write() {}, flush() {} },
+    stdin: { write(value) { writes.push(value); }, flush() {} },
     exited,
     killed: false,
     kill() {
@@ -38,6 +41,7 @@ function createControllableProc() {
 
   return {
     proc,
+    writes,
     push(message) { stdoutController.enqueue(encoder.encode(JSON.stringify(message) + '\n')); },
     // Simulate the process dying on its own (not via our kill()), e.g. an OOM.
     crash(code) { resolveExit(code); },
@@ -76,6 +80,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     spawnMock = mock();
     Bun.spawn = spawnMock;
+    versionProbe = () => Promise.resolve(false);
 
     scheduled = [];
     cleared = [];
@@ -153,6 +158,134 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     expect(ctrl.proc.killed).toBe(false);
     expect(failures).toEqual([]);
+  });
+
+  it('retires a replaced session before the replacement version probe resolves', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const firstCtrl = createControllableProc();
+    const secondCtrl = createControllableProc();
+    spawnMock.mockReturnValueOnce(firstCtrl.proc).mockReturnValueOnce(secondCtrl.proc);
+
+    const failures = [];
+    const finishes = [];
+    runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
+    runtime.onFinished((chatId, exitCode) => finishes.push({ chatId, exitCode }));
+
+    const first = runtime.startClaudeCliSession(startOptions());
+    firstCtrl.push(INIT);
+    await flush();
+
+    await runtime.abortClaudeInternalSession('session-1');
+    const [abortTimerId] = abortTimerIds();
+
+    let resolveProbe;
+    versionProbe = () => new Promise((resolve) => { resolveProbe = resolve; });
+    const second = runtime.startClaudeCliSession(startOptions({ command: 'replacement' }));
+    await flush();
+
+    expect(firstCtrl.proc.killed).toBe(true);
+    expect(cleared).toContain(abortTimerId);
+    await first;
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // Output and exit from the retired process must not finish or fail the
+    // replacement while its version probe is still pending.
+    firstCtrl.push(RESULT);
+    await flush();
+    expect(finishes).toEqual([]);
+    expect(failures).toEqual([]);
+
+    resolveProbe(false);
+    await flush();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    secondCtrl.push(INIT);
+    secondCtrl.push(RESULT);
+    await second;
+    expect(finishes).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
+    expect(failures).toEqual([]);
+  });
+
+  it('queues a resume behind a start whose version probe is still pending', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    let resolveStartProbe;
+    const startProbe = new Promise((resolve) => { resolveStartProbe = resolve; });
+    let probeCalls = 0;
+    versionProbe = () => (++probeCalls === 1 ? startProbe : Promise.resolve(false));
+
+    let startResolved = false;
+    let resumeResolved = false;
+    const start = runtime.startClaudeCliSession(startOptions({ command: 'initial' }))
+      .then(() => { startResolved = true; });
+    const resume = runtime.runClaudeTurn(startOptions({ command: 'resume' }))
+      .then(() => { resumeResolved = true; });
+    await flush();
+
+    expect(spawnMock).toHaveBeenCalledTimes(0);
+    expect(startResolved).toBe(false);
+    expect(resumeResolved).toBe(false);
+
+    resolveStartProbe(false);
+    await flush();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(ctrl.writes.map((line) => JSON.parse(line).message?.content).filter(Boolean)).toEqual(['initial']);
+
+    ctrl.push(INIT);
+    ctrl.push(RESULT);
+    await start;
+    await flush();
+
+    expect(startResolved).toBe(true);
+    expect(resumeResolved).toBe(false);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(ctrl.writes.map((line) => JSON.parse(line).message?.content).filter(Boolean)).toEqual(['initial', 'resume']);
+
+    ctrl.push(RESULT);
+    await resume;
+    expect(resumeResolved).toBe(true);
+  });
+
+  it('serializes concurrent resumes on the persistent process', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    const start = runtime.startClaudeCliSession(startOptions({ command: 'initial' }));
+    ctrl.push(INIT);
+    await flush();
+    ctrl.push(RESULT);
+    await start;
+
+    let firstResolved = false;
+    let secondResolved = false;
+    const first = runtime.runClaudeTurn(startOptions({ command: 'first resume' }))
+      .then(() => { firstResolved = true; });
+    const second = runtime.runClaudeTurn(startOptions({ command: 'second resume' }))
+      .then(() => { secondResolved = true; });
+    await flush();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(ctrl.writes.map((line) => JSON.parse(line).message?.content).filter(Boolean))
+      .toEqual(['initial', 'first resume']);
+    expect(firstResolved).toBe(false);
+    expect(secondResolved).toBe(false);
+
+    ctrl.push(RESULT);
+    await first;
+    await flush();
+
+    expect(firstResolved).toBe(true);
+    expect(secondResolved).toBe(false);
+    expect(ctrl.writes.map((line) => JSON.parse(line).message?.content).filter(Boolean))
+      .toEqual(['initial', 'first resume', 'second resume']);
+
+    ctrl.push(RESULT);
+    await second;
+    expect(secondResolved).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 
   it('still force-kills when the interrupt is never acknowledged', async () => {

--- a/server/agents/claude/__tests__/abort-timer.test.js
+++ b/server/agents/claude/__tests__/abort-timer.test.js
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// The version probe would otherwise consume the mocked Bun.spawn used to fake
+// the CLI process; stub it so spawn only ever produces the controllable proc.
+mock.module('../cli-version.js', () => ({
+  claudeCliSupportsLegacyThinkingFlag: () => Promise.resolve(false),
+}));
+
+import { ClaudeCliRuntime } from '../claude-cli.js';
+
+// Real timer, captured before the per-test global patch, used to flush the
+// async stdout reader loop without going through the tracking wrapper.
+const realSetTimeout = globalThis.setTimeout;
+const flush = () => new Promise((resolve) => realSetTimeout(resolve, 0));
+
+// Fake CLI process backed by a controllable stdout stream. Mirrors the surface
+// ClaudeCliRuntime touches: streamed stdout/stderr, a writable stdin sink, an
+// `exited` promise, and a kill() that resolves it with SIGTERM's 143.
+function createControllableProc() {
+  let stdoutController;
+  const stdout = new ReadableStream({ start(controller) { stdoutController = controller; } });
+  const stderr = new ReadableStream({ start(controller) { controller.close(); } });
+  let resolveExit;
+  const exited = new Promise((resolve) => { resolveExit = resolve; });
+  const encoder = new TextEncoder();
+
+  const proc = {
+    stdout,
+    stderr,
+    stdin: { write() {}, flush() {} },
+    exited,
+    killed: false,
+    kill() {
+      this.killed = true;
+      resolveExit(143);
+    },
+  };
+
+  return {
+    proc,
+    push(message) { stdoutController.enqueue(encoder.encode(JSON.stringify(message) + '\n')); },
+    // Simulate the process dying on its own (not via our kill()), e.g. an OOM.
+    crash(code) { resolveExit(code); },
+  };
+}
+
+function startOptions(overrides = {}) {
+  return {
+    command: 'hello',
+    agentSessionId: 'session-1',
+    chatId: 'chat-1',
+    model: 'sonnet',
+    permissionMode: 'default',
+    projectPath: '/tmp',
+    thinkingMode: 'none',
+    claudeThinkingMode: 'auto',
+    ...overrides,
+  };
+}
+
+const INIT = { type: 'system', subtype: 'init', session_id: 'session-1', model: 'sonnet' };
+const RESULT = { type: 'result', is_error: false };
+
+describe('ClaudeCliRuntime abort force-kill fallback', () => {
+  let originalSpawn;
+  let originalSetTimeout;
+  let originalClearTimeout;
+  let spawnMock;
+  let scheduled;
+  let cleared;
+
+  beforeEach(() => {
+    originalSpawn = Bun.spawn;
+    originalSetTimeout = globalThis.setTimeout;
+    originalClearTimeout = globalThis.clearTimeout;
+
+    spawnMock = mock();
+    Bun.spawn = spawnMock;
+
+    scheduled = [];
+    cleared = [];
+    globalThis.setTimeout = (fn, ms, ...args) => {
+      const id = originalSetTimeout(fn, ms, ...args);
+      scheduled.push({ id, fn, ms });
+      return id;
+    };
+    globalThis.clearTimeout = (id) => {
+      cleared.push(id);
+      return originalClearTimeout(id);
+    };
+  });
+
+  afterEach(() => {
+    // Cancel any real fallback timers still pending so they cannot fire late.
+    for (const { id } of scheduled) originalClearTimeout(id);
+    Bun.spawn = originalSpawn;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  });
+
+  const abortTimerIds = () => scheduled.filter((s) => s.ms === 5000).map((s) => s.id);
+
+  it('cancels the force-kill fallback once an interrupt is acknowledged', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    const turn = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+
+    await runtime.abortClaudeInternalSession('session-1');
+    const [abortTimerId] = abortTimerIds();
+    expect(abortTimerId).toBeDefined();
+
+    // Interrupt acknowledged: the CLI ends the turn with a result while the
+    // persistent process stays alive for follow-up turns.
+    ctrl.push(RESULT);
+    await turn;
+
+    expect(cleared).toContain(abortTimerId);
+    expect(ctrl.proc.killed).toBe(false);
+  });
+
+  it('does not kill a process reused by a new turn sent right after an abort', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    const failures = [];
+    runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
+
+    const first = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+
+    await runtime.abortClaudeInternalSession('session-1');
+    const [abortTimerId] = abortTimerIds();
+    ctrl.push(RESULT);
+    await first;
+
+    // New prompt within the old 5s window reuses the same persistent process.
+    const second = runtime.runClaudeTurn(startOptions({ command: 'continue' }));
+    await flush();
+
+    // The reused process must still be the original one (no respawn) and the
+    // stale fallback must have been cancelled so it can never SIGTERM it.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(cleared).toContain(abortTimerId);
+
+    ctrl.push(RESULT);
+    await second;
+
+    expect(ctrl.proc.killed).toBe(false);
+    expect(failures).toEqual([]);
+  });
+
+  it('still force-kills when the interrupt is never acknowledged', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    const turn = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+
+    await runtime.abortClaudeInternalSession('session-1');
+    const fallback = scheduled.find((s) => s.ms === 5000);
+    expect(fallback).toBeDefined();
+
+    // No result arrives: simulate the 5s fallback elapsing.
+    fallback.fn();
+
+    expect(ctrl.proc.killed).toBe(true);
+    await turn;
+  });
+
+  it('surfaces the abort force-kill as a clean finish, not a 143 failure', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    const failures = [];
+    const finishes = [];
+    runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
+    runtime.onFinished((chatId, exitCode) => finishes.push({ chatId, exitCode }));
+
+    const turn = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+
+    // User interrupts; the CLI never acknowledges, so the fallback force-kills.
+    await runtime.abortClaudeInternalSession('session-1');
+    const fallback = scheduled.find((s) => s.ms === 5000);
+    fallback.fn();
+    await turn;
+
+    // The intentional interrupt must not look like a crash.
+    expect(failures).toEqual([]);
+    expect(finishes.some((f) => f.chatId === 'chat-1' && f.exitCode === 0)).toBe(true);
+  });
+
+  it('still reports a genuine crash during the abort window as a failure', async () => {
+    const runtime = new ClaudeCliRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+
+    const failures = [];
+    const finishes = [];
+    runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
+    runtime.onFinished((chatId, exitCode) => finishes.push({ chatId, exitCode }));
+
+    const turn = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+
+    await runtime.abortClaudeInternalSession('session-1');
+    // The process dies from an unrelated fault (e.g. OOM, code 137) before the
+    // fallback ever fires — this is NOT the abort's own kill.
+    ctrl.crash(137);
+    await turn;
+
+    // A real crash must still surface as a failure, not be masked as clean.
+    expect(failures.some((f) => f.chatId === 'chat-1' && /137/.test(f.message))).toBe(true);
+    expect(finishes.some((f) => f.exitCode === 0)).toBe(false);
+  });
+});

--- a/server/agents/claude/claude-cli.ts
+++ b/server/agents/claude/claude-cli.ts
@@ -93,6 +93,10 @@ interface ClaudeRunningSession {
   chatId: string;
   isRunning: boolean;
   turnResolve: ((value: void | PromiseLike<void>) => void) | null;
+  initialization: Promise<void> | null;
+  completeInitialization: (() => void) | null;
+  turnLocked: boolean;
+  turnWaiters: Array<() => void>;
   startTime: number;
   lastActivityAt: number;
   process: ReturnType<typeof Bun.spawn> | null;
@@ -442,6 +446,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   #pendingPermissions = new Map<string, PendingPermission>();
   #pendingControlRequests = new Map<string, PendingControlRequest>();
   #idlePurger: IdleSessionPurger<ClaudeRunningSession>;
+  #shuttingDown = false;
 
   constructor() {
     super();
@@ -478,6 +483,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   }
 
   #routeCLIMessage(session: ClaudeRunningSession, msg: CLIMessage): void {
+    if (this.#runningSessions.get(session.id) !== session) return;
+
     switch (msg.type) {
       case 'system':
         this.#handleSystemMessage(session, msg);
@@ -661,6 +668,49 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     session.process = null;
     if (!proc.killed) {
       proc.kill();
+    }
+  }
+
+  #retireSession(session: ClaudeRunningSession): void {
+    const wasRunning = session.isRunning;
+    this.#killSessionProcess(session);
+    session.isRunning = false;
+    const resolve = session.turnResolve;
+    session.turnResolve = null;
+    if (wasRunning) this.emitProcessing(session.chatId, false);
+    resolve?.();
+    this.#completeSessionInitialization(session);
+
+    for (const [permissionRequestId, pending] of this.#pendingPermissions) {
+      if (pending.agentSessionId !== session.id) continue;
+      this.#emitPermissionMessages(pending.chatId, [
+        new PermissionCancelledMessage(new Date().toISOString(), permissionRequestId, 'cancelled'),
+      ]);
+      this.#pendingPermissions.delete(permissionRequestId);
+    }
+  }
+
+  #completeSessionInitialization(session: ClaudeRunningSession): void {
+    const complete = session.completeInitialization;
+    session.completeInitialization = null;
+    session.initialization = null;
+    complete?.();
+  }
+
+  async #acquireTurn(session: ClaudeRunningSession): Promise<void> {
+    if (!session.turnLocked) {
+      session.turnLocked = true;
+      return;
+    }
+    await new Promise<void>((resolve) => session.turnWaiters.push(resolve));
+  }
+
+  #releaseTurn(session: ClaudeRunningSession): void {
+    const next = session.turnWaiters.shift();
+    if (next) {
+      next();
+    } else {
+      session.turnLocked = false;
     }
   }
 
@@ -962,8 +1012,6 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     if (!chatId) throw new Error('chatId is required when starting a Claude session');
     if (!agentSessionId) throw new Error('agentSessionId is required when starting a Claude session');
 
-    const supportsLegacyThinkingFlag = await claudeCliSupportsLegacyThinkingFlag(getClaudeBinary());
-
     const allOpts: ClaudeSessionOptions = {
       agentSessionId,
       sessionId: agentSessionId,
@@ -977,11 +1025,19 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       envOverrides,
     };
 
+    let completeInitialization: (() => void) | null = null;
+    const initialization = new Promise<void>((resolve) => {
+      completeInitialization = resolve;
+    });
     const session: ClaudeRunningSession = {
       id: agentSessionId,
       chatId,
       isRunning: true,
       turnResolve: null,
+      initialization,
+      completeInitialization,
+      turnLocked: false,
+      turnWaiters: [],
       startTime: Date.now(),
       lastActivityAt: Date.now(),
       process: null,
@@ -994,20 +1050,34 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       currentModel: model || '',
       currentEnvOverrides: envOverrides,
     };
-    // Replacing an existing session: cancel any abort fallback it still has
-    // armed so its stale timer can't fire against the new session's chat.
+
     const previous = this.#runningSessions.get(agentSessionId);
-    if (previous) this.#clearAbortTimer(previous);
+    if (previous) this.#retireSession(previous);
     this.#runningSessions.set(agentSessionId, session);
-    this.emitProcessing(chatId, true);
 
-    this.emitSessionCreated(chatId);
+    let supportsLegacyThinkingFlag: boolean;
+    try {
+      supportsLegacyThinkingFlag = await claudeCliSupportsLegacyThinkingFlag(getClaudeBinary());
+    } catch (error) {
+      if (this.#runningSessions.get(agentSessionId) === session) {
+        session.isRunning = false;
+        this.#runningSessions.delete(agentSessionId);
+      }
+      this.#completeSessionInitialization(session);
+      throw error;
+    }
+    // Another start may supersede this one while the version probe is pending.
+    if (this.#runningSessions.get(agentSessionId) !== session) return agentSessionId;
 
-    this.#spawnCLI(session, allOpts, false, supportsLegacyThinkingFlag);
-
-    this.#sendUserMessage(session, command, images);
-
-    await this.#waitForTurnComplete(session);
+    try {
+      this.emitProcessing(chatId, true);
+      this.emitSessionCreated(chatId);
+      this.#spawnCLI(session, allOpts, false, supportsLegacyThinkingFlag);
+      this.#sendUserMessage(session, command, images);
+      await this.#waitForTurnComplete(session);
+    } finally {
+      this.#completeSessionInitialization(session);
+    }
     return agentSessionId;
   }
 
@@ -1033,6 +1103,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     // Resolved before any session-state checks so the spawn path below stays
     // free of interleaving awaits.
     const supportsLegacyThinkingFlag = await claudeCliSupportsLegacyThinkingFlag(getClaudeBinary());
+    if (this.#shuttingDown) throw new Error('Claude runtime is shutting down');
 
     const allOpts: ClaudeSessionOptions = {
       agentSessionId,
@@ -1047,13 +1118,23 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       envOverrides,
     };
 
-    let session = this.#runningSessions.get(agentSessionId);
-    if (!session) {
-      session = {
+    let session: ClaudeRunningSession;
+    while (true) {
+      let candidate = this.#runningSessions.get(agentSessionId);
+      while (candidate?.initialization) {
+        await candidate.initialization;
+        candidate = this.#runningSessions.get(agentSessionId);
+      }
+      if (!candidate) {
+        candidate = {
         id: agentSessionId,
         chatId: chatId,
         isRunning: false,
         turnResolve: null,
+        initialization: null,
+        completeInitialization: null,
+        turnLocked: false,
+        turnWaiters: [],
         startTime: Date.now(),
         lastActivityAt: Date.now(),
         process: null,
@@ -1065,15 +1146,28 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
         currentClaudeThinkingMode: normalizeClaudeThinkingModeForState(claudeThinkingMode),
         currentModel: model || '',
         currentEnvOverrides: envOverrides,
-      };
-      this.#runningSessions.set(agentSessionId, session);
-    } else {
+        };
+        this.#runningSessions.set(agentSessionId, candidate);
+      }
+
+      await this.#acquireTurn(candidate);
+      if (this.#shuttingDown) {
+        this.#releaseTurn(candidate);
+        throw new Error('Claude runtime is shutting down');
+      }
+      if (this.#runningSessions.get(agentSessionId) === candidate && !candidate.initialization) {
+        session = candidate;
+        break;
+      }
+      this.#releaseTurn(candidate);
+    }
+
+    try {
       if (chatId !== session.chatId) {
         throw new Error('Chat ID mismatch');
       }
-    }
 
-    session.options = mergeClaudeSessionOptions(session.options, allOpts);
+      session.options = mergeClaudeSessionOptions(session.options, allOpts);
 
     const effectiveChatId = chatId || session.chatId;
     session.chatId = effectiveChatId;
@@ -1132,7 +1226,10 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     // before it can fire against the process now serving this turn.
     this.#clearAbortTimer(session);
     this.#sendUserMessage(session, command, images);
-    await this.#waitForTurnComplete(session);
+      await this.#waitForTurnComplete(session);
+    } finally {
+      this.#releaseTurn(session);
+    }
   }
 
   async abortClaudeInternalSession(agentSessionId: string): Promise<boolean> {
@@ -1194,6 +1291,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   }
 
   shutdown(): void {
+    this.#shuttingDown = true;
     this.#idlePurger.stop();
     for (const session of this.#runningSessions.values()) {
       this.#clearAbortTimer(session);
@@ -1207,6 +1305,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       const resolve = session.turnResolve;
       session.turnResolve = null;
       resolve?.();
+      this.#completeSessionInitialization(session);
     }
     this.#runningSessions.clear();
     this.#pendingPermissions.clear();

--- a/server/agents/claude/claude-cli.ts
+++ b/server/agents/claude/claude-cli.ts
@@ -96,6 +96,15 @@ interface ClaudeRunningSession {
   startTime: number;
   lastActivityAt: number;
   process: ReturnType<typeof Bun.spawn> | null;
+  // Fallback timer that force-kills the process if an interrupt is never
+  // acknowledged. Cleared once the turn resolves, the process exits, or a new
+  // turn reuses the persistent process, so it never kills a live follow-up turn.
+  abortTimer: ReturnType<typeof setTimeout> | null;
+  // Set to the process the abort fallback force-killed. Its exit is the intended
+  // outcome of a user interrupt, so it surfaces as a clean stop rather than a
+  // "CLI process exited with code 143" error. Only the fallback sets this, so an
+  // unrelated crash during the abort window is still reported as a failure.
+  abortKilledProc: ReturnType<typeof Bun.spawn> | null;
   options: ClaudeSessionOptions;
   currentPermissionMode: PermissionMode;
   currentThinkingMode: ThinkingMode;
@@ -559,7 +568,19 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     ]);
   }
 
+  // Cancels the pending force-kill fallback armed by an abort. Safe to call
+  // when none is armed.
+  #clearAbortTimer(session: ClaudeRunningSession): void {
+    if (session.abortTimer) {
+      clearTimeout(session.abortTimer);
+      session.abortTimer = null;
+    }
+  }
+
   #handleResultMessage(session: ClaudeRunningSession, msg: CLIMessage): void {
+    // The turn has ended (including an acknowledged interrupt), so the abort
+    // fallback must not fire against the still-alive persistent process.
+    this.#clearAbortTimer(session);
     session.isRunning = false;
     session.lastActivityAt = Date.now();
     this.emitProcessing(session.chatId, false);
@@ -634,6 +655,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   }
 
   #killSessionProcess(session: ClaudeRunningSession): void {
+    this.#clearAbortTimer(session);
     const proc = session.process;
     if (!proc) return;
     session.process = null;
@@ -842,6 +864,11 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
 
     session.process = null;
     session.lastActivityAt = Date.now();
+    this.#clearAbortTimer(session);
+    // Whether this exit is the abort fallback's own force-kill (vs an unrelated
+    // crash that merely happened during the abort window).
+    const wasAbortKill = session.abortKilledProc === proc;
+    session.abortKilledProc = null;
 
     for (const [permissionRequestId, pending] of this.#pendingPermissions) {
       if (pending.agentSessionId === session.id) {
@@ -858,7 +885,13 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       session.turnResolve = null;
       resolve?.();
       if (wasRunning) {
-        this.emitFailed(session.chatId, `CLI process exited with code ${exitCode}`);
+        if (wasAbortKill) {
+          // The exit is the intended result of a user interrupt whose CLI
+          // acknowledgement never arrived: surface a clean stop, not an error.
+          this.emitFinished(session.chatId, 0);
+        } else {
+          this.emitFailed(session.chatId, `CLI process exited with code ${exitCode}`);
+        }
       }
     }
   }
@@ -952,6 +985,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       startTime: Date.now(),
       lastActivityAt: Date.now(),
       process: null,
+      abortTimer: null,
+      abortKilledProc: null,
       options: allOpts,
       currentPermissionMode: permissionMode || 'default',
       currentThinkingMode: thinkingMode || 'none',
@@ -959,6 +994,10 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       currentModel: model || '',
       currentEnvOverrides: envOverrides,
     };
+    // Replacing an existing session: cancel any abort fallback it still has
+    // armed so its stale timer can't fire against the new session's chat.
+    const previous = this.#runningSessions.get(agentSessionId);
+    if (previous) this.#clearAbortTimer(previous);
     this.#runningSessions.set(agentSessionId, session);
     this.emitProcessing(chatId, true);
 
@@ -1018,6 +1057,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
         startTime: Date.now(),
         lastActivityAt: Date.now(),
         process: null,
+        abortTimer: null,
+        abortKilledProc: null,
         options: allOpts,
         currentPermissionMode: permissionMode || 'default',
         currentThinkingMode: thinkingMode || 'none',
@@ -1087,6 +1128,9 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     }
     session.currentPermissionMode = newMode;
 
+    // A new turn supersedes any prior abort, so cancel its force-kill fallback
+    // before it can fire against the process now serving this turn.
+    this.#clearAbortTimer(session);
     this.#sendUserMessage(session, command, images);
     await this.#waitForTurnComplete(session);
   }
@@ -1102,9 +1146,16 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     }));
 
     const proc = session.process;
-    setTimeout(() => {
+    this.#clearAbortTimer(session);
+    session.abortTimer = setTimeout(() => {
+      session.abortTimer = null;
+      // Only fires when the interrupt was never acknowledged: the same process
+      // is still stuck on the aborted turn. An acknowledged interrupt or a new
+      // turn clears this timer first, so a reused process is never killed here.
       if (session.process === proc && !proc.killed) {
         logger.warn(`cli(${agentSessionId.slice(0, 8)}): interrupt not acknowledged, force-killing process`);
+        // Mark this exit as the abort's own kill so it reads as a clean stop.
+        session.abortKilledProc = proc;
         proc.kill();
       }
     }, 5000);
@@ -1145,6 +1196,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   shutdown(): void {
     this.#idlePurger.stop();
     for (const session of this.#runningSessions.values()) {
+      this.#clearAbortTimer(session);
       if (session.process && !session.process.killed) {
         session.process.kill();
       }


### PR DESCRIPTION
**Problem**

Pressing Escape to interrupt a running turn and then sending a new prompt makes the chat "die" with **`CLI process exited with code 143`** (SIGTERM).

`abortClaudeInternalSession` sends an `interrupt` to the persistent `claude` CLI process and arms a **5s fallback timer that force-kills the process** if the interrupt is never acknowledged — but it never cancels it. In `stream-json` mode the process is reused across turns, so when a follow-up prompt is sent within that 5s window, the stale timer fires and SIGTERMs the process that is now serving the new turn. `#handleProcessExit` then reports it as a crash (`emitFailed` → `CLI process exited with code 143`). This matches the reported repro exactly: interrupt → `[Request interrupted by user]` → follow-up prompt → error 143.

**Solution**

Track the abort fallback timer on the session and cancel it the moment it is no longer needed: when the turn resolves (`#handleResultMessage`), when the process exits, when the process is intentionally killed, when a new turn reuses the process (`runClaudeTurn`), and on shutdown. This guarantees the timer can never kill a live follow-up turn.

Record the *specific process* the fallback force-kills. Only that process's exit is rendered as a clean stop (`emitFinished`) instead of a `code 143` error — an unrelated crash that merely happens during the abort window is still reported as a failure. Replacing a session retires the old process before asynchronous startup work, and stale callbacks from superseded sessions are ignored. Concurrent follow-up turns are serialized so each prompt owns its result and resolver.

**Changes**

- `server/agents/claude/claude-cli.ts`: add `abortTimer` + `abortKilledProc` to the session; add `#clearAbortTimer`; store/clear the fallback timer across abort, result, process-exit, kill, new-turn, session-replace, and shutdown; retire superseded sessions; serialize concurrent turns; render only the abort's own force-kill as a clean stop.
- `server/agents/claude/__tests__/abort-timer.test.js`: deterministic tests covering interrupt acknowledgement, process reuse, unacknowledged fallback, clean abort exit, genuine crash reporting, session replacement, start/resume ordering, and concurrent-resume serialization.

**Expected Impact**

Interrupt-then-resend no longer kills the chat with `code 143`. Follow-up prompts sent right after Escape run normally, and an unacknowledged interrupt ends as a clean stop rather than a spurious crash — while genuine process failures are still surfaced. No change to normal turn completion.

---

**Verification (dogfooded on throwaway servers)**

Ran the exact repro (interrupt a running turn, then send a follow-up within 5s) on fresh servers, comparing the pre-fix build against this fix:

| Build | Server-side outcome |
| --- | --- |
| Before (buggy) | `interrupt not acknowledged, force-killing process` → `process exited (code=143)` → `reload complete mode=process-error` — reproduced on every fresh run |
| After (fix) | no force-kill, no process-error reload — the follow-up turn runs to completion |

Unit tests (`bun test server/agents/claude`) all pass.

After — the interrupt + follow-up flow completing cleanly (no `code 143`):

![after](https://raw.githubusercontent.com/0xSolarPunk/garcon/6389afada502b6b5eda07555fc9f5a6df4408715/.pr-assets/after-interrupt-resend-clean.png)

Note: the pre-fix `code 143` surfaces as a brief error before the follow-up input is re-drained, so the reliable, reproducible signal is the server-side force-kill + `process-error` reload shown above (and the reported screenshot).