### PR TITLE
web: Allow opening review comments by clicking diff lines directly

### DIFF
--- a/web/src/lib/components/git/GitVirtualDiffRow.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffRow.svelte
@@ -8,7 +8,12 @@
 		GitDiffActionTarget,
 		GitVirtualReviewRow,
 	} from '$lib/stores/git-workbench.svelte.js';
-	import type { SplitDiffCellView, SplitDiffRowView, UnifiedDiffRowView } from './git-diff-rows';
+	import type {
+		GitDiffLineContextTarget,
+		SplitDiffCellView,
+		SplitDiffRowView,
+		UnifiedDiffRowView,
+	} from './git-diff-rows';
 	import GitVirtualCommentComposer from './GitVirtualCommentComposer.svelte';
 	import GitVirtualCommentThread from './GitVirtualCommentThread.svelte';
 	import * as m from '$lib/paraglide/messages.js';
@@ -74,7 +79,7 @@
 	let rowLineHeight = $derived(Math.max(18, Math.round(fontSize * 1.5)));
 	let headerFontSize = $derived(Math.max(10, Math.round(fontSize * 0.82)));
 
-	function handleLineClick(
+	function selectLine(
 		event: MouseEvent | KeyboardEvent,
 		selectionKey: string | null,
 		selectableLineKeys: string[],
@@ -88,14 +93,35 @@
 		onToggleLineSelection(selectionKey);
 	}
 
-	function handleLineKeydown(
-		event: KeyboardEvent,
+	function hasSelectedText(container: EventTarget | null): boolean {
+		if (!(container instanceof Node)) return false;
+		const selection = window.getSelection();
+		if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false;
+		return container.contains(selection.getRangeAt(0).commonAncestorContainer);
+	}
+
+	function usesLineSelectionModifier(event: MouseEvent | KeyboardEvent): boolean {
+		return event.shiftKey || event.ctrlKey || event.metaKey;
+	}
+
+	function openReview(filePath: string, target: GitDiffLineContextTarget | null): void {
+		if (!target) return;
+		onAddCommentForFile(filePath, target.side, target.line);
+	}
+
+	function handleReviewClick(
+		event: MouseEvent,
+		filePath: string,
+		target: GitDiffLineContextTarget | null,
 		selectionKey: string | null,
 		selectableLineKeys: string[],
 	): void {
-		if (event.key !== 'Enter' && event.key !== ' ') return;
-		event.preventDefault();
-		handleLineClick(event, selectionKey, selectableLineKeys);
+		if (hasSelectedText(event.currentTarget)) return;
+		if (usesLineSelectionModifier(event) && selectionKey) {
+			selectLine(event, selectionKey, selectableLineKeys);
+			return;
+		}
+		openReview(filePath, target);
 	}
 
 	function startHunkAction(actionTarget: GitDiffActionTarget, hunkIndex: number): void {
@@ -116,16 +142,12 @@
 		return activeTab === 'unstaged' ? m.git_action_stage_hunk() : m.git_action_unstage_hunk();
 	}
 
-	function addCommentForUnified(filePath: string, view: UnifiedDiffRowView): void {
-		const target = view.row.kind === 'del' ? view.beforeContextTarget : view.afterContextTarget;
-		if (!target) return;
-		onAddCommentForFile(filePath, target.side, target.line);
+	function unifiedReviewTarget(view: UnifiedDiffRowView): GitDiffLineContextTarget | null {
+		return view.row.kind === 'del' ? view.beforeContextTarget : view.afterContextTarget;
 	}
 
-	function addCommentForSplit(filePath: string, cellView: SplitDiffCellView | null): void {
-		const target = cellView?.contextTarget;
-		if (!target) return;
-		onAddCommentForFile(filePath, target.side, target.line);
+	function splitReviewTarget(cellView: SplitDiffCellView | null): GitDiffLineContextTarget | null {
+		return cellView?.contextTarget ?? null;
 	}
 
 	function openEditor(filePath: string, line: number | null): void {
@@ -137,6 +159,21 @@
 		return [view.left, view.right];
 	}
 </script>
+
+{#snippet reviewAffordance(filePath: string, target: GitDiffLineContextTarget | null)}
+	{#if target}
+		<button
+			type="button"
+			data-git-comment-affordance
+			class="absolute right-1 top-1/2 z-10 inline-flex -translate-y-1/2 items-center justify-center rounded border border-border bg-background/95 p-0.5 text-muted-foreground opacity-100 shadow-sm transition-[color,background-color,opacity] hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent [@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/diff-cell:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within/diff-cell:opacity-100"
+			title={m.git_comment_add()}
+			aria-label={m.git_comment_add()}
+			onclick={() => openReview(filePath, target)}
+		>
+			<MessageSquarePlus class="h-3 w-3" />
+		</button>
+	{/if}
+{/snippet}
 
 {#if row.kind === 'unified-row'}
 	<div
@@ -162,15 +199,9 @@
 				</button>
 			</div>
 		{:else}
-			<!-- svelte-ignore a11y_no_noninteractive_tabindex (Selectable diff rows cannot be buttons because they contain nested staging and comment buttons.) -->
 			<div
-				class="grid select-none grid-cols-[2rem_3rem_3rem_minmax(0,1fr)_2rem] {row.view.bgClass} {row.view.isSelectable
-					? 'cursor-pointer hover:brightness-95'
-					: ''}"
-				tabindex={row.view.isSelectable ? 0 : -1}
-				role={row.view.isSelectable ? 'button' : undefined}
-				onclick={(event) => handleLineClick(event, row.view.selectionKey, row.selectableLineKeys)}
-				onkeydown={(event) => handleLineKeydown(event, row.view.selectionKey, row.selectableLineKeys)}
+				data-git-diff-review-row
+				class="diff-review-row group/diff-cell relative grid select-none grid-cols-[2rem_3rem_3rem_minmax(0,1fr)] {row.view.bgClass}"
 			>
 				<div class="flex items-center justify-center border-r border-border/30">
 					{#if row.view.row.kind === 'add' || row.view.row.kind === 'del'}
@@ -191,37 +222,55 @@
 				</div>
 				<button
 					type="button"
-					class="select-none border-r border-border/30 pr-2 text-right {row.view.lineNumClass}"
+					class="cursor-pointer select-none border-r border-border/30 pr-2 text-right {row.view.lineNumClass} focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent"
+					onclick={(event) =>
+						handleReviewClick(
+							event,
+							row.file.path,
+							unifiedReviewTarget(row.view),
+							row.view.selectionKey,
+							row.selectableLineKeys,
+						)}
 					ondblclick={() => openEditor(row.file.path, row.view.row.beforeLine)}
-					title="Open before line in editor"
+					title={m.git_comment_add()}
+					aria-label={m.git_comment_add()}
 				>
 					{row.view.row.beforeLine ?? ''}
 				</button>
 				<button
 					type="button"
-					class="select-none border-r border-border/30 pr-2 text-right {row.view.lineNumClass}"
+					class="cursor-pointer select-none border-r border-border/30 pr-2 text-right {row.view.lineNumClass} focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent"
+					onclick={(event) =>
+						handleReviewClick(
+							event,
+							row.file.path,
+							unifiedReviewTarget(row.view),
+							row.view.selectionKey,
+							row.selectableLineKeys,
+						)}
 					ondblclick={() => openEditor(row.file.path, row.view.row.afterLine)}
-					title="Open after line in editor"
+					title={m.git_comment_add()}
+					aria-label={m.git_comment_add()}
 				>
 					{row.view.row.afterLine ?? ''}
 				</button>
-				<div class="whitespace-pre-wrap break-all pl-2 pr-3">
+				<button
+					type="button"
+					class="cursor-pointer whitespace-pre-wrap break-all pl-2 pr-8 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent"
+					title={m.git_comment_add()}
+					aria-label={m.git_comment_add()}
+					onclick={(event) =>
+						handleReviewClick(
+							event,
+							row.file.path,
+							unifiedReviewTarget(row.view),
+							row.view.selectionKey,
+							row.selectableLineKeys,
+						)}
+				>
 					<span class="{row.view.textClass} select-text">{row.view.textPrefix}{row.view.text}</span>
-				</div>
-				<div class="pr-1 text-right">
-					<button
-						type="button"
-						class="rounded p-0.5 text-muted-foreground/35 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-						title={m.git_comment_add()}
-						aria-label={m.git_comment_add()}
-						onclick={(event) => {
-							event.stopPropagation();
-							addCommentForUnified(row.file.path, row.view);
-						}}
-					>
-						<MessageSquarePlus class="h-3 w-3" />
-					</button>
-				</div>
+				</button>
+				{@render reviewAffordance(row.file.path, unifiedReviewTarget(row.view))}
 			</div>
 		{/if}
 		<GitVirtualCommentThread
@@ -269,57 +318,74 @@
 				</button>
 			</div>
 		{:else}
-			<div class="grid grid-cols-[3rem_minmax(0,1fr)_1px_3rem_minmax(0,1fr)]">
+			<div
+				data-git-diff-review-row
+				class="diff-review-row grid grid-cols-[minmax(0,1fr)_1px_minmax(0,1fr)]"
+			>
 				{#each splitCellViews(row.view) as cellView, index}
-					<button
-						type="button"
-						class="select-none border-r border-border/30 pr-2 text-right {cellView?.lineNumClass ?? 'text-muted-foreground/30'} {cellView?.bgClass ?? ''}"
-						ondblclick={() => openEditor(row.file.path, cellView?.side === 'after' ? cellView.cell.line : null)}
-						title="Open after line in editor"
-					>
-						{cellView?.cell.line ?? ''}
-					</button>
-					<!-- svelte-ignore a11y_no_noninteractive_tabindex (Selectable split diff cells cannot be buttons because they contain nested staging and comment buttons.) -->
 					<div
-						class="border-r border-border/30 pl-2 pr-2 whitespace-pre-wrap break-all {cellView?.bgClass ?? ''} {cellView?.isSelectable
-							? 'cursor-pointer hover:brightness-95'
-							: ''}"
-						class:opacity-40={!cellView || cellView.cell.kind === 'empty'}
-						tabindex={cellView?.isSelectable ? 0 : -1}
-						role={cellView?.isSelectable ? 'button' : undefined}
-						onclick={(event) => handleLineClick(event, cellView?.selectionKey ?? null, row.selectableLineKeys)}
-						onkeydown={(event) => handleLineKeydown(event, cellView?.selectionKey ?? null, row.selectableLineKeys)}
+						class="group/diff-cell grid min-w-0 grid-cols-[3rem_minmax(0,1fr)] {cellView?.bgClass ?? ''}"
 					>
-						{#if cellView && cellView.cell.kind !== 'empty'}
-							<button
-								type="button"
-								class="mr-1 rounded p-0.5 text-muted-foreground/35 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-								title={m.git_comment_add()}
-								aria-label={m.git_comment_add()}
-								onclick={(event) => {
-									event.stopPropagation();
-									addCommentForSplit(row.file.path, cellView);
-								}}
-							>
-								<MessageSquarePlus class="inline h-3 w-3" />
-							</button>
-							{#if cellView.cell.kind === 'add' || cellView.cell.kind === 'del'}
+						<button
+							type="button"
+							disabled={!cellView || cellView.cell.kind === 'empty'}
+							class="cursor-pointer select-none border-r border-border/30 pr-2 text-right {cellView?.lineNumClass ?? 'text-muted-foreground/30'} disabled:cursor-default focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent"
+							onclick={(event) =>
+								handleReviewClick(
+									event,
+									row.file.path,
+									splitReviewTarget(cellView),
+									cellView?.selectionKey ?? null,
+									row.selectableLineKeys,
+								)}
+							ondblclick={() =>
+								openEditor(row.file.path, cellView?.side === 'after' ? cellView.cell.line : null)}
+							title={cellView && cellView.cell.kind !== 'empty' ? m.git_comment_add() : undefined}
+							aria-label={cellView && cellView.cell.kind !== 'empty' ? m.git_comment_add() : undefined}
+						>
+							{cellView?.cell.line ?? ''}
+						</button>
+						<div
+							class="relative min-w-0 border-r border-border/30"
+							class:opacity-40={!cellView || cellView.cell.kind === 'empty'}
+						>
+							{#if cellView && cellView.cell.kind !== 'empty'}
 								<button
 									type="button"
-									disabled={operationPending}
-									class="mr-1 rounded p-0.5 text-muted-foreground/40 hover:bg-muted hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-									title={lineActionTitle()}
-									aria-label={lineActionTitle()}
-									onclick={(event) => {
-										event.stopPropagation();
-										startLineAction(row.actionTarget, cellView.cell.diffLineIndex);
-									}}
+									class="block min-h-full w-full cursor-pointer whitespace-pre-wrap break-all py-0 pr-8 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent {cellView.cell.kind === 'add' || cellView.cell.kind === 'del' ? 'pl-7' : 'pl-2'}"
+									title={m.git_comment_add()}
+									aria-label={m.git_comment_add()}
+									onclick={(event) =>
+										handleReviewClick(
+											event,
+											row.file.path,
+											cellView.contextTarget,
+											cellView.selectionKey,
+											row.selectableLineKeys,
+										)}
 								>
-									{#if activeTab === 'unstaged'}<Plus class="inline h-3 w-3" />{:else}<Minus class="inline h-3 w-3" />{/if}
+									<span class="{cellView.textClass} select-text"
+										>{cellView.textPrefix}{cellView.cell.text}</span
+									>
 								</button>
+								{#if cellView.cell.kind === 'add' || cellView.cell.kind === 'del'}
+									<button
+										type="button"
+										disabled={operationPending}
+										class="absolute left-1 top-1/2 z-10 -translate-y-1/2 rounded p-0.5 text-muted-foreground/40 hover:bg-muted hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+										title={lineActionTitle()}
+										aria-label={lineActionTitle()}
+										onclick={() =>
+											startLineAction(row.actionTarget, cellView.cell.diffLineIndex)}
+									>
+										{#if activeTab === 'unstaged'}<Plus class="h-3 w-3" />{:else}<Minus
+												class="h-3 w-3"
+											/>{/if}
+									</button>
+								{/if}
+								{@render reviewAffordance(row.file.path, cellView.contextTarget)}
 							{/if}
-							<span class="{cellView.textClass} select-text">{cellView.textPrefix}{cellView.cell.text}</span>
-						{/if}
+						</div>
 					</div>
 					{#if index === 0}
 						<div class="bg-border/40 p-0"></div>
@@ -349,3 +415,14 @@
 		{/if}
 	</div>
 {/if}
+
+<style>
+	.diff-review-row {
+		transition: box-shadow 120ms ease;
+	}
+
+	.diff-review-row:hover,
+	.diff-review-row:focus-within {
+		box-shadow: inset 0 0 0 1px hsl(var(--interactive-accent) / 0.65);
+	}
+</style>

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
@@ -183,7 +183,7 @@ describe('GitVirtualDiffRow', () => {
 		added.unmount();
 
 		renderRow(contextRow, { onAddCommentForFile });
-		await fireEvent.click(screen.getByText(' shared line'));
+		await fireEvent.click(screen.getByText(/shared line/));
 		expect(onAddCommentForFile).toHaveBeenLastCalledWith('src/example.ts', 'after', 2);
 	});
 

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
@@ -1,0 +1,248 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { GitRenderedDiffRow, GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git';
+import {
+	buildVirtualRows,
+	type GitVirtualReviewRow,
+} from '$lib/stores/git/git-virtual-review-document.svelte';
+import GitVirtualDiffRow from '../GitVirtualDiffRow.svelte';
+
+type DiffContentRow = Extract<GitVirtualReviewRow, { kind: 'unified-row' | 'split-row' }>;
+type UnifiedContentRow = Extract<GitVirtualReviewRow, { kind: 'unified-row' }>;
+type SplitContentRow = Extract<GitVirtualReviewRow, { kind: 'split-row' }>;
+type GitVirtualDiffRowProps = ComponentProps<typeof GitVirtualDiffRow>;
+
+const file: GitReviewFileSummary = {
+	path: 'src/example.ts',
+	indexStatus: ' ',
+	workTreeStatus: 'M',
+	category: 'normal',
+	additions: 1,
+	deletions: 1,
+	estimatedRows: 4,
+	bodyState: 'loaded',
+	bodyFingerprint: 'fingerprint:src/example.ts',
+	isGenerated: false,
+	isBinary: false,
+	isTooLarge: false,
+};
+
+const renderedRows: GitRenderedDiffRow[] = [
+	{
+		key: 'hunk:0:hunk-0',
+		kind: 'hunk',
+		hunkIndex: 0,
+		hunkId: 'hunk-0',
+		beforeLine: null,
+		afterLine: null,
+		text: '@@ -1,2 +1,2 @@',
+		diffLineIndex: -1,
+	},
+	{
+		key: 'line:0:del:1',
+		kind: 'del',
+		hunkIndex: 0,
+		hunkId: 'hunk-0',
+		beforeLine: 1,
+		afterLine: null,
+		text: 'old line',
+		diffLineIndex: 0,
+	},
+	{
+		key: 'line:1:add:1',
+		kind: 'add',
+		hunkIndex: 0,
+		hunkId: 'hunk-0',
+		beforeLine: null,
+		afterLine: 1,
+		text: 'new line',
+		diffLineIndex: 1,
+	},
+	{
+		key: 'line:2:context:2',
+		kind: 'context',
+		hunkIndex: 0,
+		hunkId: 'hunk-0',
+		beforeLine: 2,
+		afterLine: 2,
+		text: 'shared line',
+		diffLineIndex: 2,
+	},
+];
+
+function buildRows(diffMode: 'unified' | 'split'): DiffContentRow[] {
+	const body: GitReviewFileBody = {
+		path: file.path,
+		bodyFingerprint: file.bodyFingerprint,
+		bodyState: 'loaded',
+		category: 'normal',
+		isBinary: false,
+		isTooLarge: false,
+		rows: renderedRows,
+		hunks: [],
+	};
+	return buildVirtualRows({
+		summary: {
+			documentId: 'document-1',
+			project: '/project',
+			mode: 'working',
+			context: 5,
+			files: [file],
+			limits: {
+				maxSummaryFiles: 100,
+				maxBodyBatchFiles: 20,
+				maxLoadedRows: 10_000,
+				maxLoadedPatchBytes: 1_000_000,
+				maxFileRows: 1_000,
+				maxFilePatchBytes: 100_000,
+				maxLineBytes: 10_000,
+				maxContextLines: 20,
+				bodyConcurrency: 2,
+			},
+		},
+		visibleFilePaths: [file.path],
+		fileBodies: { [file.path]: body },
+		loadingBodies: new Set(),
+		focusedFilePath: file.path,
+		diffMode,
+		activeTab: 'unstaged',
+		contextLines: 5,
+		commentsByFile: {},
+		composerState: {
+			open: false,
+			filePath: '',
+			side: 'after',
+			line: 0,
+			body: '',
+			severity: 'note',
+		},
+		selectedLineKeys: new Set(),
+	}).filter((row): row is DiffContentRow => row.kind === 'unified-row' || row.kind === 'split-row');
+}
+
+function renderRow(
+	row: DiffContentRow,
+	overrides: Partial<GitVirtualDiffRowProps> = {},
+) {
+	const props: GitVirtualDiffRowProps = {
+		row,
+		activeTab: 'unstaged',
+		fontSize: 12,
+		selectedLineKeys: new Set(),
+		operationPending: false,
+		composerState: {
+			open: false,
+			filePath: '',
+			side: 'after',
+			line: 0,
+			body: '',
+			severity: 'note',
+		},
+		editingCommentId: null,
+		editBody: '',
+		onStartEdit: vi.fn(),
+		onCancelEdit: vi.fn(),
+		onEditBodyChange: vi.fn(),
+		onSaveEdit: vi.fn(),
+		onRemoveComment: vi.fn(),
+		onToggleLineSelection: vi.fn(),
+		onSelectLineRange: vi.fn(),
+		onStageHunk: vi.fn(),
+		onUnstageHunk: vi.fn(),
+		onStageLine: vi.fn(),
+		onUnstageLine: vi.fn(),
+		onAddCommentForFile: vi.fn(),
+		...overrides,
+	};
+	return { ...render(GitVirtualDiffRow, { props }), props };
+}
+
+function findUnifiedRow(kind: 'add' | 'context'): UnifiedContentRow {
+	return buildRows('unified').find(
+		(row): row is UnifiedContentRow => row.kind === 'unified-row' && row.view.row.kind === kind,
+	)!;
+}
+
+function findSplitChangeRow(): SplitContentRow {
+	return buildRows('split').find(
+		(row): row is SplitContentRow =>
+			row.kind === 'split-row' && row.view.left?.cell.kind === 'del',
+	)!;
+}
+
+describe('GitVirtualDiffRow', () => {
+	it('opens review from changed and context rows in unified mode', async () => {
+		const onAddCommentForFile = vi.fn();
+		const addedRow = findUnifiedRow('add');
+		const contextRow = findUnifiedRow('context');
+
+		const added = renderRow(addedRow, { onAddCommentForFile });
+		await fireEvent.click(screen.getByText('+new line'));
+		expect(onAddCommentForFile).toHaveBeenLastCalledWith('src/example.ts', 'after', 1);
+		added.unmount();
+
+		renderRow(contextRow, { onAddCommentForFile });
+		await fireEvent.click(screen.getByText(' shared line'));
+		expect(onAddCommentForFile).toHaveBeenLastCalledWith('src/example.ts', 'after', 2);
+	});
+
+	it('keeps modifier-click line selection without opening review', async () => {
+		const addedRow = findUnifiedRow('add');
+		const onAddCommentForFile = vi.fn();
+		const onToggleLineSelection = vi.fn();
+		renderRow(addedRow, { onAddCommentForFile, onToggleLineSelection });
+
+		await fireEvent.click(screen.getByText('+new line'), { ctrlKey: true });
+
+		expect(onToggleLineSelection).toHaveBeenCalledWith(addedRow.view.selectionKey);
+		expect(onAddCommentForFile).not.toHaveBeenCalled();
+	});
+
+	it('isolates the unified stage button from review activation', async () => {
+		const addedRow = findUnifiedRow('add');
+		const onAddCommentForFile = vi.fn();
+		const onStageLine = vi.fn();
+		renderRow(addedRow, { onAddCommentForFile, onStageLine });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Stage line' }));
+
+		expect(onStageLine).toHaveBeenCalledWith(addedRow.actionTarget, 1);
+		expect(onAddCommentForFile).not.toHaveBeenCalled();
+	});
+
+	it('renders the comment icon as a floating hover affordance', () => {
+		const addedRow = findUnifiedRow('add');
+		const { container } = renderRow(addedRow);
+
+		const affordance = container.querySelector<HTMLElement>('[data-git-comment-affordance]');
+		expect(affordance).not.toBeNull();
+		expect(affordance?.className).toContain('absolute');
+		expect(affordance?.className).toContain('group-hover/diff-cell:opacity-100');
+		expect(container.querySelector('[data-git-diff-review-row]')).not.toBeNull();
+	});
+
+	it('opens the correct review side in split mode and isolates staging', async () => {
+		const splitRow = findSplitChangeRow();
+		const onAddCommentForFile = vi.fn();
+		const onStageLine = vi.fn();
+		renderRow(splitRow, { onAddCommentForFile, onStageLine });
+
+		await fireEvent.click(screen.getByText('-old line'));
+		expect(onAddCommentForFile).toHaveBeenLastCalledWith('src/example.ts', 'before', 1);
+		await fireEvent.click(screen.getByText('+new line'));
+		expect(onAddCommentForFile).toHaveBeenLastCalledWith('src/example.ts', 'after', 1);
+
+		onAddCommentForFile.mockClear();
+		await fireEvent.click(screen.getAllByRole('button', { name: 'Stage line' })[0]);
+		expect(onStageLine).toHaveBeenCalledWith(splitRow.actionTarget, 0);
+		expect(onAddCommentForFile).not.toHaveBeenCalled();
+	});
+
+	it('uses native buttons for keyboard-reachable review activation', () => {
+		const addedRow = findUnifiedRow('add');
+		renderRow(addedRow);
+
+		expect(screen.getByText('+new line').closest('button')).not.toBeNull();
+	});
+});

--- a/web/src/lib/paraglide/messages/sidebar_select_all.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_all.js
@@ -19,6 +19,6 @@ const en_sidebar_select_all = /** @type {(inputs: Sidebar_Select_AllInputs) => L
 * @returns {LocalizedString}
 */
 export const sidebar_select_all = /** @type {((inputs?: Sidebar_Select_AllInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_AllInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_all(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_archive.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_archive.js
@@ -19,6 +19,6 @@ const en_sidebar_select_archive = /** @type {(inputs: Sidebar_Select_ArchiveInpu
 * @returns {LocalizedString}
 */
 export const sidebar_select_archive = /** @type {((inputs?: Sidebar_Select_ArchiveInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_ArchiveInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_archive(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_count.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_count.js
@@ -19,6 +19,6 @@ const en_sidebar_select_count = /** @type {(inputs: Sidebar_Select_CountInputs) 
 * @returns {LocalizedString}
 */
 export const sidebar_select_count = /** @type {((inputs: Sidebar_Select_CountInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_CountInputs, { locale?: "en" }, {}>} */ ((inputs, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_count(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_delete.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_delete.js
@@ -19,6 +19,6 @@ const en_sidebar_select_delete = /** @type {(inputs: Sidebar_Select_DeleteInputs
 * @returns {LocalizedString}
 */
 export const sidebar_select_delete = /** @type {((inputs?: Sidebar_Select_DeleteInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_DeleteInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_delete(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_delete_confirm_and_more.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_delete_confirm_and_more.js
@@ -19,6 +19,6 @@ const en_sidebar_select_delete_confirm_and_more = /** @type {(inputs: Sidebar_Se
 * @returns {LocalizedString}
 */
 export const sidebar_select_delete_confirm_and_more = /** @type {((inputs: Sidebar_Select_Delete_Confirm_And_MoreInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_Delete_Confirm_And_MoreInputs, { locale?: "en" }, {}>} */ ((inputs, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_delete_confirm_and_more(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_delete_confirm_description.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_delete_confirm_description.js
@@ -19,6 +19,6 @@ const en_sidebar_select_delete_confirm_description = /** @type {(inputs: Sidebar
 * @returns {LocalizedString}
 */
 export const sidebar_select_delete_confirm_description = /** @type {((inputs?: Sidebar_Select_Delete_Confirm_DescriptionInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_Delete_Confirm_DescriptionInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_delete_confirm_description(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_delete_confirm_title.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_delete_confirm_title.js
@@ -19,6 +19,6 @@ const en_sidebar_select_delete_confirm_title = /** @type {(inputs: Sidebar_Selec
 * @returns {LocalizedString}
 */
 export const sidebar_select_delete_confirm_title = /** @type {((inputs: Sidebar_Select_Delete_Confirm_TitleInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_Delete_Confirm_TitleInputs, { locale?: "en" }, {}>} */ ((inputs, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_delete_confirm_title(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_done.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_done.js
@@ -19,6 +19,6 @@ const en_sidebar_select_done = /** @type {(inputs: Sidebar_Select_DoneInputs) =>
 * @returns {LocalizedString}
 */
 export const sidebar_select_done = /** @type {((inputs?: Sidebar_Select_DoneInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_DoneInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_done(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_enter.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_enter.js
@@ -19,6 +19,6 @@ const en_sidebar_select_enter = /** @type {(inputs: Sidebar_Select_EnterInputs) 
 * @returns {LocalizedString}
 */
 export const sidebar_select_enter = /** @type {((inputs?: Sidebar_Select_EnterInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_EnterInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_enter(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_none.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_none.js
@@ -19,6 +19,6 @@ const en_sidebar_select_none = /** @type {(inputs: Sidebar_Select_NoneInputs) =>
 * @returns {LocalizedString}
 */
 export const sidebar_select_none = /** @type {((inputs?: Sidebar_Select_NoneInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_NoneInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_none(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_pin.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_pin.js
@@ -19,6 +19,6 @@ const en_sidebar_select_pin = /** @type {(inputs: Sidebar_Select_PinInputs) => L
 * @returns {LocalizedString}
 */
 export const sidebar_select_pin = /** @type {((inputs?: Sidebar_Select_PinInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_PinInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_pin(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_unarchive.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_unarchive.js
@@ -19,6 +19,6 @@ const en_sidebar_select_unarchive = /** @type {(inputs: Sidebar_Select_Unarchive
 * @returns {LocalizedString}
 */
 export const sidebar_select_unarchive = /** @type {((inputs?: Sidebar_Select_UnarchiveInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_UnarchiveInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_unarchive(inputs)
 });

--- a/web/src/lib/paraglide/messages/sidebar_select_unpin.js
+++ b/web/src/lib/paraglide/messages/sidebar_select_unpin.js
@@ -19,6 +19,6 @@ const en_sidebar_select_unpin = /** @type {(inputs: Sidebar_Select_UnpinInputs) 
 * @returns {LocalizedString}
 */
 export const sidebar_select_unpin = /** @type {((inputs?: Sidebar_Select_UnpinInputs, options?: { locale?: "en" }) => LocalizedString) & import('../runtime.js').MessageMetadata<Sidebar_Select_UnpinInputs, { locale?: "en" }, {}>} */ ((inputs = {}, options = {}) => {
-	experimentalStaticLocale ?? options.locale ?? getLocale()
+	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()
 	return en_sidebar_select_unpin(inputs)
 });

--- a/web/src/lib/stores/__tests__/git-review-drafts.test.ts
+++ b/web/src/lib/stores/__tests__/git-review-drafts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { GitReviewDrafts } from '../git/git-review-drafts.svelte';
+
+describe('GitReviewDrafts', () => {
+	it('preserves an in-progress draft when its row is activated again', () => {
+		const drafts = new GitReviewDrafts();
+		drafts.openCommentComposer('src/a.ts', 'after', 12);
+		drafts.commentComposer = {
+			...drafts.commentComposer,
+			body: 'Keep this draft',
+			severity: 'warning',
+		};
+
+		drafts.openCommentComposer('src/a.ts', 'after', 12);
+
+		expect(drafts.commentComposer.body).toBe('Keep this draft');
+		expect(drafts.commentComposer.severity).toBe('warning');
+	});
+});

--- a/web/src/lib/stores/git/git-review-drafts.svelte.ts
+++ b/web/src/lib/stores/git/git-review-drafts.svelte.ts
@@ -38,6 +38,14 @@ export class GitReviewDrafts {
 	}
 
 	openCommentComposer(filePath: string, side: 'before' | 'after', line: number): void {
+		if (
+			this.commentComposer.open &&
+			this.commentComposer.filePath === filePath &&
+			this.commentComposer.side === side &&
+			this.commentComposer.line === line
+		) {
+			return;
+		}
 		this.commentComposer = { open: true, filePath, side, line, body: '', severity: 'note' };
 	}
 


### PR DESCRIPTION
Adds a clickable affordance and direct row/cell click handlers to open the review comment composer on specific lines in both unified and split diff views. Text selection and staging operations remain isolated from opening the composer. Additionally, preserves in-progress comment drafts when activating the same composer target multiple times.

## Summary

Describe what changed and why.

## Checklist

- [ ] Scope is focused and behavior is covered by tests
- [ ] API/WS contract changes include type and test updates
