### PR TITLE
web/settings: Expand agent card when login yields a device auth code

### DIFF
--- a/server/agents/__tests__/auth-login.test.js
+++ b/server/agents/__tests__/auth-login.test.js
@@ -166,6 +166,30 @@ describe('AgentAuthLoginManager', () => {
     expect(relaunch.launched).toBe(true);
   });
 
+  it('reports a running login session with device auth until it exits', async () => {
+    const manager = new AgentAuthLoginManager();
+    const pty = createFakePty();
+    spawn.mockImplementation(() => pty);
+
+    expect(manager.status('codex')).toEqual({ running: false });
+
+    const resultPromise = manager.launch('codex');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    pty.emitData(DEVICE_AUTH_OUTPUT);
+    await resultPromise;
+
+    expect(manager.status('codex')).toEqual({
+      running: true,
+      deviceAuth: {
+        url: 'https://auth.openai.com/codex/device',
+        code: 'AB12-CD34',
+      },
+    });
+
+    pty.emitExit({ exitCode: 0, signal: null });
+    expect(manager.status('codex')).toEqual({ running: false });
+  });
+
   it('rejects agents without a supported UI login flow', async () => {
     const manager = new AgentAuthLoginManager();
 

--- a/server/agents/__tests__/auth-login.test.js
+++ b/server/agents/__tests__/auth-login.test.js
@@ -121,7 +121,7 @@ describe('AgentAuthLoginManager', () => {
     expect(args).toEqual(['login', '--device-auth']);
   });
 
-  it('returns alreadyRunning when a codex session is in progress', async () => {
+  it('returns alreadyRunning with the cached device auth when a codex session is in progress', async () => {
     const manager = new AgentAuthLoginManager();
     const pty = createFakePty();
     spawn.mockImplementation(() => pty);
@@ -132,7 +132,38 @@ describe('AgentAuthLoginManager', () => {
     await resultPromise;
 
     const second = await manager.launch('codex');
-    expect(second).toEqual({ launched: false, alreadyRunning: true });
+    expect(second).toEqual({
+      launched: false,
+      alreadyRunning: true,
+      deviceAuth: {
+        url: 'https://auth.openai.com/codex/device',
+        code: 'AB12-CD34',
+      },
+    });
+  });
+
+  it('drops the cached device auth once the codex session exits', async () => {
+    const manager = new AgentAuthLoginManager();
+    const pty = createFakePty();
+    spawn.mockImplementation(() => pty);
+
+    const resultPromise = manager.launch('codex');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    pty.emitData(DEVICE_AUTH_OUTPUT);
+    await resultPromise;
+
+    pty.emitExit({ exitCode: 0, signal: null });
+
+    const nextPty = createFakePty();
+    spawn.mockImplementationOnce(() => nextPty);
+    const relaunchPromise = manager.launch('codex');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const followUp = await manager.launch('codex');
+    expect(followUp.deviceAuth).toBeUndefined();
+
+    nextPty.emitData(DEVICE_AUTH_OUTPUT);
+    const relaunch = await relaunchPromise;
+    expect(relaunch.launched).toBe(true);
   });
 
   it('rejects agents without a supported UI login flow', async () => {

--- a/server/agents/auth-login.ts
+++ b/server/agents/auth-login.ts
@@ -26,6 +26,11 @@ interface AuthLoginCompleteResult {
   completed: boolean;
 }
 
+interface AuthLoginStatusResult {
+  running: boolean;
+  deviceAuth?: DeviceAuthInfo;
+}
+
 const CLAUDE_LOGIN_WRAPPER = `
 delete process.env.CLAUDECODE;
 const [binary, ...args] = process.argv.slice(1);
@@ -214,6 +219,17 @@ export class AgentAuthLoginManager {
     }
   }
 
+  // Reports whether a login session is still in progress so clients can keep
+  // device auth details visible until the session actually ends. Auth status
+  // is not a usable completion signal because agents with stale credentials
+  // report authenticated throughout a re-login.
+  status(agentId: string): AuthLoginStatusResult {
+    if (this.#sessions.has(agentId) || this.#browserSessions.has(agentId)) {
+      return { running: true, deviceAuth: this.#deviceAuthByAgent.get(agentId) };
+    }
+    return { running: false };
+  }
+
   async complete(agentId: string, code: string): Promise<AuthLoginCompleteResult> {
     const proc = this.#browserSessions.get(agentId);
     if (!proc) {
@@ -291,4 +307,8 @@ export function launchAgentAuthLogin(agentId: string): Promise<AuthLoginLaunchRe
 
 export function completeAgentAuthLogin(agentId: string, code: string): Promise<AuthLoginCompleteResult> {
   return agentAuthLogin.complete(agentId, code);
+}
+
+export function getAgentAuthLoginStatus(agentId: string): AuthLoginStatusResult {
+  return agentAuthLogin.status(agentId);
 }

--- a/server/agents/auth-login.ts
+++ b/server/agents/auth-login.ts
@@ -182,6 +182,9 @@ function defaultProcessSpawner(command: LoginCommand, agentId: string): SpawnedL
 export class AgentAuthLoginManager {
   #sessions = new Map<string, IPty>();
   #browserSessions = new Map<string, SpawnedLoginProcess>();
+  // Retains device auth details while a login session is in progress so
+  // repeated launch calls can re-surface the code instead of dropping it.
+  #deviceAuthByAgent = new Map<string, DeviceAuthInfo>();
   #spawnProcess: LoginProcessSpawner;
 
   constructor(options: { spawnProcess?: LoginProcessSpawner } = {}) {
@@ -195,13 +198,14 @@ export class AgentAuthLoginManager {
     }
 
     if (this.#sessions.has(agentId) || this.#browserSessions.has(agentId)) {
-      return { launched: false, alreadyRunning: true };
+      return { launched: false, alreadyRunning: true, deviceAuth: this.#deviceAuthByAgent.get(agentId) };
     }
 
     try {
       const proc = await this.#spawnPty(agentId, command);
       const useDeviceAuth = DEVICE_AUTH_AGENTS.has(agentId);
       const deviceAuth = useDeviceAuth ? (await readDeviceAuthFromPty(proc)) ?? undefined : undefined;
+      if (deviceAuth) this.#deviceAuthByAgent.set(agentId, deviceAuth);
       return { launched: true, alreadyRunning: false, deviceAuth };
     } catch (error) {
       if (agentId !== 'claude') throw error;
@@ -240,7 +244,10 @@ export class AgentAuthLoginManager {
   async #launchClaudeBrowserCodeLogin(agentId: string): Promise<AuthLoginLaunchResult> {
     const proc = this.#spawnProcess(getClaudePipeLoginCommand(), agentId);
     this.#browserSessions.set(agentId, proc);
-    void proc.exited.finally(() => this.#browserSessions.delete(agentId));
+    void proc.exited.finally(() => {
+      this.#browserSessions.delete(agentId);
+      this.#deviceAuthByAgent.delete(agentId);
+    });
 
     const deviceAuth = await readBrowserAuthFromProcess(proc);
     if (!deviceAuth) {
@@ -248,6 +255,7 @@ export class AgentAuthLoginManager {
       proc.kill();
       throw new Error('Claude auth login did not print a sign-in URL');
     }
+    this.#deviceAuthByAgent.set(agentId, deviceAuth);
     return { launched: true, alreadyRunning: false, deviceAuth };
   }
 
@@ -265,6 +273,7 @@ export class AgentAuthLoginManager {
     this.#sessions.set(agentId, proc);
     proc.onExit((exit: IExitEvent) => {
       this.#sessions.delete(agentId);
+      this.#deviceAuthByAgent.delete(agentId);
       if (exit.exitCode !== 0) {
         logger.warn(`agents: ${agentId} auth login exited with code ${exit.exitCode}${exit.signal ? ` (${exit.signal})` : ''}`);
       }

--- a/server/agents/claude/index.ts
+++ b/server/agents/claude/index.ts
@@ -9,7 +9,7 @@ import type {
   StartedAgentSession,
 } from '../session-types.js';
 import { getClaudeAuthStatus } from './claude-auth.js';
-import { completeAgentAuthLogin, launchAgentAuthLogin } from '../auth-login.js';
+import { completeAgentAuthLogin, getAgentAuthLoginStatus, launchAgentAuthLogin } from '../auth-login.js';
 import { createAgentCapabilities } from '../capabilities.js';
 import { loadClaudeChatMessages, getClaudePreviewFromNativePath, loadClaudeChatMessagePage } from './history-loader.js';
 import type { ChatMessage } from '../../../common/chat-types.js';
@@ -119,6 +119,7 @@ export function createClaudeAgent(claude: ClaudeCliRuntime): Agent {
       getAuthStatus: () => getClaudeAuthStatus(),
       launchLogin: () => launchAgentAuthLogin('claude'),
       completeLogin: (code) => completeAgentAuthLogin('claude', code),
+      loginStatus: () => getAgentAuthLoginStatus('claude'),
     },
     capabilities: createAgentCapabilities({
       supportsFork: true,

--- a/server/agents/codex/index.ts
+++ b/server/agents/codex/index.ts
@@ -2,7 +2,7 @@ import type { ChatMessage } from '../../../common/chat-types.js';
 import { runSingleQuery as runSingleQueryCodex } from './app-server/run-single-query.js';
 import type { CodexAppServerRuntime } from './app-server/runtime.js';
 import { getCodexAuthStatus } from './codex-auth.js';
-import { launchAgentAuthLogin } from '../auth-login.js';
+import { getAgentAuthLoginStatus, launchAgentAuthLogin } from '../auth-login.js';
 import { createAgentCapabilities } from '../capabilities.js';
 import type { Agent } from '../types.js';
 import { buildCodexAppServerEndpointRuntime } from './app-server/endpoint-runtime.js';
@@ -30,6 +30,7 @@ export function createCodexAgent(codex: CodexAppServerRuntime): Agent {
     auth: {
       getAuthStatus: () => getCodexAuthStatus(),
       launchLogin: () => launchAgentAuthLogin('codex'),
+      loginStatus: () => getAgentAuthLoginStatus('codex'),
     },
     capabilities: createAgentCapabilities({
       supportsFork: true,

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -74,6 +74,10 @@ export interface AgentRegistryServiceContract {
     deviceAuth?: { url: string; code?: string; needsCode?: boolean };
   }>;
   completeAgentAuthLogin(agentId: string, code: string): Promise<{ completed: boolean }>;
+  getAgentAuthLoginStatus(agentId: string): Promise<{
+    running: boolean;
+    deviceAuth?: { url: string; code?: string; needsCode?: boolean };
+  }>;
   modelSupportsImages(input: {
     agentId: string;
     model: string;
@@ -310,6 +314,16 @@ export class AgentRegistry implements AgentRegistryServiceContract {
       throw new Error(`Auth login completion is not supported for agent: ${agentId}`);
     }
     return agent.auth.completeLogin(code);
+  }
+
+  async getAgentAuthLoginStatus(agentId: string): Promise<{
+    running: boolean;
+    deviceAuth?: { url: string; code?: string; needsCode?: boolean };
+  }> {
+    const agent = this.#directory.get(agentId);
+    if (!agent) throw new Error(`Unsupported agent: ${agentId}`);
+    if (!agent.auth.loginStatus) return { running: false };
+    return agent.auth.loginStatus();
   }
 
   async getAgentAuthStatus(agentId: string): Promise<unknown | null> {

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -65,6 +65,10 @@ export interface AgentAuth {
     deviceAuth?: { url: string; code?: string; needsCode?: boolean };
   }>;
   completeLogin?(code: string): Promise<{ completed: boolean }>;
+  loginStatus?(): {
+    running: boolean;
+    deviceAuth?: { url: string; code?: string; needsCode?: boolean };
+  };
 }
 
 export interface AgentModelQuery {

--- a/server/routes/agents.ts
+++ b/server/routes/agents.ts
@@ -60,6 +60,18 @@ export default function createAgentRoutes({ agents, apiProviders }: AgentRouteDe
     }
   }
 
+  async function getAgentAuthLoginStatus(_request: Request, url: URL): Promise<Response> {
+    const agentId = url.searchParams.get('agent');
+    if (!agentId) {
+      return Response.json({ error: 'agent is required' }, { status: 400 });
+    }
+    try {
+      return Response.json(await agents.getAgentAuthLoginStatus(agentId));
+    } catch (error) {
+      return Response.json({ error: errorMessage(error) }, { status: 500 });
+    }
+  }
+
   async function postAgentAuthComplete(body: JsonBody): Promise<Response> {
     try {
       const input = asJsonBody(body);
@@ -81,7 +93,10 @@ export default function createAgentRoutes({ agents, apiProviders }: AgentRouteDe
     '/api/v1/agents': { GET: getAgents },
     '/api/v1/agents/auth': { GET: getAgentAuth },
     '/api/v1/agents/readiness': { GET: getAgentReadiness },
-    '/api/v1/agents/auth/login': { POST: withJsonBody(postAgentAuthLogin) },
+    '/api/v1/agents/auth/login': {
+      GET: getAgentAuthLoginStatus,
+      POST: withJsonBody(postAgentAuthLogin),
+    },
     '/api/v1/agents/auth/login/complete': { POST: withJsonBody(postAgentAuthComplete) },
   };
 }

--- a/web/src/lib/api/agents.ts
+++ b/web/src/lib/api/agents.ts
@@ -32,6 +32,11 @@ export interface AgentAuthLoginResult {
 	deviceAuth?: DeviceAuthInfo;
 }
 
+export interface AgentAuthLoginStatus {
+	running: boolean;
+	deviceAuth?: DeviceAuthInfo;
+}
+
 export async function getAgentAuthStatus(agent: AgentName): Promise<AgentAuthStatus> {
 	const result = await apiGet<Record<string, AgentAuthStatus>>(
 		`/api/v1/agents/auth?agent=${encodeURIComponent(agent)}`,
@@ -53,4 +58,8 @@ export async function launchAgentAuthLogin(agent: AgentName): Promise<AgentAuthL
 
 export async function completeAgentAuthLogin(agent: AgentName, code: string): Promise<{ completed: boolean }> {
 	return apiPost<{ completed: boolean }>('/api/v1/agents/auth/login/complete', { agentId: agent, code });
+}
+
+export async function getAgentAuthLoginStatus(agent: AgentName): Promise<AgentAuthLoginStatus> {
+	return apiGet<AgentAuthLoginStatus>(`/api/v1/agents/auth/login?agent=${encodeURIComponent(agent)}`);
 }

--- a/web/src/lib/components/settings/AgentCard.svelte
+++ b/web/src/lib/components/settings/AgentCard.svelte
@@ -42,7 +42,7 @@
 		auth: AuthStatus;
 		open?: boolean;
 		onOpenChange?: (open: boolean) => void;
-		onLogin?: () => void;
+		onLogin?: () => void | Promise<void>;
 		onCompleteLogin?: (code: string) => void;
 		cliOnly?: boolean;
 		loginCommand?: string;
@@ -54,6 +54,13 @@
 
 	let codeCopied = $state(false);
 	let authCode = $state('');
+
+	// Expands the card once login yields device auth details, which render
+	// inside the collapsible content and would otherwise stay hidden.
+	async function handleLoginClick() {
+		await onLogin();
+		if (deviceAuth) onOpenChange?.(true);
+	}
 
 	async function copyDeviceCode() {
 		if (!deviceAuth?.code) return;
@@ -136,7 +143,7 @@
 			</Collapsible.Trigger>
 
 			{#if !cliOnly && !noLogin && !auth.loading && !auth.authenticated && !open && auth.canReauth && !deviceAuth}
-				<Button variant="outline" size="sm" onclick={onLogin} disabled={pending}>
+				<Button variant="outline" size="sm" onclick={handleLoginClick} disabled={pending}>
 					{#if pending}
 						<LoaderIcon class="size-3.5 mr-1.5 animate-spin" />
 					{:else}
@@ -256,7 +263,7 @@
 						<Button
 							variant={auth.authenticated ? 'outline' : 'default'}
 							size="sm"
-							onclick={onLogin}
+							onclick={handleLoginClick}
 							disabled={pending}
 						>
 							{#if pending}

--- a/web/src/lib/components/settings/ApiProviderProtocolPanel.svelte
+++ b/web/src/lib/components/settings/ApiProviderProtocolPanel.svelte
@@ -56,7 +56,7 @@
 		readiness?: AgentReadiness;
 		deviceAuth?: DeviceAuthInfo;
 		pending?: boolean;
-		onLogin?: () => void;
+		onLogin?: () => void | Promise<void>;
 		onCompleteLogin?: (code: string) => void;
 	} = $props();
 

--- a/web/src/lib/components/settings/ApiProvidersSection.svelte
+++ b/web/src/lib/components/settings/ApiProvidersSection.svelte
@@ -26,7 +26,7 @@
 		readiness={settingsAuth.readinessFor('codex')}
 		deviceAuth={settingsAuth.deviceAuthFor('codex')}
 		pending={settingsAuth.isLoginPending('codex')}
-		onLogin={() => void settingsAuth.handleLogin('codex')}
+		onLogin={() => settingsAuth.handleLogin('codex')}
 		onCompleteLogin={completeCodexLogin}
 	/>
 
@@ -40,7 +40,7 @@
 		readiness={settingsAuth.readinessFor('claude')}
 		deviceAuth={settingsAuth.deviceAuthFor('claude')}
 		pending={settingsAuth.isLoginPending('claude')}
-		onLogin={() => void settingsAuth.handleLogin('claude')}
+		onLogin={() => settingsAuth.handleLogin('claude')}
 		onCompleteLogin={completeClaudeLogin}
 	/>
 </section>

--- a/web/src/lib/components/settings/__tests__/AgentCard.test.ts
+++ b/web/src/lib/components/settings/__tests__/AgentCard.test.ts
@@ -54,6 +54,51 @@ describe('AgentCard', () => {
 		expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
 	});
 
+	it('requests card expansion when sign-in from collapsed header yields device auth', async () => {
+		const onOpenChange = vi.fn();
+		let resolveLogin!: () => void;
+		const onLogin = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveLogin = resolve;
+				}),
+		);
+		const { rerender } = render(AgentCard, {
+			agentId: 'codex',
+			agentName: 'Codex',
+			auth: { authenticated: false, canReauth: true, label: '', loading: false, error: null },
+			open: false,
+			onLogin,
+			onOpenChange,
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+		await rerender({ deviceAuth: { url: 'https://example.test/device', code: 'AAAA-BBBBB' } });
+		resolveLogin();
+		await vi.waitFor(() => {
+			expect(onOpenChange).toHaveBeenCalledWith(true);
+		});
+	});
+
+	it('does not request expansion when sign-in yields no device auth', async () => {
+		const onOpenChange = vi.fn();
+		const onLogin = vi.fn(() => Promise.resolve());
+		render(AgentCard, {
+			agentId: 'claude',
+			agentName: 'Claude',
+			auth: { authenticated: false, canReauth: true, label: '', loading: false, error: null },
+			open: false,
+			onLogin,
+			onOpenChange,
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+		await vi.waitFor(() => {
+			expect(onLogin).toHaveBeenCalled();
+		});
+		expect(onOpenChange).not.toHaveBeenCalled();
+	});
+
 	it('submits browser auth code with Enter when enabled', async () => {
 		const onCompleteLogin = vi.fn();
 		renderCard(

--- a/web/src/lib/components/settings/__tests__/settings-auth-state.test.ts
+++ b/web/src/lib/components/settings/__tests__/settings-auth-state.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsAuthState } from '../settings-auth-state.svelte.js';
+import {
+	getAgentAuthLoginStatus,
+	getAgentAuthStatus,
+	launchAgentAuthLogin,
+} from '$lib/api/agents.js';
+import type { ModelCatalogStore } from '$lib/stores/model-catalog.svelte.js';
+
+vi.mock('$lib/api/agents.js', () => ({
+	completeAgentAuthLogin: vi.fn(),
+	getAgentAuthLoginStatus: vi.fn(),
+	getAgentAuthStatus: vi.fn(),
+	getAgentReadiness: vi.fn(async () => ({})),
+	launchAgentAuthLogin: vi.fn(),
+}));
+
+const DEVICE_AUTH = { url: 'https://example.test/device', code: 'AAAA-BBBBB' };
+const POLL_TICK_MS = 1500;
+
+const modelCatalog = {
+	getAgent: () => ({ authLoginSupported: true }),
+	forceRefresh: async () => undefined,
+} as unknown as ModelCatalogStore;
+
+describe('SettingsAuthState device auth login', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		vi.stubGlobal('open', vi.fn());
+		vi.mocked(launchAgentAuthLogin).mockResolvedValue({
+			launched: true,
+			alreadyRunning: false,
+			deviceAuth: DEVICE_AUTH,
+		});
+		// Simulates stale credentials: auth status reports authenticated
+		// throughout the re-login.
+		vi.mocked(getAgentAuthStatus).mockResolvedValue({
+			authenticated: true,
+			canReauth: true,
+			label: 'user@example.com',
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it('keeps the device code visible while the login session is running', async () => {
+		vi.mocked(getAgentAuthLoginStatus).mockResolvedValue({
+			running: true,
+			deviceAuth: DEVICE_AUTH,
+		});
+
+		const settingsAuth = new SettingsAuthState(modelCatalog);
+		await settingsAuth.handleLogin('codex');
+		expect(settingsAuth.deviceAuthFor('codex')).toEqual(DEVICE_AUTH);
+
+		await vi.advanceTimersByTimeAsync(POLL_TICK_MS * 3);
+
+		expect(getAgentAuthLoginStatus).toHaveBeenCalledWith('codex');
+		expect(settingsAuth.deviceAuthFor('codex')).toEqual(DEVICE_AUTH);
+	});
+
+	it('clears the device code and refreshes auth once the session ends', async () => {
+		vi.mocked(getAgentAuthLoginStatus)
+			.mockResolvedValueOnce({ running: true, deviceAuth: DEVICE_AUTH })
+			.mockResolvedValue({ running: false });
+
+		const settingsAuth = new SettingsAuthState(modelCatalog);
+		await settingsAuth.handleLogin('codex');
+		vi.mocked(getAgentAuthStatus).mockClear();
+
+		await vi.advanceTimersByTimeAsync(POLL_TICK_MS);
+		expect(settingsAuth.deviceAuthFor('codex')).toEqual(DEVICE_AUTH);
+
+		await vi.advanceTimersByTimeAsync(POLL_TICK_MS);
+		expect(settingsAuth.deviceAuthFor('codex')).toBeUndefined();
+		expect(getAgentAuthStatus).toHaveBeenCalledWith('codex');
+		expect(settingsAuth.authFor('codex').authenticated).toBe(true);
+	});
+});

--- a/web/src/lib/components/settings/settings-auth-state.svelte.ts
+++ b/web/src/lib/components/settings/settings-auth-state.svelte.ts
@@ -1,5 +1,6 @@
 import {
 	completeAgentAuthLogin,
+	getAgentAuthLoginStatus,
 	getAgentAuthStatus,
 	getAgentReadiness,
 	launchAgentAuthLogin,
@@ -20,6 +21,8 @@ export type SettingsAgentId = string;
 
 const AUTH_POLL_INTERVAL_MS = 1500;
 const AUTH_POLL_TIMEOUT_MS = 5 * 60_000;
+// Device codes stay valid for 15 minutes, so the session poll must outlive them.
+const LOGIN_SESSION_POLL_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_AUTH: AuthStatus = {
 	authenticated: false,
 	canReauth: true,
@@ -90,7 +93,7 @@ export class SettingsAuthState {
 				this.loginPending = { ...this.loginPending, [agentId]: false };
 				if (!result.deviceAuth.needsCode) {
 					window.open(result.deviceAuth.url, '_blank', 'noopener');
-					this.#startAuthPolling(agentId);
+					this.#startLoginSessionPolling(agentId);
 				}
 				return;
 			}
@@ -208,6 +211,47 @@ export class SettingsAuthState {
 		this.#authPollStartedAt[agentId] = Date.now();
 		this.#authPollTimers[agentId] = setTimeout(() => {
 			void this.#pollAuthUntilAuthenticated(agentId, sessionId);
+		}, AUTH_POLL_INTERVAL_MS);
+	}
+
+	// Polls the server-side login session while a device code is displayed.
+	// Auth status cannot signal completion here: agents with existing
+	// credentials report authenticated during the whole re-login, which would
+	// clear the code before the user can enter it.
+	async #pollLoginSessionUntilDone(agentId: SettingsAgentId, sessionId: number): Promise<void> {
+		if (this.#authPollSessionIds[agentId] !== sessionId) return;
+
+		let running = true;
+		try {
+			running = (await getAgentAuthLoginStatus(agentId)).running;
+		} catch {
+			// Treats transient status failures as still running; the timeout bounds the loop.
+		}
+		if (this.#authPollSessionIds[agentId] !== sessionId) return;
+
+		const startedAt = this.#authPollStartedAt[agentId];
+		const expired =
+			startedAt === undefined || Date.now() - startedAt >= LOGIN_SESSION_POLL_TIMEOUT_MS;
+
+		if (!running || expired) {
+			this.#stopAuthPolling(agentId);
+			this.#clearDeviceAuth(agentId);
+			await this.#checkAuth(agentId);
+			return;
+		}
+
+		this.#authPollTimers[agentId] = setTimeout(() => {
+			void this.#pollLoginSessionUntilDone(agentId, sessionId);
+		}, AUTH_POLL_INTERVAL_MS);
+	}
+
+	#startLoginSessionPolling(agentId: SettingsAgentId): void {
+		this.#stopAuthPolling(agentId);
+		const sessionId = ++this.#nextAuthPollSessionId;
+		this.#authPollSessionIds[agentId] = sessionId;
+		this.#authPollStartedAt[agentId] = Date.now();
+		this.#authPollTimers[agentId] = setTimeout(() => {
+			void this.#pollLoginSessionUntilDone(agentId, sessionId);
 		}, AUTH_POLL_INTERVAL_MS);
 	}
 


### PR DESCRIPTION
Fixes the codex device-auth login flow in the settings UI, which had three compounding bugs that made it effectively unusable:

**Bug 1 (UI): device code rendered inside a collapsed card.** The device auth panel (URL + one-time code) lives inside `Collapsible.Content`, but clicking Sign in from the collapsed header never expanded the card, so the code was never visible. `AgentCard` now awaits `onLogin` and requests expansion via `onOpenChange(true)` when device auth details are present. This also covers the claude paste-code fallback flow.

**Bug 2 (server): retries while a login session was pending returned no device auth.** `codex login --device-auth` keeps its PTY session alive until the code expires (~15 min). Repeated launch calls during that window returned `{launched: false, alreadyRunning: true}` without the code, so a second Sign in click could never surface it. The login manager now caches parsed device auth per agent for the session lifetime, returns it on repeat launches, and drops it on session exit.

**Bug 3 (client): auth-status polling cleared the code 1.5s after it appeared.** After launching a device-auth login, the client polled agent auth status and treated `authenticated: true` as completion. But agents with existing credentials (e.g. codex re-login, where `codex login status` still reports "Logged in using ChatGPT") are authenticated throughout the flow, so the very first poll tick wiped the code before the user could enter it. This adds `GET /api/v1/agents/auth/login?agent=<id>` returning `{running, deviceAuth}` from the login manager, and the client now polls the login session instead while a device code is displayed — clearing the code and refreshing auth status only once the session actually ends (poll timeout matches the 15 min code validity).

**Testing**
- `bun run check`: 0 errors
- Web suite: 191 files / 1761 tests pass, including new `AgentCard` expansion tests and new `settings-auth-state` session-polling tests
- Server: new `AgentAuthLoginManager` tests for cached device auth and session status lifecycle
- Verified live against codex-cli 0.124.0: launch returns the parsed code, status reports `running: true` with the cached code while the session is open, and the code persists across auth-status polls until the session exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)