### PR TITLE
web/components: Reserve chat content space for the top floating toolbar

### DIFF
--- a/web/src/lib/components/chat/ChatSurface.svelte
+++ b/web/src/lib/components/chat/ChatSurface.svelte
@@ -50,6 +50,7 @@
 
 	interface ChatSurfaceProps {
 		isMobile: boolean;
+		reserveTopFloatingToolbar: boolean;
 		isVisible: boolean;
 		isInteractive: boolean;
 		onMenuClick?: () => void;
@@ -62,6 +63,7 @@
 
 	let {
 		isMobile,
+		reserveTopFloatingToolbar,
 		isVisible,
 		isInteractive,
 		onMenuClick,
@@ -95,6 +97,9 @@
 	const canRenderConversation = $derived(chatSurfacePresentation === 'conversation');
 	const showChatLoadingState = $derived(chatSurfacePresentation === 'loading');
 	const isMobileLayout = $derived(isMobile);
+	const reserveConversationTopFloatingToolbar = $derived(
+		reserveTopFloatingToolbar || (isMobileLayout && hasUsableChatContext),
+	);
 	const canToggleDesktopFullscreen = $derived(!isMobileLayout && !!onToggleDesktopFullscreen);
 	const canUpdateSelectedProjectPath = $derived(
 		selectedChat
@@ -380,6 +385,8 @@
 					onRegisterSubmit={handleRegisterSubmit}
 					{onRegisterReload}
 					transcriptCache={chatTranscriptCache}
+					reserveTopFloatingToolbar={reserveConversationTopFloatingToolbar}
+					reserveFeedTopFloatingToolbar={reserveTopFloatingToolbar}
 					isVisible={conversationWorkspaceVisible}
 					textScale={conversationWorkspaceTextScale}
 					getVisibleChatIds={getVisibleSplitChatIds}

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -41,6 +41,7 @@
 		pendingPermissionRequests?: PendingPermissionRequest[];
 		onRetry?: () => void;
 		reserveComposerTraySpace?: boolean;
+		reserveTopFloatingToolbar?: boolean;
 		isPreparingInitialScroll?: boolean;
 		textScale?: number;
 		isProcessing?: boolean;
@@ -58,6 +59,7 @@
 		pendingPermissionRequests = [],
 		onRetry,
 		reserveComposerTraySpace = false,
+		reserveTopFloatingToolbar = false,
 		isPreparingInitialScroll = false,
 		textScale = 1,
 		isProcessing = false,
@@ -257,6 +259,14 @@
 	>
 		<div bind:this={scrollContentContainer} class={feedContentClass}>
 			<div style="overflow-anchor: none;">
+				{#if reserveTopFloatingToolbar}
+					<!-- Reserves the floating taskbar only at the transcript's scroll origin. -->
+					<div
+						aria-hidden="true"
+						class="h-[var(--workspace-floating-taskbar-inset)] shrink-0"
+						data-chat-feed-top-floating-toolbar-spacer
+					></div>
+				{/if}
 				{@render feedContent()}
 			</div>
 			<div

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -61,6 +61,8 @@
 		onRegisterSubmit?: (fn: (message: string) => Promise<boolean>) => void;
 		onRegisterReload?: (fn: (chatId: string) => Promise<void>) => void;
 		transcriptCache?: ChatTranscriptCache;
+		reserveTopFloatingToolbar?: boolean;
+		reserveFeedTopFloatingToolbar?: boolean;
 		getVisibleChatIds?: () => string[];
 		isVisiblePreviewChat?: (chatId: string) => boolean;
 		getVisiblePreviewCursor?: (chatId: string) => SplitPanePreviewCursor | null;
@@ -82,6 +84,8 @@
 		onRegisterSubmit,
 		onRegisterReload,
 		transcriptCache: providedTranscriptCache,
+		reserveTopFloatingToolbar = false,
+		reserveFeedTopFloatingToolbar = false,
 		getVisibleChatIds,
 		isVisiblePreviewChat,
 		getVisiblePreviewCursor,
@@ -159,7 +163,7 @@
 	const scrollToTopButtonClass = $derived(
 		cn(
 			'absolute right-5 sm:right-6 z-20 w-11 h-11 rounded-full shadow-md hover:shadow-lg',
-			'top-3',
+			reserveTopFloatingToolbar ? 'top-16' : 'top-3',
 		),
 	);
 	const selectedIsProcessing = $derived(isChatProcessing(sessions.selectedChat));
@@ -520,6 +524,7 @@
 			}}
 			onGenerateTitleFromMessage={generateTitleFromMessage}
 			reserveComposerTraySpace={composerCapSpace.feed}
+			reserveTopFloatingToolbar={reserveFeedTopFloatingToolbar}
 			{isPreparingInitialScroll}
 			isProcessing={selectedIsProcessing}
 			{textScale}

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -14,12 +14,24 @@ describe('ConversationFeed', () => {
 		expect(container.querySelector('[data-chat-feed-top-floating-toolbar-spacer]')).toBeNull();
 	});
 
-	it('keeps the feed log and bottom anchor in the normal content flow', () => {
-		const { container } = render(ConversationFeedTestHost);
+	it('renders the floating toolbar reservation inside scrollable feed content', () => {
+		const { container } = render(ConversationFeedTestHost, {
+			reserveTopFloatingToolbar: true,
+		});
+
 		const viewport = screen.getByRole('log');
+		const spacer = container.querySelector<HTMLElement>(
+			'[data-chat-feed-top-floating-toolbar-spacer]',
+		);
 		const bottomAnchor = container.querySelector<HTMLElement>('[data-chat-bottom-anchor]');
 
+		expect(spacer).toBeTruthy();
 		expect(bottomAnchor).toBeTruthy();
+		expect(viewport.contains(spacer)).toBe(true);
 		expect(viewport.contains(bottomAnchor)).toBe(true);
+		expect(spacer?.classList.contains('h-[var(--workspace-floating-taskbar-inset)]')).toBe(true);
+		expect(spacer?.compareDocumentPosition(bottomAnchor as Node)).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING,
+		);
 	});
 });

--- a/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
@@ -10,6 +10,12 @@
 		setModelCatalog,
 	} from '$lib/context';
 
