### PR TITLE
web: Respect requested host during terminal creation placement

### DIFF
--- a/web/src/lib/components/workspace/WorkspaceTaskBar.test.ts
+++ b/web/src/lib/components/workspace/WorkspaceTaskBar.test.ts
@@ -9,6 +9,7 @@ const {
 	popOutFile,
 	closeSurface,
 	showOpenFiles,
+	createTerminal,
 	openTerminalSession,
 	terminalRegistry,
 } = vi.hoisted(() => ({
@@ -22,6 +23,7 @@ const {
 	popOutFile: vi.fn(async () => true),
 	closeSurface: vi.fn(async () => true),
 	showOpenFiles: vi.fn(),
+	createTerminal: vi.fn(async () => 'terminal-created'),
 	openTerminalSession: vi.fn(async () => undefined),
 	terminalRegistry: {
 		orderedSessions: [] as Array<{
@@ -41,7 +43,7 @@ vi.mock('$lib/context', () => ({
 		closeSurface,
 		isSurfaceCloseBlocked: () => false,
 		openSingleton: vi.fn(),
-		createTerminal: vi.fn(),
+		createTerminal,
 		openTerminalSession,
 	}),
 	getTerminalRegistry: () => terminalRegistry,
@@ -90,6 +92,26 @@ describe('WorkspaceTaskBar', () => {
 
 		await fireEvent.click(moveItem);
 		expect(moveSurface).toHaveBeenCalledWith('singleton:git', 'sidebar');
+	});
+
+	it('creates a terminal in the taskbar host', async () => {
+		render(WorkspaceTaskBar, {
+			host: 'sidebar',
+			hostState: {
+				order: ['singleton:files'],
+				activeId: 'singleton:files',
+				mru: ['singleton:files'],
+			},
+			labelFor: () => 'Files',
+			onSelect: vi.fn(),
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Workspace actions' }));
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.workspace_new_terminal() }));
+
+		await waitFor(() =>
+			expect(createTerminal).toHaveBeenCalledWith('sidebar', 'workspace-taskbar:sidebar'),
+		);
 	});
 
 	it('offers move, pop out, and close for an inactive tab context menu', async () => {

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -792,6 +792,24 @@ describe('WorkspaceCoordinator', () => {
 		expect(onTerminalLauncherDismissed).not.toHaveBeenCalled();
 	});
 
+	it('honors the requested host when reconciliation places a terminal during creation', async () => {
+		const creation = deferred<string>();
+		const { coordinator, terminals, layout } = createHarness();
+		terminals.create.mockReturnValue(creation.promise);
+
+		const opening = coordinator.createTerminal('sidebar', 'workspace-taskbar:sidebar');
+		await vi.waitFor(() => expect(terminals.create).toHaveBeenCalledOnce());
+		await coordinator.reconcileTerminals(['terminal-race'], { deriveLauncher: false });
+		expect(layout.snapshot.main.order).toContain(terminalSurfaceId('terminal-race'));
+
+		creation.resolve('terminal-race');
+		await opening;
+
+		expect(layout.snapshot.main.order).not.toContain(terminalSurfaceId('terminal-race'));
+		expect(layout.snapshot.sidebar.order).toContain(terminalSurfaceId('terminal-race'));
+		expect(layout.snapshot.sidebar.activeId).toBe(terminalSurfaceId('terminal-race'));
+	});
+
 	it('terminates a newly created terminal when its placement cannot publish', async () => {
 		const { coordinator, terminals, layout } = createHarness({ failLayoutPublishAt: 1 });
 		terminals.create.mockResolvedValue('terminal-unplaced');

--- a/web/src/lib/workspace/terminal-placement-service.ts
+++ b/web/src/lib/workspace/terminal-placement-service.ts
@@ -70,30 +70,21 @@ export class TerminalPlacementService {
 			? await this.#retryCreate(requestKey)
 			: await this.#createWithRequestId(createRandomId());
 		const surfaceId = terminalSurfaceId(terminalId);
-		if (!this.deps.layout.surface(surfaceId)) {
-			let current = false;
-			try {
-				current = await this.deps.commit(
-					(latest) => {
-						if (latest.surfaces[surfaceId]) {
-							const existingHost = latest.main.order.includes(surfaceId) ? 'main' : 'sidebar';
-							return [{ type: 'focus-host', host: existingHost, surfaceId }];
-						}
-						const mutations: WorkspaceLayoutMutation[] = [];
-						if (
-							latest.surfaces['terminal-launcher']?.type === 'terminal-launcher' &&
-							!this.deps.reservations.has('terminal-launcher')
-						) {
-							mutations.push({ type: 'remove-surface', surfaceId: 'terminal-launcher' });
-						}
-						mutations.push(
-							{
-								type: 'register-surface',
-								surface: { id: surfaceId, type: 'terminal', terminalId },
-								host,
-							},
-							{ type: 'focus-host', host, surfaceId },
-						);
+		let current = false;
+		try {
+			current = await this.deps.commit(
+				(latest) => {
+					if (latest.surfaces[surfaceId]) {
+						const existingHost = latest.main.order.includes(surfaceId)
+							? 'main'
+							: latest.sidebar.order.includes(surfaceId)
+								? 'sidebar'
+								: null;
+						const mutations: WorkspaceLayoutMutation[] = [
+							existingHost === host
+								? { type: 'focus-host', host, surfaceId }
+								: { type: 'move-to-host', surfaceId, destination: host },
+						];
 						if (this.deps.isMobile()) {
 							mutations.push({
 								type: 'set-mobile-presentation',
@@ -102,16 +93,37 @@ export class TerminalPlacementService {
 							});
 						}
 						return mutations;
-					},
-					{ requiredPublication: true },
-				);
-			} catch (error) {
-				await this.#rollbackUnplaced(terminalId, error);
-			}
-			if (!current) return terminalId;
-		} else {
-			await this.deps.focusSurface(surfaceId);
+					}
+					const mutations: WorkspaceLayoutMutation[] = [];
+					if (
+						latest.surfaces['terminal-launcher']?.type === 'terminal-launcher' &&
+						!this.deps.reservations.has('terminal-launcher')
+					) {
+						mutations.push({ type: 'remove-surface', surfaceId: 'terminal-launcher' });
+					}
+					mutations.push(
+						{
+							type: 'register-surface',
+							surface: { id: surfaceId, type: 'terminal', terminalId },
+							host,
+						},
+						{ type: 'focus-host', host, surfaceId },
+					);
+					if (this.deps.isMobile()) {
+						mutations.push({
+							type: 'set-mobile-presentation',
+							activeId: surfaceId,
+							returnStack: latest.mobileReturnStack,
+						});
+					}
+					return mutations;
+				},
+				{ requiredPublication: true },
+			);
+		} catch (error) {
+			await this.#rollbackUnplaced(terminalId, error);
 		}
+		if (!current) return terminalId;
 		this.deps.present(surfaceId);
 		return terminalId;
 	}


### PR DESCRIPTION
Ensures that terminals created via a specific taskbar host are placed and focused in that host. If terminal reconciliation registers the new terminal in a different host prior to completion, the service now moves and focuses the terminal in the originally requested host.

## Summary

Describe what changed and why.

## Checklist

- [ ] Scope is focused and behavior is covered by tests
- [ ] API/WS contract changes include type and test updates
