### PR TITLE
web: Add terminal font size setting to toolbar

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -691,6 +691,8 @@
 	"pull_requests_all": "All pull requests",
 	"pull_requests_select": "Select a pull request to view its diff.",
 	"terminal_session": "Terminal session",
+	"terminal_settings": "Terminal settings",
+	"terminal_font_size": "Font size",
 	"terminal_session_status": "Terminal {number} - {status}",
 	"terminal_initial_working_directory": "Started in {path}",
 	"terminal_reattach": "Reattach terminal",

--- a/web/src/lib/components/files/EditorSettingsMenu.svelte
+++ b/web/src/lib/components/files/EditorSettingsMenu.svelte
@@ -5,10 +5,10 @@
 	import * as Select from '$lib/components/ui/select';
 	import Settings from '@lucide/svelte/icons/settings';
 	import { getLocalSettings } from '$lib/context';
+	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const localSettings = getLocalSettings();
-	const fontSizeOptions = ['10', '11', '12', '13', '14', '15', '16', '18', '20'];
 
 	let menuOpen = $state(false);
 
@@ -54,7 +54,7 @@
 						{localSettings.codeEditorFontSize}px
 					</Select.Trigger>
 					<Select.Content>
-						{#each fontSizeOptions as size}
+						{#each FONT_SIZE_OPTIONS as size}
 							<Select.Item value={size} label="{size}px">{size}px</Select.Item>
 						{/each}
 					</Select.Content>

--- a/web/src/lib/components/files/EditorSettingsMenu.svelte
+++ b/web/src/lib/components/files/EditorSettingsMenu.svelte
@@ -5,7 +5,7 @@
 	import * as Select from '$lib/components/ui/select';
 	import Settings from '@lucide/svelte/icons/settings';
 	import { getLocalSettings } from '$lib/context';
-	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
+	import { FONT_SIZE_OPTIONS } from '$lib/settings/font-size.js';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const localSettings = getLocalSettings();

--- a/web/src/lib/components/files/MarkdownViewerSettingsMenu.svelte
+++ b/web/src/lib/components/files/MarkdownViewerSettingsMenu.svelte
@@ -4,7 +4,7 @@
 	import * as Select from '$lib/components/ui/select';
 	import Settings from '@lucide/svelte/icons/settings';
 	import { getLocalSettings } from '$lib/context';
-	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
+	import { FONT_SIZE_OPTIONS } from '$lib/settings/font-size.js';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const localSettings = getLocalSettings();

--- a/web/src/lib/components/git/GitDiffSettingsMenu.svelte
+++ b/web/src/lib/components/git/GitDiffSettingsMenu.svelte
@@ -5,6 +5,7 @@
 	import * as Popover from '$lib/components/ui/popover';
 	import * as Select from '$lib/components/ui/select';
 	import { Button } from '$lib/components/ui/button';
+	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
 	import Settings from '@lucide/svelte/icons/settings';
 	import type { DiffMode } from '$lib/stores/git-workbench.svelte.js';
 	import * as m from '$lib/paraglide/messages.js';
@@ -28,14 +29,17 @@
 	}: Props = $props();
 
 	const CONTEXT_OPTIONS = ['3', '5', '10', '20'];
-	const FONT_SIZE_OPTIONS = ['10', '11', '12', '13', '14', '15', '16', '18', '20'];
-
 	let popoverOpen = $state(false);
 </script>
 
 <Popover.Root bind:open={popoverOpen}>
 	<Popover.Trigger>
-		<Button variant="ghost" size="icon-sm" aria-label={m.git_diff_settings()} title={m.git_diff_settings()}>
+		<Button
+			variant="ghost"
+			size="icon-sm"
+			aria-label={m.git_diff_settings()}
+			title={m.git_diff_settings()}
+		>
 			<Settings class="w-4 h-4" />
 		</Button>
 	</Popover.Trigger>

--- a/web/src/lib/components/git/GitDiffSettingsMenu.svelte
+++ b/web/src/lib/components/git/GitDiffSettingsMenu.svelte
@@ -5,7 +5,7 @@
 	import * as Popover from '$lib/components/ui/popover';
 	import * as Select from '$lib/components/ui/select';
 	import { Button } from '$lib/components/ui/button';
-	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
+	import { FONT_SIZE_OPTIONS } from '$lib/settings/font-size.js';
 	import Settings from '@lucide/svelte/icons/settings';
 	import type { DiffMode } from '$lib/stores/git-workbench.svelte.js';
 	import * as m from '$lib/paraglide/messages.js';

--- a/web/src/lib/components/shared/font-size-options.ts
+++ b/web/src/lib/components/shared/font-size-options.ts
@@ -1,1 +1,0 @@
-export const FONT_SIZE_OPTIONS = ['10', '11', '12', '13', '14', '15', '16', '18', '20'] as const;

--- a/web/src/lib/components/shared/font-size-options.ts
+++ b/web/src/lib/components/shared/font-size-options.ts
@@ -1,0 +1,1 @@
+export const FONT_SIZE_OPTIONS = ['10', '11', '12', '13', '14', '15', '16', '18', '20'] as const;

--- a/web/src/lib/components/terminal/TerminalSettingsMenu.svelte
+++ b/web/src/lib/components/terminal/TerminalSettingsMenu.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
-	import * as Popover from '$lib/components/ui/popover';
-	import { Button } from '$lib/components/ui/button';
-	import * as Select from '$lib/components/ui/select';
 	import Settings from '@lucide/svelte/icons/settings';
 	import { getLocalSettings } from '$lib/context';
 	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
+	import { Button } from '$lib/components/ui/button';
+	import * as Popover from '$lib/components/ui/popover';
+	import * as Select from '$lib/components/ui/select';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const localSettings = getLocalSettings();
-
 	let menuOpen = $state(false);
 
 	function setFontSize(size: string): void {
-		localSettings.set('markdownViewerFontSize', size);
+		localSettings.set('terminalFontSize', size);
 	}
 </script>
 
@@ -21,28 +20,26 @@
 		<Button
 			variant="ghost"
 			size="icon-sm"
-			aria-label={m.editor_settings_button_label()}
-			title={m.editor_settings_button_label()}
+			aria-label={m.terminal_settings()}
+			title={m.terminal_settings()}
 		>
-			<Settings class="w-4 h-4" />
+			<Settings class="h-4 w-4" />
 		</Button>
 	</Popover.Trigger>
 
 	<Popover.Content class="w-72 p-0" align="end" sideOffset={8}>
-		<div class="bg-card text-foreground rounded-md border border-border divide-y divide-border">
+		<div class="rounded-md border border-border bg-card text-foreground">
 			<div class="flex items-center justify-between px-4 py-3">
-				<div class="text-sm font-medium text-foreground">
-					{m.settings_appearance_settings_code_editor_font_size_label()}
-				</div>
+				<div class="text-sm font-medium text-foreground">{m.terminal_font_size()}</div>
 				<Select.Root
 					type="single"
-					value={localSettings.markdownViewerFontSize}
+					value={localSettings.terminalFontSize}
 					onValueChange={(value) => {
 						if (value) setFontSize(value);
 					}}
 				>
-					<Select.Trigger class="w-[80px]" size="sm">
-						{localSettings.markdownViewerFontSize}px
+					<Select.Trigger class="w-[80px]" size="sm" aria-label={m.terminal_font_size()}>
+						{localSettings.terminalFontSize}px
 					</Select.Trigger>
 					<Select.Content>
 						{#each FONT_SIZE_OPTIONS as size}

--- a/web/src/lib/components/terminal/TerminalSettingsMenu.svelte
+++ b/web/src/lib/components/terminal/TerminalSettingsMenu.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import Settings from '@lucide/svelte/icons/settings';
 	import { getLocalSettings } from '$lib/context';
-	import { FONT_SIZE_OPTIONS } from '$lib/components/shared/font-size-options.js';
-	import { Button } from '$lib/components/ui/button';
+	import { FONT_SIZE_OPTIONS, isFontSizeOption } from '$lib/settings/font-size.js';
+	import { buttonVariants } from '$lib/components/ui/button';
 	import * as Popover from '$lib/components/ui/popover';
 	import * as Select from '$lib/components/ui/select';
 	import * as m from '$lib/paraglide/messages.js';
@@ -11,20 +11,18 @@
 	let menuOpen = $state(false);
 
 	function setFontSize(size: string): void {
+		if (!isFontSizeOption(size)) return;
 		localSettings.set('terminalFontSize', size);
 	}
 </script>
 
 <Popover.Root bind:open={menuOpen}>
-	<Popover.Trigger>
-		<Button
-			variant="ghost"
-			size="icon-sm"
-			aria-label={m.terminal_settings()}
-			title={m.terminal_settings()}
-		>
-			<Settings class="h-4 w-4" />
-		</Button>
+	<Popover.Trigger
+		class={buttonVariants({ variant: 'ghost', size: 'icon-sm' })}
+		aria-label={m.terminal_settings()}
+		title={m.terminal_settings()}
+	>
+		<Settings class="h-4 w-4" />
 	</Popover.Trigger>
 
 	<Popover.Content class="w-72 p-0" align="end" sideOffset={8}>

--- a/web/src/lib/components/terminal/TerminalSurface.svelte
+++ b/web/src/lib/components/terminal/TerminalSurface.svelte
@@ -134,7 +134,7 @@
 
 	$effect(() => {
 		const retainedRuntime = runtime;
-		const fontSize = Number.parseInt(localSettings.terminalFontSize, 10) || 13;
+		const fontSize = Number(localSettings.terminalFontSize);
 		retainedRuntime?.applyFontSize(fontSize);
 	});
 

--- a/web/src/lib/components/terminal/TerminalSurface.svelte
+++ b/web/src/lib/components/terminal/TerminalSurface.svelte
@@ -5,7 +5,7 @@
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Square from '@lucide/svelte/icons/square';
 	import X from '@lucide/svelte/icons/x';
-	import { getTerminalRegistry, getWorkspaceCoordinator } from '$lib/context';
+	import { getLocalSettings, getTerminalRegistry, getWorkspaceCoordinator } from '$lib/context';
 	import { terminalSurfaceId, type HostId } from '$lib/workspace/surface-types';
 	import type { TerminalToolbarKey } from './terminal-input-controls.svelte.js';
 	import { TERMINAL_SESSION_LIMIT } from '$shared/terminal';
@@ -15,6 +15,7 @@
 	import ResponsiveSurfaceActions, {
 		type ResponsiveSurfaceAction,
 	} from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
+	import TerminalSettingsMenu from './TerminalSettingsMenu.svelte';
 
 	let {
 		terminalId,
@@ -27,6 +28,7 @@
 	} = $props();
 	const terminals = getTerminalRegistry();
 	const workspace = getWorkspaceCoordinator();
+	const localSettings = getLocalSettings();
 	const frame = getSurfaceFrameBridge();
 	let terminalHost = $state<HTMLDivElement | null>(null);
 	let sessionPicker = $state<HTMLSelectElement | null>(null);
@@ -132,6 +134,12 @@
 
 	$effect(() => {
 		const retainedRuntime = runtime;
+		const fontSize = Number.parseInt(localSettings.terminalFontSize, 10) || 13;
+		retainedRuntime?.applyFontSize(fontSize);
+	});
+
+	$effect(() => {
+		const retainedRuntime = runtime;
 		const element = terminalHost;
 		if (!element || !retainedRuntime) return;
 		const detach = () => {
@@ -231,6 +239,7 @@
 			menuLabel={m.workspace_surface_actions()}
 			class="max-w-28"
 		/>
+		<TerminalSettingsMenu />
 		{#if host === 'mobile'}
 			<button
 				type="button"

--- a/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
@@ -1,9 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TerminalSurfaceTestHost from './TerminalSurfaceTestHost.svelte';
 import { ApiError } from '$lib/api/client';
+import { LOCAL_STORAGE_KEYS } from '$lib/utils/local-persistence';
 
 describe('TerminalSurface', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
 	it('labels the terminal path as its initial directory rather than its current directory', () => {
 		render(TerminalSurfaceTestHost, { host: 'main' });
 
@@ -111,5 +116,20 @@ describe('TerminalSurface', () => {
 		await rerender({ host: 'main', onFocus, focusRequestToken: 1 });
 
 		expect(onFocus).toHaveBeenCalledOnce();
+	});
+
+	it('changes and persists the terminal font size from the toolbar settings', async () => {
+		const onFontSize = vi.fn();
+		render(TerminalSurfaceTestHost, { host: 'main', onFontSize });
+
+		await waitFor(() => expect(onFontSize).toHaveBeenLastCalledWith(13));
+		await fireEvent.click(screen.getByRole('button', { name: 'Terminal settings' }));
+		await fireEvent.click(screen.getByRole('combobox', { name: 'Font size' }));
+		await fireEvent.click(screen.getByRole('option', { name: '18px' }));
+
+		await waitFor(() => expect(onFontSize).toHaveBeenLastCalledWith(18));
+		expect(
+			JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.localSettings) ?? '{}'),
+		).toMatchObject({ terminalFontSize: '18' });
 	});
 });

--- a/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import TerminalSurfaceTestHost from './TerminalSurfaceTestHost.svelte';
 import { ApiError } from '$lib/api/client';
 import { LOCAL_STORAGE_KEYS } from '$lib/utils/local-persistence';
@@ -7,6 +7,10 @@ import { LOCAL_STORAGE_KEYS } from '$lib/utils/local-persistence';
 describe('TerminalSurface', () => {
 	beforeEach(() => {
 		localStorage.clear();
+	});
+	afterEach(async () => {
+		cleanup();
+		await new Promise((resolve) => window.setTimeout(resolve, 30));
 	});
 
 	it('labels the terminal path as its initial directory rather than its current directory', () => {
@@ -124,8 +128,14 @@ describe('TerminalSurface', () => {
 
 		await waitFor(() => expect(onFontSize).toHaveBeenLastCalledWith(13));
 		await fireEvent.click(screen.getByRole('button', { name: 'Terminal settings' }));
-		await fireEvent.click(screen.getByRole('combobox', { name: 'Font size' }));
-		await fireEvent.click(screen.getByRole('option', { name: '18px' }));
+		await fireEvent.pointerDown(screen.getByRole('button', { name: 'Font size' }), {
+			button: 0,
+			ctrlKey: false,
+			pointerType: 'mouse',
+		});
+		await fireEvent.pointerUp(await screen.findByRole('option', { name: '18px' }), {
+			pointerType: 'mouse',
+		});
 
 		await waitFor(() => expect(onFontSize).toHaveBeenLastCalledWith(18));
 		expect(

--- a/web/src/lib/components/terminal/__tests__/TerminalSurfaceTestHost.svelte
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurfaceTestHost.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import type { HostId } from '$lib/workspace/surface-types';
-	import { setTerminalRegistry, setWorkspaceCoordinator } from '$lib/context';
+	import { setLocalSettings, setTerminalRegistry, setWorkspaceCoordinator } from '$lib/context';
+	import { createLocalSettingsStore } from '$lib/stores/local-settings.svelte';
 	import { setSurfaceFrameBridge, SurfaceFrameBridge } from '$lib/workspace/surface-frame-context';
 	import TerminalSurface from '../TerminalSurface.svelte';
 
@@ -13,6 +15,7 @@
 		onCreateReplacing?: (currentTerminalId: string) => void;
 		onTerminate?: (terminalId: string) => void;
 		onFocus?: () => void;
+		onFontSize?: (fontSize: number) => void;
 		focusRequestToken?: number;
 		createError?: Error | null;
 	}
@@ -26,10 +29,12 @@
 		onCreateReplacing = () => undefined,
 		onTerminate = () => undefined,
 		onFocus = () => undefined,
+		onFontSize = () => undefined,
 		focusRequestToken = 0,
 		createError = null,
 	}: Props = $props();
 	const terminalId = 'terminal-1';
+	const localSettings = createLocalSettingsStore();
 	const session = {
 		metadata: {
 			terminalId,
@@ -60,6 +65,7 @@
 		scheduleFit: () => undefined,
 		focus: () => onFocus(),
 		pasteFromClipboard: () => Promise.resolve(),
+		applyFontSize: (fontSize: number) => onFontSize(fontSize),
 	};
 	const frameBridge = new SurfaceFrameBridge();
 
@@ -68,6 +74,7 @@
 	});
 
 	setSurfaceFrameBridge(() => frameBridge);
+	setLocalSettings(localSettings);
 	setTerminalRegistry({
 		sessions: { [terminalId]: session, 'terminal-2': secondSession },
 		orderedSessions: [session, secondSession],
@@ -102,6 +109,8 @@
 		},
 		isSurfaceCloseBlocked: () => false,
 	} as never);
+
+	onDestroy(() => localSettings.destroy());
 </script>
 
 <TerminalSurface {terminalId} {host} />

--- a/web/src/lib/components/terminal/__tests__/terminal-runtime.test.ts
+++ b/web/src/lib/components/terminal/__tests__/terminal-runtime.test.ts
@@ -160,10 +160,13 @@ describe('TerminalRuntime', () => {
 
 	it('updates the terminal font size without replacing the runtime', () => {
 		const runtime = new TerminalRuntime({ onInput: vi.fn(), onResize: vi.fn(), initialTheme: {} });
+		const scheduleFit = vi.spyOn(runtime, 'scheduleFit');
 
+		runtime.applyFontSize(18);
 		runtime.applyFontSize(18);
 
 		expect(fakes.terminals).toHaveLength(1);
 		expect(fakes.terminals[0].options.fontSize).toBe(18);
+		expect(scheduleFit).toHaveBeenCalledOnce();
 	});
 });

--- a/web/src/lib/components/terminal/__tests__/terminal-runtime.test.ts
+++ b/web/src/lib/components/terminal/__tests__/terminal-runtime.test.ts
@@ -157,4 +157,13 @@ describe('TerminalRuntime', () => {
 		expect(fakes.terminals[0].options.theme).toEqual({ foreground: '#fff' });
 		expect(fakes.terminals[0].dispose).toHaveBeenCalledOnce();
 	});
+
+	it('updates the terminal font size without replacing the runtime', () => {
+		const runtime = new TerminalRuntime({ onInput: vi.fn(), onResize: vi.fn(), initialTheme: {} });
+
+		runtime.applyFontSize(18);
+
+		expect(fakes.terminals).toHaveLength(1);
+		expect(fakes.terminals[0].options.fontSize).toBe(18);
+	});
 });

--- a/web/src/lib/components/terminal/terminal-runtime.svelte.ts
+++ b/web/src/lib/components/terminal/terminal-runtime.svelte.ts
@@ -115,6 +115,12 @@ export class TerminalRuntime {
 		if (this.#presentationActive) this.terminal.refresh(0, Math.max(0, this.terminal.rows - 1));
 	}
 
+	applyFontSize(fontSize: number): void {
+		if (this.terminal.options.fontSize === fontSize) return;
+		this.terminal.options.fontSize = fontSize;
+		this.scheduleFit();
+	}
+
 	focus(): void {
 		this.terminal.focus();
 		this.terminal.textarea?.focus();

--- a/web/src/lib/settings/font-size.ts
+++ b/web/src/lib/settings/font-size.ts
@@ -1,0 +1,11 @@
+export const FONT_SIZE_OPTIONS = ['10', '11', '12', '13', '14', '15', '16', '18', '20'] as const;
+
+export type FontSizeOption = (typeof FONT_SIZE_OPTIONS)[number];
+
+export function isFontSizeOption(value: unknown): value is FontSizeOption {
+	return typeof value === 'string' && FONT_SIZE_OPTIONS.includes(value as FontSizeOption);
+}
+
+export function parseFontSizeOption(value: unknown, fallback: FontSizeOption): FontSizeOption {
+	return isFontSizeOption(value) ? value : fallback;
+}

--- a/web/src/lib/stores/__tests__/local-settings.test.ts
+++ b/web/src/lib/stores/__tests__/local-settings.test.ts
@@ -19,9 +19,25 @@ describe('LocalSettingsStore', () => {
 		expect(store.textEditorOpenPlacement).toBe('dialog');
 		expect(store.imageViewerOpenPlacement).toBe('dialog');
 		expect(store.markdownViewerOpenPlacement).toBe('dialog');
+		expect(store.terminalFontSize).toBe('13');
 		expect(store.hiddenToolTypes).toEqual([]);
 
 		store.destroy();
+	});
+
+	it('persists the terminal font size', () => {
+		const store = createLocalSettingsStore();
+		store.set('terminalFontSize', '18');
+
+		expect(
+			JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.localSettings) ?? '{}'),
+		).toMatchObject({ terminalFontSize: '18' });
+
+		const restored = createLocalSettingsStore();
+		expect(restored.terminalFontSize).toBe('18');
+
+		store.destroy();
+		restored.destroy();
 	});
 
 	it('persists independent file opening placements', () => {

--- a/web/src/lib/stores/__tests__/local-settings.test.ts
+++ b/web/src/lib/stores/__tests__/local-settings.test.ts
@@ -40,6 +40,18 @@ describe('LocalSettingsStore', () => {
 		restored.destroy();
 	});
 
+	it('falls back to a valid terminal font size for malformed persisted settings', () => {
+		localStorage.setItem(
+			LOCAL_STORAGE_KEYS.localSettings,
+			JSON.stringify({ terminalFontSize: '-1' }),
+		);
+
+		const store = createLocalSettingsStore();
+
+		expect(store.terminalFontSize).toBe('13');
+		store.destroy();
+	});
+
 	it('persists independent file opening placements', () => {
 		const store = createLocalSettingsStore();
 		store.set('textEditorOpenPlacement', 'main');

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -7,6 +7,7 @@ import {
 	setLocalStorageItem,
 } from '$lib/utils/local-persistence';
 import type { DesktopPlacement } from '$lib/workspace/surface-types.js';
+import { parseFontSizeOption, type FontSizeOption } from '$lib/settings/font-size.js';
 
 export type ThemeMode = 'dark' | 'light' | 'system';
 export const CHAT_MAX_WIDTH_VALUES = ['none', 'large', 'medium', 'small'] as const;
@@ -91,7 +92,7 @@ export interface LocalSettingsSnapshot {
 	codeEditorFontSize: string;
 	gitDiffFontSize: string;
 	markdownViewerFontSize: string;
-	terminalFontSize: string;
+	terminalFontSize: FontSizeOption;
 	textEditorOpenPlacement: DesktopPlacement;
 	imageViewerOpenPlacement: DesktopPlacement;
 	markdownViewerOpenPlacement: DesktopPlacement;
@@ -235,7 +236,7 @@ function parseFromRaw(parsed: Record<string, unknown>): LocalSettingsSnapshot {
 			parsed.markdownViewerFontSize,
 			DEFAULTS.markdownViewerFontSize,
 		),
-		terminalFontSize: parseString(parsed.terminalFontSize, DEFAULTS.terminalFontSize),
+		terminalFontSize: parseFontSizeOption(parsed.terminalFontSize, DEFAULTS.terminalFontSize),
 		textEditorOpenPlacement: parseFileOpenPlacement(
 			parsed.textEditorOpenPlacement,
 			DEFAULTS.textEditorOpenPlacement,

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -91,6 +91,7 @@ export interface LocalSettingsSnapshot {
 	codeEditorFontSize: string;
 	gitDiffFontSize: string;
 	markdownViewerFontSize: string;
+	terminalFontSize: string;
 	textEditorOpenPlacement: DesktopPlacement;
 	imageViewerOpenPlacement: DesktopPlacement;
 	markdownViewerOpenPlacement: DesktopPlacement;
@@ -134,6 +135,7 @@ const DEFAULTS: LocalSettingsSnapshot = {
 	codeEditorFontSize: '12',
 	gitDiffFontSize: '12',
 	markdownViewerFontSize: '12',
+	terminalFontSize: '13',
 	textEditorOpenPlacement: 'dialog',
 	imageViewerOpenPlacement: 'dialog',
 	markdownViewerOpenPlacement: 'dialog',
@@ -233,6 +235,7 @@ function parseFromRaw(parsed: Record<string, unknown>): LocalSettingsSnapshot {
 			parsed.markdownViewerFontSize,
 			DEFAULTS.markdownViewerFontSize,
 		),
+		terminalFontSize: parseString(parsed.terminalFontSize, DEFAULTS.terminalFontSize),
 		textEditorOpenPlacement: parseFileOpenPlacement(
 			parsed.textEditorOpenPlacement,
 			DEFAULTS.textEditorOpenPlacement,
@@ -291,6 +294,7 @@ export class LocalSettingsStore {
 	codeEditorFontSize = $state(DEFAULTS.codeEditorFontSize);
 	gitDiffFontSize = $state(DEFAULTS.gitDiffFontSize);
 	markdownViewerFontSize = $state(DEFAULTS.markdownViewerFontSize);
+	terminalFontSize = $state(DEFAULTS.terminalFontSize);
 	textEditorOpenPlacement = $state<DesktopPlacement>(DEFAULTS.textEditorOpenPlacement);
 	imageViewerOpenPlacement = $state<DesktopPlacement>(DEFAULTS.imageViewerOpenPlacement);
 	markdownViewerOpenPlacement = $state<DesktopPlacement>(DEFAULTS.markdownViewerOpenPlacement);
@@ -361,6 +365,7 @@ export class LocalSettingsStore {
 			codeEditorFontSize: this.codeEditorFontSize,
 			gitDiffFontSize: this.gitDiffFontSize,
 			markdownViewerFontSize: this.markdownViewerFontSize,
+			terminalFontSize: this.terminalFontSize,
 			textEditorOpenPlacement: this.textEditorOpenPlacement,
 			imageViewerOpenPlacement: this.imageViewerOpenPlacement,
 			markdownViewerOpenPlacement: this.markdownViewerOpenPlacement,
@@ -390,6 +395,7 @@ export class LocalSettingsStore {
 		this.codeEditorFontSize = snap.codeEditorFontSize;
 		this.gitDiffFontSize = snap.gitDiffFontSize;
 		this.markdownViewerFontSize = snap.markdownViewerFontSize;
+		this.terminalFontSize = snap.terminalFontSize;
 		this.textEditorOpenPlacement = snap.textEditorOpenPlacement;
 		this.imageViewerOpenPlacement = snap.imageViewerOpenPlacement;
 		this.markdownViewerOpenPlacement = snap.markdownViewerOpenPlacement;


### PR DESCRIPTION
- Adds TerminalSettingsMenu with font size selector
- Persists choice via terminalFontSize local setting
- Extracts shared FONT_SIZE_OPTIONS across editor, markdown, git diff, and terminal menus
- Applies size live via TerminalRuntime.applyFontSize