### PR TITLE
web/components/sidebar: Allow Git worktree selection in project path sidebar dialog

### DIFF
--- a/web/src/lib/components/sidebar/SidebarProjectPathDialog.svelte
+++ b/web/src/lib/components/sidebar/SidebarProjectPathDialog.svelte
@@ -6,6 +6,7 @@
 	import DirectoryBrowser from '$lib/components/chat/DirectoryBrowser.svelte';
 	import ProjectPinnedPathList from '$lib/components/chat/ProjectPinnedPathList.svelte';
 	import ProjectPinnedPathToggleButton from '$lib/components/chat/ProjectPinnedPathToggleButton.svelte';
+	import GitWorktreePickerModal from '$lib/components/git/GitWorktreePickerModal.svelte';
 	import { ProjectPathDialogState } from './project-path-dialog-state.svelte';
 	import { isPinnedProjectPath } from '$lib/chat/project-pinned-paths.js';
 	import type { ChatProjectPathDialog } from './sidebar-dialogs-state.svelte';
@@ -54,6 +55,9 @@
 			Boolean(onTogglePinnedProjectPath) &&
 			!projectPathDialogState.isSubmitting &&
 			!isUpdatingPinnedProjectPath,
+	);
+	let canOpenWorktreePicker = $derived(
+		projectPathDialogState.canSelectWorktree && !isUpdatingPinnedProjectPath,
 	);
 
 	$effect(() => {
@@ -129,138 +133,173 @@
 	}
 </script>
 
-<Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-	<Dialog.Content
-		class="h-dvh w-full max-w-full rounded-none border-0 p-0 sm:h-auto sm:max-w-lg sm:rounded-lg sm:border"
-		onOpenAutoFocus={handleOpenAutoFocus}
-	>
-		<div class="flex h-full flex-col sm:h-auto">
-			<Dialog.Header class="border-b border-border px-5 py-4">
-				<Dialog.Title>{m.sidebar_project_path_title()}</Dialog.Title>
-				<Dialog.Description class="min-w-0 truncate">
-					{projectPathDialog?.chatTitle || m.sidebar_chats_unnamed()}
-				</Dialog.Description>
-			</Dialog.Header>
+{#if isOpen && projectPathDialogState.worktreePickerOpen}
+	<GitWorktreePickerModal
+		worktrees={projectPathDialogState.worktrees}
+		isLoading={projectPathDialogState.isLoadingWorktrees}
+		isCreating={projectPathDialogState.isCreatingWorktree}
+		errorMessage={projectPathDialogState.worktreeError}
+		onSelect={(path) => projectPathDialogState.selectWorktree(path)}
+		onCreate={(path, branch, baseRef) =>
+			projectPathDialogState.createWorktree(path, branch, baseRef)}
+		onRefresh={() => {
+			void projectPathDialogState.loadWorktrees();
+		}}
+		onClose={() => projectPathDialogState.closeWorktreePicker()}
+	/>
+{:else}
+	<Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+		<Dialog.Content
+			class="h-dvh w-full max-w-full rounded-none border-0 p-0 sm:h-auto sm:max-w-lg sm:rounded-lg sm:border"
+			onOpenAutoFocus={handleOpenAutoFocus}
+		>
+			<div class="flex h-full flex-col sm:h-auto">
+				<Dialog.Header class="border-b border-border px-5 py-4">
+					<Dialog.Title>{m.sidebar_project_path_title()}</Dialog.Title>
+					<Dialog.Description class="min-w-0 truncate">
+						{projectPathDialog?.chatTitle || m.sidebar_chats_unnamed()}
+					</Dialog.Description>
+				</Dialog.Header>
 
-			<div class="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
-				<div class="space-y-1.5">
-					<span class="text-sm font-medium text-muted-foreground">
-						{m.sidebar_project_path_current_label()}
-					</span>
-					<div
-						class="min-h-9 rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-xs text-foreground"
-					>
-						<span class="block truncate">{projectPathDialog?.currentProjectPath ?? ''}</span>
+				<div class="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
+					<div class="space-y-1.5">
+						<span class="text-sm font-medium text-muted-foreground">
+							{m.sidebar_project_path_current_label()}
+						</span>
+						<div
+							class="min-h-9 rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-xs text-foreground"
+						>
+							<span class="block truncate">{projectPathDialog?.currentProjectPath ?? ''}</span>
+						</div>
 					</div>
-				</div>
 
-				<div class="space-y-1.5">
-					<label
-						for="sidebar-project-path-input"
-						class="block text-sm font-medium text-muted-foreground"
-					>
-						{m.sidebar_project_path_new_label()}
-					</label>
-					<div class="relative">
-						<div class="flex gap-2">
-							<div class="relative min-w-0 flex-1">
-								<Input
-									id="sidebar-project-path-input"
-									bind:ref={pathInputRef}
-									type="text"
-									bind:value={projectPathDialogState.candidatePath}
-									placeholder={activeProjectBasePath}
-									disabled={projectPathDialogState.isSubmitting}
-									readonly={isUpdatingPinnedProjectPath}
-									aria-invalid={isPathInvalid}
-									aria-describedby="sidebar-project-path-feedback"
-									oninput={() => {
-										projectPathDialogState.submitError = null;
-									}}
-									onkeydown={handlePathKeydown}
-									class="pr-9 font-mono text-base sm:text-xs"
-								/>
-								<div class="absolute right-2 top-1/2 -translate-y-1/2">
-									{#if !projectPathDialogState.trimmedPath}
-										<span aria-hidden="true"></span>
-									{:else if projectPathDialogState.validationStatus === 'checking'}
-										<Loader2 class="h-4 w-4 animate-spin text-muted-foreground" />
-									{:else if projectPathDialogState.validationStatus === 'valid'}
-										<Check class="h-4 w-4 text-status-success-foreground" />
-									{:else if projectPathDialogState.validationStatus === 'invalid'}
-										<X class="h-4 w-4 text-destructive" />
-									{/if}
+					<div class="space-y-1.5">
+						<label
+							for="sidebar-project-path-input"
+							class="block text-sm font-medium text-muted-foreground"
+						>
+							{m.sidebar_project_path_new_label()}
+						</label>
+						<div class="relative">
+							<div class="flex gap-2">
+								<div class="relative min-w-0 flex-1">
+									<Input
+										id="sidebar-project-path-input"
+										bind:ref={pathInputRef}
+										type="text"
+										bind:value={projectPathDialogState.candidatePath}
+										placeholder={activeProjectBasePath}
+										disabled={projectPathDialogState.isSubmitting}
+										readonly={isUpdatingPinnedProjectPath}
+										aria-invalid={isPathInvalid}
+										aria-describedby="sidebar-project-path-feedback"
+										oninput={() => {
+											projectPathDialogState.submitError = null;
+										}}
+										onkeydown={handlePathKeydown}
+										class="pr-9 font-mono text-base sm:text-xs"
+									/>
+									<div class="absolute right-2 top-1/2 -translate-y-1/2">
+										{#if !projectPathDialogState.trimmedPath}
+											<span aria-hidden="true"></span>
+										{:else if projectPathDialogState.validationStatus === 'checking'}
+											<Loader2 class="h-4 w-4 animate-spin text-muted-foreground" />
+										{:else if projectPathDialogState.validationStatus === 'valid'}
+											<Check class="h-4 w-4 text-status-success-foreground" />
+										{:else if projectPathDialogState.validationStatus === 'invalid'}
+											<X class="h-4 w-4 text-destructive" />
+										{/if}
+									</div>
 								</div>
+								<ProjectPinnedPathToggleButton
+									isPinned={isCandidatePinned}
+									disabled={!canTogglePinnedProjectPath}
+									loading={isUpdatingPinnedProjectPath}
+									class="h-9 rounded-md border border-border px-3 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+									onToggle={togglePinnedProjectPath}
+								/>
+								<Button
+									type="button"
+									variant="outline"
+									size="icon"
+									disabled={projectPathDialogState.isSubmitting || isUpdatingPinnedProjectPath}
+									onclick={() => {
+										projectPathDialogState.showBrowser = true;
+									}}
+									title={m.sidebar_project_path_browse()}
+									aria-label={m.sidebar_project_path_browse()}
+								>
+									<FolderOpen class="h-4 w-4" />
+								</Button>
 							</div>
-							<ProjectPinnedPathToggleButton
-								isPinned={isCandidatePinned}
-								disabled={!canTogglePinnedProjectPath}
-								loading={isUpdatingPinnedProjectPath}
-								class="h-9 rounded-md border border-border px-3 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-								onToggle={togglePinnedProjectPath}
-							/>
-							<Button
-								type="button"
-								variant="outline"
-								size="icon"
-								disabled={projectPathDialogState.isSubmitting || isUpdatingPinnedProjectPath}
-								onclick={() => {
-									projectPathDialogState.showBrowser = true;
-								}}
-								title={m.sidebar_project_path_browse()}
-								aria-label={m.sidebar_project_path_browse()}
-							>
-								<FolderOpen class="h-4 w-4" />
-							</Button>
+
+							{#if projectPathDialogState.showBrowser && !isUpdatingPinnedProjectPath}
+								<DirectoryBrowser
+									currentPath={projectPathDialogState.trimmedPath || activeProjectBasePath}
+									basePath={activeProjectBasePath}
+									onSelect={(path) => {
+										if (isUpdatingPinnedProjectPath) return;
+										projectPathDialogState.setCandidatePath(path);
+									}}
+									onClose={() => (projectPathDialogState.showBrowser = false)}
+									{isMobile}
+								/>
+							{/if}
 						</div>
 
-						{#if projectPathDialogState.showBrowser && !isUpdatingPinnedProjectPath}
-							<DirectoryBrowser
-								currentPath={projectPathDialogState.trimmedPath || activeProjectBasePath}
-								basePath={activeProjectBasePath}
-								onSelect={(path) => {
-									if (isUpdatingPinnedProjectPath) return;
-									projectPathDialogState.setCandidatePath(path);
-								}}
-								onClose={() => (projectPathDialogState.showBrowser = false)}
-								{isMobile}
-							/>
+						<div class="min-h-5">
+							{#if projectPathDialogState.gitRepoStatus === 'git' && projectPathDialogState.validationStatus === 'valid'}
+								<button
+									type="button"
+									disabled={!canOpenWorktreePicker}
+									onclick={() => projectPathDialogState.openWorktreePicker()}
+									class="flex items-center gap-1.5 text-xs text-interactive-accent transition-colors hover:underline disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:no-underline"
+								>
+									{m.chat_new_chat_select_different_worktree()}
+								</button>
+							{:else}
+								<span aria-hidden="true"></span>
+							{/if}
+						</div>
+					</div>
+
+					<ProjectPinnedPathList
+						{pinnedProjectPaths}
+						selectedPath={projectPathDialogState.candidatePath}
+						disabled={projectPathDialogState.isSubmitting || isUpdatingPinnedProjectPath}
+						onSelect={selectPinnedProjectPath}
+					/>
+
+					<div id="sidebar-project-path-feedback" class="min-h-5">
+						{#if validationMessage}
+							<p class="text-xs text-destructive">{validationMessage}</p>
+						{:else if projectPathDialogState.isUnchanged}
+							<p class="text-xs text-muted-foreground">{m.sidebar_project_path_unchanged()}</p>
 						{/if}
 					</div>
 				</div>
 
-				<ProjectPinnedPathList
-					{pinnedProjectPaths}
-					selectedPath={projectPathDialogState.candidatePath}
-					disabled={projectPathDialogState.isSubmitting || isUpdatingPinnedProjectPath}
-					onSelect={selectPinnedProjectPath}
-				/>
-
-				<div id="sidebar-project-path-feedback" class="min-h-5">
-					{#if validationMessage}
-						<p class="text-xs text-destructive">{validationMessage}</p>
-					{:else if projectPathDialogState.isUnchanged}
-						<p class="text-xs text-muted-foreground">{m.sidebar_project_path_unchanged()}</p>
-					{/if}
+				<div class="flex justify-end gap-2 border-t border-border px-5 py-3">
+					<Button
+						variant="outline"
+						onclick={onClose}
+						disabled={projectPathDialogState.isSubmitting}
+					>
+						{m.sidebar_actions_cancel()}
+					</Button>
+					<Button
+						onclick={() => {
+							void submitProjectPath();
+						}}
+						disabled={!projectPathDialogState.canSubmit}
+					>
+						{#if projectPathDialogState.isSubmitting}
+							<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+						{/if}
+						{m.sidebar_project_path_update_button()}
+					</Button>
 				</div>
 			</div>
-
-			<div class="flex justify-end gap-2 border-t border-border px-5 py-3">
-				<Button variant="outline" onclick={onClose} disabled={projectPathDialogState.isSubmitting}>
-					{m.sidebar_actions_cancel()}
-				</Button>
-				<Button
-					onclick={() => {
-						void submitProjectPath();
-					}}
-					disabled={!projectPathDialogState.canSubmit}
-				>
-					{#if projectPathDialogState.isSubmitting}
-						<Loader2 class="mr-2 h-4 w-4 animate-spin" />
-					{/if}
-					{m.sidebar_project_path_update_button()}
-				</Button>
-			</div>
-		</div>
-	</Dialog.Content>
-</Dialog.Root>
+		</Dialog.Content>
+	</Dialog.Root>
+{/if}

--- a/web/src/lib/components/sidebar/__tests__/sidebar-dialogs.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-dialogs.test.ts
@@ -6,6 +6,8 @@ import SidebarTagDialog from '../SidebarTagDialog.svelte';
 import SidebarProjectPathDialog from '../SidebarProjectPathDialog.svelte';
 import { ApiError } from '$lib/api/client';
 import * as chatsApi from '$lib/api/chats';
+import * as gitApi from '$lib/api/git';
+import type { GitWorktreeItem } from '$lib/api/git';
 
 vi.mock('$lib/api/chats', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api/chats')>();
@@ -14,6 +16,11 @@ vi.mock('$lib/api/chats', async (importOriginal) => {
 		validateStart: vi.fn(),
 	};
 });
+
+vi.mock('$lib/api/git', () => ({
+	getGitWorktrees: vi.fn(),
+	gitCreateWorktree: vi.fn(),
+}));
 
 interface RenderedDialog {
 	unmount: () => void;
@@ -35,6 +42,17 @@ function deferred<T>() {
 		resolve = res;
 	});
 	return { promise, resolve };
+}
+
+function makeWorktree(path: string, branch: string, isCurrent = false): GitWorktreeItem {
+	return {
+		name: branch,
+		path,
+		branch,
+		isCurrent,
+		isMain: branch === 'main',
+		isPathMissing: false,
+	};
 }
 
 describe('Sidebar dialogs', () => {
@@ -128,6 +146,99 @@ describe('Sidebar dialogs', () => {
 		}
 	});
 
+	it('selects a worktree in the project path dialog without applying until update', async () => {
+		vi.useFakeTimers();
+		const selectedPath = '/workspace/repo-feature';
+		vi.mocked(chatsApi.validateStart).mockResolvedValue({ valid: true, isGitRepo: true });
+		vi.mocked(gitApi.getGitWorktrees).mockResolvedValue({
+			worktrees: [
+				makeWorktree('/workspace/repo', 'main', true),
+				makeWorktree(selectedPath, 'feature'),
+			],
+		});
+		const onConfirm = vi.fn();
+
+		const rendered = render(SidebarProjectPathDialog, {
+			projectPathDialog: {
+				chatId: 'chat-1',
+				chatTitle: 'Feature chat',
+				currentProjectPath: '/workspace/repo',
+			},
+			projectBasePath: '/workspace',
+			isMobile: false,
+			onClose: vi.fn(),
+			onConfirm,
+		});
+
+		try {
+			await vi.advanceTimersByTimeAsync(250);
+			const selectWorktree = await screen.findByRole('button', {
+				name: 'Select a different worktree',
+			});
+			await fireEvent.click(selectWorktree);
+
+			const worktreeDialog = await screen.findByRole('dialog', { name: 'Select worktree' });
+			expect(worktreeDialog).toBeTruthy();
+			expect(gitApi.getGitWorktrees).toHaveBeenCalledWith(
+				'/workspace/repo',
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			);
+			await fireEvent.click(await screen.findByRole('option', { name: /feature/ }));
+
+			expect((screen.getByRole('textbox', { name: /new path/i }) as HTMLInputElement).value).toBe(
+				selectedPath,
+			);
+			expect(onConfirm).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(250);
+			const updateButton = await screen.findByRole('button', { name: 'Update path' });
+			await waitFor(() => {
+				expect((updateButton as HTMLButtonElement).disabled).toBe(false);
+			});
+			await fireEvent.click(updateButton);
+
+			await waitFor(() => {
+				expect(onConfirm).toHaveBeenCalledWith('chat-1', selectedPath);
+			});
+		} finally {
+			rendered.unmount();
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
+		}
+	});
+
+	it('hides the project path worktree link for valid non-git folders', async () => {
+		vi.useFakeTimers();
+		vi.mocked(chatsApi.validateStart).mockResolvedValue({ valid: true, isGitRepo: false });
+
+		const rendered = render(SidebarProjectPathDialog, {
+			projectPathDialog: {
+				chatId: 'chat-1',
+				chatTitle: 'Feature chat',
+				currentProjectPath: '/workspace/plain-folder',
+			},
+			projectBasePath: '/workspace',
+			isMobile: false,
+			onClose: vi.fn(),
+			onConfirm: vi.fn(),
+		});
+
+		try {
+			await vi.advanceTimersByTimeAsync(250);
+			await waitFor(() => {
+				expect(chatsApi.validateStart).toHaveBeenCalledWith(
+					'/workspace/plain-folder',
+					expect.objectContaining({ signal: expect.any(AbortSignal) }),
+				);
+			});
+			expect(screen.queryByRole('button', { name: 'Select a different worktree' })).toBeNull();
+		} finally {
+			rendered.unmount();
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
+		}
+	});
+
 	it('requests pinning the edited project path', async () => {
 		vi.useFakeTimers();
 		const onTogglePinnedProjectPath = vi.fn();
@@ -193,7 +304,9 @@ describe('Sidebar dialogs', () => {
 			const toggleButton = screen.getByRole('button', { name: 'Pin project path' });
 			await fireEvent.click(toggleButton);
 
-			const browseButton = screen.getByRole('button', { name: 'Browse folders' }) as HTMLButtonElement;
+			const browseButton = screen.getByRole('button', {
+				name: 'Browse folders',
+			}) as HTMLButtonElement;
 			expect(toggleButton.getAttribute('aria-busy')).toBe('true');
 			expect(toggleButton.querySelector('.animate-spin')).toBeTruthy();
 			expect(input.readOnly).toBe(true);

--- a/web/src/lib/components/sidebar/project-path-dialog-state.svelte.ts
+++ b/web/src/lib/components/sidebar/project-path-dialog-state.svelte.ts
@@ -1,8 +1,10 @@
 import { ApiError } from '$lib/api/client.js';
 import { validateStart, type ValidateStartErrorCode } from '$lib/api/chats.js';
+import { getGitWorktrees, gitCreateWorktree, type GitWorktreeItem } from '$lib/api/git.js';
 import * as m from '$lib/paraglide/messages.js';
 
 export type ProjectPathValidationStatus = 'idle' | 'checking' | 'valid' | 'invalid';
+export type ProjectPathGitRepoStatus = 'unknown' | 'git' | 'non-git';
 
 const VALIDATION_DELAY_MS = 250;
 
@@ -13,12 +15,20 @@ export class ProjectPathDialogState {
 	validationError = $state<string | null>(null);
 	submitError = $state<string | null>(null);
 	isSubmitting = $state(false);
+	gitRepoStatus = $state<ProjectPathGitRepoStatus>('unknown');
+	worktreePickerOpen = $state(false);
+	worktrees = $state<GitWorktreeItem[]>([]);
+	isLoadingWorktrees = $state(false);
+	isCreatingWorktree = $state(false);
+	worktreeError = $state<string | null>(null);
 
 	currentProjectPath = '';
 
 	#validationTimer: ReturnType<typeof setTimeout> | null = null;
 	#validationGeneration = 0;
 	#validationAbort: AbortController | null = null;
+	#worktreeGeneration = 0;
+	#worktreeAbort: AbortController | null = null;
 
 	get trimmedPath(): string {
 		return this.candidatePath.trim();
@@ -37,6 +47,15 @@ export class ProjectPathDialogState {
 		);
 	}
 
+	get canSelectWorktree(): boolean {
+		return (
+			this.validationStatus === 'valid' &&
+			this.gitRepoStatus === 'git' &&
+			Boolean(this.trimmedPath) &&
+			!this.isSubmitting
+		);
+	}
+
 	open(currentProjectPath: string): void {
 		this.currentProjectPath = currentProjectPath;
 		this.candidatePath = currentProjectPath;
@@ -45,7 +64,14 @@ export class ProjectPathDialogState {
 		this.validationError = null;
 		this.submitError = null;
 		this.isSubmitting = false;
+		this.gitRepoStatus = 'unknown';
+		this.worktreePickerOpen = false;
+		this.worktrees = [];
+		this.worktreeError = null;
+		this.isLoadingWorktrees = false;
+		this.isCreatingWorktree = false;
 		this.#clearPendingValidation();
+		this.#clearPendingWorktreeLoad();
 		this.#validationGeneration += 1;
 	}
 
@@ -53,13 +79,17 @@ export class ProjectPathDialogState {
 		this.showBrowser = false;
 		this.submitError = null;
 		this.isSubmitting = false;
+		this.worktreePickerOpen = false;
+		this.worktreeError = null;
 		this.#clearPendingValidation();
+		this.#clearPendingWorktreeLoad();
 	}
 
 	setCandidatePath(path: string): void {
 		this.candidatePath = path;
 		this.validationError = null;
 		this.submitError = null;
+		this.worktreeError = null;
 	}
 
 	scheduleValidation(): void {
@@ -70,10 +100,11 @@ export class ProjectPathDialogState {
 			this.#validationGeneration += 1;
 			this.validationStatus = 'idle';
 			this.validationError = null;
+			this.gitRepoStatus = 'unknown';
 			return;
 		}
 
-		if (path === this.currentProjectPath) {
+		if (path === this.currentProjectPath && this.gitRepoStatus !== 'unknown') {
 			this.#validationGeneration += 1;
 			this.validationStatus = 'valid';
 			this.validationError = null;
@@ -82,11 +113,84 @@ export class ProjectPathDialogState {
 
 		this.validationStatus = 'checking';
 		this.validationError = null;
+		this.gitRepoStatus = 'unknown';
 		const generation = ++this.#validationGeneration;
 
 		this.#validationTimer = setTimeout(() => {
 			void this.#validatePath(path, generation);
 		}, VALIDATION_DELAY_MS);
+	}
+
+	openWorktreePicker(): void {
+		if (!this.canSelectWorktree) return;
+		this.worktreePickerOpen = true;
+		this.worktreeError = null;
+		this.worktrees = [];
+		void this.loadWorktrees();
+	}
+
+	closeWorktreePicker(): void {
+		this.worktreePickerOpen = false;
+		this.worktreeError = null;
+	}
+
+	selectWorktree(worktreePath: string): void {
+		this.setCandidatePath(worktreePath);
+		this.validationStatus = 'valid';
+		this.validationError = null;
+		this.gitRepoStatus = 'git';
+		this.showBrowser = false;
+		this.worktreePickerOpen = false;
+	}
+
+	async loadWorktrees(): Promise<void> {
+		const path = this.trimmedPath;
+		if (!path) return;
+
+		this.#clearPendingWorktreeLoad();
+		const abort = new AbortController();
+		this.#worktreeAbort = abort;
+		const generation = ++this.#worktreeGeneration;
+		this.isLoadingWorktrees = true;
+		this.worktreeError = null;
+
+		try {
+			const result = await getGitWorktrees(path, { signal: abort.signal });
+			if (!this.#isCurrentWorktreeLoad(generation, abort.signal)) return;
+			this.worktrees = result.worktrees;
+		} catch (error) {
+			if (this.#isAbortError(error) || !this.#isCurrentWorktreeLoad(generation, abort.signal))
+				return;
+			this.worktreeError = m.git_target_load_worktrees_failed();
+			this.worktrees = [];
+		} finally {
+			if (this.#isCurrentWorktreeLoad(generation, abort.signal)) {
+				this.isLoadingWorktrees = false;
+			}
+		}
+	}
+
+	async createWorktree(worktreePath: string, branch?: string, baseRef?: string): Promise<void> {
+		const projectPath = this.trimmedPath;
+		if (!projectPath) return;
+
+		this.isCreatingWorktree = true;
+		this.worktreeError = null;
+
+		try {
+			const result = await gitCreateWorktree(projectPath, worktreePath, { branch, baseRef });
+			if (!result.success) {
+				this.worktreeError =
+					result.error || result.message || m.chat_new_chat_create_worktree_failed();
+				return;
+			}
+			this.selectWorktree(result.worktreePath || worktreePath);
+		} catch (error) {
+			this.worktreeError =
+				error instanceof Error ? error.message : m.chat_new_chat_create_worktree_failed();
+		} finally {
+			this.isCreatingWorktree = false;
+		}
 	}
 
 	setSubmitFailure(error: unknown): void {
@@ -100,6 +204,7 @@ export class ProjectPathDialogState {
 
 	dispose(): void {
 		this.#clearPendingValidation();
+		this.#clearPendingWorktreeLoad();
 	}
 
 	async #validatePath(path: string, generation: number): Promise<void> {
@@ -113,17 +218,20 @@ export class ProjectPathDialogState {
 			if (!data.valid) {
 				this.validationStatus = 'invalid';
 				this.validationError = this.#validationErrorMessage(data.errorCode);
+				this.gitRepoStatus = 'non-git';
 				return;
 			}
 
 			this.validationStatus = 'valid';
 			this.validationError = null;
+			this.gitRepoStatus = data.isGitRepo ? 'git' : 'non-git';
 		} catch (error) {
 			if (this.#isAbortError(error) || !this.#isCurrentValidation(path, generation, abort.signal)) {
 				return;
 			}
 			this.validationStatus = 'invalid';
 			this.validationError = m.chat_new_chat_errors_invalid_directory();
+			this.gitRepoStatus = 'non-git';
 		} finally {
 			if (this.#validationAbort === abort) this.#validationAbort = null;
 		}
@@ -136,12 +244,19 @@ export class ProjectPathDialogState {
 		this.#validationAbort = null;
 	}
 
+	#clearPendingWorktreeLoad(): void {
+		this.#worktreeAbort?.abort();
+		this.#worktreeAbort = null;
+	}
+
 	#isCurrentValidation(path: string, generation: number, signal: AbortSignal): boolean {
 		return (
-			!signal.aborted &&
-			generation === this.#validationGeneration &&
-			path === this.trimmedPath
+			!signal.aborted && generation === this.#validationGeneration && path === this.trimmedPath
 		);
+	}
+
+	#isCurrentWorktreeLoad(generation: number, signal: AbortSignal): boolean {
+		return !signal.aborted && generation === this.#worktreeGeneration;
 	}
 
 	#validationErrorMessage(errorCode?: ValidateStartErrorCode): string {
@@ -160,7 +275,8 @@ export class ProjectPathDialogState {
 		if (error.errorCode === 'PROJECT_PATH_OUTSIDE_BASE') {
 			return m.chat_new_chat_errors_path_outside_base_dir();
 		}
-		if (error.errorCode === 'PROJECT_PATH_NOT_FOUND') return m.chat_new_chat_errors_path_not_found();
+		if (error.errorCode === 'PROJECT_PATH_NOT_FOUND')
+			return m.chat_new_chat_errors_path_not_found();
 		if (error.errorCode === 'PROJECT_PATH_NOT_DIRECTORY') {
 			return m.chat_new_chat_errors_path_not_directory();
 		}


### PR DESCRIPTION
Adds support for selecting and creating Git worktrees directly from the sidebar project path dialog. Validated project paths that are Git repositories now display a link to open a worktree picker modal before applying the updated project path.

## Summary

Describe what changed and why.

## Checklist

- [ ] Scope is focused and behavior is covered by tests
- [ ] API/WS contract changes include type and test updates
