### PR TITLE
perf(startup): skip redundant builds and defer Pi loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "server/",
     "common/",
+    "scripts/",
     "web/build/",
     "README.md"
   ],
@@ -19,7 +20,7 @@
   },
   "scripts": {
     "install": "bun install --cwd server && bun install --cwd web",
-    "build": "bun run --cwd web build",
+    "build": "bun scripts/build-web.js",
     "build-exe:compile": "bun scripts/build-exe.js",
     "build-exe:smoke": "bun scripts/smoke-exe.js",
     "build-exe:smoke:linux-x64": "bun scripts/smoke-exe.js --target=linux-x64",
@@ -27,7 +28,7 @@
     "build-exe:smoke:windows-x64": "bun scripts/smoke-exe.js --target=windows-x64",
     "build-exe": "bun run check && bun run test && bun run build && bun run build-exe:compile && bun run build-exe:smoke",
     "server": "bun server/main.ts",
-    "start": "bun run build && bun run server",
+    "start": "bun scripts/start.js",
     "test": "for f in server/**/__tests__/*.test.js; do bun test \"$f\" || exit 1; done && bun run --cwd web test",
     "lint": "bun run --cwd web lint",
     "check": "bun run lint && bun run --cwd web check",

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+
+import { computeWebBuildHash, recordWebBuild, repoRoot } from './web-build-cache.js';
+
+const inputHash = await computeWebBuildHash();
+const build = Bun.spawn(['bun', 'run', '--cwd', 'web', 'build'], {
+  cwd: repoRoot,
+  stdin: 'inherit',
+  stdout: 'inherit',
+  stderr: 'inherit',
+});
+const exitCode = await build.exited;
+if (exitCode !== 0) process.exit(exitCode);
+await recordWebBuild({ hash: inputHash });

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+
+import { isWebBuildCurrent } from './web-build-cache.js';
+
+if (await isWebBuildCurrent()) {
+  console.log('Web build is current; skipping rebuild.');
+} else {
+  await import('./build-web.js');
+}
+
+await import('../server/main.js');

--- a/scripts/web-build-cache.js
+++ b/scripts/web-build-cache.js
@@ -8,22 +8,32 @@ export const repoRoot = path.resolve(scriptsDir, '..');
 export const webBuildDir = path.join(repoRoot, 'web', 'build');
 export const webBuildMarker = path.join(webBuildDir, '.garcon-build-input-hash');
 const webBuildMarkerVersion = 1;
+const webBuildEnvironmentPrefixes = ['PUBLIC_', 'VITE_'];
+// Excludes Paraglide output that Vite rewrites from the canonical messages and settings inputs.
+const webBuildIgnoredInputPaths = new Set([
+  path.join(repoRoot, 'web', 'src', 'lib', 'paraglide'),
+]);
 
 export const webBuildInputs = [
   path.join(repoRoot, 'common'),
+  path.join(repoRoot, 'web', '.env'),
+  path.join(repoRoot, 'web', '.env.local'),
+  path.join(repoRoot, 'web', '.env.production'),
+  path.join(repoRoot, 'web', '.env.production.local'),
   path.join(repoRoot, 'web', 'messages'),
   path.join(repoRoot, 'web', 'src'),
   path.join(repoRoot, 'web', 'static'),
   path.join(repoRoot, 'web', 'bun.lock'),
   path.join(repoRoot, 'web', 'codemirror-packages.ts'),
   path.join(repoRoot, 'web', 'package.json'),
-  path.join(repoRoot, 'web', 'project.inlang'),
+  path.join(repoRoot, 'web', 'project.inlang', 'settings.json'),
   path.join(repoRoot, 'web', 'svelte.config.js'),
   path.join(repoRoot, 'web', 'tsconfig.json'),
   path.join(repoRoot, 'web', 'vite.config.ts'),
 ];
 
-async function collectFiles(inputPath, rootPath, inputIndex, files) {
+async function collectFiles(inputPath, rootPath, inputIndex, files, ignoredPaths) {
+  if (ignoredPaths.has(inputPath)) return;
   const stat = await fs.stat(inputPath).catch(() => null);
   if (!stat) return;
   if (stat.isFile()) {
@@ -41,14 +51,33 @@ async function collectFiles(inputPath, rootPath, inputIndex, files) {
     if (entry.name === 'node_modules' || entry.name === '.svelte-kit' || entry.name === 'build') {
       continue;
     }
-    await collectFiles(path.join(inputPath, entry.name), rootPath, inputIndex, files);
+    await collectFiles(
+      path.join(inputPath, entry.name),
+      rootPath,
+      inputIndex,
+      files,
+      ignoredPaths,
+    );
   }
 }
 
-export async function computeWebBuildHash(inputs = webBuildInputs) {
+function buildEnvironmentEntries(environment) {
+  const entries = [['NODE_ENV', environment.NODE_ENV ?? 'production']];
+  entries.push(...Object.entries(environment).filter(([key, value]) => {
+    return value !== undefined
+      && webBuildEnvironmentPrefixes.some((prefix) => key.startsWith(prefix));
+  }));
+  return entries.sort(([left], [right]) => left.localeCompare(right));
+}
+
+export async function computeWebBuildHash(
+  inputs = webBuildInputs,
+  environment = process.env,
+  ignoredPaths = webBuildIgnoredInputPaths,
+) {
   const files = [];
   for (const [index, inputPath] of inputs.entries()) {
-    await collectFiles(inputPath, inputPath, index, files);
+    await collectFiles(inputPath, inputPath, index, files, ignoredPaths);
   }
   files.sort((left, right) => {
     return left.inputIndex - right.inputIndex
@@ -60,6 +89,10 @@ export async function computeWebBuildHash(inputs = webBuildInputs) {
     hash.update(`${file.inputIndex}:${file.relativePath}\0`);
     hash.update(await fs.readFile(file.absolutePath));
     hash.update('\0');
+  }
+  // Captures variables that Vite and SvelteKit inline into client bundles.
+  for (const [key, value] of buildEnvironmentEntries(environment)) {
+    hash.update(`environment:${key}\0${value}\0`);
   }
   return hash.digest('hex');
 }

--- a/scripts/web-build-cache.js
+++ b/scripts/web-build-cache.js
@@ -1,0 +1,157 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+export const repoRoot = path.resolve(scriptsDir, '..');
+export const webBuildDir = path.join(repoRoot, 'web', 'build');
+export const webBuildMarker = path.join(webBuildDir, '.garcon-build-input-hash');
+const webBuildMarkerVersion = 1;
+
+export const webBuildInputs = [
+  path.join(repoRoot, 'common'),
+  path.join(repoRoot, 'web', 'messages'),
+  path.join(repoRoot, 'web', 'src'),
+  path.join(repoRoot, 'web', 'static'),
+  path.join(repoRoot, 'web', 'bun.lock'),
+  path.join(repoRoot, 'web', 'codemirror-packages.ts'),
+  path.join(repoRoot, 'web', 'package.json'),
+  path.join(repoRoot, 'web', 'project.inlang'),
+  path.join(repoRoot, 'web', 'svelte.config.js'),
+  path.join(repoRoot, 'web', 'tsconfig.json'),
+  path.join(repoRoot, 'web', 'vite.config.ts'),
+];
+
+async function collectFiles(inputPath, rootPath, inputIndex, files) {
+  const stat = await fs.stat(inputPath).catch(() => null);
+  if (!stat) return;
+  if (stat.isFile()) {
+    files.push({
+      absolutePath: inputPath,
+      inputIndex,
+      relativePath: path.relative(rootPath, inputPath),
+    });
+    return;
+  }
+  if (!stat.isDirectory()) return;
+
+  const entries = await fs.readdir(inputPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.svelte-kit' || entry.name === 'build') {
+      continue;
+    }
+    await collectFiles(path.join(inputPath, entry.name), rootPath, inputIndex, files);
+  }
+}
+
+export async function computeWebBuildHash(inputs = webBuildInputs) {
+  const files = [];
+  for (const [index, inputPath] of inputs.entries()) {
+    await collectFiles(inputPath, inputPath, index, files);
+  }
+  files.sort((left, right) => {
+    return left.inputIndex - right.inputIndex
+      || left.relativePath.localeCompare(right.relativePath);
+  });
+
+  const hash = createHash('sha256');
+  for (const file of files) {
+    hash.update(`${file.inputIndex}:${file.relativePath}\0`);
+    hash.update(await fs.readFile(file.absolutePath));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+async function collectBuildAssets(directory, buildDir, markerPath, assets) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await collectBuildAssets(absolutePath, buildDir, markerPath, assets);
+    } else if (entry.isFile() && absolutePath !== markerPath) {
+      const stat = await fs.stat(absolutePath);
+      assets.push({
+        path: path.relative(buildDir, absolutePath).split(path.sep).join('/'),
+        size: stat.size,
+      });
+    }
+  }
+}
+
+async function listBuildAssets(buildDir, markerPath) {
+  const assets = [];
+  await collectBuildAssets(buildDir, buildDir, markerPath, assets);
+  return assets.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function isSafeAssetPath(assetPath) {
+  return typeof assetPath === 'string'
+    && !path.posix.isAbsolute(assetPath)
+    && assetPath.split('/').every((part) => part !== '' && part !== '.' && part !== '..');
+}
+
+function parseBuildMarker(contents) {
+  try {
+    const marker = JSON.parse(contents);
+    if (
+      marker?.version !== webBuildMarkerVersion
+      || typeof marker.hash !== 'string'
+      || !Array.isArray(marker.assets)
+      || marker.assets.length === 0
+      || marker.assets.some((asset) => {
+        return !asset
+          || !isSafeAssetPath(asset.path)
+          || !Number.isSafeInteger(asset.size)
+          || asset.size < 0;
+      })
+    ) {
+      return null;
+    }
+    return marker;
+  } catch {
+    return null;
+  }
+}
+
+async function hasRecordedBuildAssets(buildDir, assets) {
+  const stats = await Promise.all(
+    assets.map((asset) => fs.stat(
+      path.join(buildDir, ...asset.path.split('/')),
+    ).catch(() => null)),
+  );
+  return stats.every((stat, index) => stat?.isFile() && stat.size === assets[index].size);
+}
+
+export async function isWebBuildCurrent({
+  buildDir = webBuildDir,
+  markerPath = webBuildMarker,
+  inputs = webBuildInputs,
+  sourcePath = path.join(repoRoot, 'web', 'src'),
+} = {}) {
+  const [sourceStat, markerContents] = await Promise.all([
+    fs.stat(sourcePath).catch(() => null),
+    fs.readFile(markerPath, 'utf8').catch(() => ''),
+  ]);
+  const marker = parseBuildMarker(markerContents);
+  if (!marker || !await hasRecordedBuildAssets(buildDir, marker.assets)) return false;
+  // Published packages contain the compiled client but not its source tree.
+  if (!sourceStat) return true;
+  return marker.hash === await computeWebBuildHash(inputs);
+}
+
+export async function recordWebBuild({
+  buildDir = webBuildDir,
+  hash,
+  markerPath = webBuildMarker,
+  inputs = webBuildInputs,
+} = {}) {
+  await fs.mkdir(buildDir, { recursive: true });
+  const marker = {
+    version: webBuildMarkerVersion,
+    hash: hash ?? await computeWebBuildHash(inputs),
+    assets: await listBuildAssets(buildDir, markerPath),
+  };
+  await fs.writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+}

--- a/server/agents/default-agent-suite.ts
+++ b/server/agents/default-agent-suite.ts
@@ -4,7 +4,6 @@ import { CodexAppServerRuntime } from './codex/app-server/runtime.js';
 import { OpenCodeRuntime } from './opencode/opencode.js';
 import { AmpCliRuntime } from './amp/amp-cli.js';
 import { FactoryCliRuntime } from './factory/factory-cli.js';
-import { PiCliRuntime } from './pi/pi-cli.js';
 import { createAmpAgent } from './amp/index.js';
 import { createClaudeAgent } from './claude/index.js';
 import { createCodexAgent } from './codex/index.js';
@@ -15,6 +14,7 @@ import { createDirectOpenAiResponsesAgent } from './direct/openai-responses.js';
 import { createFactoryAgent } from './factory/index.js';
 import { createOpenCodeAgent } from './opencode/index.js';
 import { createPiAgent } from './pi/index.js';
+import { LazyPiRuntime } from './pi/lazy-runtime.js';
 import type { Agent } from './types.js';
 import type { AgentId } from '../../common/agents.js';
 
@@ -79,7 +79,7 @@ export const integratedAgentModules = [
   },
   {
     id: 'pi',
-    createAgent: () => createPiAgent(new PiCliRuntime()),
+    createAgent: () => createPiAgent(new LazyPiRuntime()),
   },
 ] satisfies readonly AgentModule[];
 

--- a/server/agents/pi/__tests__/lazy-runtime.test.js
+++ b/server/agents/pi/__tests__/lazy-runtime.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { AgentEventEmitterRuntime } from '../../shared/event-emitter-runtime.ts';
+import { LazyPiRuntime } from '../lazy-runtime.ts';
+
+class FakePiRuntime extends AgentEventEmitterRuntime {
+  startSession = mock(async () => ({ agentSessionId: 'pi-session', nativePath: null }));
+  runTurn = mock(async () => {});
+  abort = mock(() => true);
+  isRunning = mock(() => true);
+  getRunningSessions = mock(() => [{ id: 'pi-session' }]);
+  startPurgeTimer = mock(() => {});
+  shutdown = mock(() => {});
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('LazyPiRuntime', () => {
+  it('loads Pi only when an asynchronous runtime operation needs it', async () => {
+    const loaded = new FakePiRuntime();
+    const loadRuntime = mock(async () => loaded);
+    const runtime = new LazyPiRuntime(loadRuntime);
+
+    runtime.startPurgeTimer();
+    expect(runtime.isRunning('pi-session')).toBe(false);
+    expect(runtime.getRunningSessions()).toEqual([]);
+    expect(runtime.abort('pi-session')).toBe(false);
+    expect(loadRuntime).not.toHaveBeenCalled();
+
+    await runtime.startSession({});
+
+    expect(loadRuntime).toHaveBeenCalledTimes(1);
+    expect(loaded.startSession).toHaveBeenCalledTimes(1);
+    expect(loaded.startPurgeTimer).toHaveBeenCalledTimes(1);
+    expect(runtime.isRunning('pi-session')).toBe(true);
+  });
+
+  it('shares an in-flight load and forwards runtime events', async () => {
+    const loaded = new FakePiRuntime();
+    const loadRuntime = mock(async () => loaded);
+    const runtime = new LazyPiRuntime(loadRuntime);
+    const received = mock(() => {});
+    runtime.onMessages(received);
+
+    await Promise.all([runtime.startSession({}), runtime.runTurn({})]);
+    loaded.emitMessages('chat-1', ['hello']);
+
+    expect(loadRuntime).toHaveBeenCalledTimes(1);
+    expect(received).toHaveBeenCalledWith('chat-1', ['hello']);
+  });
+
+  it('cancels only the matching queued turn when aborted during loading', async () => {
+    const loaded = new FakePiRuntime();
+    const loader = deferred();
+    const runtime = new LazyPiRuntime(() => loader.promise);
+    const start = runtime.startSession({});
+    const turn = runtime.runTurn({ agentSessionId: 'pi-session' });
+    const unrelatedTurn = runtime.runTurn({ agentSessionId: 'other-session' });
+
+    expect(runtime.abort('pi-session')).toBe(true);
+    expect(runtime.abort('missing-session')).toBe(false);
+    loader.resolve(loaded);
+
+    const results = await Promise.allSettled([start, turn, unrelatedTurn]);
+    expect(results.map(({ status }) => status)).toEqual(['fulfilled', 'rejected', 'fulfilled']);
+    expect(results[1].reason).toMatchObject({ name: 'AbortError' });
+    expect(loaded.startSession).toHaveBeenCalledTimes(1);
+    expect(loaded.runTurn).toHaveBeenCalledTimes(1);
+    expect(loaded.runTurn).toHaveBeenCalledWith({ agentSessionId: 'other-session' });
+    expect(loaded.abort).not.toHaveBeenCalled();
+  });
+
+  it('aborts an active runtime turn while cancelling a matching queued turn', async () => {
+    const loaded = new FakePiRuntime();
+    const activeTurn = deferred();
+    const activeTurnStarted = deferred();
+    loaded.runTurn = mock(() => {
+      activeTurnStarted.resolve();
+      return activeTurn.promise;
+    });
+    loaded.abort = mock(async () => false);
+    const runtime = new LazyPiRuntime(async () => loaded);
+    await runtime.startSession({});
+
+    const runningTurn = runtime.runTurn({ agentSessionId: 'pi-session' });
+    await activeTurnStarted.promise;
+    const queuedTurn = runtime.runTurn({ agentSessionId: 'pi-session' });
+    const turnResults = Promise.allSettled([runningTurn, queuedTurn]);
+
+    const abortResult = runtime.abort('pi-session');
+    expect(abortResult).toBeInstanceOf(Promise);
+    await expect(abortResult).resolves.toBe(true);
+    expect(loaded.abort).toHaveBeenCalledWith('pi-session');
+    activeTurn.resolve();
+
+    const results = await turnResults;
+    expect(results.map(({ status }) => status)).toEqual(['fulfilled', 'rejected']);
+    expect(results[1].reason).toMatchObject({ name: 'AbortError' });
+    expect(loaded.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('shuts down a deferred runtime without starting queued operations', async () => {
+    const loaded = new FakePiRuntime();
+    const loader = deferred();
+    const runtime = new LazyPiRuntime(() => loader.promise);
+    const start = runtime.startSession({});
+    const turn = runtime.runTurn({});
+
+    runtime.shutdown();
+    loader.resolve(loaded);
+
+    const results = await Promise.allSettled([start, turn]);
+    expect(results.map(({ status }) => status)).toEqual(['rejected', 'rejected']);
+    expect(loaded.shutdown).toHaveBeenCalledTimes(1);
+    expect(loaded.startSession).not.toHaveBeenCalled();
+    expect(loaded.runTurn).not.toHaveBeenCalled();
+    await expect(runtime.startSession({})).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/server/agents/pi/index.ts
+++ b/server/agents/pi/index.ts
@@ -1,46 +1,43 @@
-import { runSingleQuery as runSingleQueryPi, type PiCliRuntime } from './pi-cli.js';
-import { forkPiSession } from './pi-fork.js';
-import {
-  getPiPreviewFromSessionId,
-  getPiPreviewFromSessionPath,
-  loadPiChatMessages,
-  loadPiChatMessagesBySessionId,
-} from './history-loader.js';
-import { getPiModelsStrict } from './pi-models.js';
-import { findPiSessionFileBySessionId } from './pi-session-paths.js';
-import { getPiAuthStatus } from './pi-auth.js';
 import { createAgentCapabilities } from '../capabilities.js';
 import { createArtificialNativePath, isArtificialNativePath } from '../../chats/artificial-native-path.js';
-import type { Agent } from '../types.js';
+import type { Agent, AgentRuntime } from '../types.js';
 import type { AgentChatEntry } from '../session-types.js';
 
 function hasRealPiNativePath(session: AgentChatEntry): session is AgentChatEntry & { nativePath: string } {
   return Boolean(session.nativePath) && !isArtificialNativePath(session.nativePath);
 }
 
-export function createPiAgent(pi: PiCliRuntime): Agent {
+export function createPiAgent(pi: AgentRuntime): Agent {
   return {
     id: 'pi',
     label: 'Pi',
     runtime: pi,
     transcript: {
       async loadMessages(session) {
-        if (hasRealPiNativePath(session)) return loadPiChatMessages(session.nativePath);
+        const history = await import('./history-loader.js');
+        if (hasRealPiNativePath(session)) return history.loadPiChatMessages(session.nativePath);
         if (!session.agentSessionId) return [];
-        return loadPiChatMessagesBySessionId(session.agentSessionId, session.projectPath);
+        return history.loadPiChatMessagesBySessionId(session.agentSessionId, session.projectPath);
       },
       async getPreview(session) {
-        if (hasRealPiNativePath(session)) return getPiPreviewFromSessionPath(session.nativePath);
+        const history = await import('./history-loader.js');
+        if (hasRealPiNativePath(session)) return history.getPiPreviewFromSessionPath(session.nativePath);
         if (!session.agentSessionId) return null;
-        return getPiPreviewFromSessionId(session.agentSessionId, session.projectPath);
+        return history.getPiPreviewFromSessionId(session.agentSessionId, session.projectPath);
       },
       async resolveNativePath(session) {
         if (!session.agentSessionId) return null;
+        const { findPiSessionFileBySessionId } = await import('./pi-session-paths.js');
         const found = await findPiSessionFileBySessionId(session.agentSessionId, session.projectPath);
         return found || createArtificialNativePath(session.agentId, session.agentSessionId);
       },
     },
-    auth: { getAuthStatus: () => getPiAuthStatus() },
+    auth: {
+      async getAuthStatus() {
+        const { getPiAuthStatus } = await import('./pi-auth.js');
+        return getPiAuthStatus();
+      },
+    },
     capabilities: createAgentCapabilities({
       supportsFork: true,
       supportsForkAtMessage: false,
@@ -51,11 +48,16 @@ export function createPiAgent(pi: PiCliRuntime): Agent {
       supportedProtocols: [],
       authLoginSupported: false,
       requiresStrictModelDiscovery: true,
-      getModels: (query) => query?.strict ? getPiModelsStrict() : pi.getModels(),
+      async getModels(query) {
+        const models = await import('./pi-models.js');
+        return query?.strict ? models.getPiModelsStrict() : models.getPiModels();
+      },
     }),
     forkSession({ sourceSession }) {
-      return forkPiSession(sourceSession);
+      return import('./pi-fork.js').then(({ forkPiSession }) => forkPiSession(sourceSession));
     },
-    runSingleQuery: runSingleQueryPi,
+    runSingleQuery(prompt, options) {
+      return import('./pi-cli.js').then(({ runSingleQuery }) => runSingleQuery(prompt, options));
+    },
   };
 }

--- a/server/agents/pi/lazy-runtime.ts
+++ b/server/agents/pi/lazy-runtime.ts
@@ -1,0 +1,138 @@
+import { AgentEventEmitterRuntime } from '../shared/event-emitter-runtime.js';
+import type {
+  ResumeTurnRequest,
+  StartSessionRequest,
+  StartedAgentSession,
+} from '../session-types.js';
+import type { AgentRuntime } from '../types.js';
+
+type PiRuntime = AgentRuntime & {
+  startPurgeTimer(): void;
+  shutdown(): void;
+};
+
+export type PiRuntimeLoader = () => Promise<PiRuntime>;
+
+interface PendingRuntimeOperation {
+  agentSessionId: string | null;
+  cancelled: boolean;
+}
+
+function loadPiRuntime(): Promise<PiRuntime> {
+  return import('./pi-cli.js').then(({ PiCliRuntime }) => new PiCliRuntime());
+}
+
+export class LazyPiRuntime extends AgentEventEmitterRuntime implements AgentRuntime {
+  readonly #loadRuntime: PiRuntimeLoader;
+  #runtime: PiRuntime | null = null;
+  #runtimePromise: Promise<PiRuntime> | null = null;
+  readonly #pendingOperations = new Set<PendingRuntimeOperation>();
+  #purgeTimerRequested = false;
+  #shutdownRequested = false;
+
+  constructor(loadRuntime: PiRuntimeLoader = loadPiRuntime) {
+    super();
+    this.#loadRuntime = loadRuntime;
+  }
+
+  async startSession(request: StartSessionRequest): Promise<StartedAgentSession> {
+    return this.#runAfterLoad(null, (runtime) => runtime.startSession(request));
+  }
+
+  async runTurn(request: ResumeTurnRequest): Promise<void> {
+    return this.#runAfterLoad(request.agentSessionId, (runtime) => runtime.runTurn(request));
+  }
+
+  abort(agentSessionId: string): boolean | Promise<boolean> {
+    const pendingCancelled = this.#cancelPendingOperations(agentSessionId);
+    const runtimeAbort = this.#runtime?.abort(agentSessionId);
+    if (runtimeAbort === undefined) return pendingCancelled;
+    if (typeof runtimeAbort === 'boolean') return pendingCancelled || runtimeAbort;
+    return runtimeAbort.then((aborted) => pendingCancelled || aborted);
+  }
+
+  isRunning(agentSessionId: string): boolean {
+    return this.#runtime?.isRunning(agentSessionId) ?? false;
+  }
+
+  getRunningSessions(): Array<{ id: string; status?: string; startedAt?: string }> {
+    return this.#runtime?.getRunningSessions() ?? [];
+  }
+
+  startPurgeTimer(): void {
+    this.#purgeTimerRequested = true;
+    this.#runtime?.startPurgeTimer();
+  }
+
+  shutdown(): void {
+    this.#shutdownRequested = true;
+    this.#cancelPendingOperations();
+    this.#runtime?.shutdown();
+  }
+
+  async #runAfterLoad<T>(
+    agentSessionId: string | null,
+    operation: (runtime: PiRuntime) => Promise<T>,
+  ): Promise<T> {
+    if (this.#shutdownRequested) throw this.#cancelledOperationError();
+
+    const pending: PendingRuntimeOperation = { agentSessionId, cancelled: false };
+    this.#pendingOperations.add(pending);
+    let runtime: PiRuntime;
+    try {
+      runtime = await this.#getRuntime();
+      if (pending.cancelled || this.#shutdownRequested) {
+        throw this.#cancelledOperationError();
+      }
+    } finally {
+      this.#pendingOperations.delete(pending);
+    }
+    return operation(runtime);
+  }
+
+  #cancelPendingOperations(agentSessionId?: string): boolean {
+    let cancelled = false;
+    for (const operation of this.#pendingOperations) {
+      if (agentSessionId !== undefined && operation.agentSessionId !== agentSessionId) continue;
+      operation.cancelled = true;
+      cancelled = true;
+    }
+    return cancelled;
+  }
+
+  #cancelledOperationError(): Error {
+    const error = new Error('Pi runtime operation cancelled before initialization');
+    error.name = 'AbortError';
+    return error;
+  }
+
+  async #getRuntime(): Promise<PiRuntime> {
+    if (this.#runtime) return this.#runtime;
+    if (this.#runtimePromise) return this.#runtimePromise;
+
+    this.#runtimePromise = this.#loadRuntime().then((runtime) => {
+      this.#runtime = runtime;
+      runtime.onMessages((chatId, messages, metadata) =>
+        this.emitMessages(chatId, messages, metadata),
+      );
+      runtime.onProcessing((chatId, isProcessing) =>
+        this.emitProcessing(chatId, isProcessing),
+      );
+      runtime.onSessionCreated((chatId) => this.emitSessionCreated(chatId));
+      runtime.onFinished((chatId, exitCode, metadata) =>
+        this.emitFinished(chatId, exitCode, metadata),
+      );
+      runtime.onFailed((chatId, message) => this.emitFailed(chatId, message));
+      if (this.#purgeTimerRequested) runtime.startPurgeTimer();
+      if (this.#shutdownRequested) runtime.shutdown();
+      return runtime;
+    });
+
+    try {
+      return await this.#runtimePromise;
+    } catch (error) {
+      this.#runtimePromise = null;
+      throw error;
+    }
+  }
+}

--- a/server/lib/__tests__/web-build-cache.test.js
+++ b/server/lib/__tests__/web-build-cache.test.js
@@ -43,6 +43,51 @@ describe('web build cache', () => {
     expect(await computeWebBuildHash([fixture.input])).not.toBe(first);
   });
 
+  it('invalidates for standard client build environment changes', async () => {
+    const fixture = await createFixture();
+    const baseline = {
+      NODE_ENV: 'production',
+      PUBLIC_APP_NAME: 'Garcon',
+      VITE_FEATURE: 'enabled',
+      UNRELATED: 'first',
+    };
+    const first = await computeWebBuildHash([fixture.input], baseline);
+
+    expect(await computeWebBuildHash([fixture.input], {
+      ...baseline,
+      VITE_FEATURE: 'disabled',
+    })).not.toBe(first);
+    expect(await computeWebBuildHash([fixture.input], {
+      ...baseline,
+      PUBLIC_APP_NAME: 'Garcon Dev',
+    })).not.toBe(first);
+    expect(await computeWebBuildHash([fixture.input], {
+      ...baseline,
+      NODE_ENV: 'development',
+    })).not.toBe(first);
+    expect(await computeWebBuildHash([fixture.input], {
+      PUBLIC_APP_NAME: baseline.PUBLIC_APP_NAME,
+      VITE_FEATURE: baseline.VITE_FEATURE,
+    })).toBe(first);
+    expect(await computeWebBuildHash([fixture.input], {
+      ...baseline,
+      UNRELATED: 'second',
+    })).toBe(first);
+  });
+
+  it('ignores generated input directories', async () => {
+    const fixture = await createFixture();
+    const generated = path.join(fixture.input, 'generated');
+    await fs.mkdir(generated);
+    await fs.writeFile(path.join(generated, 'messages.js'), 'first');
+    const ignoredPaths = new Set([generated]);
+    const first = await computeWebBuildHash([fixture.input], {}, ignoredPaths);
+
+    await fs.writeFile(path.join(generated, 'messages.js'), 'second');
+
+    expect(await computeWebBuildHash([fixture.input], {}, ignoredPaths)).toBe(first);
+  });
+
   it('invalidates the marker when an input changes or output is missing', async () => {
     const fixture = await createFixture();
     const options = { ...fixture, inputs: [fixture.input], sourcePath: fixture.input };

--- a/server/lib/__tests__/web-build-cache.test.js
+++ b/server/lib/__tests__/web-build-cache.test.js
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  computeWebBuildHash,
+  isWebBuildCurrent,
+  recordWebBuild,
+} from '../../../scripts/web-build-cache.js';
+
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      fs.rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+async function createFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-web-build-cache-'));
+  temporaryDirectories.push(root);
+  const input = path.join(root, 'input');
+  const buildDir = path.join(root, 'build');
+  const markerPath = path.join(buildDir, '.marker');
+  await fs.mkdir(input);
+  await fs.mkdir(path.join(buildDir, '_app'), { recursive: true });
+  await fs.writeFile(path.join(input, 'app.ts'), 'first');
+  await fs.writeFile(path.join(buildDir, 'index.html'), '<main></main>');
+  await fs.writeFile(path.join(buildDir, '_app', 'app.js'), 'compiled');
+  return { input, buildDir, markerPath };
+}
+
+describe('web build cache', () => {
+  it('hashes file content and paths deterministically', async () => {
+    const fixture = await createFixture();
+    const first = await computeWebBuildHash([fixture.input]);
+    const second = await computeWebBuildHash([fixture.input]);
+    await fs.writeFile(path.join(fixture.input, 'app.ts'), 'second');
+
+    expect(second).toBe(first);
+    expect(await computeWebBuildHash([fixture.input])).not.toBe(first);
+  });
+
+  it('invalidates the marker when an input changes or output is missing', async () => {
+    const fixture = await createFixture();
+    const options = { ...fixture, inputs: [fixture.input], sourcePath: fixture.input };
+    await recordWebBuild(options);
+    expect(await isWebBuildCurrent(options)).toBe(true);
+
+    await fs.writeFile(path.join(fixture.input, 'app.ts'), 'changed');
+    expect(await isWebBuildCurrent(options)).toBe(false);
+
+    await recordWebBuild(options);
+    await fs.rm(path.join(fixture.buildDir, 'index.html'));
+    expect(await isWebBuildCurrent(options)).toBe(false);
+  });
+
+  it('invalidates the marker when a recorded emitted asset is missing', async () => {
+    const fixture = await createFixture();
+    const options = { ...fixture, inputs: [fixture.input], sourcePath: fixture.input };
+    await recordWebBuild(options);
+
+    await fs.rm(path.join(fixture.buildDir, '_app', 'app.js'));
+
+    expect(await isWebBuildCurrent(options)).toBe(false);
+  });
+
+  it('invalidates the marker when a recorded emitted asset is truncated', async () => {
+    const fixture = await createFixture();
+    const options = { ...fixture, inputs: [fixture.input], sourcePath: fixture.input };
+    await recordWebBuild(options);
+
+    await fs.writeFile(path.join(fixture.buildDir, '_app', 'app.js'), 'x');
+
+    expect(await isWebBuildCurrent(options)).toBe(false);
+  });
+
+  it('uses the compiled client when a published package omits web sources', async () => {
+    const fixture = await createFixture();
+    await recordWebBuild({ ...fixture, inputs: [fixture.input] });
+    expect(await isWebBuildCurrent({
+      ...fixture,
+      sourcePath: path.join(fixture.input, 'missing'),
+    })).toBe(true);
+  });
+
+  it('records the pre-build hash so concurrent source changes stay invalidated', async () => {
+    const fixture = await createFixture();
+    const options = { ...fixture, inputs: [fixture.input], sourcePath: fixture.input };
+    const preBuildHash = await computeWebBuildHash(options.inputs);
+    await fs.writeFile(path.join(fixture.input, 'app.ts'), 'changed during build');
+    await recordWebBuild({ ...options, hash: preBuildHash });
+
+    expect(await isWebBuildCurrent(options)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Reuses the compiled frontend when its source hash and complete emitted-asset inventory still match.
- Defers the heavy Pi SDK/runtime import until Pi functionality is first used.
- Preserves existing behavior and does not change HTTP or WebSocket contracts.

## Architecture

```mermaid
flowchart LR
  A[Start Garcon] --> B[Build frontend unconditionally]
  B --> C[Import every agent runtime]
  C --> D[Start server]
```

```mermaid
flowchart LR
  A[Start Garcon] --> B{Frontend cache current?}
  B -->|No| C[Build and record source plus asset inventory]
  B -->|Yes| D[Use compiled frontend]
  C --> D
  D --> E[Import lightweight agent suite]
  E --> F[Start server]
  F --> G[Load Pi runtime on first Pi operation]
```

The cache is accepted only when source inputs match and every recorded output still exists at its expected size. Published packages without frontend source validate their packaged compiled assets instead. The Pi wrapper preserves event forwarding, abort, purge, and shutdown semantics across an in-flight lazy import.

## Benchmarks

Measured with fresh processes on the same runtime and checkout. Startup readiness was timed from process launch to the server-ready log; each post-change figure is five runs.

| Measurement | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Cached `bun run start` readiness | 9,528 ms | 304 ms median, 300-328 ms | 96.8% |
| `server/server.ts` import | about 325 ms | 80.6 ms median, 78.6-88.0 ms | about 75% |

The final startup measurement includes complete asset-inventory validation.

## Tests

- `bun run build`
- `bun run check`
- `bun run test` — all server tests and 249 web test files / 2,115 web tests passed
- `bun pm pack --dry-run` — startup scripts and build marker included
- `bun run start --port 0` — isolated startup smoke passed

The audit also identified transcript paging and cache retention as a larger-memory follow-up. That redesign is intentionally outside this behavior-preserving startup PR.
