### PR TITLE
perf(chat): page transcript history and bound cache memory

### DIFF
--- a/server/agents/claude/__tests__/history-loader.test.js
+++ b/server/agents/claude/__tests__/history-loader.test.js
@@ -8,6 +8,7 @@ import {
   loadClaudeChatMessagePage,
 } from '../history-loader.js';
 import { getNativeMessageSource } from '../../shared/native-message-source.js';
+import { transcriptRevision } from '../../../lib/transcript-revision.js';
 
 async function withTempJsonl(lines, fn) {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-load-test-'));
@@ -71,10 +72,200 @@ describe('loadClaudeChatMessagePage', () => {
     expect(page.messages.map((message) => message.content)).toEqual(['prompt 4', 'reply 5']);
   });
 
-  it('returns null for older tail pages so callers use the full loader', async () => {
-    const page = await loadClaudeChatMessagePage('/tmp/missing.jsonl', 2, 1);
+  it('uses deterministic source timestamps when native timestamps are missing or non-string', async () => {
+    const lines = [undefined, 123].map((timestamp, index) => JSON.stringify({
+      sessionId: 'session-1',
+      type: 'assistant',
+      ...(timestamp === undefined ? {} : { timestamp }),
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: `reply ${index}` }],
+      },
+    }));
 
-    expect(page).toBeNull();
+    await withTempJsonl(lines, async (filePath) => {
+      const first = await loadClaudeChatMessages(filePath);
+      const second = await loadClaudeChatMessages(filePath);
+      const firstPage = await loadClaudeChatMessagePage(filePath, 2, 0);
+      const secondPage = await loadClaudeChatMessagePage(filePath, 2, 0);
+
+      expect(second).toEqual(first);
+      expect(first.map((message) => message.timestamp)).toEqual([
+        '2000-01-01T00:00:00.001Z',
+        '2000-01-01T00:00:00.002Z',
+      ]);
+      expect(secondPage.revision).toBe(firstPage.revision);
+      expect(firstPage.revision).toBe(transcriptRevision(first));
+    });
+  });
+
+  it('loads older pages with an exact total without retaining full messages', async () => {
+    const lines = Array.from({ length: 600 }, (_, index) => JSON.stringify({
+      sessionId: 'session-1',
+      type: 'assistant',
+      timestamp: new Date(Date.UTC(2026, 1, 21, 10, 0, index)).toISOString(),
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: `reply ${index} ${'x'.repeat(800)}` }],
+      },
+    }));
+
+    const page = await withTempJsonl(lines, (filePath) => loadClaudeChatMessagePage(filePath, 3, 5));
+
+    expect(page).toMatchObject({ total: 600, hasMore: true, offset: 5, limit: 3 });
+    expect(page.messages.map((message) => message.content.slice(0, 9))).toEqual([
+      'reply 592', 'reply 593', 'reply 594',
+    ]);
+  });
+
+  it('matches full-loader ordering for out-of-order timestamps at arbitrary offsets', async () => {
+    const timestamps = [5, 0, 1, 2, 3, 4];
+    const lines = timestamps.map((second, index) => JSON.stringify({
+      sessionId: 'session-1',
+      type: 'assistant',
+      timestamp: `2026-02-21T10:00:0${second}.000Z`,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      const full = await loadClaudeChatMessages(filePath);
+      for (const offset of [0, 2]) {
+        const page = await loadClaudeChatMessagePage(filePath, 2, offset);
+        const end = full.length - offset;
+        expect(page.messages).toEqual(full.slice(end - 2, end));
+        expect(page.revision).toBe(transcriptRevision(full));
+      }
+    });
+  });
+
+  it('matches legacy ordering with mixed invalid and missing timestamps', async () => {
+    const timestamps = ['2026-02-21T10:00:03.000Z', 'invalid', undefined,
+      '2026-02-21T10:00:01.000Z', '2026-02-21T10:00:02.000Z'];
+    const lines = timestamps.map((timestamp, index) => JSON.stringify({
+      sessionId: 'session-1',
+      type: 'assistant',
+      ...(timestamp === undefined ? {} : { timestamp }),
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      const expected = (await loadClaudeChatMessages(filePath)).map((message) => message.content);
+      for (const offset of [0, 1, 3]) {
+        const page = await loadClaudeChatMessagePage(filePath, 2, offset);
+        const end = expected.length - offset;
+        expect(page.messages.map((message) => message.content)).toEqual(
+          expected.slice(Math.max(0, end - 2), end),
+        );
+      }
+    });
+  });
+
+  it('preserves stable ordering for equal timestamps at multiple offsets', async () => {
+    const lines = Array.from({ length: 6 }, (_, index) => JSON.stringify({
+      sessionId: 'session-1',
+      type: 'assistant',
+      timestamp: '2026-02-21T10:00:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      for (const offset of [0, 2, 4]) {
+        const page = await loadClaudeChatMessagePage(filePath, 2, offset);
+        expect(page.messages.map((message) => message.content)).toEqual(
+          [`reply ${4 - offset}`, `reply ${5 - offset}`],
+        );
+      }
+    });
+  });
+
+  it('changes revisions when same-source message parts are reversed', async () => {
+    const entry = (content) => JSON.stringify({
+      sessionId: 'session-1',
+      type: 'assistant',
+      timestamp: '2026-02-21T10:00:00.000Z',
+      message: { role: 'assistant', content },
+    });
+    const thinking = { type: 'thinking', thinking: 'reasoning' };
+    const text = { type: 'text', text: 'answer' };
+    let firstRevision;
+    await withTempJsonl([entry([thinking, text])], async (filePath) => {
+      firstRevision = (await loadClaudeChatMessagePage(filePath, 2, 0)).revision;
+    });
+    await withTempJsonl([entry([text, thinking])], async (filePath) => {
+      const secondRevision = (await loadClaudeChatMessagePage(filePath, 2, 0)).revision;
+      expect(secondRevision).not.toBe(firstRevision);
+    });
+  });
+
+  it('binds each compaction metadata tuple to its boundary position', async () => {
+    const lines = (swap) => [
+      JSON.stringify({
+        sessionId: 'session-1', type: 'system', subtype: 'compact_boundary',
+        timestamp: '2026-02-21T10:00:01.000Z',
+        compactMetadata: swap
+          ? { trigger: 'auto', preTokens: 200, postTokens: 20 }
+          : { trigger: 'manual', preTokens: 100, postTokens: 10 },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', type: 'user', isCompactSummary: true,
+        timestamp: '2026-02-21T10:00:02.000Z',
+        message: { role: 'user', content: 'Summary: first' },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', type: 'system', subtype: 'compact_boundary',
+        timestamp: '2026-02-21T10:00:03.000Z',
+        compactMetadata: swap
+          ? { trigger: 'manual', preTokens: 100, postTokens: 10 }
+          : { trigger: 'auto', preTokens: 200, postTokens: 20 },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', type: 'user', isCompactSummary: true,
+        timestamp: '2026-02-21T10:00:04.000Z',
+        message: { role: 'user', content: 'Summary: second' },
+      }),
+    ];
+    let firstRevision;
+    await withTempJsonl(lines(false), async (filePath) => {
+      firstRevision = (await loadClaudeChatMessagePage(filePath, 2, 0)).revision;
+    });
+    await withTempJsonl(lines(true), async (filePath) => {
+      const secondRevision = (await loadClaudeChatMessagePage(filePath, 2, 0)).revision;
+      expect(secondRevision).not.toBe(firstRevision);
+    });
+  });
+
+  it('preserves compaction pairing with a one-message bounded page', async () => {
+    const lines = Array.from({ length: 200 }, (_, index) => [
+      JSON.stringify({
+        sessionId: 'session-1',
+        type: 'system',
+        subtype: 'compact_boundary',
+        timestamp: new Date(Date.UTC(2026, 1, 21, 10, 0, index * 2 + 1)).toISOString(),
+        compactMetadata: { trigger: index % 2 ? 'auto' : 'manual', preTokens: index },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1',
+        type: 'user',
+        isCompactSummary: true,
+        timestamp: new Date(Date.UTC(2026, 1, 21, 10, 0, index * 2)).toISOString(),
+        message: { role: 'user', content: `Summary: compaction ${index}` },
+      }),
+    ]).flat();
+
+    await withTempJsonl(lines, async (filePath) => {
+      const full = await loadClaudeChatMessages(filePath);
+      const page = await loadClaudeChatMessagePage(filePath, 1, 0);
+      expect(page.messages).toEqual(full.slice(-1));
+    });
   });
 
   it('preserves AskUserQuestion toolUseResult metadata from JSONL tool results', async () => {

--- a/server/agents/claude/__tests__/history-loader.test.js
+++ b/server/agents/claude/__tests__/history-loader.test.js
@@ -243,6 +243,52 @@ describe('loadClaudeChatMessagePage', () => {
     });
   });
 
+  it('changes revisions when boundary timestamps change compaction pairing', async () => {
+    const lines = (reverseBoundaries) => [
+      JSON.stringify({
+        sessionId: 'session-1', type: 'system', subtype: 'compact_boundary',
+        timestamp: reverseBoundaries
+          ? '2026-02-21T10:00:03.000Z' : '2026-02-21T10:00:01.000Z',
+        compactMetadata: { trigger: 'manual', preTokens: 100, postTokens: 10 },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', type: 'user', isCompactSummary: true,
+        timestamp: '2026-02-21T10:00:02.000Z',
+        message: { role: 'user', content: 'Summary: first' },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', type: 'system', subtype: 'compact_boundary',
+        timestamp: reverseBoundaries
+          ? '2026-02-21T10:00:01.000Z' : '2026-02-21T10:00:03.000Z',
+        compactMetadata: { trigger: 'auto', preTokens: 200, postTokens: 20 },
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', type: 'user', isCompactSummary: true,
+        timestamp: '2026-02-21T10:00:04.000Z',
+        message: { role: 'user', content: 'Summary: second' },
+      }),
+    ];
+    const load = (reverseBoundaries) => withTempJsonl(lines(reverseBoundaries), async (filePath) => {
+      const messages = await loadClaudeChatMessages(filePath);
+      const page = await loadClaudeChatMessagePage(filePath, 2, 0);
+      return {
+        metadata: messages.map(({ trigger, preTokens, postTokens }) => ({
+          trigger, preTokens, postTokens,
+        })),
+        revision: page.revision,
+        fullRevision: transcriptRevision(messages),
+      };
+    });
+
+    const first = await load(false);
+    const second = await load(true);
+
+    expect(second.metadata).not.toEqual(first.metadata);
+    expect(second.revision).not.toBe(first.revision);
+    expect(first.revision).toBe(first.fullRevision);
+    expect(second.revision).toBe(second.fullRevision);
+  });
+
   it('preserves compaction pairing with a one-message bounded page', async () => {
     const lines = Array.from({ length: 200 }, (_, index) => [
       JSON.stringify({

--- a/server/agents/claude/history-loader.ts
+++ b/server/agents/claude/history-loader.ts
@@ -257,7 +257,10 @@ function convertClaudeEntries(entries: Record<string, unknown>[]): ChatMessage[]
     .filter((entry) => entry.type === 'system' && entry.subtype === 'compact_boundary')
     .map((entry) => ({
       info: parseCompactMetadata(entry.compactMetadata ?? entry.compact_metadata),
-      source: getNativeMessageSource(entry),
+      source: {
+        ...getNativeMessageSource(entry),
+        pairingTimestamp: timestampMs(entry.timestamp),
+      },
     }));
   let compactionIndex = 0;
 
@@ -426,7 +429,10 @@ async function scanClaudeMessagePage(
         sourceOrder,
         info,
       });
-      revision.addCompactionMetadata(info, getNativeMessageSource(entry) ?? { sourceOrder });
+      revision.addCompactionMetadata(info, {
+        ...(getNativeMessageSource(entry) ?? { sourceOrder }),
+        pairingTimestamp: entryTimestamp,
+      });
       totalCompactionBoundaries += 1;
     }
     const converted = convertClaudeEntries([entry]);

--- a/server/agents/claude/history-loader.ts
+++ b/server/agents/claude/history-loader.ts
@@ -3,7 +3,10 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-import { readJsonlTailLines } from '../shared/history-loader-utils.ts';
+import {
+  readJsonlLineEntries,
+  readJsonlTailLines,
+} from '../shared/history-loader-utils.ts';
 import { normalizeToolResultContent } from '../shared/normalize-util.js';
 import {
   UserMessage,
@@ -21,6 +24,12 @@ import { attachNativeMessageSource, getNativeMessageSource } from '../shared/nat
 import { createLogger } from '../../lib/log.js';
 import { parseFirstJsonlValue } from '../../lib/jsonl.js';
 import type { AgentTranscriptPage } from '../types.js';
+import {
+  TranscriptRevisionAccumulator,
+  attachCompactionRevisionSource,
+  transcriptRevision,
+} from '../../lib/transcript-revision.js';
+import { deterministicTranscriptTimestamp } from '../shared/transcript-timestamp.js';
 
 const logger = createLogger('agents:claude:history-loader');
 
@@ -39,6 +48,85 @@ interface PaginatedRawMessages {
   hasMore: boolean;
   offset: number;
   limit: number;
+}
+
+interface OrderedClaudeMessage {
+  message: ChatMessage;
+  timestamp: number;
+  sourceOrder: number;
+  partOrder: number;
+}
+
+interface OrderedCompactionBoundary {
+  timestamp: number;
+  sourceOrder: number;
+  info: ReturnType<typeof parseCompactMetadata>;
+}
+
+class BoundedLatest<T> {
+  #items: T[] = [];
+
+  constructor(
+    private readonly limit: number,
+    private readonly compare: (left: T, right: T) => number,
+  ) {}
+
+  add(candidate: T): void {
+    if (this.limit === 0) return;
+    if (this.#items.length < this.limit) {
+      this.#items.push(candidate);
+      this.#siftUp(this.#items.length - 1);
+    } else if (this.compare(candidate, this.#items[0]) > 0) {
+      this.#items[0] = candidate;
+      this.#siftDown(0);
+    }
+  }
+
+  values(): T[] {
+    return this.#items;
+  }
+
+  #siftUp(index: number): void {
+    while (index > 0) {
+      const parent = (index - 1) >> 1;
+      if (this.compare(this.#items[parent], this.#items[index]) <= 0) break;
+      [this.#items[parent], this.#items[index]] = [this.#items[index], this.#items[parent]];
+      index = parent;
+    }
+  }
+
+  #siftDown(index: number): void {
+    while (true) {
+      const left = index * 2 + 1;
+      const right = left + 1;
+      let smallest = index;
+      if (left < this.#items.length && this.compare(this.#items[left], this.#items[smallest]) < 0) smallest = left;
+      if (right < this.#items.length && this.compare(this.#items[right], this.#items[smallest]) < 0) smallest = right;
+      if (smallest === index) break;
+      [this.#items[index], this.#items[smallest]] = [this.#items[smallest], this.#items[index]];
+      index = smallest;
+    }
+  }
+}
+
+function compareOrderedClaudeMessages(
+  left: OrderedClaudeMessage,
+  right: OrderedClaudeMessage,
+): number {
+  if (left.timestamp > 0 && right.timestamp > 0 && left.timestamp !== right.timestamp) {
+    return left.timestamp - right.timestamp;
+  }
+  return left.sourceOrder - right.sourceOrder || left.partOrder - right.partOrder;
+}
+
+function compareCompactionBoundaries(
+  left: OrderedCompactionBoundary,
+  right: OrderedCompactionBoundary,
+): number {
+  if (left.timestamp > 0 && right.timestamp > 0 && left.timestamp !== right.timestamp) {
+    return left.timestamp - right.timestamp;
+  }
+  return left.sourceOrder - right.sourceOrder;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -124,11 +212,17 @@ function parseClaudeJsonlEntry(line: string): Record<string, unknown> | null {
   return entry.sessionId ? entry : null;
 }
 
-function parseClaudeJsonlEntryWithSource(line: string, lineNumber: number): Record<string, unknown> | null {
+function parseClaudeJsonlEntryWithSource(
+  line: string,
+  lineNumber: number,
+): Record<string, unknown> | null {
   const entry = parseClaudeJsonlEntry(line);
   if (!entry) return null;
   const entryId = asString(entry.uuid) || asString(entry.id) || asString(entry.messageId);
-  return attachNativeMessageSource(entry, { lineNumber, ...(entryId ? { entryId } : {}) });
+  return attachNativeMessageSource(entry, {
+    lineNumber,
+    ...(entryId ? { entryId } : {}),
+  });
 }
 
 function sortClaudeEntries(entries: Record<string, unknown>[]): Record<string, unknown>[] {
@@ -145,9 +239,15 @@ function sortClaudeEntries(entries: Record<string, unknown>[]): Record<string, u
 
 function convertClaudeEntries(entries: Record<string, unknown>[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
+  const sourceOrdinals = new WeakMap<Record<string, unknown>, number>();
 
   function pushMessage(entry: Record<string, unknown>, message: ChatMessage): void {
-    messages.push(attachNativeMessageSource(message, getNativeMessageSource(entry)));
+    const withinSourceOrdinal = sourceOrdinals.get(entry) ?? 0;
+    sourceOrdinals.set(entry, withinSourceOrdinal + 1);
+    messages.push(attachNativeMessageSource(message, {
+      ...getNativeMessageSource(entry),
+      withinSourceOrdinal,
+    }));
   }
 
   // A compact_boundary and its summary carry near-identical timestamps and can be
@@ -155,11 +255,16 @@ function convertClaudeEntries(entries: Record<string, unknown>[]): ChatMessage[]
   // pair it FIFO with the summaries rather than relying on boundary-before-summary order.
   const compactions = entries
     .filter((entry) => entry.type === 'system' && entry.subtype === 'compact_boundary')
-    .map((entry) => parseCompactMetadata(entry.compactMetadata ?? entry.compact_metadata));
+    .map((entry) => ({
+      info: parseCompactMetadata(entry.compactMetadata ?? entry.compact_metadata),
+      source: getNativeMessageSource(entry),
+    }));
   let compactionIndex = 0;
 
   for (const entry of entries) {
-    const ts = asString(entry.timestamp) || new Date().toISOString();
+    const source = getNativeMessageSource(entry);
+    const ts = asString(entry.timestamp)
+      || deterministicTranscriptTimestamp(source?.lineNumber, source?.byteOffset);
     const message = asRecord(entry.message);
 
     if (entry.type === 'progress' || entry.type === 'queue-operation' ||
@@ -172,8 +277,19 @@ function convertClaudeEntries(entries: Record<string, unknown>[]): ChatMessage[]
     if (entry.isCompactSummary) {
       const summaryText = getMessageText(message.content);
       if (summaryText) {
-        const info = compactions[compactionIndex++] ?? { trigger: 'manual' as const };
-        pushMessage(entry, new CompactionMessage(ts, info.trigger, extractCompactionSummary(summaryText), info.preTokens, info.postTokens));
+        const compaction = compactions[compactionIndex++];
+        const info = compaction?.info ?? { trigger: 'manual' as const };
+        const compactionMessage = new CompactionMessage(
+          ts,
+          info.trigger,
+          extractCompactionSummary(summaryText),
+          info.preTokens,
+          info.postTokens,
+        );
+        pushMessage(
+          entry,
+          attachCompactionRevisionSource(compactionMessage, compaction?.source),
+        );
       }
       continue;
     }
@@ -269,12 +385,105 @@ export async function loadClaudeChatMessages(nativePath: string | null | undefin
   }
 }
 
+async function scanClaudeMessagePage(
+  nativePath: string,
+  windowSize: number,
+): Promise<{
+  total: number;
+  messages: ChatMessage[];
+  revision: string;
+  requiresFullLoad: boolean;
+}> {
+  let total = 0;
+  let sourceOrder = 0;
+  let totalCompactionSummaries = 0;
+  let totalCompactionBoundaries = 0;
+  let requiresFullLoad = false;
+  const revision = new TranscriptRevisionAccumulator();
+  const messages = new BoundedLatest<OrderedClaudeMessage>(
+    windowSize,
+    compareOrderedClaudeMessages,
+  );
+  const compactionSummaries = new BoundedLatest<OrderedClaudeMessage>(
+    windowSize,
+    compareOrderedClaudeMessages,
+  );
+  const compactionBoundaries = new BoundedLatest<OrderedCompactionBoundary>(
+    windowSize,
+    compareCompactionBoundaries,
+  );
+  for await (const lineEntry of readJsonlLineEntries(nativePath)) {
+    const entry = parseClaudeJsonlEntryWithSource(lineEntry.line, lineEntry.lineNumber ?? 1);
+    if (!entry) {
+      sourceOrder += 1;
+      continue;
+    }
+    const entryTimestamp = timestampMs(entry.timestamp);
+    if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+      const info = parseCompactMetadata(entry.compactMetadata ?? entry.compact_metadata);
+      compactionBoundaries.add({
+        timestamp: entryTimestamp,
+        sourceOrder,
+        info,
+      });
+      revision.addCompactionMetadata(info, getNativeMessageSource(entry) ?? { sourceOrder });
+      totalCompactionBoundaries += 1;
+    }
+    const converted = convertClaudeEntries([entry]);
+    if (
+      (converted.length > 0 || entry.type === 'system' && entry.subtype === 'compact_boundary')
+      && entryTimestamp <= 0
+    ) {
+      requiresFullLoad = true;
+    }
+    converted.forEach((message, partOrder) => {
+      const candidate = { message, timestamp: entryTimestamp, sourceOrder, partOrder };
+      messages.add(candidate);
+      revision.add(message, { deferCompactionMetadata: message.type === 'compaction' });
+      total += 1;
+      if (message.type === 'compaction') {
+        compactionSummaries.add(candidate);
+        totalCompactionSummaries += 1;
+      }
+    });
+    sourceOrder += 1;
+  }
+
+  if (totalCompactionBoundaries !== totalCompactionSummaries) requiresFullLoad = true;
+  const retainedBoundaries = compactionBoundaries.values().sort(compareCompactionBoundaries);
+  const retainedSummaries = compactionSummaries.values().sort(compareOrderedClaudeMessages);
+  retainedSummaries.forEach((candidate, index) => {
+    const summaryIndex = totalCompactionSummaries - retainedSummaries.length + index;
+    const retainedBoundaryIndex = summaryIndex
+      - (totalCompactionBoundaries - retainedBoundaries.length);
+    const info = retainedBoundaries[retainedBoundaryIndex]?.info;
+    if (!info || candidate.message.type !== 'compaction') return;
+    candidate.message.trigger = info.trigger;
+    candidate.message.preTokens = info.preTokens;
+    candidate.message.postTokens = info.postTokens;
+  });
+
+  return {
+    total,
+    messages: messages.values().sort(compareOrderedClaudeMessages).map((entry) => entry.message),
+    revision: revision.finish(),
+    requiresFullLoad,
+  };
+}
+
 export async function loadClaudeChatMessagePage(
   nativePath: string | null | undefined,
   limit: number,
   offset: number,
 ): Promise<AgentTranscriptPage | null> {
-  if (!nativePath || offset > 0 || limit <= 0) return null;
+  if (
+    !nativePath
+    || !Number.isSafeInteger(offset)
+    || offset < 0
+    || !Number.isSafeInteger(limit)
+    || limit <= 0
+    || offset > Number.MAX_SAFE_INTEGER - limit
+  ) return null;
   try {
     await fs.access(nativePath);
   } catch {
@@ -282,29 +491,50 @@ export async function loadClaudeChatMessagePage(
   }
 
   try {
-    let maxBytes = 256 * 1024;
-    let maxLines = Math.max(500, limit * 40);
-    while (true) {
-      const { lines, fullyRead } = await readJsonlTailLines(nativePath, maxBytes, maxLines);
-      const messages = parseClaudeJsonlLines(lines);
-      if (messages.length >= limit || fullyRead) {
-        const pageMessages = messages.slice(Math.max(0, messages.length - limit));
-        const hasMore = !fullyRead || messages.length > pageMessages.length;
-        return {
-          messages: pageMessages,
-          total: fullyRead ? messages.length : pageMessages.length + 1,
-          hasMore,
-          offset,
-          limit,
-        };
-      }
-      maxBytes *= 2;
-      maxLines *= 2;
+    // Retains the newest offset + limit messages because exact arbitrary-offset
+    // selection under global timestamp ordering requires the skipped suffix too.
+    const scan = await scanClaudeMessagePage(nativePath, offset + limit);
+    if (scan.requiresFullLoad) {
+      return pageFromMessages(await loadClaudeChatMessages(nativePath), limit, offset);
     }
+    const { total, messages, revision } = scan;
+    if (offset >= total) {
+      return { messages: [], total, hasMore: false, offset, limit, revision };
+    }
+
+    const end = Math.max(0, messages.length - offset);
+    const start = Math.max(0, end - limit);
+    const pageMessages = messages.slice(start, end);
+    return {
+      messages: pageMessages,
+      total,
+      hasMore: total > offset + pageMessages.length,
+      offset,
+      limit,
+      revision,
+    };
   } catch (error) {
     logger.warn(`claude: tail page load failed for ${nativePath}:`, error);
     return null;
   }
+}
+
+function pageFromMessages(
+  messages: ChatMessage[],
+  limit: number,
+  offset: number,
+): AgentTranscriptPage {
+  const total = messages.length;
+  const end = Math.max(0, total - offset);
+  const start = Math.max(0, end - limit);
+  return {
+    messages: messages.slice(start, end),
+    total,
+    hasMore: start > 0,
+    offset,
+    limit,
+    revision: transcriptRevision(messages),
+  };
 }
 
 // Reads session messages from an absolute JSONL path.

--- a/server/agents/codex/__tests__/history-loader.test.js
+++ b/server/agents/codex/__tests__/history-loader.test.js
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { loadCodexChatMessages, loadCodexChatMessagePage } from '../history-loader.js';
 import { getNativeMessageSource } from '../../shared/native-message-source.js';
+import { transcriptRevision } from '../../../lib/transcript-revision.js';
 
 async function withTempJsonl(lines, fn) {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-load-test-'));
@@ -479,6 +480,33 @@ describe('loadCodexChatMessages', () => {
     expect(result).toEqual([]);
   });
 
+  it('uses deterministic source timestamps when native timestamps are missing or non-string', async () => {
+    const lines = [undefined, 123].map((timestamp, index) => JSON.stringify({
+      type: 'response_item',
+      ...(timestamp === undefined ? {} : { timestamp }),
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      const first = await loadCodexChatMessages(filePath);
+      const second = await loadCodexChatMessages(filePath);
+      const firstPage = await loadCodexChatMessagePage(filePath, 2, 0);
+      const secondPage = await loadCodexChatMessagePage(filePath, 2, 0);
+
+      expect(second).toEqual(first);
+      expect(first.map((message) => message.timestamp)).toEqual([
+        '2000-01-01T00:00:00.001Z',
+        '2000-01-01T00:00:00.002Z',
+      ]);
+      expect(secondPage.revision).toBe(firstPage.revision);
+      expect(firstPage.revision).toBe(transcriptRevision(first));
+    });
+  });
+
   it('loads the initial page from tail canonical entries', async () => {
     const lines = Array.from({ length: 12 }, (_, index) => JSON.stringify({
       type: 'response_item',
@@ -538,9 +566,91 @@ describe('loadCodexChatMessages', () => {
     });
   });
 
-  it('returns null for older tail pages so callers use the full loader', async () => {
-    const page = await loadCodexChatMessagePage('/tmp/missing.jsonl', 3, 2);
+  it('loads older pages with an exact total without retaining full messages', async () => {
+    const lines = Array.from({ length: 600 }, (_, index) => JSON.stringify({
+      type: 'response_item',
+      timestamp: new Date(Date.UTC(2026, 1, 21, 10, 0, index)).toISOString(),
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: `reply ${index} ${'x'.repeat(800)}` }],
+      },
+    }));
 
-    expect(page).toBeNull();
+    const page = await withTempJsonl(lines, (filePath) => loadCodexChatMessagePage(filePath, 3, 5));
+
+    expect(page).toMatchObject({ total: 600, hasMore: true, offset: 5, limit: 3 });
+    expect(page.messages.map((message) => message.content.slice(0, 9))).toEqual([
+      'reply 592', 'reply 593', 'reply 594',
+    ]);
+  });
+
+  it('matches full-loader ordering for out-of-order timestamps at arbitrary offsets', async () => {
+    const timestamps = [5, 0, 1, 2, 3, 4];
+    const lines = timestamps.map((second, index) => JSON.stringify({
+      type: 'response_item',
+      timestamp: `2026-02-21T10:00:0${second}.000Z`,
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      const full = await loadCodexChatMessages(filePath);
+      for (const offset of [0, 2]) {
+        const page = await loadCodexChatMessagePage(filePath, 2, offset);
+        const end = full.length - offset;
+        expect(page.messages).toEqual(full.slice(end - 2, end));
+        expect(page.revision).toBe(transcriptRevision(full));
+      }
+    });
+  });
+
+  it('matches legacy ordering with mixed invalid and missing timestamps', async () => {
+    const timestamps = ['2026-02-21T10:00:03.000Z', 'invalid', undefined,
+      '2026-02-21T10:00:01.000Z', '2026-02-21T10:00:02.000Z'];
+    const lines = timestamps.map((timestamp, index) => JSON.stringify({
+      type: 'response_item',
+      ...(timestamp === undefined ? {} : { timestamp }),
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      const expected = (await loadCodexChatMessages(filePath)).map((message) => message.content);
+      for (const offset of [0, 1, 3]) {
+        const page = await loadCodexChatMessagePage(filePath, 2, offset);
+        const end = expected.length - offset;
+        expect(page.messages.map((message) => message.content)).toEqual(
+          expected.slice(Math.max(0, end - 2), end),
+        );
+      }
+    });
+  });
+
+  it('preserves stable ordering for equal timestamps at multiple offsets', async () => {
+    const lines = Array.from({ length: 6 }, (_, index) => JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-02-21T10:00:00.000Z',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: `reply ${index}` }],
+      },
+    }));
+
+    await withTempJsonl(lines, async (filePath) => {
+      for (const offset of [0, 2, 4]) {
+        const page = await loadCodexChatMessagePage(filePath, 2, offset);
+        expect(page.messages.map((message) => message.content)).toEqual(
+          [`reply ${4 - offset}`, `reply ${5 - offset}`],
+        );
+      }
+    });
   });
 });

--- a/server/agents/codex/history-loader.ts
+++ b/server/agents/codex/history-loader.ts
@@ -2,21 +2,21 @@
 // Accepts absolute nativePath instead of scanning ~/.codex/sessions/.
 
 import { promises as fs } from 'fs';
-import {
-  readJsonlLineEntries,
-  readJsonlTailLines,
-  type JsonlLineEntry,
-} from '../shared/history-loader-utils.ts';
+import { readJsonlLineEntries, readJsonlTailLines } from '../shared/history-loader-utils.ts';
 import {
   normalizeCodexJsonlEntry,
   extractTextContent,
   type CodexJsonlNormalizationContext,
 } from './history-normalizer.js';
-import { attachNativeSourceToMessages } from '../shared/native-message-source.js';
+import { attachNativeMessageSource } from '../shared/native-message-source.js';
 import type { ChatMessage } from '../../../common/chat-types.js';
 import type { AgentTranscriptPage } from '../types.js';
 import { createLogger } from '../../lib/log.js';
 import { parseFirstJsonlValue } from '../../lib/jsonl.js';
+import {
+  TranscriptRevisionAccumulator,
+  transcriptRevision,
+} from '../../lib/transcript-revision.js';
 
 const logger = createLogger('agents:codex:history-loader');
 
@@ -28,6 +28,79 @@ interface CodexMessageBuckets {
   hasCanonicalUser: boolean;
   hasCanonicalAssistant: boolean;
   hasCanonicalThinking: boolean;
+}
+
+interface CodexMessageSummary {
+  canonical: number;
+  fallbackUser: number;
+  fallbackAssistant: number;
+  fallbackThinking: number;
+  hasCanonicalUser: boolean;
+  hasCanonicalAssistant: boolean;
+  hasCanonicalThinking: boolean;
+  total: number;
+}
+
+interface OrderedMessage {
+  message: ChatMessage;
+  timestamp: number;
+  order: number;
+}
+
+class BoundedLatestMessages {
+  #items: OrderedMessage[] = [];
+
+  constructor(private readonly limit: number) {}
+
+  add(message: ChatMessage, order: number): void {
+    if (this.limit === 0) return;
+    const candidate = { message, timestamp: timestampMs(message.timestamp), order };
+    if (this.#items.length < this.limit) {
+      this.#items.push(candidate);
+      this.#siftUp(this.#items.length - 1);
+    } else if (compareOrderedMessages(candidate, this.#items[0]) > 0) {
+      this.#items[0] = candidate;
+      this.#siftDown(0);
+    }
+  }
+
+  values(): OrderedMessage[] {
+    return this.#items;
+  }
+
+  #siftUp(index: number): void {
+    while (index > 0) {
+      const parent = (index - 1) >> 1;
+      if (compareOrderedMessages(this.#items[parent], this.#items[index]) <= 0) break;
+      [this.#items[parent], this.#items[index]] = [this.#items[index], this.#items[parent]];
+      index = parent;
+    }
+  }
+
+  #siftDown(index: number): void {
+    while (true) {
+      const left = index * 2 + 1;
+      const right = left + 1;
+      let smallest = index;
+      if (left < this.#items.length && compareOrderedMessages(this.#items[left], this.#items[smallest]) < 0) smallest = left;
+      if (right < this.#items.length && compareOrderedMessages(this.#items[right], this.#items[smallest]) < 0) smallest = right;
+      if (smallest === index) break;
+      [this.#items[index], this.#items[smallest]] = [this.#items[smallest], this.#items[index]];
+      index = smallest;
+    }
+  }
+}
+
+function timestampMs(value: unknown): number {
+  const time = new Date((value as string | number | Date | undefined) ?? 0).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function compareOrderedMessages(left: OrderedMessage, right: OrderedMessage): number {
+  if (left.timestamp > 0 && right.timestamp > 0 && left.timestamp !== right.timestamp) {
+    return left.timestamp - right.timestamp;
+  }
+  return left.order - right.order;
 }
 
 function sortChatMessagesByTimestamp(messages: ChatMessage[]): ChatMessage[] {
@@ -58,33 +131,42 @@ function addCodexJsonlLine(
   buckets: CodexMessageBuckets,
   line: string,
   context: CodexJsonlNormalizationContext = {},
-): void {
+): boolean {
   const entry = parseCodexJsonlEntry(line);
-  if (!entry) return;
+  if (!entry) return false;
   try {
     const result = normalizeCodexJsonlEntry(entry, context);
-    if (!result) return;
+    if (!result) return false;
 
-    buckets.canonical.push(...attachNativeSourceToMessages(result.canonical, {
-      byteOffset: context.sourceByteOffset,
-      lineNumber: context.sourceLineNumber,
-    }));
-    buckets.fallbackUser.push(...attachNativeSourceToMessages(result.fallbackUser, {
-      byteOffset: context.sourceByteOffset,
-      lineNumber: context.sourceLineNumber,
-    }));
-    buckets.fallbackAssistant.push(...attachNativeSourceToMessages(result.fallbackAssistant, {
-      byteOffset: context.sourceByteOffset,
-      lineNumber: context.sourceLineNumber,
-    }));
-    buckets.fallbackThinking.push(...attachNativeSourceToMessages(result.fallbackThinking, {
-      byteOffset: context.sourceByteOffset,
-      lineNumber: context.sourceLineNumber,
-    }));
+    let withinSourceOrdinal = 0;
+    const appendMessages = (target: ChatMessage[], messages: ChatMessage[]): void => {
+      for (const message of messages) {
+        target.push(attachNativeMessageSource(message, {
+          byteOffset: context.sourceByteOffset,
+          lineNumber: context.sourceLineNumber,
+          withinSourceOrdinal,
+        }));
+        withinSourceOrdinal += 1;
+      }
+    };
+    appendMessages(buckets.canonical, result.canonical);
+    appendMessages(buckets.fallbackUser, result.fallbackUser);
+    appendMessages(buckets.fallbackAssistant, result.fallbackAssistant);
+    appendMessages(buckets.fallbackThinking, result.fallbackThinking);
     if (result.isCanonicalUser) buckets.hasCanonicalUser = true;
     if (result.isCanonicalAssistant) buckets.hasCanonicalAssistant = true;
     if (result.isCanonicalThinking) buckets.hasCanonicalThinking = true;
-  } catch { }
+    const emitted = result.canonical.length
+      + result.fallbackUser.length
+      + result.fallbackAssistant.length
+      + result.fallbackThinking.length > 0;
+    return emitted && (
+      typeof entry.timestamp !== 'string'
+      || timestampMs(entry.timestamp) <= 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 function parseCodexJsonlEntry(line: string): Record<string, unknown> | null {
@@ -100,18 +182,86 @@ function finishCodexMessages(buckets: CodexMessageBuckets, includeFallback: bool
   return sortChatMessagesByTimestamp(messages);
 }
 
-function collectCodexMessagesFromLineEntries(
-  lineEntries: JsonlLineEntry[],
-  includeFallback: boolean,
-): ChatMessage[] {
-  const buckets = createCodexMessageBuckets();
-  for (const entry of lineEntries) {
-    addCodexJsonlLine(buckets, entry.line, {
+async function scanCodexMessagePage(
+  nativePath: string,
+  windowSize: number,
+): Promise<{
+  summary: CodexMessageSummary;
+  messages: ChatMessage[];
+  revision: string;
+  requiresFullLoad: boolean;
+}> {
+  const summary: CodexMessageSummary = {
+    canonical: 0,
+    fallbackUser: 0,
+    fallbackAssistant: 0,
+    fallbackThinking: 0,
+    hasCanonicalUser: false,
+    hasCanonicalAssistant: false,
+    hasCanonicalThinking: false,
+    total: 0,
+  };
+  const bucketNames = [
+    'canonical',
+    'fallbackUser',
+    'fallbackAssistant',
+    'fallbackThinking',
+  ] as const;
+  const windows = Object.fromEntries(
+    bucketNames.map((name) => [name, new BoundedLatestMessages(windowSize)]),
+  ) as Record<(typeof bucketNames)[number], BoundedLatestMessages>;
+  const revisions = Object.fromEntries(
+    bucketNames.map((name) => [name, new TranscriptRevisionAccumulator()]),
+  ) as Record<(typeof bucketNames)[number], TranscriptRevisionAccumulator>;
+  let requiresFullLoad = false;
+
+  for await (const entry of readJsonlLineEntries(nativePath)) {
+    const buckets = createCodexMessageBuckets();
+    const hasMalformedTimestamp = addCodexJsonlLine(buckets, entry.line, {
       sourceByteOffset: entry.byteOffset,
       sourceLineNumber: entry.lineNumber,
     });
+    requiresFullLoad ||= hasMalformedTimestamp;
+    for (const name of bucketNames) {
+      for (const message of buckets[name]) {
+        windows[name].add(message, summary[name]);
+        revisions[name].add(message);
+        summary[name] += 1;
+      }
+    }
+    summary.hasCanonicalUser ||= buckets.hasCanonicalUser;
+    summary.hasCanonicalAssistant ||= buckets.hasCanonicalAssistant;
+    summary.hasCanonicalThinking ||= buckets.hasCanonicalThinking;
   }
-  return finishCodexMessages(buckets, includeFallback);
+
+  summary.total = summary.canonical
+    + (summary.hasCanonicalUser ? 0 : summary.fallbackUser)
+    + (summary.hasCanonicalAssistant ? 0 : summary.fallbackAssistant)
+    + (summary.hasCanonicalThinking ? 0 : summary.fallbackThinking);
+  const includedNames = [
+    'canonical',
+    ...(!summary.hasCanonicalUser ? ['fallbackUser'] as const : []),
+    ...(!summary.hasCanonicalAssistant ? ['fallbackAssistant'] as const : []),
+    ...(!summary.hasCanonicalThinking ? ['fallbackThinking'] as const : []),
+  ] as const;
+  const combined = includedNames.flatMap((name, bucketRank) => {
+    const bucketStart = includedNames
+      .slice(0, bucketRank)
+      .reduce((count, previousName) => count + summary[previousName], 0);
+    return windows[name].values().map((entry) => ({
+      ...entry,
+      order: bucketStart + entry.order,
+    }));
+  });
+  combined.sort(compareOrderedMessages);
+  const revision = new TranscriptRevisionAccumulator();
+  for (const name of includedNames) revision.merge(revisions[name]);
+  return {
+    summary,
+    messages: combined.slice(-Math.min(summary.total, windowSize)).map((entry) => entry.message),
+    revision: revision.finish(),
+    requiresFullLoad,
+  };
 }
 
 // Reads a Codex JSONL file and returns ChatMessage[].
@@ -143,32 +293,61 @@ export async function loadCodexChatMessagePage(
   limit: number,
   offset: number,
 ): Promise<AgentTranscriptPage | null> {
-  if (!nativePath || offset > 0 || limit <= 0) return null;
+  if (
+    !nativePath
+    || !Number.isSafeInteger(offset)
+    || offset < 0
+    || !Number.isSafeInteger(limit)
+    || limit <= 0
+    || offset > Number.MAX_SAFE_INTEGER - limit
+  ) return null;
 
   try {
-    let maxBytes = 256 * 1024;
-    let maxLines = Math.max(500, limit * 40);
-    while (true) {
-      const { lineEntries, fullyRead } = await readJsonlTailLines(nativePath, maxBytes, maxLines);
-      const messages = collectCodexMessagesFromLineEntries(lineEntries, fullyRead);
-      if (messages.length >= limit || fullyRead) {
-        const pageMessages = messages.slice(Math.max(0, messages.length - limit));
-        const hasMore = !fullyRead || messages.length > pageMessages.length;
-        return {
-          messages: pageMessages,
-          total: fullyRead ? messages.length : pageMessages.length + 1,
-          hasMore,
-          offset,
-          limit,
-        };
-      }
-      maxBytes *= 2;
-      maxLines *= 2;
+    // Retains the newest offset + limit messages because exact arbitrary-offset
+    // selection under global timestamp ordering requires the skipped suffix too.
+    const windowSize = offset + limit;
+    const scan = await scanCodexMessagePage(nativePath, windowSize);
+    if (scan.requiresFullLoad) {
+      return pageFromMessages(await loadCodexChatMessages(nativePath), limit, offset);
     }
+    const { summary, messages, revision } = scan;
+    if (offset >= summary.total) {
+      return { messages: [], total: summary.total, hasMore: false, offset, limit, revision };
+    }
+    const end = Math.max(0, messages.length - offset);
+    const start = Math.max(0, end - limit);
+    const pageMessages = messages.slice(start, end);
+    return {
+      messages: pageMessages,
+      total: summary.total,
+      hasMore: summary.total > offset + pageMessages.length,
+      offset,
+      limit,
+      revision,
+    };
   } catch (error) {
     logger.warn(`codex: tail page load failed for ${nativePath}:`, error);
     return null;
   }
+}
+
+function pageFromMessages(
+  messages: ChatMessage[],
+  limit: number,
+  offset: number,
+): AgentTranscriptPage {
+  const total = messages.length;
+  const end = Math.max(0, total - offset);
+  const start = Math.max(0, end - limit);
+  const pageMessages = messages.slice(start, end);
+  return {
+    messages: pageMessages,
+    total,
+    hasMore: start > 0,
+    offset,
+    limit,
+    revision: transcriptRevision(messages),
+  };
 }
 
 const CODEX_HEAD_BYTES = 96 * 1024;

--- a/server/agents/codex/history-normalizer.ts
+++ b/server/agents/codex/history-normalizer.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../common/chat-types.js';
 import { convertCodexFunctionCall, convertCodexCustomToolCall } from './jsonl-tool-use-converter.js';
 import { stripResolvedFileMentionContext } from '../shared/file-mention-context.ts';
+import { deterministicTranscriptTimestamp } from '../shared/transcript-timestamp.js';
 
 export interface CodexJsonlNormalizationResult {
   canonical: ChatMessage[];
@@ -162,7 +163,9 @@ export function normalizeCodexJsonlEntry(
   const rawEntry = asRecord(entry);
   if (Object.keys(rawEntry).length === 0) return null;
 
-  const ts = typeof rawEntry.timestamp === 'string' ? rawEntry.timestamp : new Date().toISOString();
+  const ts = typeof rawEntry.timestamp === 'string'
+    ? rawEntry.timestamp
+    : deterministicTranscriptTimestamp(context.sourceLineNumber, context.sourceByteOffset);
 
   if (rawEntry.type === 'event_msg') {
     return normalizeEventMsg(rawEntry.payload, ts);

--- a/server/agents/shared/native-message-source.ts
+++ b/server/agents/shared/native-message-source.ts
@@ -4,12 +4,17 @@ export interface NativeMessageSource {
   entryId?: string;
   lineNumber?: number;
   byteOffset?: number;
+  withinSourceOrdinal?: number;
 }
 
 const NATIVE_MESSAGE_SOURCE = Symbol('garcon.nativeMessageSource');
 
 function isPositiveInt(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
 function nonEmptyString(value: unknown): value is string {
@@ -20,12 +25,20 @@ export function attachNativeMessageSource<T extends object>(
   target: T,
   source: NativeMessageSource | null | undefined,
 ): T {
-  if (!source || (!nonEmptyString(source.entryId) && !isPositiveInt(source.lineNumber) && !isPositiveInt(source.byteOffset))) return target;
+  if (!source || (
+    !nonEmptyString(source.entryId)
+    && !isPositiveInt(source.lineNumber)
+    && !isPositiveInt(source.byteOffset)
+    && !isNonNegativeInt(source.withinSourceOrdinal)
+  )) return target;
   Object.defineProperty(target, NATIVE_MESSAGE_SOURCE, {
     value: {
       ...(nonEmptyString(source.entryId) ? { entryId: source.entryId } : {}),
       ...(isPositiveInt(source.lineNumber) ? { lineNumber: source.lineNumber } : {}),
       ...(isPositiveInt(source.byteOffset) ? { byteOffset: source.byteOffset } : {}),
+      ...(isNonNegativeInt(source.withinSourceOrdinal)
+        ? { withinSourceOrdinal: source.withinSourceOrdinal }
+        : {}),
     },
     enumerable: false,
     configurable: true,
@@ -44,6 +57,17 @@ export function attachNativeSourceToMessages<T extends ChatMessage>(
 }
 
 export function getNativeMessageSource(value: unknown): NativeMessageSource | null {
+  const source = getStoredNativeMessageSource(value);
+  if (!source) return null;
+  const { withinSourceOrdinal: _withinSourceOrdinal, ...publicSource } = source;
+  return publicSource;
+}
+
+export function getNativeMessageRevisionSource(value: unknown): NativeMessageSource | null {
+  return getStoredNativeMessageSource(value);
+}
+
+function getStoredNativeMessageSource(value: unknown): NativeMessageSource | null {
   if (!value || typeof value !== 'object') return null;
   const source = (value as Record<PropertyKey, unknown>)[NATIVE_MESSAGE_SOURCE];
   if (!source || typeof source !== 'object') return null;
@@ -52,5 +76,8 @@ export function getNativeMessageSource(value: unknown): NativeMessageSource | nu
     ...(nonEmptyString(raw.entryId) ? { entryId: raw.entryId } : {}),
     ...(isPositiveInt(raw.lineNumber) ? { lineNumber: raw.lineNumber } : {}),
     ...(isPositiveInt(raw.byteOffset) ? { byteOffset: raw.byteOffset } : {}),
+    ...(isNonNegativeInt(raw.withinSourceOrdinal)
+      ? { withinSourceOrdinal: raw.withinSourceOrdinal }
+      : {}),
   };
 }

--- a/server/agents/shared/transcript-timestamp.ts
+++ b/server/agents/shared/transcript-timestamp.ts
@@ -1,0 +1,9 @@
+const SOURCE_TIMESTAMP_EPOCH_MS = Date.UTC(2000, 0, 1);
+
+export function deterministicTranscriptTimestamp(
+  lineNumber?: number,
+  byteOffset?: number,
+): string {
+  const sourcePosition = lineNumber ?? byteOffset ?? 0;
+  return new Date(SOURCE_TIMESTAMP_EPOCH_MS + sourcePosition).toISOString();
+}

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -68,6 +68,7 @@ export interface AgentTranscriptPage {
   hasMore: boolean;
   offset: number;
   limit: number;
+  revision?: string;
 }
 
 export interface AgentAuth {

--- a/server/chats/__tests__/chat-view-store.test.js
+++ b/server/chats/__tests__/chat-view-store.test.js
@@ -1,6 +1,12 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { ChatViewStore } from '../chat-view-store.js';
-import { AssistantMessage, ErrorMessage, UserMessage } from '../../../common/chat-types.js';
+import {
+  AssistantMessage,
+  CompactionMessage,
+  ErrorMessage,
+  UserMessage,
+} from '../../../common/chat-types.js';
+import { transcriptRevision } from '../../lib/transcript-revision.js';
 
 const TS = '2026-06-01T00:00:00.000Z';
 
@@ -16,12 +22,35 @@ function contents(page) {
   return page.messages.map((entry) => entry.message.content);
 }
 
+function fullLoader(loadAll) {
+  return { loadAll };
+}
+
+function pagedLoader(historyRef) {
+  return {
+    loadAll: async () => historyRef.current,
+    loadPage: async (limit, offset) => {
+      const history = historyRef.current;
+      const end = history.length - offset;
+      const start = Math.max(0, end - limit);
+      return {
+        messages: history.slice(start, end),
+        total: history.length,
+        hasMore: start > 0,
+        offset,
+        limit,
+        revision: transcriptRevision(history),
+      };
+    },
+  };
+}
+
 describe('ChatViewStore', () => {
   it('creates an empty generation from an empty native read', async () => {
     const store = new ChatViewStore(() => false);
     const loadNative = mock(async () => []);
 
-    const page = await store.getOrCreatePage('chat-1', loadNative, 20);
+    const page = await store.getOrCreatePage('chat-1', fullLoader(loadNative), 20);
 
     expect(page.generationId).toBeTruthy();
     expect(page.lastSeq).toBe(0);
@@ -33,7 +62,7 @@ describe('ChatViewStore', () => {
     const store = new ChatViewStore(() => false);
     const page = await store.getOrCreatePage(
       'chat-1',
-      async () => [user('hello'), assistant('hi')],
+      fullLoader(async () => [user('hello'), assistant('hi')]),
       1,
     );
 
@@ -49,7 +78,7 @@ describe('ChatViewStore', () => {
 
   it('replaces native generations intentionally', async () => {
     const store = new ChatViewStore(() => false);
-    const first = await store.getOrCreatePage('chat-1', async () => [user('old')], 20);
+    const first = await store.getOrCreatePage('chat-1', fullLoader(async () => [user('old')]), 20);
     const replacement = await store.replaceFromNative('chat-1', async () => [assistant('fresh')]);
 
     expect(replacement.generationId).not.toBe(first.generationId);
@@ -82,7 +111,7 @@ describe('ChatViewStore', () => {
 
     const page = await store.getOrCreatePage(
       'chat-1',
-      async () => [assistant('native after live')],
+      fullLoader(async () => [assistant('native after live')]),
       20,
     );
 
@@ -157,10 +186,10 @@ describe('ChatViewStore', () => {
 
   it('eviction causes the next access to mint a new generation', async () => {
     const store = new ChatViewStore(() => false);
-    const first = await store.getOrCreatePage('chat-1', async () => [assistant('old')], 20);
+    const first = await store.getOrCreatePage('chat-1', fullLoader(async () => [assistant('old')]), 20);
 
     store.evict('chat-1');
-    const second = await store.getOrCreatePage('chat-1', async () => [assistant('new')], 20);
+    const second = await store.getOrCreatePage('chat-1', fullLoader(async () => [assistant('new')]), 20);
 
     expect(second.generationId).not.toBe(first.generationId);
     expect(contents(second)).toEqual(['new']);
@@ -183,5 +212,550 @@ describe('ChatViewStore', () => {
     expect(stale.skipped).toBe(true);
     expect(stale.messages).toEqual([]);
     expect(contents(page)).toEqual(['native']);
+  });
+
+  it('loads and retains only requested contiguous history pages', async () => {
+    const store = new ChatViewStore(() => false);
+    const loadAll = mock(async () => [
+      user('one'), assistant('two'), assistant('three'), assistant('four'), assistant('five'),
+    ]);
+    const all = await loadAll();
+    loadAll.mockClear();
+    const loadPage = mock(async (limit, offset) => {
+      const end = all.length - offset;
+      const start = Math.max(0, end - limit);
+      return {
+        messages: all.slice(start, end),
+        total: all.length,
+        hasMore: start > 0,
+        offset,
+        limit,
+      };
+    });
+
+    const recent = await store.getOrCreatePage('chat-1', { loadAll, loadPage }, 2);
+    expect(recent.messages.map((entry) => entry.seq)).toEqual([4, 5]);
+    expect(contents(recent)).toEqual(['four', 'five']);
+
+    const middle = await store.getOrCreatePage('chat-1', { loadAll, loadPage }, 2, 4);
+    expect(middle.messages.map((entry) => entry.seq)).toEqual([2, 3]);
+    expect(contents(middle)).toEqual(['two', 'three']);
+
+    const oldest = await store.getOrCreatePage('chat-1', { loadAll, loadPage }, 2, 2);
+    expect(oldest.messages.map((entry) => entry.seq)).toEqual([1]);
+    expect(oldest.hasMore).toBe(false);
+    expect(loadPage.mock.calls.map((call) => call.slice(0, 2))).toEqual([[2, 0], [2, 2], [1, 4]]);
+    expect(loadAll).not.toHaveBeenCalled();
+  });
+
+  it('serves non-contiguous page requests without making the retained suffix sparse', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = Array.from({ length: 10 }, (_, index) => assistant(String(index + 1)));
+    const loadPage = mock(async (limit, offset) => {
+      const end = history.length - offset;
+      const start = Math.max(0, end - limit);
+      return {
+        messages: history.slice(start, end),
+        total: history.length,
+        hasMore: start > 0,
+        offset,
+        limit,
+      };
+    });
+    const loader = { loadAll: async () => history, loadPage };
+
+    const recent = await store.getOrCreatePage('chat-1', loader, 2);
+    const skipped = await store.getOrCreatePage('chat-1', loader, 2, 5);
+    const contiguous = await store.getOrCreatePage('chat-1', loader, 2, recent.pageOldestSeq);
+
+    expect(skipped.messages.map((entry) => entry.seq)).toEqual([3, 4]);
+    expect(contiguous.messages.map((entry) => entry.seq)).toEqual([7, 8]);
+    expect(store.readPage('chat-1', 10).messages.map((entry) => entry.seq)).toEqual([7, 8, 9, 10]);
+  });
+
+  it('fills a wider latest-page request from an existing partial suffix', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = Array.from({ length: 10 }, (_, index) => assistant(String(index + 1)));
+    const loadPage = mock(async (limit, offset) => {
+      const end = history.length - offset;
+      const start = Math.max(0, end - limit);
+      return { messages: history.slice(start, end), total: 10, hasMore: start > 0, offset, limit };
+    });
+    const loader = { loadAll: async () => history, loadPage };
+
+    await store.getOrCreatePage('chat-1', loader, 2);
+    const wider = await store.getOrCreatePage('chat-1', loader, 6);
+
+    expect(wider.messages.map((entry) => entry.seq)).toEqual([5, 6, 7, 8, 9, 10]);
+    expect(loadPage.mock.calls.map((call) => call.slice(0, 2))).toEqual([[2, 0], [4, 2]]);
+  });
+
+  it('fills the missing prefix when beforeSeq overlaps the retained suffix', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = Array.from({ length: 10 }, (_, index) => assistant(String(index + 1)));
+    const loadPage = mock(async (limit, offset) => {
+      const end = history.length - offset;
+      const start = Math.max(0, end - limit);
+      return { messages: history.slice(start, end), total: 10, hasMore: start > 0, offset, limit };
+    });
+    const loader = { loadAll: async () => history, loadPage };
+
+    await store.getOrCreatePage('chat-1', loader, 2);
+    const overlapping = await store.getOrCreatePage('chat-1', loader, 5, 10);
+
+    expect(overlapping.messages.map((entry) => entry.seq)).toEqual([5, 6, 7, 8, 9]);
+    expect(loadPage.mock.calls.map((call) => call.slice(0, 2))).toEqual([[2, 0], [4, 2]]);
+  });
+
+  it('does not prune a view while an older page load is in flight', async () => {
+    let now = 0;
+    let releaseOlderPage;
+    let markOlderPageStarted;
+    const olderPageStarted = new Promise((resolve) => { markOlderPageStarted = resolve; });
+    const olderPageGate = new Promise((resolve) => { releaseOlderPage = resolve; });
+    const history = Array.from({ length: 4 }, (_, index) => assistant(String(index + 1)));
+    const loader = {
+      loadAll: async () => history,
+      loadPage: async (limit, offset) => {
+        if (offset > 0) {
+          markOlderPageStarted();
+          await olderPageGate;
+        }
+        const end = history.length - offset;
+        const start = Math.max(0, end - limit);
+        return { messages: history.slice(start, end), total: 4, hasMore: start > 0, offset, limit };
+      },
+    };
+    const store = new ChatViewStore(() => false, { staleNonActiveMs: 10, now: () => now });
+    const recent = await store.getOrCreatePage('chat-1', loader, 1);
+
+    now = 11;
+    const pending = store.getOrCreatePage('chat-1', loader, 1, recent.pageOldestSeq);
+    await olderPageStarted;
+    now = 100;
+    store.prune();
+    releaseOlderPage();
+    await pending;
+
+    expect(store.readPage('chat-1', 4)?.generationId).toBe(recent.generationId);
+  });
+
+  it('bounds one active view and requires snapshots before its retained suffix', async () => {
+    const store = new ChatViewStore(() => true, { messageLimit: 3 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => Array.from({ length: 5 }, (_, index) => assistant(String(index + 1))),
+      [assistant('live')],
+    );
+
+    const retained = store.readPage('chat-1', 10);
+    expect(retained.messages.map((entry) => entry.seq)).toEqual([4, 5, 6]);
+    expect(contents(retained)).toEqual(['4', '5', 'live']);
+    expect(store.getLoadedMessages('chat-1')).toBeNull();
+    expect(store.readReplay('chat-1', appended.generationId, 2)?.mode).toBe('snapshot-required');
+    expect(store.readReplay('chat-1', appended.generationId, 3)).toMatchObject({
+      mode: 'delta',
+      messages: retained.messages,
+    });
+  });
+
+  it('trims active views to the global message budget without changing generations', async () => {
+    const store = new ChatViewStore(() => true, { messageLimit: 3 });
+    const first = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => [],
+      [assistant('1'), assistant('2')],
+    );
+    const second = await store.appendAfterEnsuringGeneration(
+      'chat-2',
+      async () => [],
+      [assistant('3'), assistant('4')],
+    );
+
+    const firstRetained = store.readPage('chat-1', 10);
+    const secondRetained = store.readPage('chat-2', 10);
+    expect(firstRetained.generationId).toBe(first.generationId);
+    expect(secondRetained.generationId).toBe(second.generationId);
+    expect(firstRetained.messages.length + secondRetained.messages.length).toBe(3);
+    expect(store.readReplay('chat-1', first.generationId, 0)?.mode).toBe('snapshot-required');
+  });
+
+  it('returns a wider in-flight page without growing the retained suffix past its cap', async () => {
+    const history = Array.from({ length: 6 }, (_, index) => assistant(String(index + 1)));
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const loader = {
+      loadAll: async () => history,
+      loadPage: async (limit, offset) => {
+        const end = history.length - offset;
+        const start = Math.max(0, end - limit);
+        return { messages: history.slice(start, end), total: 6, hasMore: start > 0, offset, limit };
+      },
+    };
+
+    await store.getOrCreatePage('chat-1', loader, 2);
+    const wider = await store.getOrCreatePage('chat-1', loader, 5);
+
+    expect(wider.messages.map((entry) => entry.seq)).toEqual([2, 3, 4, 5, 6]);
+    expect(store.readPage('chat-1', 10)?.messages.map((entry) => entry.seq)).toEqual([5, 6]);
+  });
+
+  it('serves the requested page from a transient full load when transcript totals change', async () => {
+    const initialHistory = Array.from({ length: 6 }, (_, index) => assistant(String(index + 1)));
+    const updatedHistory = Array.from({ length: 7 }, (_, index) => assistant(String(index + 1)));
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const loader = {
+      loadAll: mock(async () => updatedHistory),
+      loadPage: mock(async (limit, offset) => {
+        const source = offset === 0 ? initialHistory : updatedHistory;
+        const end = source.length - offset;
+        const start = Math.max(0, end - limit);
+        return {
+          messages: source.slice(start, end),
+          total: source.length,
+          hasMore: start > 0,
+          offset,
+          limit,
+        };
+      }),
+    };
+
+    const recent = await store.getOrCreatePage('chat-1', loader, 2);
+    const older = await store.getOrCreatePage('chat-1', loader, 2, 5);
+
+    expect(older.generationId).not.toBe(recent.generationId);
+    expect(older.messages.map((entry) => entry.seq)).toEqual([3, 4]);
+    expect(contents(older)).toEqual(['3', '4']);
+    expect(store.readPage('chat-1', 10)?.messages.map((entry) => entry.seq)).toEqual([6, 7]);
+    expect(loader.loadAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('changes generation when an unretained native row changes at the same total', async () => {
+    const historyRef = {
+      current: Array.from({ length: 6 }, (_, index) => assistant(String(index + 1))),
+    };
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const loader = pagedLoader(historyRef);
+    const recent = await store.getOrCreatePage('chat-1', loader, 2);
+
+    historyRef.current = [assistant('replacement'), ...historyRef.current.slice(1)];
+    const older = await store.getOrCreatePage('chat-1', loader, 2, recent.pageOldestSeq);
+
+    expect(older.generationId).not.toBe(recent.generationId);
+    expect(contents(older)).toEqual(['3', '4']);
+    expect(store.readPage('chat-1', 10)?.generationId).toBe(older.generationId);
+  });
+
+  it('changes generation when unretained native timestamps reorder rows', async () => {
+    const first = new AssistantMessage('2026-06-01T00:00:01.000Z', 'first');
+    const second = new AssistantMessage('2026-06-01T00:00:02.000Z', 'second');
+    const tail = Array.from({ length: 4 }, (_, index) => (
+      new AssistantMessage(`2026-06-01T00:00:0${index + 3}.000Z`, `tail-${index + 1}`)
+    ));
+    const historyRef = { current: [first, second, ...tail] };
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const loader = pagedLoader(historyRef);
+    const recent = await store.getOrCreatePage('chat-1', loader, 2);
+
+    historyRef.current = [second, first, ...tail];
+    const older = await store.getOrCreatePage('chat-1', loader, 2, recent.pageOldestSeq);
+
+    expect(older.generationId).not.toBe(recent.generationId);
+  });
+
+  it('changes generation when unretained compaction metadata changes', async () => {
+    const historyRef = {
+      current: [
+        new CompactionMessage(TS, 'manual', 'summary', 100, 20),
+        ...Array.from({ length: 5 }, (_, index) => assistant(String(index + 2))),
+      ],
+    };
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const loader = pagedLoader(historyRef);
+    const recent = await store.getOrCreatePage('chat-1', loader, 2);
+
+    historyRef.current = [
+      new CompactionMessage(TS, 'auto', 'summary', 120, 24),
+      ...historyRef.current.slice(1),
+    ];
+    const older = await store.getOrCreatePage('chat-1', loader, 2, recent.pageOldestSeq);
+
+    expect(older.generationId).not.toBe(recent.generationId);
+  });
+
+  it('pages older full-only history under the same capped generation', async () => {
+    const history = Array.from({ length: 6 }, (_, index) => assistant(String(index + 1)));
+    const store = new ChatViewStore(() => false, { messageLimit: 3 });
+    const loader = fullLoader(mock(async () => history));
+
+    const recent = await store.getOrCreatePage('chat-1', loader, 2);
+    const older = await store.getOrCreatePage('chat-1', loader, 2, recent.pageOldestSeq);
+
+    expect(older.generationId).toBe(recent.generationId);
+    expect(older.messages.map((entry) => entry.seq)).toEqual([3, 4]);
+    expect(contents(older)).toEqual(['3', '4']);
+    expect(store.readPage('chat-1', 10)?.messages.map((entry) => entry.seq)).toEqual([4, 5, 6]);
+  });
+
+  it('preserves generation when a trimmed live append becomes native history', async () => {
+    const history = Array.from({ length: 6 }, (_, index) => assistant(String(index + 1)));
+    const store = new ChatViewStore(() => false, { messageLimit: 3 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [assistant('7')],
+    );
+
+    const reconciled = await store.getOrCreateMessages(
+      'chat-1',
+      async () => [...history, assistant('7')],
+    );
+
+    expect(store.getCursor('chat-1')?.generationId).toBe(appended.generationId);
+    expect(reconciled.map((message) => message.content)).toEqual(['1', '2', '3', '4', '5', '6', '7']);
+    expect(store.readPage('chat-1', 10)?.messages.map((entry) => entry.seq)).toEqual([5, 6, 7]);
+  });
+
+  it('keeps the newest unpersisted live row after partial native persistence', async () => {
+    const history = Array.from({ length: 6 }, (_, index) => assistant(String(index + 1)));
+    const store = new ChatViewStore(() => false, { messageLimit: 3 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [assistant('7'), assistant('8')],
+    );
+
+    const reconciled = await store.getOrCreateMessages(
+      'chat-1',
+      async () => [...history, assistant('7')],
+    );
+
+    expect(store.getCursor('chat-1')?.generationId).toBe(appended.generationId);
+    expect(reconciled.map((message) => message.content)).toEqual([
+      '1', '2', '3', '4', '5', '6', '7', '8',
+    ]);
+    expect(store.readPage('chat-1', 10)?.messages.map((entry) => entry.seq)).toEqual([6, 7, 8]);
+    expect(contents(store.readPage('chat-1', 10))).toEqual(['6', '7', '8']);
+  });
+
+  it('preserves retained live rows when native growth closes the trimmed prefix', async () => {
+    const history = [assistant('h1'), assistant('h2')];
+    const live = [assistant('l3'), assistant('l4'), assistant('l5'), assistant('l6')];
+    const store = new ChatViewStore(() => false, { messageLimit: 3 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      live,
+    );
+
+    const reconciled = await store.getOrCreateMessages(
+      'chat-1',
+      async () => [...history, live[0]],
+    );
+
+    expect(store.getCursor('chat-1')?.generationId).toBe(appended.generationId);
+    expect(reconciled.map((message) => message.content)).toEqual([
+      'h1', 'h2', 'l3', 'l4', 'l5', 'l6',
+    ]);
+    const retained = store.readPage('chat-1', 10);
+    expect(retained.messages.map((entry) => entry.seq)).toEqual([4, 5, 6]);
+    expect(contents(retained)).toEqual(['l4', 'l5', 'l6']);
+  });
+
+  it('rotates generation when persisted native growth mismatches evicted live rows', async () => {
+    const history = [assistant('h1'), assistant('h2')];
+    const live = [assistant('l3'), assistant('l4'), assistant('l5'), assistant('l6')];
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      live,
+    );
+
+    const reconciled = await store.getOrCreateMessages('chat-1', async () => [
+      ...history,
+      assistant('wrong-l3'),
+      live[1],
+    ]);
+
+    expect(store.getCursor('chat-1')?.generationId).not.toBe(appended.generationId);
+    expect(reconciled.map((message) => message.content)).toEqual([
+      'h1', 'h2', 'wrong-l3', 'l4', 'l5', 'l6',
+    ]);
+    expect(contents(store.readPage('chat-1', 10))).toEqual(['l5', 'l6']);
+  });
+
+  it('resequences retained live rows when an evicted gap is not yet persisted', async () => {
+    const history = [assistant('h1'), assistant('h2')];
+    const live = [assistant('l3'), assistant('l4'), assistant('l5'), assistant('l6')];
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      live,
+    );
+
+    const reconciled = await store.getOrCreateMessages('chat-1', async () => history);
+
+    expect(store.getCursor('chat-1')?.generationId).not.toBe(appended.generationId);
+    expect(reconciled.map((message) => message.content)).toEqual(['h1', 'h2', 'l5', 'l6']);
+    const retained = store.readPage('chat-1', 10);
+    expect(retained.messages.map((entry) => entry.seq)).toEqual([3, 4]);
+    expect(contents(retained)).toEqual(['l5', 'l6']);
+  });
+
+  it('reconciles an unpersisted evicted live gap before paging across it', async () => {
+    const historyRef = { current: [assistant('h1'), assistant('h2')] };
+    const live = [assistant('l3'), assistant('l4'), assistant('l5'), assistant('l6')];
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => historyRef.current,
+      live,
+    );
+
+    const acrossGap = await store.getOrCreatePage(
+      'chat-1',
+      pagedLoader(historyRef),
+      2,
+      5,
+    );
+
+    expect(acrossGap.generationId).not.toBe(appended.generationId);
+    expect(acrossGap.messages.map((entry) => entry.seq)).toEqual([3, 4]);
+    expect(contents(acrossGap)).toEqual(['l5', 'l6']);
+    expect(acrossGap.hasMore).toBe(true);
+
+    const olderNative = await store.getOrCreatePage(
+      'chat-1',
+      pagedLoader(historyRef),
+      2,
+      3,
+    );
+    expect(olderNative.generationId).toBe(acrossGap.generationId);
+    expect(contents(olderNative)).toEqual(['h1', 'h2']);
+    expect(olderNative.hasMore).toBe(false);
+  });
+
+  it('preserves generation when native history closes the evicted live gap', async () => {
+    const historyRef = { current: [assistant('h1'), assistant('h2')] };
+    const live = [assistant('l3'), assistant('l4'), assistant('l5'), assistant('l6')];
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => historyRef.current,
+      live,
+    );
+    historyRef.current = [...historyRef.current, live[0], live[1]];
+
+    const acrossGap = await store.getOrCreatePage(
+      'chat-1',
+      pagedLoader(historyRef),
+      2,
+      5,
+    );
+
+    expect(acrossGap.generationId).toBe(appended.generationId);
+    expect(acrossGap.messages.map((entry) => entry.seq)).toEqual([3, 4]);
+    expect(contents(acrossGap)).toEqual(['l3', 'l4']);
+    expect(acrossGap.hasMore).toBe(true);
+  });
+
+  it('changes generation when persisted live timestamps differ', async () => {
+    const history = [assistant('h1'), assistant('h2')];
+    const live = new AssistantMessage('2026-06-01T00:00:03.000Z', 'l3');
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [live],
+    );
+
+    await store.getOrCreateMessages('chat-1', async () => [
+      ...history,
+      new AssistantMessage('2026-06-01T00:00:04.000Z', 'l3'),
+    ]);
+
+    expect(store.getCursor('chat-1')?.generationId).not.toBe(appended.generationId);
+  });
+
+  it('changes generation when persisted live metadata differs', async () => {
+    const history = [assistant('h1'), assistant('h2')];
+    const live = new UserMessage(TS, 'l3', undefined, { turnId: 'live-turn' });
+    const store = new ChatViewStore(() => false, { messageLimit: 2 });
+    const appended = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [live],
+    );
+
+    await store.getOrCreateMessages('chat-1', async () => [
+      ...history,
+      new UserMessage(TS, 'l3', undefined, { turnId: 'native-turn' }),
+    ]);
+
+    expect(store.getCursor('chat-1')?.generationId).not.toBe(appended.generationId);
+  });
+
+  it('upgrades a partial view only when a full-history consumer requires it', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = [user('one'), assistant('two'), assistant('three')];
+    const loadAll = mock(async () => history);
+    const loadPage = mock(async (limit, offset) => ({
+      messages: history.slice(2),
+      total: history.length,
+      hasMore: true,
+      offset,
+      limit,
+    }));
+
+    const page = await store.getOrCreatePage('chat-1', { loadAll, loadPage }, 1);
+    expect(contents(page)).toEqual(['three']);
+    expect(store.getLoadedMessages('chat-1')).toBeNull();
+
+    const loaded = await store.getOrCreateMessages('chat-1', loadAll);
+    expect(loaded.map((message) => message.content)).toEqual(['one', 'two', 'three']);
+    expect(store.getLoadedMessages('chat-1')).toHaveLength(3);
+    expect(loadAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires a snapshot when a replay cursor predates the retained tail', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = [user('one'), assistant('two'), assistant('three')];
+    const page = await store.getOrCreatePage('chat-1', {
+      loadAll: async () => history,
+      loadPage: async (limit, offset) => ({
+        messages: history.slice(2), total: 3, hasMore: true, offset, limit,
+      }),
+    }, 1);
+
+    expect(store.readReplay('chat-1', page.generationId, 0)).toMatchObject({
+      mode: 'snapshot-required',
+      lastSeq: 3,
+    });
+  });
+
+  it('prunes stale views below the entry cap and enforces the message budget', async () => {
+    let now = 0;
+    const store = new ChatViewStore(() => false, {
+      cacheLimit: 100,
+      messageLimit: 2,
+      staleNonActiveMs: 10,
+      now: () => now,
+    });
+    const loads = new Map();
+    const loaderFor = (chatId) => fullLoader(async () => {
+      loads.set(chatId, (loads.get(chatId) ?? 0) + 1);
+      return [assistant(chatId)];
+    });
+
+    await store.getOrCreatePage('chat-1', loaderFor('chat-1'), 1);
+    now = 11;
+    await store.getOrCreatePage('chat-2', loaderFor('chat-2'), 1);
+    await store.getOrCreatePage('chat-1', loaderFor('chat-1'), 1);
+    expect(loads.get('chat-1')).toBe(2);
+
+    await store.getOrCreatePage('chat-3', loaderFor('chat-3'), 1);
+    await store.getOrCreatePage('chat-2', loaderFor('chat-2'), 1);
+    expect(loads.get('chat-2')).toBe(2);
   });
 });

--- a/server/chats/__tests__/pending-user-input-service.test.js
+++ b/server/chats/__tests__/pending-user-input-service.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { PendingUserInputService } from '../pending-user-input-service.js';
+import { AssistantMessage, UserMessage } from '../../../common/chat-types.js';
 
 function createReader() {
   return {
@@ -62,5 +63,28 @@ describe('PendingUserInputService', () => {
       deliveryStatus: 'failed',
     });
     expect(cleared).toEqual([]);
+  });
+
+  it('reconciles from the returned full transcript when the retained cache is capped', async () => {
+    const history = Array.from({ length: 20_000 }, () => (
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history')
+    ));
+    history.unshift(new UserMessage(
+      '2026-06-01T00:00:00.000Z',
+      'persisted',
+      undefined,
+      { clientRequestId: 'req-1' },
+    ));
+    const reader = {
+      ensureLoaded: mock(async () => history),
+      getMessages: mock(() => null),
+    };
+    const service = new PendingUserInputService(reader);
+
+    await service.register('chat-1', 'persisted', { clientRequestId: 'req-1' });
+    await service.reconcile('chat-1');
+
+    expect(service.listForChat('chat-1')).toEqual([]);
+    expect(reader.ensureLoaded).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/chats/chat-message-reader.ts
+++ b/server/chats/chat-message-reader.ts
@@ -2,7 +2,7 @@ import type { ChatMessage } from '../../common/chat-types.js';
 import type { ChatViewPage } from '../../common/chat-view.js';
 
 export interface ChatMessageReader {
-  ensureLoaded(chatId: string): Promise<unknown>;
+  ensureLoaded(chatId: string): Promise<ChatMessage[]>;
   getMessages(chatId: string): ChatMessage[] | null;
 }
 

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -3,14 +3,35 @@ import { ErrorMessage, type ChatMessage } from '../../common/chat-types.js';
 import type { ChatReplayResult, ChatViewMessage, ChatViewPage } from '../../common/chat-view.js';
 import { KeyedPromiseLock } from '../lib/keyed-lock.js';
 import { createLogger } from '../lib/log.js';
+import {
+  OrderedTranscriptDigest,
+  orderedTranscriptDigest,
+  transcriptRevision,
+  transcriptRevisions,
+} from '../lib/transcript-revision.js';
 
 const logger = createLogger('chat-view');
 
 export interface ChatViewStoreOptions {
   replayLimit?: number;
   cacheLimit?: number;
+  messageLimit?: number;
   staleNonActiveMs?: number;
   now?: () => number;
+}
+
+export interface ChatHistoryPage {
+  messages: ChatMessage[];
+  total: number;
+  hasMore: boolean;
+  offset: number;
+  limit: number;
+  revision?: string;
+}
+
+export interface ChatViewLoader {
+  loadAll(): Promise<ChatMessage[]>;
+  loadPage?(limit: number, offset: number): Promise<ChatHistoryPage | null>;
 }
 
 export interface AppendedChatViewMessages {
@@ -20,6 +41,10 @@ export interface AppendedChatViewMessages {
   skipped?: boolean;
 }
 
+type MissingHistoryRequest =
+  | { kind: 'page'; limit: number; offset: number }
+  | { kind: 'full' };
+
 interface ChatView {
   chatId: string;
   generationId: string;
@@ -27,20 +52,31 @@ interface ChatView {
   historyReadAt: string;
   messages: ChatViewMessage[];
   lastSeq: number;
+  historyLastSeq: number;
+  complete: boolean;
+  loadedFromFullHistory: boolean;
+  retainedStartSeq: number;
+  nativeRevision?: string;
+  evictedLiveStartSeq?: number;
+  evictedLiveEndSeq?: number;
+  evictedLiveDigest: OrderedTranscriptDigest;
   streamFence: number;
   lastAccessAt: number;
 }
 
 const REPLAY_LIMIT = 2048;
 const CACHE_LIMIT = 100;
+const MESSAGE_LIMIT = 20_000;
 const STALE_NON_ACTIVE_MS = 10 * 60 * 1000;
 
 export class ChatViewStore {
   #views = new Map<string, ChatView>();
   #locks = new KeyedPromiseLock();
   #fences = new Map<string, number>();
+  #inFlightChats = new Set<string>();
   #replayLimit: number;
   #cacheLimit: number;
+  #messageLimit: number;
   #staleNonActiveMs: number;
   #now: () => number;
   #isChatActive: (chatId: string) => boolean;
@@ -52,6 +88,7 @@ export class ChatViewStore {
     this.#isChatActive = isChatActive;
     this.#replayLimit = options.replayLimit ?? REPLAY_LIMIT;
     this.#cacheLimit = options.cacheLimit ?? CACHE_LIMIT;
+    this.#messageLimit = Math.max(1, Math.floor(options.messageLimit ?? MESSAGE_LIMIT));
     this.#staleNonActiveMs = options.staleNonActiveMs ?? STALE_NON_ACTIVE_MS;
     this.#now = options.now ?? (() => Date.now());
   }
@@ -77,7 +114,7 @@ export class ChatViewStore {
 
   getLoadedMessages(chatId: string): ChatMessage[] | null {
     const view = this.#views.get(chatId);
-    if (!view) return null;
+    if (!view?.complete) return null;
     view.lastAccessAt = this.#now();
     return view.messages.map((entry) => entry.message);
   }
@@ -87,19 +124,81 @@ export class ChatViewStore {
     loadNativeMessages: () => Promise<ChatMessage[]>,
   ): Promise<ChatMessage[]> {
     return this.#withChat(chatId, async () => {
-      const view = await this.#getOrCreateView(chatId, loadNativeMessages);
-      return view.messages.map((entry) => entry.message);
+      const loaded = await this.#loadFullView(chatId, loadNativeMessages);
+      return loaded.messages;
     });
   }
 
   async getOrCreatePage(
     chatId: string,
-    loadNativeMessages: () => Promise<ChatMessage[]>,
+    loader: ChatViewLoader,
     limit: number,
     beforeSeq?: number,
   ): Promise<ChatViewPage> {
     return this.#withChat(chatId, async () => {
-      const view = await this.#getOrCreateView(chatId, loadNativeMessages);
+      let view = this.#views.get(chatId);
+      if (!view) {
+        const initialPage = await loader.loadPage?.(limit, 0);
+        if (initialPage) {
+          view = this.#createGenerationFromPage(chatId, initialPage);
+          this.#views.set(chatId, view);
+          if (initialPage.messages.length > view.messages.length) {
+            return this.#pageFromHistoryPage(view, initialPage);
+          }
+        } else {
+          const fullMessages = await loader.loadAll();
+          const reconciled = this.#reconcileFullView(chatId, fullMessages);
+          view = reconciled.view;
+          if (fullMessages.length > view.messages.length) {
+            return this.#pageFromFullMessages(view, fullMessages, limit, beforeSeq);
+          }
+        }
+      }
+
+      const missingHistory = this.#missingHistoryRequest(view, limit, beforeSeq);
+      if (missingHistory) {
+        view.lastAccessAt = this.#now();
+        if (missingHistory.kind === 'full') {
+          const fullMessages = await loader.loadAll();
+          const reconciled = this.#reconcileFullView(chatId, fullMessages);
+          return this.#pageFromFullMessages(
+            reconciled.view,
+            reconciled.messages,
+            limit,
+            beforeSeq,
+          );
+        }
+        const olderPage = await loader.loadPage?.(
+          missingHistory.limit,
+          missingHistory.offset,
+        );
+        if (
+          olderPage
+          && olderPage.total === view.historyLastSeq
+          && revisionsMatch(view.nativeRevision, olderPage.revision)
+        ) {
+          const pageEndSeq = olderPage.total - olderPage.offset;
+          const oldestRetainedSeq = view.messages[0]?.seq ?? view.historyLastSeq + 1;
+          if (pageEndSeq < oldestRetainedSeq - 1) {
+            return this.#pageFromHistoryPage(view, olderPage);
+          }
+          if (view.messages.length + olderPage.messages.length > this.#messageLimit) {
+            return this.#pageFromHistoryAndRetained(view, olderPage, limit, beforeSeq);
+          }
+          this.#mergeHistoryPage(view, olderPage);
+        } else {
+          const fullMessages = await loader.loadAll();
+          const reconciled = this.#reconcileFullView(chatId, fullMessages);
+          return this.#pageFromFullMessages(
+            reconciled.view,
+            reconciled.messages,
+            limit,
+            beforeSeq,
+          );
+        }
+      }
+
+      view.lastAccessAt = this.#now();
       return this.#readPageFromView(view, limit, beforeSeq);
     });
   }
@@ -116,7 +215,6 @@ export class ChatViewStore {
         this.#appendToView(view, [new ErrorMessage(new Date().toISOString(), options.processErrorNotice)]);
       }
       this.#views.set(chatId, view);
-      this.#pruneIfNeeded();
       return this.#readPageFromView(view, Number.MAX_SAFE_INTEGER);
     });
   }
@@ -128,12 +226,11 @@ export class ChatViewStore {
     options: { fence?: number } = {},
   ): Promise<AppendedChatViewMessages> {
     return this.#withChat(chatId, async () => {
-      const view = await this.#getOrCreateView(chatId, loadNativeMessages);
+      const view = await this.#getOrCreateAppendView(chatId, loadNativeMessages);
       if (options.fence !== undefined && options.fence !== view.streamFence) {
         return { generationId: view.generationId, messages: [], lastSeq: view.lastSeq, skipped: true };
       }
       const appended = this.#appendToView(view, messages);
-      this.#pruneIfNeeded();
       return { generationId: view.generationId, messages: appended, lastSeq: view.lastSeq };
     });
   }
@@ -149,7 +246,6 @@ export class ChatViewStore {
         this.#views.set(chatId, view);
       }
       const appended = this.#appendToView(view, messages);
-      this.#pruneIfNeeded();
       return { generationId: view.generationId, messages: appended, lastSeq: view.lastSeq };
     });
   }
@@ -167,6 +263,7 @@ export class ChatViewStore {
     if (
       view.generationId !== generationId ||
       afterSeq > view.lastSeq ||
+      afterSeq < view.retainedStartSeq - 1 ||
       view.lastSeq - afterSeq > this.#replayLimit
     ) {
       return {
@@ -202,34 +299,186 @@ export class ChatViewStore {
     const now = this.#now();
     const views = [...this.#views.values()].sort((a, b) => a.lastAccessAt - b.lastAccessAt);
     for (const view of views) {
-      if (this.#isChatActive(view.chatId)) continue;
+      if (this.#isChatActive(view.chatId) || this.#inFlightChats.has(view.chatId)) continue;
       const isStale = now - view.lastAccessAt > this.#staleNonActiveMs;
-      const isOverLimit = this.#views.size > this.#cacheLimit;
-      if (isStale || isOverLimit) this.#views.delete(view.chatId);
+      if (isStale) this.#views.delete(view.chatId);
+    }
+
+    let cachedMessages = this.#cachedMessageCount();
+    for (const view of views) {
+      if (
+        this.#views.size <= this.#cacheLimit
+        && cachedMessages <= this.#messageLimit
+      ) {
+        break;
+      }
+      if (
+        !this.#views.has(view.chatId)
+        || this.#isChatActive(view.chatId)
+        || this.#inFlightChats.has(view.chatId)
+      ) continue;
+      this.#views.delete(view.chatId);
+      cachedMessages -= view.messages.length;
+    }
+
+    // Active views keep their generation but not an exemption from the global
+    // message budget. In-flight views remain pinned until their request finishes;
+    // the operation's final prune, or the periodic prune, trims them afterward.
+    for (const view of views) {
+      if (cachedMessages <= this.#messageLimit) break;
+      if (!this.#views.has(view.chatId) || this.#inFlightChats.has(view.chatId)) continue;
+      const trimCount = Math.min(
+        cachedMessages - this.#messageLimit,
+        view.messages.length,
+      );
+      this.#trimOldestMessages(view, trimCount);
+      cachedMessages -= trimCount;
     }
   }
 
   async #withChat<T>(chatId: string, fn: () => Promise<T>): Promise<T> {
-    return this.#locks.runExclusive(`chat:${chatId}`, fn);
+    return this.#locks.runExclusive(`chat:${chatId}`, async () => {
+      this.#inFlightChats.add(chatId);
+      const view = this.#views.get(chatId);
+      if (view) view.lastAccessAt = this.#now();
+      try {
+        return await fn();
+      } finally {
+        this.#inFlightChats.delete(chatId);
+        this.prune();
+      }
+    });
   }
 
-  async #getOrCreateView(
+  async #getOrCreateAppendView(
     chatId: string,
     loadNativeMessages: () => Promise<ChatMessage[]>,
   ): Promise<ChatView> {
-    let view = this.#views.get(chatId);
-    if (view) {
+    const view = this.#views.get(chatId);
+    if (view?.loadedFromFullHistory) {
       view.lastAccessAt = this.#now();
       return view;
     }
+    return (await this.#loadFullView(chatId, loadNativeMessages)).view;
+  }
+
+  async #loadFullView(
+    chatId: string,
+    loadNativeMessages: () => Promise<ChatMessage[]>,
+  ): Promise<{ view: ChatView; messages: ChatMessage[] }> {
+    let view = this.#views.get(chatId);
+    if (view?.complete) {
+      view.lastAccessAt = this.#now();
+      return { view, messages: view.messages.map((entry) => entry.message) };
+    }
     const nativeMessages = await loadNativeMessages();
-    view = this.#createGeneration(chatId, nativeMessages);
+    return this.#reconcileFullView(chatId, nativeMessages);
+  }
+
+  #reconcileFullView(
+    chatId: string,
+    nativeMessages: ChatMessage[],
+  ): { view: ChatView; messages: ChatMessage[] } {
+    const previous = this.#views.get(chatId);
+    const revisions = transcriptRevisions(
+      nativeMessages,
+      previous?.historyLastSeq ?? nativeMessages.length,
+    );
+    const retainedLiveEntries = previous?.messages.filter(
+      (entry) => entry.seq > previous.historyLastSeq,
+    ) ?? [];
+    const priorNativePrefixMatches = previous
+      && previous.nativeRevision !== undefined
+      && nativeMessages.length >= previous.historyLastSeq
+      && revisions.prefix === previous.nativeRevision;
+    const retainedLiveStartSeq = previous
+      ? Math.max(previous.historyLastSeq + 1, previous.retainedStartSeq)
+      : 1;
+    const retainedLiveIsContiguous = previous
+      ? retainedLiveEntries.every(
+        (entry, index) => entry.seq === retainedLiveStartSeq + index,
+      )
+      : false;
+    const nativeGrowthClosesTrimmedGap = previous
+      ? nativeMessages.length >= Math.min(retainedLiveStartSeq - 1, previous.lastSeq)
+      : false;
+    const evictedLiveRangeClosed = previous?.evictedLiveEndSeq === undefined
+      || nativeMessages.length >= previous.evictedLiveEndSeq;
+    const evictedLiveMatches = previous?.evictedLiveStartSeq === undefined
+      || previous.evictedLiveEndSeq === undefined
+      || evictedLiveRangeClosed && orderedTranscriptDigest(
+        nativeMessages
+          .slice(previous.evictedLiveStartSeq - 1, previous.evictedLiveEndSeq)
+          .map((message, index) => ({
+            seq: previous.evictedLiveStartSeq! + index,
+            message,
+          })),
+      ) === previous.evictedLiveDigest.finish();
+    const retainedNativeOverlapMatches = previous
+      ? retainedLiveEntries
+        .filter((entry) => entry.seq <= nativeMessages.length)
+        .every((entry) => wireMessagesEqual(entry.message, nativeMessages[entry.seq - 1]))
+      : false;
+    const preservesGeneration = Boolean(
+      previous
+      && priorNativePrefixMatches
+      && retainedLiveIsContiguous
+      && nativeGrowthClosesTrimmedGap
+      && evictedLiveRangeClosed
+      && evictedLiveMatches
+      && retainedNativeOverlapMatches,
+    );
+
+    const view = this.#createGeneration(
+      chatId,
+      nativeMessages,
+      preservesGeneration ? previous?.generationId : undefined,
+      revisions.full,
+    );
+    const unpersistedLiveMessages = previous
+      ? retainedLiveEntries
+        .filter((entry) => entry.seq > nativeMessages.length)
+        .map((entry) => entry.message)
+      : [];
+    let fullMessages = nativeMessages;
+    if (unpersistedLiveMessages.length > 0) {
+      this.#appendToView(view, unpersistedLiveMessages);
+      fullMessages = [...nativeMessages, ...unpersistedLiveMessages];
+    }
     this.#views.set(chatId, view);
-    this.#pruneIfNeeded();
+    return { view, messages: fullMessages };
+  }
+
+  #createGeneration(
+    chatId: string,
+    messages: ChatMessage[],
+    generationId = crypto.randomUUID(),
+    nativeRevision = transcriptRevision(messages),
+  ): ChatView {
+    const now = this.#now();
+    const isoNow = new Date(now).toISOString();
+    const view: ChatView = {
+      chatId,
+      generationId,
+      createdAt: isoNow,
+      historyReadAt: isoNow,
+      messages: [],
+      lastSeq: 0,
+      historyLastSeq: messages.length,
+      complete: true,
+      loadedFromFullHistory: true,
+      retainedStartSeq: 1,
+      nativeRevision,
+      evictedLiveDigest: new OrderedTranscriptDigest(),
+      streamFence: this.captureFence(chatId),
+      lastAccessAt: now,
+    };
+    this.#appendToView(view, messages);
+    logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${messages.length} lastSeq=${view.lastSeq}`);
     return view;
   }
 
-  #createGeneration(chatId: string, messages: ChatMessage[]): ChatView {
+  #createGenerationFromPage(chatId: string, page: ChatHistoryPage): ChatView {
     const now = this.#now();
     const isoNow = new Date(now).toISOString();
     const view: ChatView = {
@@ -238,12 +487,18 @@ export class ChatViewStore {
       createdAt: isoNow,
       historyReadAt: isoNow,
       messages: [],
-      lastSeq: 0,
+      lastSeq: page.total,
+      historyLastSeq: page.total,
+      complete: !page.hasMore && page.offset === 0,
+      loadedFromFullHistory: !page.hasMore && page.offset === 0,
+      retainedStartSeq: page.total + 1,
+      nativeRevision: page.revision,
+      evictedLiveDigest: new OrderedTranscriptDigest(),
       streamFence: this.captureFence(chatId),
       lastAccessAt: now,
     };
-    this.#appendToView(view, messages);
-    logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${messages.length} lastSeq=${view.lastSeq}`);
+    this.#mergeHistoryPage(view, page);
+    logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${page.messages.length} lastSeq=${view.lastSeq}`);
     return view;
   }
 
@@ -257,29 +512,196 @@ export class ChatViewStore {
       };
     });
     view.messages.push(...appended);
+    this.#enforceViewMessageLimit(view);
     view.lastAccessAt = this.#now();
     return appended;
   }
 
+  #mergeHistoryPage(view: ChatView, page: ChatHistoryPage): void {
+    const pageMessages = this.#messagesFromHistoryPage(page);
+    if (pageMessages.length === 0) return;
+
+    const oldestRetainedSeq = view.messages[0]?.seq;
+    const newestRetainedSeq = view.messages.at(-1)?.seq;
+    if (oldestRetainedSeq === undefined) {
+      view.messages = pageMessages;
+    } else if (pageMessages.at(-1)?.seq === oldestRetainedSeq - 1) {
+      view.messages = [...pageMessages, ...view.messages];
+    } else if (pageMessages[0]?.seq === (newestRetainedSeq ?? 0) + 1) {
+      view.messages.push(...pageMessages);
+    } else {
+      const bySeq = new Map(view.messages.map((entry) => [entry.seq, entry]));
+      for (const entry of pageMessages) bySeq.set(entry.seq, entry);
+      view.messages = [...bySeq.values()].sort((left, right) => left.seq - right.seq);
+    }
+
+    view.historyLastSeq = page.total;
+    view.lastSeq = Math.max(view.lastSeq, page.total);
+    this.#enforceViewMessageLimit(view);
+    view.lastAccessAt = this.#now();
+  }
+
+  #messagesFromHistoryPage(page: ChatHistoryPage): ChatViewMessage[] {
+    if (
+      !Number.isSafeInteger(page.total)
+      || page.total < 0
+      || !Number.isSafeInteger(page.offset)
+      || page.offset < 0
+      || page.messages.length > page.total
+    ) {
+      throw new Error('Invalid paged transcript metadata');
+    }
+
+    const endSeq = page.total - page.offset;
+    const startSeq = endSeq - page.messages.length + 1;
+    if (page.messages.length > 0 && (startSeq < 1 || endSeq > page.total)) {
+      throw new Error('Invalid paged transcript range');
+    }
+    return page.messages.map((message, index) => {
+      assertValidChatMessage(message);
+      return { seq: startSeq + index, message };
+    });
+  }
+
+  #pageFromHistoryPage(view: ChatView, page: ChatHistoryPage): ChatViewPage {
+    const messages = this.#messagesFromHistoryPage(page);
+    return {
+      generationId: view.generationId,
+      messages,
+      lastSeq: view.lastSeq,
+      pageOldestSeq: messages[0]?.seq ?? 0,
+      hasMore: page.hasMore,
+    };
+  }
+
+  #pageFromHistoryAndRetained(
+    view: ChatView,
+    page: ChatHistoryPage,
+    limit: number,
+    beforeSeq?: number,
+  ): ChatViewPage {
+    const pageMessages = this.#messagesFromHistoryPage(page);
+    const combined = pageMessages.at(-1)?.seq === (view.messages[0]?.seq ?? 1) - 1
+      ? [...pageMessages, ...view.messages]
+      : pageMessages;
+    return this.#readPageFromMessages(view, combined, limit, beforeSeq);
+  }
+
+  #pageFromFullMessages(
+    view: ChatView,
+    messages: ChatMessage[],
+    limit: number,
+    beforeSeq?: number,
+  ): ChatViewPage {
+    return this.#readPageFromMessages(
+      view,
+      messages.map((message, index) => ({ seq: index + 1, message })),
+      limit,
+      beforeSeq,
+    );
+  }
+
+  #hasCompleteHistory(view: ChatView): boolean {
+    if (!view.loadedFromFullHistory || view.messages.length !== view.lastSeq) return false;
+    for (let index = 0; index < view.lastSeq; index += 1) {
+      if (view.messages[index]?.seq !== index + 1) return false;
+    }
+    return true;
+  }
+
+  #enforceViewMessageLimit(view: ChatView): void {
+    const excess = view.messages.length - this.#messageLimit;
+    if (excess > 0) this.#trimOldestMessages(view, excess);
+    else this.#refreshRetainedState(view);
+  }
+
+  #trimOldestMessages(view: ChatView, count: number): void {
+    if (count > 0) {
+      const removed = view.messages.splice(0, count);
+      for (const entry of removed) {
+        if (entry.seq <= view.historyLastSeq) continue;
+        view.evictedLiveStartSeq ??= entry.seq;
+        view.evictedLiveEndSeq = entry.seq;
+        view.evictedLiveDigest.add(entry.message, entry.seq);
+      }
+    }
+    this.#refreshRetainedState(view);
+  }
+
+  #refreshRetainedState(view: ChatView): void {
+    view.retainedStartSeq = view.messages[0]?.seq ?? view.lastSeq + 1;
+    view.complete = this.#hasCompleteHistory(view);
+  }
+
+  #missingHistoryRequest(
+    view: ChatView,
+    limit: number,
+    beforeSeq?: number,
+  ): MissingHistoryRequest | null {
+    if (view.complete) return null;
+    const boundedLimit = Math.max(0, Math.floor(limit));
+    if (boundedLimit === 0) return null;
+
+    const requestedEndSeq = beforeSeq && beforeSeq > 0
+      ? Math.min(beforeSeq - 1, view.lastSeq)
+      : view.lastSeq;
+    const requestedStartSeq = Math.max(1, requestedEndSeq - boundedLimit + 1);
+    if (
+      view.evictedLiveStartSeq !== undefined
+      && view.evictedLiveEndSeq !== undefined
+      && requestedStartSeq <= view.evictedLiveEndSeq
+      && requestedEndSeq >= view.evictedLiveStartSeq
+    ) {
+      return { kind: 'full' };
+    }
+    const oldestRetainedSeq = view.retainedStartSeq;
+    if (requestedStartSeq >= oldestRetainedSeq || requestedStartSeq > view.historyLastSeq) {
+      return null;
+    }
+
+    const missingEndSeq = Math.min(
+      requestedEndSeq,
+      oldestRetainedSeq - 1,
+      view.historyLastSeq,
+    );
+    if (missingEndSeq < requestedStartSeq) return null;
+    return {
+      kind: 'page',
+      limit: missingEndSeq - requestedStartSeq + 1,
+      offset: view.historyLastSeq - missingEndSeq,
+    };
+  }
+
   #readPageFromView(view: ChatView, limit: number, beforeSeq?: number): ChatViewPage {
     view.lastAccessAt = this.#now();
+    return this.#readPageFromMessages(view, view.messages, limit, beforeSeq);
+  }
+
+  #readPageFromMessages(
+    view: ChatView,
+    messages: ChatViewMessage[],
+    limit: number,
+    beforeSeq?: number,
+  ): ChatViewPage {
     const boundedLimit = Math.max(0, Math.floor(limit));
     const end = beforeSeq && beforeSeq > 0
-      ? lowerBoundBySeq(view.messages, beforeSeq)
-      : view.messages.length;
+      ? lowerBoundBySeq(messages, beforeSeq)
+      : messages.length;
     const start = Math.max(0, end - boundedLimit);
-    const page = view.messages.slice(start, end);
+    const page = messages.slice(start, end);
     return {
       generationId: view.generationId,
       messages: page,
       lastSeq: view.lastSeq,
       pageOldestSeq: page[0]?.seq ?? 0,
-      hasMore: start > 0,
+      hasMore: (page[0]?.seq ?? 1) > 1,
     };
   }
 
-  #pruneIfNeeded(): void {
-    if (this.#views.size > this.#cacheLimit) this.prune();
+  #cachedMessageCount(): number {
+    let count = 0;
+    for (const view of this.#views.values()) count += view.messages.length;
+    return count;
   }
 }
 
@@ -298,4 +720,12 @@ function assertValidChatMessage(message: ChatMessage): void {
   if (!message || typeof message !== 'object' || typeof message.type !== 'string') {
     throw new Error('Invalid chat message');
   }
+}
+
+function wireMessagesEqual(left: ChatMessage, right: ChatMessage | undefined): boolean {
+  return right !== undefined && JSON.stringify(left) === JSON.stringify(right);
+}
+
+function revisionsMatch(previous: string | undefined, current: string | undefined): boolean {
+  return previous === current;
 }

--- a/server/chats/pending-user-input-service.ts
+++ b/server/chats/pending-user-input-service.ts
@@ -85,8 +85,7 @@ export class PendingUserInputService implements PendingUserInputServiceContract 
     const reconcilePromise = (async () => {
       let messages = this.#messages.getMessages(chatId);
       try {
-        await this.#messages.ensureLoaded(chatId);
-        messages = this.#messages.getMessages(chatId);
+        messages = await this.#messages.ensureLoaded(chatId);
       } catch {
         // Falls back to the currently loaded transcript when native reload fails.
       }

--- a/server/lib/transcript-revision.ts
+++ b/server/lib/transcript-revision.ts
@@ -1,0 +1,155 @@
+import type { ChatMessage, CompactionMessage } from '../../common/chat-types.js';
+import {
+  getNativeMessageRevisionSource,
+  type NativeMessageSource,
+} from '../agents/shared/native-message-source.js';
+
+const COMPACTION_REVISION_SOURCE = Symbol('garcon.compactionRevisionSource');
+
+interface AddOptions {
+  deferCompactionMetadata?: boolean;
+}
+
+export class TranscriptRevisionAccumulator {
+  #messageCount = 0;
+  #fragmentCount = 0;
+  #sumA = 0;
+  #sumB = 0;
+
+  add(message: ChatMessage, options: AddOptions = {}): void {
+    const source = getNativeMessageRevisionSource(message) ?? { order: this.#messageCount };
+    const wireValue = message.type === 'compaction'
+      ? compactionWithoutMetadata(message)
+      : message;
+    this.#addValue('message', wireValue, source);
+    this.#messageCount += 1;
+    if (message.type === 'compaction' && !options.deferCompactionMetadata) {
+      this.addCompactionMetadata(
+        message,
+        getCompactionRevisionSource(message) ?? source,
+      );
+    }
+  }
+
+  addCompactionMetadata(
+    value: Pick<CompactionMessage, 'trigger' | 'preTokens' | 'postTokens'>,
+    position: unknown,
+  ): void {
+    this.#addValue('compaction-metadata', {
+      trigger: value.trigger,
+      preTokens: value.preTokens,
+      postTokens: value.postTokens,
+    }, position);
+    this.#fragmentCount += 1;
+  }
+
+  merge(other: TranscriptRevisionAccumulator): void {
+    this.#sumA = (this.#sumA + other.#sumA) >>> 0;
+    this.#sumB = (this.#sumB + other.#sumB) >>> 0;
+    this.#messageCount += other.#messageCount;
+    this.#fragmentCount += other.#fragmentCount;
+  }
+
+  finish(): string {
+    const digest = this.#sumA.toString(16).padStart(8, '0')
+      + this.#sumB.toString(16).padStart(8, '0');
+    return `v3:${this.#messageCount}:${this.#fragmentCount}:${digest}`;
+  }
+
+  #addValue(kind: string, value: unknown, source?: unknown): void {
+    const [hashA, hashB] = hashRevisionValue(kind, value, source);
+    this.#sumA = (this.#sumA + hashA) >>> 0;
+    this.#sumB = (this.#sumB + hashB) >>> 0;
+  }
+}
+
+export class OrderedTranscriptDigest {
+  #count = 0;
+  #sumA = 0;
+  #sumB = 0;
+
+  add(message: ChatMessage, seq: number): void {
+    const [hashA, hashB] = hashRevisionValue('ordered-message', message, { seq });
+    this.#sumA = (this.#sumA + hashA) >>> 0;
+    this.#sumB = (this.#sumB + hashB) >>> 0;
+    this.#count += 1;
+  }
+
+  finish(): string {
+    const digest = this.#sumA.toString(16).padStart(8, '0')
+      + this.#sumB.toString(16).padStart(8, '0');
+    return `ordered-v1:${this.#count}:${digest}`;
+  }
+}
+
+export function orderedTranscriptDigest(
+  entries: Array<{ seq: number; message: ChatMessage }>,
+): string {
+  const digest = new OrderedTranscriptDigest();
+  for (const entry of entries) digest.add(entry.message, entry.seq);
+  return digest.finish();
+}
+
+export function attachCompactionRevisionSource<T extends object>(
+  target: T,
+  source: NativeMessageSource | null | undefined,
+): T {
+  if (!source) return target;
+  Object.defineProperty(target, COMPACTION_REVISION_SOURCE, {
+    value: source,
+    enumerable: false,
+    configurable: true,
+  });
+  return target;
+}
+
+function getCompactionRevisionSource(value: unknown): NativeMessageSource | null {
+  if (!value || typeof value !== 'object') return null;
+  const source = (value as Record<PropertyKey, unknown>)[COMPACTION_REVISION_SOURCE];
+  if (!source || typeof source !== 'object') return null;
+  return source as NativeMessageSource;
+}
+
+function hashRevisionValue(
+  kind: string,
+  value: unknown,
+  source?: unknown,
+): [number, number] {
+    const serialized = JSON.stringify(value) ?? 'undefined';
+    let hashA = Bun.hash.xxHash32(serialized, 0x9e3779b9);
+    let hashB = Bun.hash.murmur32v3(serialized, 0x85ebca6b);
+    hashA = mixHash(hashA, Bun.hash.xxHash32(kind, 0xc2b2ae35));
+    hashB = mixHash(hashB, Bun.hash.murmur32v3(kind, 0x27d4eb2d));
+    if (source !== undefined) {
+      const serializedSource = JSON.stringify(source);
+      hashA = mixHash(hashA, Bun.hash.xxHash32(serializedSource, 0x165667b1));
+      hashB = mixHash(hashB, Bun.hash.murmur32v3(serializedSource, 0x01000193));
+    }
+    return [hashA, hashB];
+}
+
+export function transcriptRevision(messages: ChatMessage[]): string {
+  return transcriptRevisions(messages).full;
+}
+
+export function transcriptRevisions(
+  messages: ChatMessage[],
+  prefixLength = messages.length,
+): { prefix: string; full: string } {
+  const accumulator = new TranscriptRevisionAccumulator();
+  let prefix = prefixLength === 0 ? accumulator.finish() : undefined;
+  for (let index = 0; index < messages.length; index += 1) {
+    accumulator.add(messages[index]);
+    if (index + 1 === prefixLength) prefix = accumulator.finish();
+  }
+  return { prefix: prefix ?? accumulator.finish(), full: accumulator.finish() };
+}
+
+function compactionWithoutMetadata(message: CompactionMessage): Record<string, unknown> {
+  const { trigger: _trigger, preTokens: _preTokens, postTokens: _postTokens, ...wireValue } = message;
+  return wireValue;
+}
+
+function mixHash(left: number, right: number): number {
+  return Math.imul(left ^ ((right << 13) | (right >>> 19)), 0x9e3779b1) >>> 0;
+}

--- a/server/lib/transcript-revision.ts
+++ b/server/lib/transcript-revision.ts
@@ -6,6 +6,10 @@ import {
 
 const COMPACTION_REVISION_SOURCE = Symbol('garcon.compactionRevisionSource');
 
+type CompactionRevisionSource = NativeMessageSource & {
+  pairingTimestamp?: number;
+};
+
 interface AddOptions {
   deferCompactionMetadata?: boolean;
 }
@@ -92,7 +96,7 @@ export function orderedTranscriptDigest(
 
 export function attachCompactionRevisionSource<T extends object>(
   target: T,
-  source: NativeMessageSource | null | undefined,
+  source: CompactionRevisionSource | null | undefined,
 ): T {
   if (!source) return target;
   Object.defineProperty(target, COMPACTION_REVISION_SOURCE, {
@@ -103,11 +107,11 @@ export function attachCompactionRevisionSource<T extends object>(
   return target;
 }
 
-function getCompactionRevisionSource(value: unknown): NativeMessageSource | null {
+function getCompactionRevisionSource(value: unknown): CompactionRevisionSource | null {
   if (!value || typeof value !== 'object') return null;
   const source = (value as Record<PropertyKey, unknown>)[COMPACTION_REVISION_SOURCE];
   if (!source || typeof source !== 'object') return null;
-  return source as NativeMessageSource;
+  return source as CompactionRevisionSource;
 }
 
 function hashRevisionValue(

--- a/server/server.ts
+++ b/server/server.ts
@@ -201,6 +201,8 @@ export async function startServer(): Promise<void> {
     const chatViews = new ChatViewStore((chatId) =>
       agentRegistry.isChatRunning(chatId),
     );
+    const chatViewPruneTimer = setInterval(() => chatViews.prune(), 60_000);
+    chatViewPruneTimer.unref();
     // Prepends carried-over segments, interleaved with agent-switch boundary
     // markers, and strips the seed from the new session's first user turn so a
     // switched chat shows its full history once and only once.
@@ -215,6 +217,13 @@ export async function startServer(): Promise<void> {
         model: session.model,
       });
       return [...carried, ...stripFirstUserSeed(native)];
+    };
+    const loadNativeMessagePage = async (chatId: string, limit: number, offset: number) => {
+      const session = chatRegistry.getChat(chatId);
+      // Falls back to the composite full loader because carried segments and the
+      // stripped continuation seed do not share the native transcript's offsets.
+      if (!session || carryOver.getSegments(chatId).length > 0) return null;
+      return agentRegistry.loadMessagePage(session, limit, offset, chatId);
     };
     const chatNativeReloader = new ChatNativeReloader(
       chatViews,
@@ -235,7 +244,10 @@ export async function startServer(): Promise<void> {
       async getOrCreatePage(chatId: string, limit: number, beforeSeq?: number) {
         return chatViews.getOrCreatePage(
           chatId,
-          () => loadNativeMessages(chatId),
+          {
+            loadAll: () => loadNativeMessages(chatId),
+            loadPage: (limit, offset) => loadNativeMessagePage(chatId, limit, offset),
+          },
           limit,
           beforeSeq,
         );
@@ -543,6 +555,7 @@ export async function startServer(): Promise<void> {
       let abortTimedOut = false;
       let cleanupFailed = false;
       try {
+        clearInterval(chatViewPruneTimer);
         scheduledPrompts.stop();
         const abortResult = await abortRunningSessionsWithTimeout({
           runningSessions: agentRegistry.getRunningSessions(),


### PR DESCRIPTION
## Before

- A first-page request such as `limit=1` loaded and retained each complete native transcript before slicing the response.
- Inactive views were not pruned until the 100-entry limit was crossed, and cached transcript messages had no explicit budget.
- On the profiled 54-chat Codex/Claude workload, the request batch retained an additional 151.7 MiB RSS.

```mermaid
flowchart LR
  A[Messages API limit=1] --> B[Load complete native transcript]
  B --> C[Retain complete ChatView]
  C --> D[Slice one-message response]
```

## After

```mermaid
flowchart LR
  A[Messages API page request] --> B[Bounded provider scan]
  B --> C[Requested window plus transcript revision]
  C --> D[Message-capped ChatView]
  D --> E[Page response]
```

Codex and Claude now scan native JSONL into bounded ordered windows, with deterministic transcript revisions preserving generation, sequence, compaction, replay, and live-persistence semantics. `ChatViewStore` lazily merges older pages, retains at most 20,000 messages, and prunes stale views every 60 seconds even below the entry cap.

Composite carry-over chats and anomalous timestamp/compaction streams retain the exact full-loader compatibility path. HTTP, WebSocket, and UI contracts are unchanged.

Three-run medians for 54 chats and approximately 28,700 rendered messages, requesting `limit=1` once per chat:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Retained RSS increase | 151.7 MiB | 40.9 MiB | 73.0% lower |
| Max observed post-response RSS | 277.2 MiB | 180.0 MiB | 35.1% lower |
| Workload duration | 613.4 ms | 662.8 ms | 8.1% slower |

The RSS maximum is sampled after each response rather than being a true process peak. The memory result is scoped to the profiled Codex/Claude first-page workload; deep offsets retain the skipped ordered window transiently.

## Files

- Codex and Claude history loaders provide exact bounded pages and deterministic source timestamps.
- Shared transcript revision and native-source helpers bind content, ordering, and compaction metadata.
- Chat view and pending-input services preserve generation identity across paging, trimming, and native persistence.
- Server lifecycle schedules and clears periodic transcript-cache pruning.
- Provider and store tests cover ordering, malformed timestamps, revisions, cache budgets, replay, and evicted live gaps.

## Tests

- `bun run check` — passed with 0 errors and 0 warnings.
- `bun run test` — passed, including 256 web test files and 2,158 web tests.
- Focused transcript/store suite — 72 passed, 0 failed.
- Real transcript parity — 55 chats and 108 pages; zero content, source, metadata, or revision mismatches.
- Three-page HTTP pagination — stable generation and `lastSeq`, contiguous sequence ranges.
- Production startup — built and started successfully on an isolated random port.

Closes #297.

Prompted by: yk (@chiayong)
