### PR TITLE
feat(settings): default file opening to sidebar

### DIFF
--- a/web/src/lib/stores/__tests__/local-settings.test.ts
+++ b/web/src/lib/stores/__tests__/local-settings.test.ts
@@ -16,9 +16,9 @@ describe('LocalSettingsStore', () => {
 		expect(store.sidebarCompactChatItems).toBe(false);
 		expect(store.sidebarSortMode).toBe('manual');
 		expect(store.showQuickCommitTray).toBe(true);
-		expect(store.textEditorOpenPlacement).toBe('dialog');
-		expect(store.imageViewerOpenPlacement).toBe('dialog');
-		expect(store.markdownViewerOpenPlacement).toBe('dialog');
+		expect(store.textEditorOpenPlacement).toBe('sidebar');
+		expect(store.imageViewerOpenPlacement).toBe('sidebar');
+		expect(store.markdownViewerOpenPlacement).toBe('sidebar');
 		expect(store.terminalFontSize).toBe('13');
 		expect(store.hiddenToolTypes).toEqual([]);
 
@@ -87,9 +87,9 @@ describe('LocalSettingsStore', () => {
 
 		const store = createLocalSettingsStore();
 
-		expect(store.textEditorOpenPlacement).toBe('dialog');
+		expect(store.textEditorOpenPlacement).toBe('sidebar');
 		expect(store.imageViewerOpenPlacement).toBe('sidebar');
-		expect(store.markdownViewerOpenPlacement).toBe('dialog');
+		expect(store.markdownViewerOpenPlacement).toBe('sidebar');
 		store.destroy();
 	});
 

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -137,9 +137,9 @@ const DEFAULTS: LocalSettingsSnapshot = {
 	gitDiffFontSize: '12',
 	markdownViewerFontSize: '12',
 	terminalFontSize: '13',
-	textEditorOpenPlacement: 'dialog',
-	imageViewerOpenPlacement: 'dialog',
-	markdownViewerOpenPlacement: 'dialog',
+	textEditorOpenPlacement: 'sidebar',
+	imageViewerOpenPlacement: 'sidebar',
+	markdownViewerOpenPlacement: 'sidebar',
 	language: 'en',
 	hiddenToolTypes: [],
 };

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -161,6 +161,25 @@ describe('WorkspaceCoordinator', () => {
 		expect(layout.snapshot.sidebar.order).toContain(fileSurfaceId('overlay-file'));
 	});
 
+	it('releases overlay modality when sidebar file publication fails', async () => {
+		const { coordinator, layout, transientLayers, chatInteractionGate } = createHarness({
+			failLayoutPublishAt: 1,
+		});
+		const publication = { publish: vi.fn(), rollback: vi.fn() };
+		coordinator.setSidebarOverlayMode(true);
+
+		await expect(
+			coordinator.placeFileSession('failed-overlay-file', 'sidebar', publication),
+		).rejects.toThrow('layout publication failed');
+
+		expect(publication.publish).toHaveBeenCalledOnce();
+		expect(publication.rollback).toHaveBeenCalledOnce();
+		expect(transientLayers.hasPendingMainInert).toBe(false);
+		expect(transientLayers.makesMainInert).toBe(false);
+		expect(chatInteractionGate.isChatDropEligible).toBe(true);
+		expect(layout.surface(fileSurfaceId('failed-overlay-file'))).toBeNull();
+	});
+
 	it('does not reopen overlay modality when placing a file in an open sidebar', async () => {
 		const { coordinator, layout, transientLayers } = createHarness();
 		coordinator.setSidebarOverlayMode(true);
@@ -173,28 +192,45 @@ describe('WorkspaceCoordinator', () => {
 		expect(layout.snapshot.sidebar.activeId).toBe(fileSurfaceId('sidebar-file'));
 	});
 
-	it('reveals a new sidebar file while the main surface is fullscreen', async () => {
-		const { coordinator, layout } = createHarness();
-		await coordinator.setManualFullscreen(true);
+	it('opens overlay modality when queued fullscreen precedes a new sidebar file', async () => {
+		const { coordinator, layout, transientLayers } = createHarness();
+		await coordinator.openSidebar();
+		coordinator.setSidebarOverlayMode(true);
+		const open = vi
+			.spyOn(transientLayers, 'open')
+			.mockImplementation((_modality, commitOpen) => commitOpen());
 
-		await coordinator.placeFileSession('fullscreen-file', 'sidebar');
+		const fullscreen = coordinator.setManualFullscreen(true);
+		const placement = coordinator.placeFileSession('fullscreen-file', 'sidebar');
+		await Promise.all([fullscreen, placement]);
 
+		expect(open).toHaveBeenCalledWith('main-inert', expect.any(Function));
 		expect(layout.snapshot.manualFullscreen).toBe(false);
 		expect(layout.snapshot.sidebarOpen).toBe(true);
 		expect(layout.snapshot.sidebar.activeId).toBe(fileSurfaceId('fullscreen-file'));
 	});
 
-	it('reveals an existing sidebar file while the main surface is fullscreen', async () => {
-		const { coordinator, layout } = createHarness();
+	it('opens overlay modality when queued fullscreen precedes an existing sidebar file', async () => {
+		const { coordinator, layout, transientLayers } = createHarness();
 		await coordinator.placeFileSession('existing-file', 'sidebar');
-		await coordinator.closeSidebar();
-		await coordinator.setManualFullscreen(true);
+		coordinator.setSidebarOverlayMode(true);
+		const open = vi
+			.spyOn(transientLayers, 'open')
+			.mockImplementation((_modality, commitOpen) => commitOpen());
 
-		await coordinator.focusFileSession('existing-file');
+		const fullscreen = coordinator.setManualFullscreen(true);
+		const focus = coordinator.focusFileSession('existing-file');
+		await Promise.all([fullscreen, focus]);
 
+		expect(open).toHaveBeenCalledWith('main-inert', expect.any(Function));
 		expect(layout.snapshot.manualFullscreen).toBe(false);
 		expect(layout.snapshot.sidebarOpen).toBe(true);
 		expect(layout.snapshot.sidebar.activeId).toBe(fileSurfaceId('existing-file'));
+		expect(
+			layout.snapshot.sidebar.order.filter(
+				(surfaceId) => surfaceId === fileSurfaceId('existing-file'),
+			),
+		).toHaveLength(1);
 	});
 
 	it('places files in the mobile-only presentation regardless of a desktop target', async () => {

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -173,6 +173,30 @@ describe('WorkspaceCoordinator', () => {
 		expect(layout.snapshot.sidebar.activeId).toBe(fileSurfaceId('sidebar-file'));
 	});
 
+	it('reveals a new sidebar file while the main surface is fullscreen', async () => {
+		const { coordinator, layout } = createHarness();
+		await coordinator.setManualFullscreen(true);
+
+		await coordinator.placeFileSession('fullscreen-file', 'sidebar');
+
+		expect(layout.snapshot.manualFullscreen).toBe(false);
+		expect(layout.snapshot.sidebarOpen).toBe(true);
+		expect(layout.snapshot.sidebar.activeId).toBe(fileSurfaceId('fullscreen-file'));
+	});
+
+	it('reveals an existing sidebar file while the main surface is fullscreen', async () => {
+		const { coordinator, layout } = createHarness();
+		await coordinator.placeFileSession('existing-file', 'sidebar');
+		await coordinator.closeSidebar();
+		await coordinator.setManualFullscreen(true);
+
+		await coordinator.focusFileSession('existing-file');
+
+		expect(layout.snapshot.manualFullscreen).toBe(false);
+		expect(layout.snapshot.sidebarOpen).toBe(true);
+		expect(layout.snapshot.sidebar.activeId).toBe(fileSurfaceId('existing-file'));
+	});
+
 	it('places files in the mobile-only presentation regardless of a desktop target', async () => {
 		const { coordinator, layout } = createHarness();
 		await coordinator.enterMobilePresentation();

--- a/web/src/lib/workspace/__tests__/workspace-services.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-services.test.ts
@@ -26,9 +26,9 @@ describe('createWorkspaceServices', () => {
 		localStorage.clear();
 		const localSettings = createLocalSettingsStore();
 
-		expect(configuredFilePlacement(localSettings, 'code')).toBe('dialog');
-		expect(configuredFilePlacement(localSettings, 'image')).toBe('dialog');
-		expect(configuredFilePlacement(localSettings, 'markdown')).toBe('dialog');
+		expect(configuredFilePlacement(localSettings, 'code')).toBe('sidebar');
+		expect(configuredFilePlacement(localSettings, 'image')).toBe('sidebar');
+		expect(configuredFilePlacement(localSettings, 'markdown')).toBe('sidebar');
 
 		localSettings.set('textEditorOpenPlacement', 'main');
 		localSettings.set('imageViewerOpenPlacement', 'sidebar');

--- a/web/src/lib/workspace/workspace-coordinator.svelte.ts
+++ b/web/src/lib/workspace/workspace-coordinator.svelte.ts
@@ -87,6 +87,7 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 	lastFocusedSurfaceId = $state(CHAT_SURFACE_ID as string);
 	focusOwner = $state<FocusOwner>({ kind: 'surface', surfaceId: CHAT_SURFACE_ID });
 	#sidebarOverlayMode = false;
+	#inFlightCommitCount = 0;
 	#reservedSurfaceIds = new SvelteSet<string>();
 	#presentationMode = $state<'desktop' | 'mobile'>('desktop');
 	#requestedPresentationMode: 'desktop' | 'mobile' = 'desktop';
@@ -265,19 +266,17 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 					: [],
 			);
 		} else {
-			const commit = () =>
-				this.#commit((latest) => {
-					const latestHost = this.#hostOfSnapshot(latest, surfaceId);
-					if (!latestHost) return [];
-					const mutations =
-						latestHost === 'sidebar' ? revealSidebarMutations(latest) : [];
-					mutations.push({ type: 'focus-host', host: latestHost, surfaceId });
-					return mutations;
-				});
-			if (host === 'sidebar' && isSidebarHidden(this.layout.snapshot)) {
-				current = await this.#commitThroughSidebarOverlay(commit);
+			const plan = (latest: WorkspaceLayoutSnapshot) => {
+				const latestHost = this.#hostOfSnapshot(latest, surfaceId);
+				if (!latestHost) return [];
+				const mutations = latestHost === 'sidebar' ? revealSidebarMutations(latest) : [];
+				mutations.push({ type: 'focus-host', host: latestHost, surfaceId });
+				return mutations;
+			};
+			if (host === 'sidebar') {
+				current = await this.#commitSidebarReveal(plan);
 			} else {
-				current = await commit();
+				current = await this.#commit(plan);
 			}
 		}
 		if (!current) return;
@@ -499,23 +498,19 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 		if (destination === 'main' && this.isChatPresented) {
 			this.#deps.chatInteractionGate.cancelBeforeInertTransition();
 		}
-		const commit = () =>
-			this.#commit(
-				(latest) => [
-					...(destination === 'sidebar' ? revealSidebarMutations(latest) : []),
-					{
-						type: 'register-surface',
-						surface: { id: surfaceId, type: 'file', fileSessionId: sessionId },
-						host: destination,
-					},
-					{ type: 'focus-host', host: destination, surfaceId },
-				],
-				{ publication },
-			);
+		const plan = (latest: WorkspaceLayoutSnapshot): readonly WorkspaceLayoutMutation[] => [
+			...(destination === 'sidebar' ? revealSidebarMutations(latest) : []),
+			{
+				type: 'register-surface',
+				surface: { id: surfaceId, type: 'file', fileSessionId: sessionId },
+				host: destination,
+			},
+			{ type: 'focus-host', host: destination, surfaceId },
+		];
 		const current =
-			destination === 'sidebar' && isSidebarHidden(this.layout.snapshot)
-				? await this.#commitThroughSidebarOverlay(commit)
-				: await commit();
+			destination === 'sidebar'
+				? await this.#commitSidebarReveal(plan, { publication })
+				: await this.#commit(plan, { publication });
 		if (current) this.#presentSurface(surfaceId);
 		return 'placed';
 	}
@@ -827,6 +822,17 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 			: commit();
 	}
 
+	#commitSidebarReveal(
+		plan: WorkspaceMutationPlan,
+		options: WorkspaceCommitOptions = {},
+	): Promise<boolean> {
+		const commit = () => this.#commit(plan, options);
+		return this.#sidebarOverlayMode &&
+			(isSidebarHidden(this.layout.snapshot) || this.#inFlightCommitCount > 0)
+			? this.#deps.transientLayers.open('main-inert', commit)
+			: commit();
+	}
+
 	#eligibleDesktopReturn(surfaceId: string | null): string | null {
 		if (!surfaceId || !this.layout.surface(surfaceId)) return null;
 		const snapshot = this.layout.snapshot;
@@ -901,6 +907,18 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 	async #commit(
 		mutations: WorkspaceMutationPlan,
 		options: WorkspaceCommitOptions = {},
+	): Promise<boolean> {
+		this.#inFlightCommitCount += 1;
+		try {
+			return await this.#performCommit(mutations, options);
+		} finally {
+			this.#inFlightCommitCount -= 1;
+		}
+	}
+
+	async #performCommit(
+		mutations: WorkspaceMutationPlan,
+		options: WorkspaceCommitOptions,
 	): Promise<boolean> {
 		let expectations: ReturnType<WorkspacePresentationFrames['prepare']> = [];
 		let presentationGeneration: number | null = null;

--- a/web/src/lib/workspace/workspace-coordinator.svelte.ts
+++ b/web/src/lib/workspace/workspace-coordinator.svelte.ts
@@ -69,6 +69,19 @@ class WorkspacePublicationInvariantError extends Error {
 	}
 }
 
+function isSidebarHidden(snapshot: WorkspaceLayoutSnapshot): boolean {
+	return !snapshot.sidebarOpen || snapshot.manualFullscreen;
+}
+
+function revealSidebarMutations(snapshot: WorkspaceLayoutSnapshot): WorkspaceLayoutMutation[] {
+	const mutations: WorkspaceLayoutMutation[] = [];
+	if (snapshot.manualFullscreen) {
+		mutations.push({ type: 'set-manual-fullscreen', enabled: false });
+	}
+	if (!snapshot.sidebarOpen) mutations.push({ type: 'set-sidebar-open', open: true });
+	return mutations;
+}
+
 export class WorkspaceCoordinator implements FilePlacementPort {
 	readonly #deps: WorkspaceCoordinatorDeps;
 	lastFocusedSurfaceId = $state(CHAT_SURFACE_ID as string);
@@ -256,14 +269,12 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 				this.#commit((latest) => {
 					const latestHost = this.#hostOfSnapshot(latest, surfaceId);
 					if (!latestHost) return [];
-					const mutations: WorkspaceLayoutMutation[] = [];
-					if (latestHost === 'sidebar' && !latest.sidebarOpen) {
-						mutations.push({ type: 'set-sidebar-open', open: true });
-					}
+					const mutations =
+						latestHost === 'sidebar' ? revealSidebarMutations(latest) : [];
 					mutations.push({ type: 'focus-host', host: latestHost, surfaceId });
 					return mutations;
 				});
-			if (host === 'sidebar' && !this.layout.snapshot.sidebarOpen) {
+			if (host === 'sidebar' && isSidebarHidden(this.layout.snapshot)) {
 				current = await this.#commitThroughSidebarOverlay(commit);
 			} else {
 				current = await commit();
@@ -490,7 +501,8 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 		}
 		const commit = () =>
 			this.#commit(
-				[
+				(latest) => [
+					...(destination === 'sidebar' ? revealSidebarMutations(latest) : []),
 					{
 						type: 'register-surface',
 						surface: { id: surfaceId, type: 'file', fileSessionId: sessionId },
@@ -501,7 +513,7 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 				{ publication },
 			);
 		const current =
-			destination === 'sidebar' && !this.layout.snapshot.sidebarOpen
+			destination === 'sidebar' && isSidebarHidden(this.layout.snapshot)
 				? await this.#commitThroughSidebarOverlay(commit)
 				: await commit();
 		if (current) this.#presentSurface(surfaceId);


### PR DESCRIPTION
## Summary

- Defaults text editors, image viewers, and Markdown viewers to the sidebar.
- Preserves any valid placement already saved by the user.
- Reveals and focuses the sidebar when it is closed.
- Exits main-view fullscreen before presenting a new or existing sidebar file, preventing invisible opens.
- Serializes overlay modality handoff across queued layout transitions and rolls it back cleanly on publication failure.
- Adds default, routing, closed-sidebar, fullscreen, concurrency, and failure-path regression coverage.

## Validation

- `bun run check`
- `bun run test` (2,158 web tests plus server suite)
- `timeout 30s bun run start --port 0` (built successfully and started on a random port)

## Checklist

- [x] Scope is focused and behavior is covered by tests
- [x] No API/WS contract changes