### PR TITLE
web: Consolidate body-scroll-lock cleanup delay in global vitest setup

### DIFF
--- a/web/src/lib/components/chat/__tests__/ChatActionDialogs.test.ts
+++ b/web/src/lib/components/chat/__tests__/ChatActionDialogs.test.ts
@@ -3,10 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import ChatActionDialogs from '../ChatActionDialogs.svelte';
 
 describe('ChatActionDialogs', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows Bits UI body-scroll-lock's delayed cleanup to run before happy-dom removes document.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('renders chat details values in compact selectable surfaces', async () => {

--- a/web/src/lib/components/chat/__tests__/ConversationMessage.actions.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.actions.test.ts
@@ -7,14 +7,8 @@ import ConversationMessageHost from './ConversationMessageHost.svelte';
 const appCss = readFileSync('src/app.css', 'utf8');
 
 describe('ConversationMessage actions', () => {
-	async function waitForOverlayTeardown(): Promise<void> {
-		// Allows Bits UI body-scroll-lock's delayed cleanup to run before happy-dom removes document.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
-	}
-
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		await waitForOverlayTeardown();
 	});
 
 	it('renders the assistant message action button as a compact overlay', () => {

--- a/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
+++ b/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
@@ -33,10 +33,8 @@ function summary(overrides: Partial<GitQuickSummaryReady> = {}): GitQuickSummary
 }
 
 describe('GitQuickStatusTray', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('renders a centered loading indicator before the first summary', () => {

--- a/web/src/lib/components/chat/__tests__/NewChatDialog.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatDialog.test.ts
@@ -76,9 +76,8 @@ describe('NewChatDialog', () => {
 		vi.mocked(settingsApi.getRemoteSettings).mockResolvedValue(makeSnapshot());
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 		vi.unstubAllGlobals();
 		vi.clearAllMocks();
 	});

--- a/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
@@ -91,11 +91,6 @@ function makeSnapshot(overrides: SnapshotOverrides = {}): RemoteSettingsSnapshot
 	};
 }
 
-function waitForDialogTeardown(): Promise<void> {
-	// Bits UI restores body scroll styles on a delayed timer after dialog close.
-	return new Promise((resolve) => window.setTimeout(resolve, 30));
-}
-
 function stubMatchMedia(matches: boolean): void {
 	vi.stubGlobal(
 		'matchMedia',
@@ -299,7 +294,6 @@ describe('NewChatForm', () => {
 		await waitFor(() => {
 			expect(screen.queryByRole('dialog', { name: 'Select worktree' })).toBeNull();
 		});
-		await waitForDialogTeardown();
 	});
 
 	it('opens the model selector at recents when multiple recent targets exist', async () => {

--- a/web/src/lib/components/chat/__tests__/ShareChatDialog.test.ts
+++ b/web/src/lib/components/chat/__tests__/ShareChatDialog.test.ts
@@ -23,10 +23,8 @@ describe('ShareChatDialog', () => {
 		vi.mocked(clipboard.copyToClipboard).mockResolvedValue(true);
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows Bits UI body-scroll-lock's delayed cleanup to run before happy-dom removes document.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 		vi.clearAllMocks();
 	});
 

--- a/web/src/lib/components/git/__tests__/GitBranchSelector.test.ts
+++ b/web/src/lib/components/git/__tests__/GitBranchSelector.test.ts
@@ -19,10 +19,8 @@ function renderSelector(overrides: Record<string, unknown> = {}) {
 }
 
 describe('GitBranchSelector switch-confirmation dialog', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('confirms a branch switch and reclaims focus when the dialog closes', async () => {

--- a/web/src/lib/components/git/__tests__/GitTargetDialog.test.ts
+++ b/web/src/lib/components/git/__tests__/GitTargetDialog.test.ts
@@ -58,10 +58,8 @@ function deferred<T>() {
 	return { promise, resolve };
 }
 
-afterEach(async () => {
+afterEach(() => {
 	cleanup();
-	// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-	await new Promise((resolve) => window.setTimeout(resolve, 30));
 	vi.clearAllMocks();
 });
 

--- a/web/src/lib/components/git/__tests__/GitTopToolbar.test.ts
+++ b/web/src/lib/components/git/__tests__/GitTopToolbar.test.ts
@@ -151,10 +151,8 @@ function installToolbarMeasurement(initialRailWidth: number) {
 }
 
 describe('GitTopToolbar', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('uses the remote branch as the branch button label when current branch is not loaded yet', () => {

--- a/web/src/lib/components/git/__tests__/NewBranchModal.test.ts
+++ b/web/src/lib/components/git/__tests__/NewBranchModal.test.ts
@@ -24,9 +24,8 @@ function renderModal(overrides: Record<string, unknown> = {}) {
 }
 
 describe('NewBranchModal', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('searches refs for the branch base selector and selects the full ref', async () => {

--- a/web/src/lib/components/settings/__tests__/ApiProviderProtocolPanel.test.ts
+++ b/web/src/lib/components/settings/__tests__/ApiProviderProtocolPanel.test.ts
@@ -3,10 +3,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import ApiProviderProtocolPanelTestHost from './ApiProviderProtocolPanelTestHost.svelte';
 
 describe('ApiProviderProtocolPanel', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('shows protocol-specific Anthropic add-provider templates', async () => {

--- a/web/src/lib/components/settings/__tests__/ScheduledPromptsDialog.test.ts
+++ b/web/src/lib/components/settings/__tests__/ScheduledPromptsDialog.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createAppShellStore } from '$lib/stores/app-shell.svelte';
 
 vi.mock(
@@ -11,10 +11,6 @@ const ScheduledPromptsDialogTestHost = (await import('./ScheduledPromptsDialogTe
 	.default;
 
 describe('ScheduledPromptsDialog', () => {
-	afterEach(async () => {
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
-	});
-
 	it('uses a maximized mobile frame and closes through app shell state', async () => {
 		const appShell = createAppShellStore();
 		appShell.openScheduledPrompts();

--- a/web/src/lib/components/settings/__tests__/Settings.test.ts
+++ b/web/src/lib/components/settings/__tests__/Settings.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAppShellStore } from '$lib/stores/app-shell.svelte';
 import { RemoteSettingsStore } from '$lib/stores/remote-settings.svelte';
 
@@ -26,11 +26,6 @@ const providersApi = await import('$lib/api/agents.js');
 const SettingsTestHost = (await import('./SettingsTestHost.svelte')).default;
 
 describe('Settings', () => {
-	afterEach(async () => {
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
-	});
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.mocked(settingsApi.getRemoteSettings).mockReturnValue(new Promise(() => {}));

--- a/web/src/lib/components/sidebar/__tests__/mobile-sidebar-lifecycle.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/mobile-sidebar-lifecycle.test.ts
@@ -64,9 +64,8 @@ describe('mobile sidebar lifecycle', () => {
 		});
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('preserves the active saved-search pill across drawer close and reopen', async () => {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-search-flow.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-search-flow.test.ts
@@ -56,10 +56,8 @@ describe('sidebar search dialog flow', () => {
 		vi.mocked(getSavedSearches).mockResolvedValue({ savedSearches: [] });
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('restores the search dialog draft after cancelling add saved search', async () => {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-search-interactions.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-search-interactions.test.ts
@@ -54,10 +54,8 @@ function createSavedSearch(id: string, title: string, query: string): SavedChatS
 }
 
 describe('sidebar search interactions', () => {
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
-		// Allows bits-ui's delayed body-scroll cleanup to run before happy-dom teardown.
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('opens the highlighted chat from the query input and respects Ctrl-J selection', async () => {

--- a/web/src/lib/components/workspace/WorkspaceTaskBar.test.ts
+++ b/web/src/lib/components/workspace/WorkspaceTaskBar.test.ts
@@ -62,11 +62,10 @@ describe('WorkspaceTaskBar', () => {
 		vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(1_000);
 	});
 
-	afterEach(async () => {
+	afterEach(() => {
 		cleanup();
 		vi.unstubAllGlobals();
 		vi.restoreAllMocks();
-		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('puts active-tab operations at the top of the taskbar menu', async () => {

--- a/web/src/test/vitest-setup.ts
+++ b/web/src/test/vitest-setup.ts
@@ -1,3 +1,8 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { afterAll } from 'vitest';
+
+const BITS_UI_BODY_SCROLL_CLEANUP_DELAY_MS = 30;
+
 // Node may expose a partial global localStorage (e.g. via experimental flags) that
 // shadows happy-dom and omits clear(). Tests expect the full Storage interface.
 function installMemoryLocalStorage(): void {
@@ -37,3 +42,8 @@ const rejectUnexpectedFetch: typeof fetch = (input) =>
 	Promise.reject(new Error(`Unexpected network request in test: ${String(input)}`));
 
 globalThis.fetch = rejectUnexpectedFetch;
+
+afterAll(async () => {
+	// Keeps Happy DOM alive while Bits UI's 24 ms body-scroll restoration timer completes.
+	await delay(BITS_UI_BODY_SCROLL_CLEANUP_DELAY_MS);
+});


### PR DESCRIPTION
Replaces duplicate `setTimeout` logic in individual component tests with a single, global `afterAll` hook in `vitest-setup.ts`. This ensures Bits UI's body-scroll restoration timer completes safely before Happy DOM is torn down, while reducing boilerplate across the test suite.

## Summary

Describe what changed and why.

## Checklist

- [ ] Scope is focused and behavior is covered by tests
- [ ] API/WS contract changes include type and test updates
