### PR TITLE
fix(chat): preserve transcript continuity after capped reloads

### DIFF
--- a/server/chats/__tests__/pending-user-input-service.test.js
+++ b/server/chats/__tests__/pending-user-input-service.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { PendingUserInputService } from '../pending-user-input-service.js';
+import { ChatViewStore } from '../chat-view-store.js';
 import { AssistantMessage, UserMessage } from '../../../common/chat-types.js';
+import { transcriptRevision } from '../../lib/transcript-revision.js';
 
 function createReader() {
   return {
@@ -86,5 +88,205 @@ describe('PendingUserInputService', () => {
 
     expect(service.listForChat('chat-1')).toEqual([]);
     expect(reader.ensureLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves pending identity across provider timestamp differences after capped reconciliation', async () => {
+    const history = [
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history-1'),
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history-2'),
+    ];
+    let nativeMessages = history;
+    const views = new ChatViewStore(() => false, { messageLimit: 2 });
+    const reader = {
+      ensureLoaded: (chatId) => views.getOrCreateMessages(chatId, async () => nativeMessages),
+      getMessages: (chatId) => views.getLoadedMessages(chatId),
+    };
+    const service = new PendingUserInputService(reader);
+    await service.register('chat-1', 'persisted', {
+      clientRequestId: 'req-1',
+      turnId: 'turn-1',
+    });
+    const live = await views.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [new UserMessage(
+        '2026-06-01T00:00:00.000Z',
+        'persisted',
+        undefined,
+        { clientRequestId: 'req-1', turnId: 'turn-1', deliveryStatus: 'accepted' },
+      )],
+    );
+    nativeMessages = [
+      ...history,
+      new UserMessage(
+        '2026-06-01T00:00:00.125Z',
+        'persisted',
+        undefined,
+        { clientRequestId: 'req-1', turnId: 'turn-1' },
+      ),
+    ];
+
+    await service.reconcile('chat-1');
+
+    expect(service.listForChat('chat-1')).toEqual([]);
+    expect(views.getCursor('chat-1')?.generationId).toBe(live.generationId);
+    const retained = views.readPage('chat-1', 10);
+    expect(retained.messages.map((entry) => entry.seq)).toEqual([2, 3]);
+    expect(retained.messages[1].message).toMatchObject({
+      type: 'user-message',
+      metadata: {
+        clientRequestId: 'req-1',
+        turnId: 'turn-1',
+        deliveryStatus: 'accepted',
+      },
+    });
+
+    const loadAll = mock(async () => nativeMessages);
+    const loadPage = mock(async (limit, offset) => {
+      const end = nativeMessages.length - offset;
+      const start = Math.max(0, end - limit);
+      return {
+        messages: nativeMessages.slice(start, end),
+        total: nativeMessages.length,
+        hasMore: start > 0,
+        offset,
+        limit,
+        revision: transcriptRevision(nativeMessages),
+      };
+    });
+    const older = await views.getOrCreatePage(
+      'chat-1',
+      { loadAll, loadPage },
+      1,
+      retained.pageOldestSeq,
+    );
+
+    expect(older.generationId).toBe(live.generationId);
+    expect(older.messages.map((entry) => entry.seq)).toEqual([1]);
+    expect(loadPage).toHaveBeenCalledWith(1, 2);
+    expect(loadAll).not.toHaveBeenCalled();
+  });
+
+  it('retains native upstream identity during capped reconciliation', async () => {
+    const history = [
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history-1'),
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history-2'),
+    ];
+    let nativeMessages = history;
+    const views = new ChatViewStore(() => false, { messageLimit: 2 });
+    const reader = {
+      ensureLoaded: (chatId) => views.getOrCreateMessages(chatId, async () => nativeMessages),
+      getMessages: (chatId) => views.getLoadedMessages(chatId),
+    };
+    const service = new PendingUserInputService(reader);
+    await service.register('chat-1', 'persisted', {
+      clientRequestId: 'req-1',
+      turnId: 'turn-1',
+    });
+    const live = await views.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [new UserMessage(
+        '2026-06-01T00:00:00.000Z',
+        'persisted',
+        undefined,
+        { clientRequestId: 'req-1', turnId: 'turn-1', deliveryStatus: 'accepted' },
+      )],
+    );
+    nativeMessages = [
+      ...history,
+      new UserMessage(
+        '2026-06-01T00:00:00.125Z',
+        'persisted',
+        undefined,
+        { upstreamRequestId: 'upstream-1' },
+      ),
+    ];
+
+    await service.reconcile('chat-1');
+
+    expect(service.listForChat('chat-1')).toEqual([]);
+    expect(views.getCursor('chat-1')?.generationId).toBe(live.generationId);
+    const retained = views.readPage('chat-1', 10);
+    expect(retained.messages.at(-1)?.message).toMatchObject({
+      metadata: {
+        clientRequestId: 'req-1',
+        upstreamRequestId: 'upstream-1',
+        turnId: 'turn-1',
+        deliveryStatus: 'accepted',
+      },
+    });
+
+    const loadAll = mock(async () => nativeMessages);
+    const loadPage = mock(async (limit, offset) => {
+      const end = nativeMessages.length - offset;
+      const start = Math.max(0, end - limit);
+      return {
+        messages: nativeMessages.slice(start, end),
+        total: nativeMessages.length,
+        hasMore: start > 0,
+        offset,
+        limit,
+        revision: transcriptRevision(nativeMessages),
+      };
+    });
+    const older = await views.getOrCreatePage(
+      'chat-1',
+      { loadAll, loadPage },
+      1,
+      retained.pageOldestSeq,
+    );
+
+    expect(older.generationId).toBe(live.generationId);
+    expect(older.messages.map((entry) => entry.seq)).toEqual([1]);
+    expect(loadPage).toHaveBeenCalledWith(1, 2);
+    expect(loadAll).not.toHaveBeenCalled();
+  });
+
+  it('rejects conflicting native identity during capped reconciliation', async () => {
+    const history = [
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history-1'),
+      new AssistantMessage('2026-06-01T00:00:00.000Z', 'history-2'),
+    ];
+    let nativeMessages = history;
+    const views = new ChatViewStore(() => false, { messageLimit: 2 });
+    const reader = {
+      ensureLoaded: (chatId) => views.getOrCreateMessages(chatId, async () => nativeMessages),
+      getMessages: (chatId) => views.getLoadedMessages(chatId),
+    };
+    const service = new PendingUserInputService(reader);
+    await service.register('chat-1', 'persisted', {
+      clientRequestId: 'req-live',
+      turnId: 'turn-live',
+    });
+    const live = await views.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => history,
+      [new UserMessage(
+        '2026-06-01T00:00:00.000Z',
+        'persisted',
+        undefined,
+        { clientRequestId: 'req-live', turnId: 'turn-live', deliveryStatus: 'accepted' },
+      )],
+    );
+    nativeMessages = [
+      ...history,
+      new UserMessage(
+        '2026-06-01T00:00:00.125Z',
+        'persisted',
+        undefined,
+        { clientRequestId: 'req-native', turnId: 'turn-native' },
+      ),
+    ];
+
+    await service.reconcile('chat-1');
+
+    expect(service.listForChat('chat-1')).toMatchObject([
+      { clientRequestId: 'req-live', turnId: 'turn-live' },
+    ]);
+    expect(views.getCursor('chat-1')?.generationId).not.toBe(live.generationId);
+    expect(views.readPage('chat-1', 10).messages.at(-1)?.message).toMatchObject({
+      metadata: { clientRequestId: 'req-native', turnId: 'turn-native' },
+    });
   });
 });

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { ErrorMessage, type ChatMessage } from '../../common/chat-types.js';
+import { ErrorMessage, UserMessage, type ChatMessage } from '../../common/chat-types.js';
 import type { ChatReplayResult, ChatViewMessage, ChatViewPage } from '../../common/chat-view.js';
 import { KeyedPromiseLock } from '../lib/keyed-lock.js';
 import { createLogger } from '../lib/log.js';