+	interface Props {
+		reserveTopFloatingToolbar?: boolean;
+	}
+
+	let { reserveTopFloatingToolbar = false }: Props = $props();
+
 	setChatState(new ChatState());
 	setAgentState(new AgentState());
 	setLocalSettings({
@@ -30,4 +36,4 @@
 	} as never);
 </script>
 
-<ConversationFeed />
+<ConversationFeed {reserveTopFloatingToolbar} />

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -296,6 +296,7 @@
 			>
 				<ChatSurface
 					{isMobile}
+					reserveTopFloatingToolbar={!isMobile}
 					isVisible={workspace.isChatPresented}
 					isInteractive={workspace.isChatInteractive}
 					onMenuClick={isMobile ? onMenuClick : undefined}

--- a/web/src/lib/components/workspace/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/WorkspaceRoot.test.ts
@@ -377,6 +377,26 @@ describe('PortableSurfaceContent', () => {
 });
 
 describe('WorkspaceRoot', () => {
+	it('reserves chat content space only while the desktop taskbar is rendered', async () => {
+		installContext(canonicalWorkspaceSnapshot());
+		const rendered = render(WorkspaceRoot, {
+			isMobile: false,
+			chatActions,
+		});
+
+		expect(rendered.container.querySelector('[data-floating-workspace-toolbar]')).toBeTruthy();
+		expect(
+			screen.getByTestId('chat-surface-stub').getAttribute('data-reserve-top-floating-toolbar'),
+		).toBe('true');
+
+		await rendered.rerender({ isMobile: true, chatActions });
+
+		expect(rendered.container.querySelector('[data-floating-workspace-toolbar]')).toBeNull();
+		expect(
+			screen.getByTestId('chat-surface-stub').getAttribute('data-reserve-top-floating-toolbar'),
+		).toBe('false');
+	});
+
 	it('binds focus, move, and close for every portable kind without replacing Chat', async () => {
 		const { workspace } = installContext();
 		const { container } = render(WorkspaceRoot, {

--- a/web/src/lib/components/workspace/__tests__/ChatSurfaceTestStub.svelte
+++ b/web/src/lib/components/workspace/__tests__/ChatSurfaceTestStub.svelte
@@ -1,1 +1,10 @@
-<div data-testid="chat-surface-stub">Chat surface</div>
+<script lang="ts">
+	let { reserveTopFloatingToolbar }: { reserveTopFloatingToolbar: boolean } = $props();
+</script>
+
+<div
+	data-testid="chat-surface-stub"
+	data-reserve-top-floating-toolbar={reserveTopFloatingToolbar}
+>
+	Chat surface
+</div>


### PR DESCRIPTION
Introduces a `reserveTopFloatingToolbar` property to allow reserving space at the top of the chat viewport for the workspace floating taskbar.

On desktop viewports, space is reserved for the toolbar at the top of the chat feed. On mobile viewports, space is dynamically reserved based on active chat context. Also shifts the scroll-to-top button downward when the toolbar space is reserved to prevent overlapping.