@@ -380,6 +380,9 @@ export class ChatViewStore {
     nativeMessages: ChatMessage[],
   ): { view: ChatView; messages: ChatMessage[] } {
     const previous = this.#views.get(chatId);
+    const reconciledNativeMessages = previous
+      ? preserveRetainedUserIdentities(previous.messages, nativeMessages)
+      : nativeMessages;
     const revisions = transcriptRevisions(
       nativeMessages,
       previous?.historyLastSeq ?? nativeMessages.length,
@@ -389,7 +392,7 @@ export class ChatViewStore {
     ) ?? [];
     const priorNativePrefixMatches = previous
       && previous.nativeRevision !== undefined
-      && nativeMessages.length >= previous.historyLastSeq
+      && reconciledNativeMessages.length >= previous.historyLastSeq
       && revisions.prefix === previous.nativeRevision;
     const retainedLiveStartSeq = previous
       ? Math.max(previous.historyLastSeq + 1, previous.retainedStartSeq)
@@ -400,14 +403,14 @@ export class ChatViewStore {
       )
       : false;
     const nativeGrowthClosesTrimmedGap = previous
-      ? nativeMessages.length >= Math.min(retainedLiveStartSeq - 1, previous.lastSeq)
+      ? reconciledNativeMessages.length >= Math.min(retainedLiveStartSeq - 1, previous.lastSeq)
       : false;
     const evictedLiveRangeClosed = previous?.evictedLiveEndSeq === undefined
-      || nativeMessages.length >= previous.evictedLiveEndSeq;
+      || reconciledNativeMessages.length >= previous.evictedLiveEndSeq;
     const evictedLiveMatches = previous?.evictedLiveStartSeq === undefined
       || previous.evictedLiveEndSeq === undefined
       || evictedLiveRangeClosed && orderedTranscriptDigest(
-        nativeMessages
+        reconciledNativeMessages
           .slice(previous.evictedLiveStartSeq - 1, previous.evictedLiveEndSeq)
           .map((message, index) => ({
             seq: previous.evictedLiveStartSeq! + index,
@@ -416,8 +419,11 @@ export class ChatViewStore {
       ) === previous.evictedLiveDigest.finish();
     const retainedNativeOverlapMatches = previous
       ? retainedLiveEntries
-        .filter((entry) => entry.seq <= nativeMessages.length)
-        .every((entry) => wireMessagesEqual(entry.message, nativeMessages[entry.seq - 1]))
+        .filter((entry) => entry.seq <= reconciledNativeMessages.length)
+        .every((entry) => retainedMessageMatchesNative(
+          entry.message,
+          reconciledNativeMessages[entry.seq - 1],
+        ))
       : false;
     const preservesGeneration = Boolean(
       previous
@@ -431,19 +437,19 @@ export class ChatViewStore {
 
     const view = this.#createGeneration(
       chatId,
-      nativeMessages,
+      reconciledNativeMessages,
       preservesGeneration ? previous?.generationId : undefined,
       revisions.full,
     );
     const unpersistedLiveMessages = previous
       ? retainedLiveEntries
-        .filter((entry) => entry.seq > nativeMessages.length)
+        .filter((entry) => entry.seq > reconciledNativeMessages.length)
         .map((entry) => entry.message)
       : [];
-    let fullMessages = nativeMessages;
+    let fullMessages = reconciledNativeMessages;
     if (unpersistedLiveMessages.length > 0) {
       this.#appendToView(view, unpersistedLiveMessages);
-      fullMessages = [...nativeMessages, ...unpersistedLiveMessages];
+      fullMessages = [...reconciledNativeMessages, ...unpersistedLiveMessages];
     }
     this.#views.set(chatId, view);
     return { view, messages: fullMessages };
@@ -724,6 +730,81 @@ function assertValidChatMessage(message: ChatMessage): void {
 
 function wireMessagesEqual(left: ChatMessage, right: ChatMessage | undefined): boolean {
   return right !== undefined && JSON.stringify(left) === JSON.stringify(right);
+}
+
+function preserveRetainedUserIdentities(
+  retainedMessages: ChatViewMessage[],
+  nativeMessages: ChatMessage[],
+): ChatMessage[] {
+  let reconciled = nativeMessages;
+  for (const entry of retainedMessages) {
+    const nativeIndex = entry.seq - 1;
+    if (nativeIndex >= nativeMessages.length) break;
+    const nativeMessage = nativeMessages[nativeIndex];
+    const withIdentity = preserveLiveUserIdentity(entry.message, nativeMessage);
+    if (withIdentity === nativeMessage) continue;
+    if (reconciled === nativeMessages) reconciled = [...nativeMessages];
+    reconciled[nativeIndex] = withIdentity;
+  }
+  return reconciled;
+}
+
+function preserveLiveUserIdentity(liveMessage: ChatMessage, nativeMessage: ChatMessage): ChatMessage {
+  if (
+    !(liveMessage instanceof UserMessage)
+    || !(nativeMessage instanceof UserMessage)
+    || !liveMessage.metadata?.clientRequestId
+    || !userEchoesAreCompatible(liveMessage, nativeMessage)
+  ) {
+    return nativeMessage;
+  }
+  return new UserMessage(
+    liveMessage.timestamp,
+    liveMessage.content,
+    liveMessage.images,
+    { ...nativeMessage.metadata, ...liveMessage.metadata },
+  );
+}
+
+function retainedMessageMatchesNative(
+  retainedMessage: ChatMessage,
+  nativeMessage: ChatMessage | undefined,
+): boolean {
+  return wireMessagesEqual(retainedMessage, nativeMessage)
+    || retainedMessage instanceof UserMessage
+      && nativeMessage instanceof UserMessage
+      && Boolean(retainedMessage.metadata?.clientRequestId)
+      && userEchoesAreCompatible(retainedMessage, nativeMessage);
+}
+
+function userEchoesAreCompatible(
+  liveMessage: UserMessage,
+  nativeMessage: UserMessage,
+): boolean {
+  return wireMessagesEqual(
+    withoutMetadata(liveMessage, nativeMessage.timestamp),
+    withoutMetadata(nativeMessage, nativeMessage.timestamp),
+  ) && metadataIsCompatible(liveMessage.metadata, nativeMessage.metadata);
+}
+
+function withoutMetadata(message: UserMessage, timestamp: string): UserMessage {
+  return new UserMessage(
+    timestamp,
+    message.content,
+    message.images,
+  );
+}
+
+function metadataIsCompatible(
+  liveMetadata: UserMessage['metadata'],
+  nativeMetadata: UserMessage['metadata'],
+): boolean {
+  const live = liveMetadata as Record<string, unknown> | undefined;
+  for (const [key, nativeValue] of Object.entries(nativeMetadata ?? {})) {
+    const liveValue = live?.[key];
+    if (liveValue !== undefined && liveValue !== nativeValue) return false;
+  }
+  return true;
 }
 
 function revisionsMatch(previous: string | undefined, current: string | undefined): boolean {

--- a/web/src/lib/chat/conversation/__tests__/reload-chat.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/reload-chat.test.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { reloadChatFromNative, type ChatReloadPort } from '$lib/chat/conversation/reload-chat.js';
 import { ActiveTranscriptState } from '$lib/chat/transcript/active-transcript-state.svelte.js';
+import { getChatMessages } from '$lib/api/chats.js';
 import { AssistantMessage } from '$shared/chat-types';
+
+vi.mock('$lib/api/chats.js', () => ({
+	getChatMessages: vi.fn(),
+}));
 
 const TS = '2024-01-01T00:00:00.000Z';
 
@@ -15,22 +20,40 @@ function wsWithResponse(response: Record<string, unknown>): ChatReloadPort {
 describe('reloadChatFromNative', () => {
 	beforeEach(() => {
 		localStorage.clear();
+		vi.mocked(getChatMessages).mockReset();
 	});
 
-	it('applies a correlated reload response to selected chat state', async () => {
+	it('keeps older capped transcript pages reachable after a correlated reload', async () => {
 		const ws = wsWithResponse({
 			type: 'chat-reloaded',
 			clientRequestId: 'req-1',
 			chatId: 'chat-1',
 			generationId: 'generation-2',
-			lastSeq: 1,
-			pageOldestSeq: 1,
-			hasMore: false,
+			lastSeq: 4,
+			pageOldestSeq: 3,
+			hasMore: true,
 			messages: [
 				{
-					seq: 1,
-					message: { type: 'assistant-message', timestamp: TS, content: 'native' },
+					seq: 3,
+					message: { type: 'assistant-message', timestamp: TS, content: 'three' },
 				},
+				{
+					seq: 4,
+					message: { type: 'assistant-message', timestamp: TS, content: 'four' },
+				},
+			],
+		});
+		vi.mocked(getChatMessages).mockResolvedValue({
+			chatId: 'chat-1',
+			generationId: 'generation-2',
+			lastSeq: 4,
+			pageOldestSeq: 1,
+			hasMore: false,
+			limit: 50,
+			pendingUserInputs: [],
+			messages: [
+				{ seq: 1, message: new AssistantMessage(TS, 'one') },
+				{ seq: 2, message: new AssistantMessage(TS, 'two') },
 			],
 		});
 		const chat = new ActiveTranscriptState();
@@ -41,10 +64,30 @@ describe('reloadChatFromNative', () => {
 			type: 'chat-reload',
 			chatId: 'chat-1',
 		});
-		expect(chat.getCursor()).toEqual({ generationId: 'generation-2', lastSeq: 1 });
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-2', lastSeq: 4 });
+		expect(chat.oldestSeq).toBe(3);
+		expect(chat.hasMoreMessages).toBe(true);
 		expect(chat.chatMessages[0]).toBeInstanceOf(AssistantMessage);
-		expect((chat.chatMessages[0] as AssistantMessage).content).toBe('native');
-		expect(chat.transcriptCache.get('chat-1')?.lastSeq).toBe(1);
+		expect(chat.chatMessages.map((message) => (message as AssistantMessage).content)).toEqual([
+			'three',
+			'four',
+		]);
+		expect(chat.transcriptCache.get('chat-1')?.lastSeq).toBe(4);
+
+		await expect(chat.loadMoreMessages('chat-1')).resolves.toBe(true);
+
+		expect(getChatMessages).toHaveBeenCalledWith({
+			chatId: 'chat-1',
+			limit: 50,
+			beforeSeq: 3,
+		});
+		expect(chat.chatMessages.map((message) => (message as AssistantMessage).content)).toEqual([
+			'one',
+			'two',
+			'three',
+			'four',
+		]);
+		expect(chat.hasMoreMessages).toBe(false);
 	});
 
 	it('rejects unexpected reload responses', async () => {

--- a/web/src/lib/chat/conversation/reload-chat.ts
+++ b/web/src/lib/chat/conversation/reload-chat.ts
@@ -21,6 +21,8 @@ export async function reloadChatFromNative(
 
 	chatState.replaceGeneration(chatId, message.generationId, message.messages, {
 		lastSeq: message.lastSeq,
+		pageOldestSeq: message.pageOldestSeq,
+		hasMore: message.hasMore,
 	});
 	chatState.transcriptCache.markValidated(chatId);
 }

--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -226,6 +226,8 @@ describe('ActiveTranscriptState', () => {
 		const chat = new ActiveTranscriptState();
 		chat.replaceGeneration('chat-1', 'current-generation', [entry(1, assistant('current'))], {
 			lastSeq: 1,
+			pageOldestSeq: 1,
+			hasMore: false,
 		});
 		const epoch = chat.beginSnapshotLoad();
 
@@ -293,7 +295,7 @@ describe('ActiveTranscriptState', () => {
 			'chat-1',
 			'generation-2',
 			[entry(1, assistant('native')), entry(2, new ErrorMessage(TS, 'The process died.'))],
-			{ lastSeq: 2 },
+			{ lastSeq: 2, pageOldestSeq: 1, hasMore: false },
 		);
 
 		expect(chat.pendingUserInputs).toEqual([]);
@@ -325,7 +327,7 @@ describe('ActiveTranscriptState', () => {
 			'chat-1',
 			'generation-1',
 			[entry(1, user('first')), entry(2, assistant('second')), entry(3, assistant('third'))],
-			{ lastSeq: 3 },
+			{ lastSeq: 3, pageOldestSeq: 1, hasMore: false },
 		);
 
 		expect(transcriptCache.get('chat-1')?.messages.map((item) => item.seq)).toEqual([2, 3]);

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -1,4 +1,4 @@
-import { applyChatViewMessages, type ChatViewMessage } from '$shared/chat-view';
+import { applyChatViewMessages, type ChatViewMessage, type ChatViewPage } from '$shared/chat-view';
 import { UserMessage, type ChatMessage } from '$shared/chat-types';
 import { normalizePendingUserInput, type PendingUserInput } from '$shared/pending-user-input';
 import { ChatTranscriptCache } from './chat-transcript-cache.svelte';
@@ -104,13 +104,27 @@ export class ActiveTranscriptState {
 		this.#displayRows.flatMap((row) => (row.kind === 'message' ? [row.message] : [])),
 	);
 
-	#displayMessageCount = $derived.by(() => this.#displayRows.length);
+	#displayMessageCount = $derived.by(
+		() => this.entries.length + this.visiblePendingInputs.length + this.localNotices.length,
+	);
 
 	#visibleRows = $derived.by(() => {
-		if (this.#displayRows.length <= this.visibleMessageCount) {
-			return this.#displayRows;
-		}
-		return this.#displayRows.slice(-this.visibleMessageCount);
+		const noticeCount = Math.min(this.localNotices.length, this.visibleMessageCount);
+		const visibleNotices = this.localNotices.slice(-noticeCount);
+		const messageLimit = this.visibleMessageCount - noticeCount;
+		if (messageLimit === 0) return visibleNotices;
+
+		const durableRows = this.entries.slice(-messageLimit).map((entry) => ({
+			kind: 'message' as const,
+			id: `${this.generationId}:${entry.seq}`,
+			seq: entry.seq,
+			message: entry.message,
+		}));
+		const pendingInputs = this.visiblePendingInputs;
+		const messageRows = pendingInputs.length === 0
+			? durableRows
+			: mergeRowsWithPendingInputs(durableRows, pendingInputs).slice(-messageLimit);
+		return [...messageRows, ...visibleNotices];
 	});
 
 	#bottomVisibleRowId = $derived.by(() => this.#visibleRows.at(-1)?.id ?? null);
@@ -234,17 +248,25 @@ export class ActiveTranscriptState {
 		chatId: string,
 		generationId: string,
 		messages: ChatViewMessage[],
-		options: { lastSeq: number; pendingUserInputs?: PendingUserInput[] } = { lastSeq: 0 },
+		options: Pick<ChatViewPage, 'lastSeq' | 'pageOldestSeq' | 'hasMore'> & {
+			pendingUserInputs?: PendingUserInput[];
+		},
 	): void {
 		this.activeChatId = chatId;
 		this.#loadEpoch += 1;
 		this.#snapshotBuffer = null;
-		this.transcriptCache.replace(chatId, generationId, messages, options.lastSeq);
+		this.transcriptCache.replaceFromPage(chatId, {
+			generationId,
+			messages,
+			lastSeq: options.lastSeq,
+			pageOldestSeq: options.pageOldestSeq,
+			hasMore: options.hasMore,
+		});
 		this.generationId = generationId;
 		this.entries = messages;
 		this.lastSeq = options.lastSeq;
-		this.oldestSeq = messages.length > 0 ? messages[0].seq : 0;
-		this.hasMoreMessages = false;
+		this.oldestSeq = options.pageOldestSeq;
+		this.hasMoreMessages = options.hasMore;
 		this.totalMessages = messages.length;
 		this.pendingUserInputs = options.pendingUserInputs
 			? sortPendingInputs(options.pendingUserInputs)


### PR DESCRIPTION
## Summary

- preserve capped reload pagination metadata so older transcript pages remain reachable
- retain pending request identity when persisted native echoes use provider timestamps or add compatible metadata
- keep page revision checks based on raw native messages while using enriched rows for presentation continuity

## Why

Follow-up review of #306 found capped reload and pending-input reconciliation paths that could make older messages unreachable or leave a pending overlay stale.

## Validation

- all server test files passed
- web: 258 files / 2,166 tests passed
- focused transcript/provider tests passed
- ESLint and Svelte check passed with 0 errors and 0 warnings
- production web build passed
- isolated production startup smoke passed