### PR TITLE
fix(codex): track terminal subagent lifecycle

### DIFF
--- a/common/chat-types.ts
+++ b/common/chat-types.ts
@@ -247,6 +247,7 @@ export const CODEX_SUBAGENT_ACTIONS = [
   'list_agents',
   'close_agent',
   'resume_agent',
+  'agent_status',
 ] as const;
 
 export type CodexSubagentAction = (typeof CODEX_SUBAGENT_ACTIONS)[number];
@@ -259,8 +260,26 @@ export interface CodexSubagentInputItem {
   name?: string;
 }
 
+export const CODEX_SUBAGENT_STATUSES = [
+  'pendingInit',
+  'running',
+  'interrupted',
+  'completed',
+  'errored',
+  'shutdown',
+  'notFound',
+] as const;
+
+export type CodexSubagentStatus = (typeof CODEX_SUBAGENT_STATUSES)[number];
+
+export interface CodexSubagentState {
+  status: CodexSubagentStatus;
+  message?: string;
+}
+
 export interface CodexSubagentDetails {
   target?: string;
+  threadId?: string;
   targets?: string[];
   message?: string;
   taskName?: string;
@@ -274,6 +293,7 @@ export interface CodexSubagentDetails {
   pathPrefix?: string;
   interrupt?: boolean;
   items?: CodexSubagentInputItem[];
+  agentStates?: Record<string, CodexSubagentState>;
 }
 
 export class CodexSubagentToolUseMessage {
@@ -859,6 +879,7 @@ function asOptionalChanges(v: unknown): Array<{ path?: string; kind?: string }> 
 }
 
 const CODEX_SUBAGENT_ACTION_SET = new Set<string>(CODEX_SUBAGENT_ACTIONS);
+const CODEX_SUBAGENT_STATUS_SET = new Set<string>(CODEX_SUBAGENT_STATUSES);
 
 function asCodexSubagentAction(v: unknown): CodexSubagentAction | undefined {
   return typeof v === 'string' && CODEX_SUBAGENT_ACTION_SET.has(v)
@@ -882,10 +903,26 @@ function asCodexSubagentInputItems(v: unknown): CodexSubagentInputItem[] | undef
   return items.length > 0 || v.length === 0 ? items : undefined;
 }
 
+function asCodexSubagentStates(v: unknown): Record<string, CodexSubagentState> | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  const raw = asRecord(v);
+  const states: Record<string, CodexSubagentState> = {};
+  for (const [agentId, value] of Object.entries(raw)) {
+    const candidate = asRecord(value);
+    if (typeof candidate.status !== 'string' || !CODEX_SUBAGENT_STATUS_SET.has(candidate.status)) continue;
+    states[agentId] = {
+      status: candidate.status as CodexSubagentStatus,
+      ...(typeof candidate.message === 'string' ? { message: candidate.message } : {}),
+    };
+  }
+  return Object.keys(states).length > 0 || Object.keys(raw).length === 0 ? states : undefined;
+}
+
 function asCodexSubagentDetails(v: unknown): CodexSubagentDetails {
   const raw = asRecord(v);
   const details: CodexSubagentDetails = {};
   if (typeof raw.target === 'string') details.target = raw.target;
+  if (typeof raw.threadId === 'string') details.threadId = raw.threadId;
   const targets = asStringArray(raw.targets);
   if (targets !== undefined) details.targets = targets;
   if (typeof raw.message === 'string') details.message = raw.message;
@@ -902,6 +939,8 @@ function asCodexSubagentDetails(v: unknown): CodexSubagentDetails {
   if (typeof raw.interrupt === 'boolean') details.interrupt = raw.interrupt;
   const items = asCodexSubagentInputItems(raw.items);
   if (items !== undefined) details.items = items;
+  const agentStates = asCodexSubagentStates(raw.agentStates);
+  if (agentStates !== undefined) details.agentStates = agentStates;
   return details;
 }
 

--- a/common/chat-types.ts
+++ b/common/chat-types.ts
@@ -272,6 +272,21 @@ export const CODEX_SUBAGENT_STATUSES = [
 
 export type CodexSubagentStatus = (typeof CODEX_SUBAGENT_STATUSES)[number];
 
+export const CODEX_SUBAGENT_LIFECYCLE_SOURCES = ['structured', 'legacy'] as const;
+
+export type CodexSubagentLifecycleSource = (typeof CODEX_SUBAGENT_LIFECYCLE_SOURCES)[number];
+
+export function codexSubagentSourceFingerprint(content: string): string {
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let index = 0; index < content.length; index += 1) {
+    const code = content.charCodeAt(index);
+    first = Math.imul(first ^ code, 0x01000193);
+    second = Math.imul(second ^ code, 0x85ebca6b);
+  }
+  return `codex-subagent:${content.length}:${(first >>> 0).toString(16).padStart(8, '0')}${(second >>> 0).toString(16).padStart(8, '0')}`;
+}
+
 export interface CodexSubagentState {
   status: CodexSubagentStatus;
   message?: string;
@@ -294,6 +309,8 @@ export interface CodexSubagentDetails {
   interrupt?: boolean;
   items?: CodexSubagentInputItem[];
   agentStates?: Record<string, CodexSubagentState>;
+  lifecycleSource?: CodexSubagentLifecycleSource;
+  sourceFingerprint?: string;
 }
 
 export class CodexSubagentToolUseMessage {
@@ -941,6 +958,10 @@ function asCodexSubagentDetails(v: unknown): CodexSubagentDetails {
   if (items !== undefined) details.items = items;
   const agentStates = asCodexSubagentStates(raw.agentStates);
   if (agentStates !== undefined) details.agentStates = agentStates;
+  if (raw.lifecycleSource === 'structured' || raw.lifecycleSource === 'legacy') {
+    details.lifecycleSource = raw.lifecycleSource;
+  }
+  if (typeof raw.sourceFingerprint === 'string') details.sourceFingerprint = raw.sourceFingerprint;
   return details;
 }
 

--- a/server/agents/codex/__tests__/history-normalizer.test.js
+++ b/server/agents/codex/__tests__/history-normalizer.test.js
@@ -4,7 +4,7 @@ import {
   extractTextContent,
   parseApplyPatch,
 } from '../history-normalizer.js';
-import { BashToolUseMessage, CodexSubagentToolUseMessage, EditToolUseMessage, ExecToolUseMessage, ToolResultMessage, UnknownToolUseMessage, WaitToolUseMessage } from '../../../../common/chat-types.js';
+import { BashToolUseMessage, CodexSubagentToolUseMessage, EditToolUseMessage, ExecToolUseMessage, ToolResultMessage, UnknownToolUseMessage, WaitToolUseMessage, codexSubagentSourceFingerprint } from '../../../../common/chat-types.js';
 
 describe('extractTextContent', () => {
   it('returns string content directly', () => {
@@ -197,6 +197,78 @@ describe('normalizeCodexJsonlEntry', () => {
     });
   });
 
+  it('normalizes the persisted v2 inter-agent terminal envelope', () => {
+    const envelope = 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n';
+    const result = normalizeCodexJsonlEntry({
+      type: 'inter_agent_communication',
+      timestamp: ts,
+      payload: {
+        author: '/root/reviewer',
+        recipient: '/root',
+        other_recipients: [],
+        content: envelope,
+        trigger_turn: false,
+      },
+    });
+
+    expect(result.canonical).toHaveLength(1);
+    expect(result.canonical[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'completed' } },
+        lifecycleSource: 'structured',
+        sourceFingerprint: codexSubagentSourceFingerprint(envelope),
+      },
+    });
+  });
+
+  it('normalizes the canonical persisted v2 agent error envelope as errored', () => {
+    const message = "Agent errored: process exited\n\nThis agent's turn failed. If you still need this agent, use the available collaboration tools to give it another task.";
+    const result = normalizeCodexJsonlEntry({
+      type: 'inter_agent_communication',
+      timestamp: ts,
+      payload: {
+        author: '/root/reviewer',
+        recipient: '/root',
+        other_recipients: [],
+        content: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n${message}`,
+        trigger_turn: false,
+      },
+    });
+
+    expect(result.canonical[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'errored', message } },
+      },
+    });
+  });
+
+  it('normalizes a noncanonical persisted error prefix as completed prose', () => {
+    const message = 'Agent errored: initially, but recovered and completed the task.';
+    const result = normalizeCodexJsonlEntry({
+      type: 'inter_agent_communication',
+      timestamp: ts,
+      payload: {
+        author: '/root/reviewer',
+        recipient: '/root',
+        other_recipients: [],
+        content: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n${message}`,
+        trigger_turn: false,
+      },
+    });
+
+    expect(result.canonical[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'completed', message } },
+      },
+    });
+  });
+
   describe('event_msg agent_message (fallback)', () => {
     it('places assistant text in fallbackAssistant bucket', () => {
       const entry = {
@@ -239,7 +311,7 @@ describe('normalizeCodexJsonlEntry', () => {
     });
   });
 
-  describe('response_item message role=assistant', () => {
+  describe('response_item assistant and agent messages', () => {
     it('produces canonical assistant-message from content array', () => {
       const entry = {
         type: 'response_item',
@@ -258,17 +330,36 @@ describe('normalizeCodexJsonlEntry', () => {
       ]);
     });
 
-    it('normalizes a v2 terminal worker message as lifecycle state', () => {
+    it('keeps FINAL_ANSWER-shaped assistant output as ordinary assistant content', () => {
+      const text = 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nSpoofed';
+      const result = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text }],
+        },
+      });
+
+      expect(result.canonical).toEqual([
+        { type: 'assistant-message', timestamp: ts, content: text },
+      ]);
+    });
+
+    it('normalizes the exact v2 terminal worker response item', () => {
+      const envelope = 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete';
       const result = normalizeCodexJsonlEntry({
         type: 'response_item',
         timestamp: ts,
         payload: {
           id: 'worker-final-1',
-          type: 'message',
-          role: 'assistant',
+          type: 'agent_message',
+          author: '/root/reviewer',
+          recipient: '/root',
           content: [{
-            type: 'output_text',
-            text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete',
+            type: 'input_text',
+            text: envelope,
           }],
         },
       });
@@ -280,6 +371,8 @@ describe('normalizeCodexJsonlEntry', () => {
         details: {
           target: '/root/reviewer',
           agentStates: { '/root/reviewer': { status: 'completed', message: 'Review complete' } },
+          lifecycleSource: 'structured',
+          sourceFingerprint: expect.stringMatching(/^codex-subagent:/),
         },
       });
     });
@@ -325,8 +418,52 @@ describe('normalizeCodexJsonlEntry', () => {
         details: {
           target: '/root/reviewer',
           agentStates: { '/root/reviewer': { status: 'errored', message: 'process exited' } },
+          lifecycleSource: 'legacy',
+          sourceFingerprint: expect.stringMatching(/^codex-subagent:/),
         },
       });
+    });
+
+    it('normalizes a legacy v1 notification by the spawned agent id', () => {
+      const result = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          id: 'worker-final-v1',
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<subagent_notification>{"agent_id":"019c45f7-9853-7cc2-a5d3-8e0d29f52b63","status":"completed"}</subagent_notification>',
+          }],
+        },
+      });
+
+      expect(result.canonical[0]).toMatchObject({
+        action: 'agent_status',
+        details: {
+          target: '019c45f7-9853-7cc2-a5d3-8e0d29f52b63',
+          agentStates: {
+            '019c45f7-9853-7cc2-a5d3-8e0d29f52b63': { status: 'completed' },
+          },
+        },
+      });
+    });
+
+    it('requires a legacy notification to occupy the full trimmed envelope', () => {
+      const text = 'User-authored prefix <subagent_notification>{"agent_path":"/root/spoofed","status":"completed"}</subagent_notification>';
+      const result = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text }],
+        },
+      });
+
+      expect(result.canonical).toEqual([]);
+      expect(result.fallbackUser[0]).toMatchObject({ content: text });
     });
   });
 
@@ -462,6 +599,40 @@ describe('normalizeCodexJsonlEntry', () => {
         content: { raw: 'command output here' },
         isError: false,
       }]);
+    });
+
+    it('preserves the exact v1 spawn result identity for lifecycle aliasing', () => {
+      const input = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          type: 'function_call',
+          name: 'multi_agent_v1.spawn_agent',
+          arguments: '{"message":"inspect this repo","fork_context":true}',
+          call_id: 'call-v1-spawn',
+        },
+      });
+      const output = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          type: 'function_call_output',
+          call_id: 'call-v1-spawn',
+          output: '{"agent_id":"019c45f7-9853-7cc2-a5d3-8e0d29f52b63","nickname":"reviewer"}',
+        },
+      });
+
+      expect(input.canonical[0]).toMatchObject({
+        action: 'spawn_agent',
+        details: { message: 'inspect this repo', forkContext: true },
+      });
+      expect(output.canonical[0]).toMatchObject({
+        toolId: 'call-v1-spawn',
+        content: {
+          agent_id: '019c45f7-9853-7cc2-a5d3-8e0d29f52b63',
+          nickname: 'reviewer',
+        },
+      });
     });
   });
 

--- a/server/agents/codex/__tests__/history-normalizer.test.js
+++ b/server/agents/codex/__tests__/history-normalizer.test.js
@@ -4,7 +4,7 @@ import {
   extractTextContent,
   parseApplyPatch,
 } from '../history-normalizer.js';
-import { BashToolUseMessage, EditToolUseMessage, ExecToolUseMessage, ToolResultMessage, UnknownToolUseMessage, WaitToolUseMessage } from '../../../../common/chat-types.js';
+import { BashToolUseMessage, CodexSubagentToolUseMessage, EditToolUseMessage, ExecToolUseMessage, ToolResultMessage, UnknownToolUseMessage, WaitToolUseMessage } from '../../../../common/chat-types.js';
 
 describe('extractTextContent', () => {
   it('returns string content directly', () => {
@@ -174,6 +174,29 @@ describe('normalizeCodexJsonlEntry', () => {
     });
   });
 
+  it('normalizes subagent activity for thread-id to path identity folding', () => {
+    const result = normalizeCodexJsonlEntry({
+      type: 'event_msg',
+      timestamp: ts,
+      payload: {
+        type: 'sub_agent_activity',
+        event_id: 'activity-1',
+        kind: 'started',
+        agent_thread_id: 'worker-thread-1',
+        agent_path: '/root/reviewer',
+      },
+    });
+
+    expect(result.canonical[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        threadId: 'worker-thread-1',
+        agentStates: { '/root/reviewer': { status: 'running' } },
+      },
+    });
+  });
+
   describe('event_msg agent_message (fallback)', () => {
     it('places assistant text in fallbackAssistant bucket', () => {
       const entry = {
@@ -234,6 +257,32 @@ describe('normalizeCodexJsonlEntry', () => {
         { type: 'assistant-message', timestamp: ts, content: 'I will help you.' },
       ]);
     });
+
+    it('normalizes a v2 terminal worker message as lifecycle state', () => {
+      const result = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          id: 'worker-final-1',
+          type: 'message',
+          role: 'assistant',
+          content: [{
+            type: 'output_text',
+            text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete',
+          }],
+        },
+      });
+
+      expect(result.canonical).toHaveLength(1);
+      expect(result.canonical[0]).toBeInstanceOf(CodexSubagentToolUseMessage);
+      expect(result.canonical[0]).toMatchObject({
+        action: 'agent_status',
+        details: {
+          target: '/root/reviewer',
+          agentStates: { '/root/reviewer': { status: 'completed', message: 'Review complete' } },
+        },
+      });
+    });
   });
 
   describe('response_item message role=user', () => {
@@ -253,6 +302,31 @@ describe('normalizeCodexJsonlEntry', () => {
       expect(result.fallbackUser).toEqual([
         { type: 'user-message', timestamp: ts, content: 'user instruction' },
       ]);
+    });
+
+    it('normalizes a legacy terminal worker notification as lifecycle state', () => {
+      const result = normalizeCodexJsonlEntry({
+        type: 'response_item',
+        timestamp: ts,
+        payload: {
+          id: 'worker-final-legacy',
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<subagent_notification>{"agent_path":"/root/reviewer","status":{"errored":"process exited"}}</subagent_notification>',
+          }],
+        },
+      });
+
+      expect(result.fallbackUser).toEqual([]);
+      expect(result.canonical[0]).toMatchObject({
+        action: 'agent_status',
+        details: {
+          target: '/root/reviewer',
+          agentStates: { '/root/reviewer': { status: 'errored', message: 'process exited' } },
+        },
+      });
     });
   });
 

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -767,6 +767,124 @@ describe('Codex app-server converter', () => {
     });
   });
 
+  it('maps typed Codex subagent lifecycle items with per-agent states', () => {
+    const messages = convertCodexAppServerItem({
+      type: 'collabAgentToolCall',
+      id: 'collab-wait-1',
+      tool: 'wait',
+      status: 'failed',
+      senderThreadId: 'root-thread',
+      receiverThreadIds: ['worker-complete', 'worker-missing'],
+      prompt: null,
+      model: null,
+      reasoningEffort: null,
+      agentsStates: {
+        'worker-complete': { status: 'completed', message: 'Review complete' },
+        'worker-missing': { status: 'notFound', message: null },
+      },
+    }, '2026-02-21T10:00:00.000Z');
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBeInstanceOf(CodexSubagentToolUseMessage);
+    expect(messages[0]).toMatchObject({
+      action: 'wait_agent',
+      details: {
+        targets: ['worker-complete', 'worker-missing'],
+        agentStates: {
+          'worker-complete': { status: 'completed', message: 'Review complete' },
+          'worker-missing': { status: 'notFound' },
+        },
+      },
+    });
+    expect(messages[1]).toBeInstanceOf(ToolResultMessage);
+    expect(messages[1].isError).toBe(true);
+  });
+
+  it('maps completed typed spawn items during live conversion', () => {
+    const messages = convertCodexAppServerLiveItem({
+      type: 'collabAgentToolCall',
+      id: 'collab-spawn-1',
+      tool: 'spawnAgent',
+      status: 'completed',
+      senderThreadId: 'root-thread',
+      receiverThreadIds: ['worker-running'],
+      prompt: 'Review lifecycle handling',
+      model: 'gpt-5.6-codex',
+      reasoningEffort: 'high',
+      agentsStates: {
+        'worker-running': { status: 'running', message: null },
+      },
+    }, '2026-02-21T10:00:00.000Z');
+
+    expect(messages[0]).toMatchObject({
+      type: 'codex-subagent-tool-use',
+      action: 'spawn_agent',
+      details: {
+        target: 'worker-running',
+        message: 'Review lifecycle handling',
+        model: 'gpt-5.6-codex',
+        reasoningEffort: 'high',
+        agentStates: { 'worker-running': { status: 'running' } },
+      },
+    });
+    expect(messages[1]).toMatchObject({ type: 'tool-result', isError: false });
+  });
+
+  it('maps subagent activity and terminal completion notifications', () => {
+    const activity = convertCodexAppServerLiveItem({
+      type: 'subAgentActivity',
+      id: 'activity-worker-1',
+      kind: 'started',
+      agentThreadId: 'worker-thread-1',
+      agentPath: '/root/reviewer',
+    }, '2026-02-21T10:00:00.000Z');
+    const completion = convertCodexAppServerLiveItem({
+      type: 'agentMessage',
+      id: 'completion-worker-1',
+      text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete',
+      phase: null,
+      memoryCitation: null,
+    }, '2026-02-21T10:01:00.000Z');
+
+    expect(activity[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        threadId: 'worker-thread-1',
+        agentStates: { '/root/reviewer': { status: 'running' } },
+      },
+    });
+    expect(completion).toHaveLength(1);
+    expect(completion[0]).toMatchObject({
+      type: 'codex-subagent-tool-use',
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'completed', message: 'Review complete' } },
+      },
+    });
+  });
+
+  it('maps legacy missing-worker notifications even on the suppressed live user path', () => {
+    const messages = convertCodexAppServerLiveItem({
+      type: 'userMessage',
+      id: 'missing-worker-1',
+      content: [{
+        type: 'text',
+        text: '<subagent_notification>{"agent_path":"/root/reviewer","status":"not_found"}</subagent_notification>',
+      }],
+    }, '2026-02-21T10:01:00.000Z');
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'notFound' } },
+      },
+    });
+  });
+
   it('keeps namespaced dynamic tools external even when their raw name matches a subagent action', () => {
     const messages = convertCodexAppServerItem({
       type: 'dynamicToolCall',
@@ -985,6 +1103,48 @@ describe('CodexAppServerRuntime', () => {
       toolId: 'call-wait-1',
       content: { raw: 'Script completed' },
       isError: false,
+    });
+  });
+
+  it('streams terminal subagent communications without another management call', async () => {
+    const nativePath = path.join(tmpDir, 'live-subagent-thread.jsonl');
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ id: 'thread-1', path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    await provider.startSession(makeRequest());
+
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'message',
+          id: 'worker-final-1',
+          role: 'assistant',
+          content: [{
+            type: 'input_text',
+            text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete',
+          }],
+        },
+      },
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: 'codex-subagent-tool-use',
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'completed', message: 'Review complete' } },
+      },
     });
   });
 

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage, WaitToolUseMessage } from '../../../../../common/chat-types.js';
+import { CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage, WaitToolUseMessage, codexSubagentSourceFingerprint } from '../../../../../common/chat-types.js';
 import { buildApprovalResponse, createPendingApproval } from '../approvals.ts';
 import { CodexAppServerClient, CodexAppServerRpcError } from '../client.ts';
 import { convertCodexAppServerItem, convertCodexAppServerLiveItem, convertCodexRawCodeModeItem } from '../converter.ts';
@@ -830,7 +830,8 @@ describe('Codex app-server converter', () => {
     expect(messages[1]).toMatchObject({ type: 'tool-result', isError: false });
   });
 
-  it('maps subagent activity and terminal completion notifications', () => {
+  it('maps subagent activity and exact v2 terminal response items', () => {
+    const envelope = 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete';
     const activity = convertCodexAppServerLiveItem({
       type: 'subAgentActivity',
       id: 'activity-worker-1',
@@ -838,13 +839,16 @@ describe('Codex app-server converter', () => {
       agentThreadId: 'worker-thread-1',
       agentPath: '/root/reviewer',
     }, '2026-02-21T10:00:00.000Z');
-    const completion = convertCodexAppServerLiveItem({
-      type: 'agentMessage',
+    const completion = convertCodexRawCodeModeItem({
+      type: 'agent_message',
       id: 'completion-worker-1',
-      text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete',
-      phase: null,
-      memoryCitation: null,
-    }, '2026-02-21T10:01:00.000Z');
+      author: '/root/reviewer',
+      recipient: '/root',
+      content: [{
+        type: 'input_text',
+        text: envelope,
+      }],
+    }, '2026-02-21T10:01:00.000Z', new Set());
 
     expect(activity[0]).toMatchObject({
       action: 'agent_status',
@@ -861,11 +865,132 @@ describe('Codex app-server converter', () => {
       details: {
         target: '/root/reviewer',
         agentStates: { '/root/reviewer': { status: 'completed', message: 'Review complete' } },
+        lifecycleSource: 'structured',
+        sourceFingerprint: codexSubagentSourceFingerprint(envelope),
       },
     });
   });
 
-  it('maps legacy missing-worker notifications even on the suppressed live user path', () => {
+  it('maps the canonical live v2 agent error envelope as errored', () => {
+    const message = "Agent errored: process exited\n\nThis agent's turn failed. If you still need this agent, use the available collaboration tools to give it another task.";
+    const completion = convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/reviewer',
+      recipient: '/root',
+      content: [{
+        type: 'input_text',
+        text: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n${message}`,
+      }],
+    }, '2026-02-21T10:01:00.000Z', new Set());
+
+    expect(completion[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'errored', message } },
+      },
+    });
+  });
+
+  it('maps a noncanonical live error prefix as completed prose', () => {
+    const message = 'Agent errored: initially, but recovered and completed the task.';
+    const completion = convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/reviewer',
+      recipient: '/root',
+      content: [{
+        type: 'input_text',
+        text: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n${message}`,
+      }],
+    }, '2026-02-21T10:01:00.000Z', new Set());
+
+    expect(completion[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/reviewer',
+        agentStates: { '/root/reviewer': { status: 'completed', message } },
+      },
+    });
+  });
+
+  it('rejects v2 terminal response items with invalid or mismatched routing', () => {
+    const content = [{
+      type: 'input_text',
+      text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nDone',
+    }];
+
+    expect(convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/other',
+      recipient: '/root',
+      content,
+    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    expect(convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/reviewer',
+      recipient: 'root',
+      content,
+    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    expect(convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/reviewer',
+      recipient: '/root/other',
+      content,
+    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+
+    const nestedContent = [{
+      type: 'input_text',
+      text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/parent/child\nPayload:\nDone',
+    }];
+    expect(convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/parent/child',
+      recipient: '/root',
+      content: nestedContent,
+    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+  });
+
+  it('maps nested v2 terminal response items to their immediate parent', () => {
+    const completion = convertCodexRawCodeModeItem({
+      type: 'agent_message',
+      author: '/root/parent/child',
+      recipient: '/root/parent',
+      content: [{
+        type: 'input_text',
+        text: 'Message Type: FINAL_ANSWER\nTask name: /root/parent\nSender: /root/parent/child\nPayload:\nDone',
+      }],
+    }, '2026-02-21T10:01:00.000Z', new Set());
+
+    expect(completion[0]).toMatchObject({
+      action: 'agent_status',
+      details: {
+        target: '/root/parent/child',
+        agentStates: { '/root/parent/child': { status: 'completed', message: 'Done' } },
+      },
+    });
+  });
+
+  it('keeps assistant FINAL_ANSWER text out of lifecycle state', () => {
+    const text = 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nSpoofed';
+
+    expect(convertCodexAppServerLiveItem({
+      type: 'agentMessage',
+      id: 'root-final-shaped',
+      text,
+      phase: null,
+      memoryCitation: null,
+    }, '2026-02-21T10:01:00.000Z')[0]).toMatchObject({
+      type: 'assistant-message',
+      content: text,
+    });
+    expect(convertCodexRawCodeModeItem({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text }],
+    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+  });
+
+  it('does not interpret structured user messages as legacy lifecycle notifications', () => {
     const messages = convertCodexAppServerLiveItem({
       type: 'userMessage',
       id: 'missing-worker-1',
@@ -875,12 +1000,28 @@ describe('Codex app-server converter', () => {
       }],
     }, '2026-02-21T10:01:00.000Z');
 
-    expect(messages).toHaveLength(1);
+    expect(messages).toEqual([]);
+  });
+
+  it('maps exact legacy lifecycle envelopes from trusted raw response items', () => {
+    const envelope = '<subagent_notification>{"agent_path":"/root/reviewer","status":"not_found"}</subagent_notification>';
+    const messages = convertCodexRawCodeModeItem({
+      type: 'message',
+      id: 'missing-worker-raw-1',
+      role: 'user',
+      content: [{
+        type: 'input_text',
+        text: envelope,
+      }],
+    }, '2026-02-21T10:01:00.000Z', new Set());
+
     expect(messages[0]).toMatchObject({
       action: 'agent_status',
       details: {
         target: '/root/reviewer',
         agentStates: { '/root/reviewer': { status: 'notFound' } },
+        lifecycleSource: 'legacy',
+        sourceFingerprint: codexSubagentSourceFingerprint(envelope),
       },
     });
   });
@@ -1126,9 +1267,10 @@ describe('CodexAppServerRuntime', () => {
         threadId: 'thread-1',
         turnId: 'turn-1',
         item: {
-          type: 'message',
+          type: 'agent_message',
           id: 'worker-final-1',
-          role: 'assistant',
+          author: '/root/reviewer',
+          recipient: '/root',
           content: [{
             type: 'input_text',
             text: 'Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\nReview complete',

--- a/server/agents/codex/app-server/converter.ts
+++ b/server/agents/codex/app-server/converter.ts
@@ -2,6 +2,7 @@ import {
   AssistantMessage,
   BashToolUseMessage,
   CompactionMessage,
+  CodexSubagentToolUseMessage,
   EditToolUseMessage,
   ErrorMessage,
   ExecToolUseMessage,
@@ -21,13 +22,27 @@ import {
   WriteStdinToolUseMessage,
   WriteToolUseMessage,
   type ChatMessage,
+  type CodexSubagentAction,
+  type CodexSubagentDetails,
+  type CodexSubagentState,
   type CompactionTrigger,
 } from "../../../../common/chat-types.js";
 import { stripResolvedFileMentionContext } from "../../shared/file-mention-context.js";
 import { normalizeTodoItems, normalizeToolInput, normalizeToolResultContent } from "../../shared/normalize-util.js";
 import { convertCodexSubagentToolUse } from '../subagent-tool-use.js';
 import { convertCodexWaitFunctionCall } from '../jsonl-tool-use-converter.js';
-import type { CodexRawResponseItem, CodexThreadItem, CodexUserInput, CodexWebSearchAction } from './protocol.js';
+import {
+  convertCodexSubagentActivity,
+  convertCodexSubagentLifecycleText,
+} from '../subagent-lifecycle.js';
+import type {
+  CodexCollabAgentState,
+  CodexCollabAgentTool,
+  CodexRawResponseItem,
+  CodexThreadItem,
+  CodexUserInput,
+  CodexWebSearchAction,
+} from './protocol.js';
 
 export interface ConvertCodexAppServerItemOptions {
   includeUserMessages?: boolean;
@@ -50,12 +65,17 @@ export function convertCodexAppServerItem(
 ): ChatMessage[] {
   switch (item.type) {
     case 'userMessage': {
-      if (options.includeUserMessages === false) return [];
       const text = userInputText(item.content);
+      const lifecycle = convertCodexSubagentLifecycleText(timestamp, item.id, text);
+      if (lifecycle) return [lifecycle];
+      if (options.includeUserMessages === false) return [];
       return text.trim() ? [new UserMessage(timestamp, stripResolvedFileMentionContext(text))] : [];
     }
-    case 'agentMessage':
+    case 'agentMessage': {
+      const lifecycle = convertCodexSubagentLifecycleText(timestamp, item.id, item.text);
+      if (lifecycle) return [lifecycle];
       return item.text?.trim() ? [new AssistantMessage(timestamp, item.text)] : [];
+    }
     case 'plan':
       return item.text?.trim() ? [new AssistantMessage(timestamp, item.text)] : [];
     case 'reasoning': {
@@ -70,6 +90,16 @@ export function convertCodexAppServerItem(
       return convertWebSearch(item, timestamp);
     case 'dynamicToolCall':
       return convertDynamicToolCall(item, timestamp);
+    case 'collabAgentToolCall':
+      return convertCollabAgentToolCall(item, timestamp);
+    case 'subAgentActivity':
+      return [convertCodexSubagentActivity(
+        timestamp,
+        item.id,
+        item.kind,
+        item.agentThreadId,
+        item.agentPath,
+      )];
     case 'mcpToolCall':
       return convertMcpToolCall(item, timestamp);
     case 'imageGeneration':
@@ -94,6 +124,16 @@ export function convertCodexRawCodeModeItem(
   timestamp: string,
   activeCodeModeCallIds: Set<string>,
 ): ChatMessage[] {
+  if (item.type === 'message' && (item.role === 'assistant' || item.role === 'user')) {
+    const text = rawResponseItemText(item.content);
+    const lifecycle = convertCodexSubagentLifecycleText(
+      timestamp,
+      item.id ?? `subagent-lifecycle-${timestamp}`,
+      text,
+    );
+    return lifecycle ? [lifecycle] : [];
+  }
+
   if (
     item.type === 'custom_tool_call'
     && item.name === 'exec'
@@ -133,6 +173,15 @@ export function convertCodexRawCodeModeItem(
   }
 
   return [];
+}
+
+function rawResponseItemText(content: unknown): string {
+  if (!Array.isArray(content)) return typeof content === 'string' ? content : '';
+  return content
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+    .map((item) => typeof item.text === 'string' ? item.text : '')
+    .filter(Boolean)
+    .join('\n');
 }
 
 function convertCommandExecution(item: Extract<CodexThreadItem, { type: 'commandExecution' }>, timestamp: string): ChatMessage[] {
@@ -217,6 +266,54 @@ function convertDynamicToolCall(item: Extract<CodexThreadItem, { type: 'dynamicT
     ));
   }
   return messages;
+}
+
+function convertCollabAgentToolCall(
+  item: Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>,
+  timestamp: string,
+): ChatMessage[] {
+  const details: CodexSubagentDetails = {
+    ...(item.receiverThreadIds.length === 1 ? { target: item.receiverThreadIds[0] } : {}),
+    ...(item.receiverThreadIds.length > 1 ? { targets: item.receiverThreadIds } : {}),
+    ...(item.prompt ? { message: item.prompt } : {}),
+    ...(item.model ? { model: item.model } : {}),
+    ...(item.reasoningEffort ? { reasoningEffort: item.reasoningEffort } : {}),
+    agentStates: normalizeCollabAgentStates(item.agentsStates),
+  };
+  const messages: ChatMessage[] = [
+    new CodexSubagentToolUseMessage(timestamp, item.id, collabAction(item.tool), details),
+  ];
+  if (item.status !== 'inProgress') {
+    messages.push(new ToolResultMessage(
+      timestamp,
+      item.id,
+      normalizeToolResultContent(item.agentsStates),
+      item.status === 'failed',
+    ));
+  }
+  return messages;
+}
+
+function collabAction(tool: CodexCollabAgentTool): CodexSubagentAction {
+  switch (tool) {
+    case 'spawnAgent': return 'spawn_agent';
+    case 'sendInput': return 'send_input';
+    case 'resumeAgent': return 'resume_agent';
+    case 'wait': return 'wait_agent';
+    case 'closeAgent': return 'close_agent';
+  }
+}
+
+function normalizeCollabAgentStates(
+  states: Record<string, CodexCollabAgentState>,
+): Record<string, CodexSubagentState> {
+  return Object.fromEntries(Object.entries(states).map(([agentId, agentState]) => [
+    agentId,
+    {
+      status: agentState.status,
+      ...(agentState.message ? { message: agentState.message } : {}),
+    },
+  ]));
 }
 
 function convertMcpToolCall(item: Extract<CodexThreadItem, { type: 'mcpToolCall' }>, timestamp: string): ChatMessage[] {

--- a/server/agents/codex/app-server/converter.ts
+++ b/server/agents/codex/app-server/converter.ts
@@ -33,6 +33,7 @@ import { convertCodexSubagentToolUse } from '../subagent-tool-use.js';
 import { convertCodexWaitFunctionCall } from '../jsonl-tool-use-converter.js';
 import {
   convertCodexSubagentActivity,
+  convertCodexInterAgentLifecycle,
   convertCodexSubagentLifecycleText,
 } from '../subagent-lifecycle.js';
 import type {
@@ -66,14 +67,10 @@ export function convertCodexAppServerItem(
   switch (item.type) {
     case 'userMessage': {
       const text = userInputText(item.content);
-      const lifecycle = convertCodexSubagentLifecycleText(timestamp, item.id, text);
-      if (lifecycle) return [lifecycle];
       if (options.includeUserMessages === false) return [];
       return text.trim() ? [new UserMessage(timestamp, stripResolvedFileMentionContext(text))] : [];
     }
     case 'agentMessage': {
-      const lifecycle = convertCodexSubagentLifecycleText(timestamp, item.id, item.text);
-      if (lifecycle) return [lifecycle];
       return item.text?.trim() ? [new AssistantMessage(timestamp, item.text)] : [];
     }
     case 'plan':
@@ -124,7 +121,19 @@ export function convertCodexRawCodeModeItem(
   timestamp: string,
   activeCodeModeCallIds: Set<string>,
 ): ChatMessage[] {
-  if (item.type === 'message' && (item.role === 'assistant' || item.role === 'user')) {
+  if (item.type === 'agent_message') {
+    const text = rawResponseItemText(item.content);
+    const lifecycle = convertCodexInterAgentLifecycle(
+      timestamp,
+      item.id ?? `subagent-lifecycle-${timestamp}`,
+      item.author,
+      item.recipient,
+      text,
+    );
+    return lifecycle ? [lifecycle] : [];
+  }
+
+  if (item.type === 'message' && item.role === 'user') {
     const text = rawResponseItemText(item.content);
     const lifecycle = convertCodexSubagentLifecycleText(
       timestamp,

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -82,6 +82,22 @@ export type CodexWebSearchAction =
   | { type: 'findInPage' | 'find_in_page'; url?: string | null; pattern?: string | null }
   | { type: 'other' };
 
+export type CodexCollabAgentTool = 'spawnAgent' | 'sendInput' | 'resumeAgent' | 'wait' | 'closeAgent';
+export type CodexCollabAgentToolCallStatus = 'inProgress' | 'completed' | 'failed';
+export type CodexCollabAgentStatus =
+  | 'pendingInit'
+  | 'running'
+  | 'interrupted'
+  | 'completed'
+  | 'errored'
+  | 'shutdown'
+  | 'notFound';
+
+export interface CodexCollabAgentState {
+  status: CodexCollabAgentStatus;
+  message: string | null;
+}
+
 export type CodexThreadItem =
   | { type: 'userMessage'; id: string; content: CodexUserInput[] }
   | { type: 'hookPrompt'; id: string; fragments: unknown[] }
@@ -123,6 +139,25 @@ export type CodexThreadItem =
       contentItems: unknown[] | null;
       success: boolean | null;
       durationMs: number | null;
+    }
+  | {
+      type: 'collabAgentToolCall';
+      id: string;
+      tool: CodexCollabAgentTool;
+      status: CodexCollabAgentToolCallStatus;
+      senderThreadId: string;
+      receiverThreadIds: string[];
+      prompt: string | null;
+      model: string | null;
+      reasoningEffort: string | null;
+      agentsStates: Record<string, CodexCollabAgentState>;
+    }
+  | {
+      type: 'subAgentActivity';
+      id: string;
+      kind: 'started' | 'interacted' | 'interrupted';
+      agentThreadId: string;
+      agentPath: string;
     }
   | { type: 'webSearch'; id: string; query: string; action: CodexWebSearchAction | null }
   | { type: 'imageView'; id: string; path: string }
@@ -213,6 +248,9 @@ export interface ItemCompletedNotification {
 
 export interface CodexRawResponseItem {
   type: string;
+  id?: string;
+  role?: string;
+  content?: unknown;
   call_id?: string;
   name?: string;
   arguments?: string;

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -250,6 +250,8 @@ export interface CodexRawResponseItem {
   type: string;
   id?: string;
   role?: string;
+  author?: string;
+  recipient?: string;
   content?: unknown;
   call_id?: string;
   name?: string;

--- a/server/agents/codex/history-normalizer.ts
+++ b/server/agents/codex/history-normalizer.ts
@@ -14,6 +14,7 @@ import {
 import { convertCodexFunctionCall, convertCodexCustomToolCall } from './jsonl-tool-use-converter.js';
 import {
   convertCodexSubagentActivity,
+  convertCodexInterAgentLifecycle,
   convertCodexSubagentLifecycleText,
 } from './subagent-lifecycle.js';
 import { stripResolvedFileMentionContext } from '../shared/file-mention-context.ts';
@@ -179,8 +180,34 @@ export function normalizeCodexJsonlEntry(
     return normalizeResponseItem(rawEntry.payload, ts, context);
   }
 
+  if (rawEntry.type === 'inter_agent_communication') {
+    return normalizeInterAgentCommunication(rawEntry.payload, ts);
+  }
+
   // session_meta, turn_context, compacted -- skip
   return null;
+}
+
+function normalizeInterAgentCommunication(
+  payload: unknown,
+  ts: string,
+): CodexJsonlNormalizationResult | null {
+  const rawPayload = asRecord(payload);
+  const content = asString(rawPayload.content);
+  if (!content?.trim()) return null;
+
+  const lifecycle = convertCodexInterAgentLifecycle(
+    ts,
+    `subagent-lifecycle-${stableHash(content)}`,
+    rawPayload.author,
+    rawPayload.recipient,
+    content,
+  );
+  if (!lifecycle) return null;
+
+  const result = createNormalizationResult();
+  result.canonical.push(lifecycle);
+  return result;
 }
 
 function normalizeEventMsg(payload: unknown, ts: string): CodexJsonlNormalizationResult | null {
@@ -265,19 +292,27 @@ function normalizeResponseItem(
   const result = createNormalizationResult();
 
   switch (rawPayload.type) {
+    case 'agent_message': {
+      const textContent = extractTextContent(rawPayload.content);
+      const lifecycle = convertCodexInterAgentLifecycle(
+        ts,
+        asString(rawPayload.id) ?? `subagent-lifecycle-${stableHash(textContent)}`,
+        rawPayload.author,
+        rawPayload.recipient,
+        textContent,
+      );
+      if (lifecycle) result.canonical.push(lifecycle);
+      return result;
+    }
+
     case 'message': {
       if (rawPayload.role === 'developer') return null;
 
       if (rawPayload.role === 'assistant') {
         const textContent = extractTextContent(rawPayload.content);
         if (textContent?.trim()) {
-          const lifecycle = convertCodexSubagentLifecycleText(
-            ts,
-            asString(rawPayload.id) ?? `subagent-lifecycle-${stableHash(textContent)}`,
-            textContent,
-          );
           result.isCanonicalAssistant = true;
-          result.canonical.push(lifecycle ?? new AssistantMessage(ts, textContent));
+          result.canonical.push(new AssistantMessage(ts, textContent));
         }
         return result;
       }

--- a/server/agents/codex/history-normalizer.ts
+++ b/server/agents/codex/history-normalizer.ts
@@ -12,6 +12,10 @@ import {
   type ChatMessage,
 } from '../../../common/chat-types.js';
 import { convertCodexFunctionCall, convertCodexCustomToolCall } from './jsonl-tool-use-converter.js';
+import {
+  convertCodexSubagentActivity,
+  convertCodexSubagentLifecycleText,
+} from './subagent-lifecycle.js';
 import { stripResolvedFileMentionContext } from '../shared/file-mention-context.ts';
 import { deterministicTranscriptTimestamp } from '../shared/transcript-timestamp.js';
 
@@ -217,6 +221,28 @@ function normalizeEventMsg(payload: unknown, ts: string): CodexJsonlNormalizatio
       return result;
     }
 
+    case 'sub_agent_activity': {
+      const eventId = asString(rawPayload.event_id);
+      const kind = asString(rawPayload.kind);
+      const agentThreadId = asString(rawPayload.agent_thread_id);
+      const agentPath = asString(rawPayload.agent_path);
+      if (
+        eventId
+        && (kind === 'started' || kind === 'interacted' || kind === 'interrupted')
+        && agentThreadId
+        && agentPath
+      ) {
+        result.canonical.push(convertCodexSubagentActivity(
+          ts,
+          eventId,
+          kind,
+          agentThreadId,
+          agentPath,
+        ));
+      }
+      return result;
+    }
+
     // Operational events -- skip from chat transcript
     case 'token_count':
     case 'task_started':
@@ -245,8 +271,13 @@ function normalizeResponseItem(
       if (rawPayload.role === 'assistant') {
         const textContent = extractTextContent(rawPayload.content);
         if (textContent?.trim()) {
+          const lifecycle = convertCodexSubagentLifecycleText(
+            ts,
+            asString(rawPayload.id) ?? `subagent-lifecycle-${stableHash(textContent)}`,
+            textContent,
+          );
           result.isCanonicalAssistant = true;
-          result.canonical.push(new AssistantMessage(ts, textContent));
+          result.canonical.push(lifecycle ?? new AssistantMessage(ts, textContent));
         }
         return result;
       }
@@ -254,7 +285,13 @@ function normalizeResponseItem(
       if (rawPayload.role === 'user') {
         const textContent = extractTextContent(rawPayload.content);
         if (textContent?.trim()) {
-          result.fallbackUser.push(new UserMessage(ts, stripResolvedFileMentionContext(textContent)));
+          const lifecycle = convertCodexSubagentLifecycleText(
+            ts,
+            asString(rawPayload.id) ?? `subagent-lifecycle-${stableHash(textContent)}`,
+            textContent,
+          );
+          if (lifecycle) result.canonical.push(lifecycle);
+          else result.fallbackUser.push(new UserMessage(ts, stripResolvedFileMentionContext(textContent)));
         }
         return result;
       }

--- a/server/agents/codex/subagent-lifecycle.ts
+++ b/server/agents/codex/subagent-lifecycle.ts
@@ -1,0 +1,108 @@
+import {
+  CodexSubagentToolUseMessage,
+  type CodexSubagentState,
+  type CodexSubagentStatus,
+} from '../../../common/chat-types.js';
+
+const FINAL_ANSWER_PATTERN = /^Message Type: FINAL_ANSWER\r?\nTask name: [^\r\n]+\r?\nSender: ([^\r\n]+)\r?\nPayload:\r?\n([\s\S]*)$/;
+const SUBAGENT_NOTIFICATION_PATTERN = /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
+
+export function convertCodexSubagentLifecycleText(
+  timestamp: string,
+  toolId: string,
+  text: string,
+): CodexSubagentToolUseMessage | null {
+  const finalAnswer = FINAL_ANSWER_PATTERN.exec(text.trim());
+  if (finalAnswer) {
+    const target = finalAnswer[1].trim();
+    const state = stateForFinalAnswer(finalAnswer[2]);
+    return lifecycleMessage(timestamp, toolId, target, state);
+  }
+
+  const notification = SUBAGENT_NOTIFICATION_PATTERN.exec(text);
+  if (!notification) return null;
+  try {
+    const payload = asRecord(JSON.parse(notification[1]));
+    const target = stringValue(payload.agent_path) ?? stringValue(payload.agent_id);
+    const state = normalizeLegacyAgentStatus(payload.status);
+    return target && state ? lifecycleMessage(timestamp, toolId, target, state) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function convertCodexSubagentActivity(
+  timestamp: string,
+  toolId: string,
+  kind: 'started' | 'interacted' | 'interrupted',
+  agentThreadId: string,
+  agentPath: string,
+): CodexSubagentToolUseMessage {
+  const status: CodexSubagentStatus = kind === 'interrupted' ? 'interrupted' : 'running';
+  return new CodexSubagentToolUseMessage(timestamp, toolId, 'agent_status', {
+    target: agentPath,
+    threadId: agentThreadId,
+    agentStates: { [agentPath]: { status } },
+  });
+}
+
+function lifecycleMessage(
+  timestamp: string,
+  toolId: string,
+  target: string,
+  state: CodexSubagentState,
+): CodexSubagentToolUseMessage {
+  return new CodexSubagentToolUseMessage(timestamp, toolId, 'agent_status', {
+    target,
+    agentStates: { [target]: state },
+  });
+}
+
+function stateForFinalAnswer(payload: string): CodexSubagentState {
+  const message = payload.trim();
+  if (message.startsWith('Agent errored:')) return { status: 'errored', message };
+  if (message === 'Agent shut down.') return { status: 'shutdown', message };
+  if (message === 'Agent was not found.') return { status: 'notFound', message };
+  return { status: 'completed', ...(message ? { message } : {}) };
+}
+
+function normalizeLegacyAgentStatus(value: unknown): CodexSubagentState | null {
+  if (typeof value === 'string') {
+    const status = normalizeStatusName(value);
+    return status ? { status } : null;
+  }
+  const raw = asRecord(value);
+  for (const [name, message] of Object.entries(raw)) {
+    const status = normalizeStatusName(name);
+    if (!status) continue;
+    return {
+      status,
+      ...(typeof message === 'string' && message ? { message } : {}),
+    };
+  }
+  return null;
+}
+
+function normalizeStatusName(value: string): CodexSubagentStatus | null {
+  switch (value) {
+    case 'pending_init': return 'pendingInit';
+    case 'running': return 'running';
+    case 'interrupted': return 'interrupted';
+    case 'completed': return 'completed';
+    case 'errored':
+    case 'failed': return 'errored';
+    case 'shutdown': return 'shutdown';
+    case 'not_found': return 'notFound';
+    default: return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/server/agents/codex/subagent-lifecycle.ts
+++ b/server/agents/codex/subagent-lifecycle.ts
@@ -1,34 +1,96 @@
 import {
   CodexSubagentToolUseMessage,
+  codexSubagentSourceFingerprint,
   type CodexSubagentState,
   type CodexSubagentStatus,
 } from '../../../common/chat-types.js';
 
-const FINAL_ANSWER_PATTERN = /^Message Type: FINAL_ANSWER\r?\nTask name: [^\r\n]+\r?\nSender: ([^\r\n]+)\r?\nPayload:\r?\n([\s\S]*)$/;
-const SUBAGENT_NOTIFICATION_PATTERN = /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
+const FINAL_ANSWER_PATTERN = /^Message Type: FINAL_ANSWER\r?\nTask name: ([^\r\n]+)\r?\nSender: ([^\r\n]+)\r?\nPayload:(?:\r?\n([\s\S]*))?$/;
+const SUBAGENT_NOTIFICATION_PATTERN = /^<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>$/;
+const AGENT_NAME_PATTERN = /^[a-z0-9_]+$/;
+const AGENT_ERROR_PREFIX = 'Agent errored: ';
+const AGENT_ERROR_SUFFIX = "\n\nThis agent's turn failed. If you still need this agent, use the available collaboration tools to give it another task.";
+
+export function convertCodexInterAgentLifecycle(
+  timestamp: string,
+  toolId: string,
+  author: unknown,
+  recipient: unknown,
+  content: string,
+): CodexSubagentToolUseMessage | null {
+  if (
+    typeof author !== 'string'
+    || typeof recipient !== 'string'
+    || !isAgentPath(author)
+    || !isAgentPath(recipient)
+  ) return null;
+
+  const finalAnswer = parseFinalAnswer(content);
+  if (
+    !finalAnswer
+    || finalAnswer.taskName !== recipient
+    || finalAnswer.sender !== author
+    || immediateParentPath(author) !== recipient
+  ) return null;
+
+  return lifecycleMessage(
+    timestamp,
+    toolId,
+    author,
+    stateForFinalAnswer(finalAnswer.payload),
+    'structured',
+    content,
+  );
+}
+
+function immediateParentPath(agentPath: string): string | null {
+  const separator = agentPath.lastIndexOf('/');
+  return separator > 0 ? agentPath.slice(0, separator) : null;
+}
+
+function isAgentPath(value: string): boolean {
+  if (value === '/root' || value === '/morpheus') return true;
+  if (!value.startsWith('/root/')) return false;
+  return value.slice('/root/'.length).split('/').every((segment) => (
+    segment !== 'root' && AGENT_NAME_PATTERN.test(segment)
+  ));
+}
 
 export function convertCodexSubagentLifecycleText(
   timestamp: string,
   toolId: string,
   text: string,
 ): CodexSubagentToolUseMessage | null {
-  const finalAnswer = FINAL_ANSWER_PATTERN.exec(text.trim());
+  const finalAnswer = parseFinalAnswer(text);
   if (finalAnswer) {
-    const target = finalAnswer[1].trim();
-    const state = stateForFinalAnswer(finalAnswer[2]);
-    return lifecycleMessage(timestamp, toolId, target, state);
+    const state = stateForFinalAnswer(finalAnswer.payload);
+    return lifecycleMessage(timestamp, toolId, finalAnswer.sender, state, 'legacy', text);
   }
 
-  const notification = SUBAGENT_NOTIFICATION_PATTERN.exec(text);
+  const notification = SUBAGENT_NOTIFICATION_PATTERN.exec(text.trim());
   if (!notification) return null;
   try {
     const payload = asRecord(JSON.parse(notification[1]));
     const target = stringValue(payload.agent_path) ?? stringValue(payload.agent_id);
     const state = normalizeLegacyAgentStatus(payload.status);
-    return target && state ? lifecycleMessage(timestamp, toolId, target, state) : null;
+    return target && state ? lifecycleMessage(timestamp, toolId, target, state, 'legacy', text) : null;
   } catch {
     return null;
   }
+}
+
+function parseFinalAnswer(text: string): {
+  taskName: string;
+  sender: string;
+  payload: string;
+} | null {
+  const match = FINAL_ANSWER_PATTERN.exec(text.trim());
+  if (!match) return null;
+  return {
+    taskName: match[1].trim(),
+    sender: match[2].trim(),
+    payload: match[3] ?? '',
+  };
 }
 
 export function convertCodexSubagentActivity(
@@ -43,6 +105,7 @@ export function convertCodexSubagentActivity(
     target: agentPath,
     threadId: agentThreadId,
     agentStates: { [agentPath]: { status } },
+    lifecycleSource: 'structured',
   });
 }
 
@@ -51,16 +114,22 @@ function lifecycleMessage(
   toolId: string,
   target: string,
   state: CodexSubagentState,
+  source: 'structured' | 'legacy',
+  sourceContent: string,
 ): CodexSubagentToolUseMessage {
   return new CodexSubagentToolUseMessage(timestamp, toolId, 'agent_status', {
     target,
     agentStates: { [target]: state },
+    lifecycleSource: source,
+    sourceFingerprint: codexSubagentSourceFingerprint(sourceContent),
   });
 }
 
 function stateForFinalAnswer(payload: string): CodexSubagentState {
   const message = payload.trim();
-  if (message.startsWith('Agent errored:')) return { status: 'errored', message };
+  if (message.startsWith(AGENT_ERROR_PREFIX) && message.endsWith(AGENT_ERROR_SUFFIX)) {
+    return { status: 'errored', message };
+  }
   if (message === 'Agent shut down.') return { status: 'shutdown', message };
   if (message === 'Agent was not found.') return { status: 'notFound', message };
   return { status: 'completed', ...(message ? { message } : {}) };

--- a/web/src/lib/chat/tools/__tests__/tool-display-registry.test.ts
+++ b/web/src/lib/chat/tools/__tests__/tool-display-registry.test.ts
@@ -183,6 +183,21 @@ describe('tool display helpers', () => {
 		});
 	});
 
+	it('renders terminal Codex subagent state details', () => {
+		const props = TOOL_DISPLAY_REGISTRY['codex-subagent-tool-use'].input.getContentProps?.(
+			new CodexSubagentToolUseMessage('', 'tool-codex-status', 'agent_status', {
+				target: '/root/review-auth',
+				agentStates: {
+					'/root/review-auth': { status: 'errored', message: 'Process exited' },
+				},
+			}) as unknown as Record<string, unknown>,
+		);
+		expect(props).toEqual({
+			content:
+				'**Action:** Agent status\n\n**Target:** /root/review-auth\n\n**States:**\n- /root/review-auth: errored — Process exited',
+		});
+	});
+
 	it('strips transport metadata from display details', () => {
 		const details = getToolDisplayDetails(
 			new AmpOracleToolUseMessage('', 'tool-3', 'Review auth', 'Focus on session invalidation', [

--- a/web/src/lib/chat/tools/__tests__/tool-roundtrip.test.ts
+++ b/web/src/lib/chat/tools/__tests__/tool-roundtrip.test.ts
@@ -196,6 +196,9 @@ describe('tool-use serialization round-trip', () => {
 			message: 'Review auth boundaries',
 			model: 'gpt-5.5',
 			forkTurns: 'all',
+			agentStates: {
+				'worker-1': { status: 'notFound', message: 'Worker disappeared' },
+			},
 		});
 		const parsed = roundTrip(msg);
 		expect(parsed).toBeInstanceOf(CodexSubagentToolUseMessage);
@@ -205,6 +208,9 @@ describe('tool-use serialization round-trip', () => {
 			message: 'Review auth boundaries',
 			model: 'gpt-5.5',
 			forkTurns: 'all',
+			agentStates: {
+				'worker-1': { status: 'notFound', message: 'Worker disappeared' },
+			},
 		});
 	});
 

--- a/web/src/lib/chat/tools/__tests__/tool-roundtrip.test.ts
+++ b/web/src/lib/chat/tools/__tests__/tool-roundtrip.test.ts
@@ -16,6 +16,7 @@ import {
 	TodoReadToolUseMessage,
 	TaskToolUseMessage,
 	CodexSubagentToolUseMessage,
+	codexSubagentSourceFingerprint,
 	UpdatePlanToolUseMessage,
 	WriteStdinToolUseMessage,
 	EnterPlanModeToolUseMessage,
@@ -199,6 +200,8 @@ describe('tool-use serialization round-trip', () => {
 			agentStates: {
 				'worker-1': { status: 'notFound', message: 'Worker disappeared' },
 			},
+			lifecycleSource: 'structured',
+			sourceFingerprint: codexSubagentSourceFingerprint('worker source'),
 		});
 		const parsed = roundTrip(msg);
 		expect(parsed).toBeInstanceOf(CodexSubagentToolUseMessage);
@@ -211,6 +214,8 @@ describe('tool-use serialization round-trip', () => {
 			agentStates: {
 				'worker-1': { status: 'notFound', message: 'Worker disappeared' },
 			},
+			lifecycleSource: 'structured',
+			sourceFingerprint: codexSubagentSourceFingerprint('worker source'),
 		});
 	});
 
@@ -475,6 +480,22 @@ describe('wire format parsing', () => {
 
 		expect(parsed).toBeInstanceOf(UserMessage);
 		expect(parsed.metadata).toEqual({ clientRequestId: 'req-1' });
+	});
+
+	it('drops invalid Codex lifecycle provenance at the parse boundary', () => {
+		const parsed = parseChatMessage({
+			type: 'codex-subagent-tool-use',
+			timestamp: TS,
+			toolId: 'lifecycle-wire',
+			action: 'agent_status',
+			details: {
+				target: '/root/reviewer',
+				lifecycleSource: 'user',
+				sourceFingerprint: 42,
+			},
+		}) as CodexSubagentToolUseMessage;
+
+		expect(parsed.details).toEqual({ target: '/root/reviewer' });
 	});
 
 	it('filters malformed user-message images at parse boundary', () => {

--- a/web/src/lib/chat/tools/tool-display-registry.ts
+++ b/web/src/lib/chat/tools/tool-display-registry.ts
@@ -173,6 +173,8 @@ function codexSubagentActionLabel(action: string): string {
 			return 'Close agent';
 		case 'resume_agent':
 			return 'Resume agent';
+		case 'agent_status':
+			return 'Agent status';
 		default:
 			return 'Subagent';
 	}
@@ -205,6 +207,18 @@ function codexSubagentItemsMarkdown(value: unknown): string | undefined {
 	return lines.length > 0 ? lines.join('\n') : undefined;
 }
 
+function codexSubagentStatesMarkdown(value: unknown): string | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+	const lines = Object.entries(value as Record<string, unknown>).map(([target, value]) => {
+		if (!value || typeof value !== 'object' || Array.isArray(value)) return '';
+		const agentState = value as Record<string, unknown>;
+		const status = String(agentState.status ?? '').trim();
+		const message = String(agentState.message ?? '').trim();
+		return status ? `- ${target}: ${status}${message ? ` — ${message}` : ''}` : '';
+	}).filter(Boolean);
+	return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
 function codexSubagentMarkdown(input: Record<string, unknown>): string {
 	const action = String(input.action ?? '');
 	const details = codexSubagentDetails(input);
@@ -230,6 +244,7 @@ function codexSubagentMarkdown(input: Record<string, unknown>): string {
 	);
 	appendDetailLine(lines, 'Path prefix', details.pathPrefix as string | undefined);
 	appendDetailLine(lines, 'Items', codexSubagentItemsMarkdown(details.items));
+	appendDetailLine(lines, 'States', codexSubagentStatesMarkdown(details.agentStates));
 	return lines.join('\n\n');
 }
 

--- a/web/src/lib/chat/transcript/__tests__/subagent-management.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/subagent-management.test.ts
@@ -134,4 +134,74 @@ describe('buildSubagentManagementModel', () => {
 			['ui-polish', 'waiting'],
 		]);
 	});
+
+	it('uses typed lifecycle states to detect completed and missing workers', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'tool-subagent-wait', 'wait_agent', {
+				targets: ['worker-complete', 'worker-missing'],
+				agentStates: {
+					'worker-complete': { status: 'completed', message: 'Done' },
+					'worker-missing': { status: 'notFound' },
+				},
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages);
+
+		expect(model.subagents.map((entry) => [entry.name, entry.status, entry.statusLabel])).toEqual([
+			['worker-complete', 'completed', 'Completed'],
+			['worker-missing', 'error', 'Not found'],
+		]);
+	});
+
+	it('maps shutdown and errored lifecycle states without leaving workers running', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'tool-subagent-close', 'close_agent', {
+				targets: ['worker-stopped', 'worker-failed'],
+				agentStates: {
+					'worker-stopped': { status: 'shutdown' },
+					'worker-failed': { status: 'errored', message: 'Process exited' },
+				},
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages);
+
+		expect(model.subagents.map((entry) => [entry.name, entry.status, entry.statusLabel])).toEqual([
+			['worker-stopped', 'closed', 'Stopped'],
+			['worker-failed', 'error', 'Error'],
+		]);
+	});
+
+	it('folds spawn, path discovery, and terminal notification into one worker', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'spawn-1', 'spawn_agent', {
+				target: 'worker-thread-1',
+				agentStates: { 'worker-thread-1': { status: 'running' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-1', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'completion-1', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: {
+					'/root/reviewer': { status: 'completed', message: 'Review complete' },
+				},
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages);
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			id: 'worker-thread-1',
+			name: 'reviewer',
+			path: '/root/reviewer',
+			status: 'completed',
+			statusLabel: 'Completed',
+			message: 'Review complete',
+		});
+	});
 });

--- a/web/src/lib/chat/transcript/__tests__/subagent-management.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/subagent-management.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
 	CodexSubagentToolUseMessage,
 	ToolResultMessage,
+	UserMessage,
+	codexSubagentSourceFingerprint,
 	type ChatMessage,
 } from '$shared/chat-types';
 import { buildSubagentManagementModel } from '$lib/chat/transcript/subagent-management.js';
@@ -63,7 +65,7 @@ describe('buildSubagentManagementModel', () => {
 			}),
 		];
 
-		const model = buildSubagentManagementModel(messages);
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
 
 		expect(model.subagents).toHaveLength(1);
 		expect(model.subagents[0]).toMatchObject({
@@ -108,7 +110,7 @@ describe('buildSubagentManagementModel', () => {
 			new CodexSubagentToolUseMessage(TS, 'tool-subagent-list', 'list_agents'),
 		];
 
-		const model = buildSubagentManagementModel(messages);
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
 
 		expect(model.subagents).toHaveLength(0);
 	});
@@ -126,7 +128,7 @@ describe('buildSubagentManagementModel', () => {
 			}),
 		];
 
-		const model = buildSubagentManagementModel(messages);
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
 
 		expect(model.subagents).toHaveLength(2);
 		expect(model.subagents.map((entry) => [entry.name, entry.status])).toEqual([
@@ -202,6 +204,287 @@ describe('buildSubagentManagementModel', () => {
 			status: 'completed',
 			statusLabel: 'Completed',
 			message: 'Review complete',
+		});
+	});
+
+	it('keeps terminal state and canonical identity across late activity and spawn observations', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'spawn-1', 'spawn_agent', {
+				target: 'worker-thread-1',
+				agentStates: { 'worker-thread-1': { status: 'running' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-1', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'complete-1', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed', message: 'Done' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-late', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'spawn-late', 'spawn_agent', {
+				target: 'worker-thread-1',
+				agentStates: { 'worker-thread-1': { status: 'running' } },
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			name: 'reviewer',
+			path: '/root/reviewer',
+			status: 'completed',
+			statusLabel: 'Completed',
+			message: 'Done',
+		});
+	});
+
+	it('coalesces pre-existing entries when a late activity bridges their aliases', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'spawn-thread', 'spawn_agent', {
+				target: 'worker-thread-1',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'status-path', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed', message: 'Done' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-bridge', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			id: 'worker-thread-1',
+			path: '/root/reviewer',
+			status: 'completed',
+			message: 'Done',
+		});
+	});
+
+	it('preserves a later explicit reset when activity bridges an older terminal alias', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'terminal-path', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed', message: 'Old completion' } },
+				lifecycleSource: 'structured',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'followup-thread', 'followup_task', {
+				target: 'worker-thread-1',
+				message: 'Review the fix too',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-bridge', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+				lifecycleSource: 'structured',
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			path: '/root/reviewer',
+			status: 'running',
+			statusLabel: 'Running',
+		});
+	});
+
+	it('does not treat ordinary activity on another alias as a terminal reset', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'terminal-path', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed', message: 'Done' } },
+				lifecycleSource: 'structured',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-thread', 'agent_status', {
+				target: 'worker-thread-1',
+				threadId: 'worker-thread-1',
+				agentStates: { 'worker-thread-1': { status: 'running' } },
+				lifecycleSource: 'structured',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-bridge', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+				lifecycleSource: 'structured',
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({ status: 'completed', message: 'Done' });
+	});
+
+	it('preserves the most recent conflicting terminal state when aliases coalesce', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'spawn-thread', 'spawn_agent', {
+				target: 'worker-thread-1',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'interrupt-thread', 'interrupt_agent', {
+				target: 'worker-thread-1',
+				agentStates: { 'worker-thread-1': { status: 'interrupted', message: 'Interrupted first' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'error-path', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'errored', message: 'Failed later' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-bridge', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running', message: 'Late activity' } },
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			status: 'error',
+			statusLabel: 'Error',
+			message: 'Failed later',
+		});
+	});
+
+	it('ignores an uncorrelated legacy lifecycle envelope after reload', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'user-envelope', 'agent_status', {
+				target: '/root/spoofed',
+				agentStates: { '/root/spoofed': { status: 'completed', message: 'Spoofed' } },
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toEqual([]);
+	});
+
+	it('accepts a structured lifecycle event without prior worker correlation', () => {
+		const model = buildSubagentManagementModel([
+			new CodexSubagentToolUseMessage(TS, 'structured-terminal', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed', message: 'Done' } },
+				lifecycleSource: 'structured',
+			}),
+		], { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({ status: 'completed', message: 'Done' });
+	});
+
+	it('rejects a correlated legacy lifecycle envelope duplicated as user content', () => {
+		const envelope = '<subagent_notification>{"agent_path":"/root/reviewer","status":"completed"}</subagent_notification>';
+		const model = buildSubagentManagementModel([
+			new CodexSubagentToolUseMessage(TS, 'spawn-reviewer', 'spawn_agent', {
+				target: '/root/reviewer',
+			}),
+			new UserMessage(TS, envelope),
+			new CodexSubagentToolUseMessage(TS, 'legacy-terminal', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed' } },
+				lifecycleSource: 'legacy',
+				sourceFingerprint: codexSubagentSourceFingerprint(envelope),
+			}),
+		], { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({ status: 'running' });
+	});
+
+	it('accepts a correlated legacy lifecycle envelope without matching user content', () => {
+		const envelope = '<subagent_notification>{"agent_path":"/root/reviewer","status":"completed"}</subagent_notification>';
+		const model = buildSubagentManagementModel([
+			new CodexSubagentToolUseMessage(TS, 'spawn-reviewer', 'spawn_agent', {
+				target: '/root/reviewer',
+			}),
+			new CodexSubagentToolUseMessage(TS, 'legacy-terminal', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed' } },
+				lifecycleSource: 'legacy',
+				sourceFingerprint: codexSubagentSourceFingerprint(envelope),
+			}),
+		], { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({ status: 'completed' });
+	});
+
+	it('accepts a legitimate terminal event that precedes trusted activity', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'terminal-first', 'agent_status', {
+				target: '/root/reviewer',
+				agentStates: { '/root/reviewer': { status: 'completed', message: 'Done first' } },
+			}),
+			new CodexSubagentToolUseMessage(TS, 'activity-later', 'agent_status', {
+				target: '/root/reviewer',
+				threadId: 'worker-thread-1',
+				agentStates: { '/root/reviewer': { status: 'running' } },
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			path: '/root/reviewer',
+			status: 'completed',
+			message: 'Done first',
+		});
+	});
+
+	it('aliases an identity-free v1 spawn through its result and legacy notification', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'call-v1-spawn', 'spawn_agent', {
+				message: 'inspect this repo',
+				forkContext: true,
+			}),
+			new ToolResultMessage(TS, 'call-v1-spawn', {
+				agent_id: '019c45f7-9853-7cc2-a5d3-8e0d29f52b63',
+				nickname: 'reviewer',
+			}, false),
+			new CodexSubagentToolUseMessage(TS, 'legacy-notification', 'agent_status', {
+				target: '019c45f7-9853-7cc2-a5d3-8e0d29f52b63',
+				agentStates: {
+					'019c45f7-9853-7cc2-a5d3-8e0d29f52b63': { status: 'completed', message: 'Done' },
+				},
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'running' });
+
+		expect(model.subagents).toHaveLength(1);
+		expect(model.subagents[0]).toMatchObject({
+			id: '019c45f7-9853-7cc2-a5d3-8e0d29f52b63',
+			name: 'reviewer',
+			status: 'completed',
+			message: 'Done',
+		});
+	});
+
+	it('derives unresolved workers as stopped after the root runtime becomes idle', () => {
+		const messages: ChatMessage[] = [
+			new CodexSubagentToolUseMessage(TS, 'spawn-1', 'spawn_agent', {
+				taskName: 'reviewer',
+			}),
+		];
+
+		const model = buildSubagentManagementModel(messages, { rootStatus: 'idle' });
+
+		expect(model.subagents[0]).toMatchObject({
+			status: 'closed',
+			statusLabel: 'Stopped',
 		});
 	});
 });

--- a/web/src/lib/chat/transcript/subagent-management.ts
+++ b/web/src/lib/chat/transcript/subagent-management.ts
@@ -4,6 +4,7 @@ import {
 	type ChatMessage,
 	type CodexSubagentAction,
 	type CodexSubagentDetails,
+	type CodexSubagentState,
 } from '$shared/chat-types';
 
 export type SubagentManagementStatus =
@@ -11,6 +12,7 @@ export type SubagentManagementStatus =
 	| 'running'
 	| 'waiting'
 	| 'interrupted'
+	| 'completed'
 	| 'closed'
 	| 'error'
 	| 'observing';
@@ -118,15 +120,17 @@ function applySubagentEvent(
 	entry.name = displayNameFor(details, entry.name);
 	entry.path = details.target ?? details.pathPrefix ?? entry.path;
 	entry.model = details.model ?? entry.model;
-	entry.message = details.message ?? entry.message;
 	entry.lastActionLabel = actionLabelFor(message.action);
-	entry.status = statusFor(message.action, result?.isError === true);
-	entry.statusLabel = statusLabelFor(entry.status);
+	const agentState = stateForDetails(details);
+	entry.message = agentState?.message ?? details.message ?? entry.message;
+	entry.status = statusFor(message.action, result?.isError === true, agentState);
+	entry.statusLabel = agentState ? statusLabelForAgentState(agentState) : statusLabelFor(entry.status);
 }
 
 function entryDetailsForMessage(message: CodexSubagentToolUseMessage): CodexSubagentDetails[] {
 	if (message.action === 'list_agents') return [];
-	const targets = message.details.targets?.filter((target) => target.trim().length > 0) ?? [];
+	const targets = message.details.targets?.filter((target) => target.trim().length > 0)
+		?? Object.keys(message.details.agentStates ?? {});
 	if (targets.length === 0) return [message.details];
 	return targets.map((target) => ({
 		...message.details,
@@ -143,6 +147,7 @@ function resolveEntryKey(
 ): string | null {
 	const candidates = [
 		details.target,
+		details.threadId,
 		details.pathPrefix,
 		details.taskName ? `/root/${details.taskName}` : undefined,
 		details.taskName,
@@ -167,6 +172,7 @@ function registerAliases(
 ): void {
 	const aliases = [
 		details.target,
+		details.threadId,
 		details.pathPrefix,
 		details.taskName,
 		details.taskName ? `/root/${details.taskName}` : undefined,
@@ -207,10 +213,36 @@ function actionLabelFor(action: CodexSubagentAction): string {
 			return 'Closed';
 		case 'resume_agent':
 			return 'Resumed';
+		case 'agent_status':
+			return 'Status';
 	}
 }
 
-function statusFor(action: CodexSubagentAction, isError: boolean): SubagentManagementStatus {
+function stateForDetails(details: CodexSubagentDetails): CodexSubagentState | undefined {
+	return details.target ? details.agentStates?.[details.target] : undefined;
+}
+
+function statusFor(
+	action: CodexSubagentAction,
+	isError: boolean,
+	agentState?: CodexSubagentState,
+): SubagentManagementStatus {
+	if (agentState) {
+		switch (agentState.status) {
+			case 'pendingInit':
+			case 'running':
+				return 'running';
+			case 'interrupted':
+				return 'interrupted';
+			case 'completed':
+				return 'completed';
+			case 'shutdown':
+				return 'closed';
+			case 'errored':
+			case 'notFound':
+				return 'error';
+		}
+	}
 	if (isError) return 'error';
 	switch (action) {
 		case 'close_agent':
@@ -220,6 +252,7 @@ function statusFor(action: CodexSubagentAction, isError: boolean): SubagentManag
 		case 'wait_agent':
 			return 'waiting';
 		case 'list_agents':
+		case 'agent_status':
 			return 'observing';
 		case 'spawn_agent':
 		case 'send_input':
@@ -227,6 +260,18 @@ function statusFor(action: CodexSubagentAction, isError: boolean): SubagentManag
 		case 'followup_task':
 		case 'resume_agent':
 			return 'running';
+	}
+}
+
+function statusLabelForAgentState(agentState: CodexSubagentState): string {
+	switch (agentState.status) {
+		case 'pendingInit': return 'Starting';
+		case 'running': return 'Running';
+		case 'interrupted': return 'Interrupted';
+		case 'completed': return 'Completed';
+		case 'errored': return 'Error';
+		case 'shutdown': return 'Stopped';
+		case 'notFound': return 'Not found';
 	}
 }
 
@@ -240,6 +285,8 @@ function statusLabelFor(status: SubagentManagementStatus): string {
 			return 'Waiting';
 		case 'interrupted':
 			return 'Interrupted';
+		case 'completed':
+			return 'Completed';
 		case 'closed':
 			return 'Closed';
 		case 'error':

--- a/web/src/lib/chat/transcript/subagent-management.ts
+++ b/web/src/lib/chat/transcript/subagent-management.ts
@@ -1,6 +1,8 @@
 import {
 	CodexSubagentToolUseMessage,
 	ToolResultMessage,
+	UserMessage,
+	codexSubagentSourceFingerprint,
 	type ChatMessage,
 	type CodexSubagentAction,
 	type CodexSubagentDetails,
@@ -41,6 +43,12 @@ export interface BuildSubagentManagementOptions {
 	rootStatus?: 'idle' | 'running';
 }
 
+interface ReducerEntryMetadata {
+	statusOrder: number;
+	messageOrder: number;
+	resetOrder: number;
+}
+
 export function buildSubagentManagementModel(
 	messages: ChatMessage[],
 	options: BuildSubagentManagementOptions = {},
@@ -65,24 +73,66 @@ export function buildSubagentManagementModel(
 	const orderedSubagents: SubagentManagementEntry[] = [];
 	const subagentsByKey = new Map<string, SubagentManagementEntry>();
 	const aliasToKey = new Map<string, string>();
+	const reducerMetadata = new Map<SubagentManagementEntry, ReducerEntryMetadata>();
+	const knownAliases = collectKnownAliases(messages, resultsByToolId);
+	const userSourceFingerprints = new Set(
+		messages
+			.filter((message): message is UserMessage => message instanceof UserMessage)
+			.map((message) => codexSubagentSourceFingerprint(message.content)),
+	);
+	let eventOrder = 0;
 
 	for (const message of messages) {
 		if (!(message instanceof CodexSubagentToolUseMessage)) continue;
 
 		const result = resultsByToolId.get(message.toolId);
-		for (const eventDetails of entryDetailsForMessage(message)) {
-			const key = resolveEntryKey(eventDetails, message.toolId, aliasToKey, message.action);
+		for (const rawDetails of entryDetailsForMessage(message)) {
+			eventOrder += 1;
+			const eventDetails = detailsWithSpawnResult(rawDetails, message.action, result);
+			if (isRejectedTextLifecycle(message.action, eventDetails, knownAliases, userSourceFingerprints)) continue;
+			const key = resolveEntryKey(
+				eventDetails,
+				message.toolId,
+				aliasToKey,
+				message.action,
+			);
 			if (!key) continue;
 
 			let entry = subagentsByKey.get(key);
 			if (!entry) {
 				entry = createSubagentEntry(key, message, eventDetails);
+				reducerMetadata.set(entry, { statusOrder: -1, messageOrder: -1, resetOrder: -1 });
 				subagentsByKey.set(key, entry);
 				orderedSubagents.push(entry);
 			}
 
-			registerAliases(key, eventDetails, aliasToKey);
-			applySubagentEvent(entry, message, result, eventDetails);
+			entry = coalesceAliasedEntries(
+				entry,
+				eventDetails,
+				subagentsByKey,
+				aliasToKey,
+				orderedSubagents,
+				reducerMetadata,
+			);
+			registerAliases(entry.id, eventDetails, aliasToKey);
+			applySubagentEvent(
+				entry,
+				message,
+				result,
+				eventDetails,
+				eventOrder,
+				reducerMetadata.get(entry)!,
+			);
+		}
+	}
+
+	if (rootStatus === 'idle') {
+		// An idle Garcon session has shut down its dedicated Codex client and workers.
+		for (const entry of orderedSubagents) {
+			if (entry.status === 'running' || entry.status === 'waiting' || entry.status === 'observing') {
+				entry.status = 'closed';
+				entry.statusLabel = 'Stopped';
+			}
 		}
 	}
 
@@ -90,6 +140,69 @@ export function buildSubagentManagementModel(
 		entries: [rootEntry, ...orderedSubagents],
 		subagents: orderedSubagents,
 	};
+}
+
+function collectKnownAliases(
+	messages: ChatMessage[],
+	resultsByToolId: Map<string, ToolResultMessage>,
+): Set<string> {
+	const aliases = new Set<string>();
+	for (const message of messages) {
+		if (!(message instanceof CodexSubagentToolUseMessage) || message.action === 'list_agents') continue;
+		const result = resultsByToolId.get(message.toolId);
+		for (const rawDetails of entryDetailsForMessage(message)) {
+			const details = detailsWithSpawnResult(rawDetails, message.action, result);
+			if (message.action === 'agent_status' && !details.threadId) continue;
+			for (const alias of aliasesFor(details)) aliases.add(normalizeAlias(alias));
+		}
+	}
+	return aliases;
+}
+
+function isRejectedTextLifecycle(
+	action: CodexSubagentAction,
+	details: CodexSubagentDetails,
+	knownAliases: Set<string>,
+	userSourceFingerprints: Set<string>,
+): boolean {
+	if (action !== 'agent_status' || details.lifecycleSource === 'structured') return false;
+	if (
+		details.lifecycleSource === 'legacy'
+		&& details.sourceFingerprint
+		&& userSourceFingerprints.has(details.sourceFingerprint)
+	) return true;
+	return !details.threadId
+		&& !aliasesFor(details).some((alias) => knownAliases.has(normalizeAlias(alias)));
+}
+
+function detailsWithSpawnResult(
+	details: CodexSubagentDetails,
+	action: CodexSubagentAction,
+	result: ToolResultMessage | undefined,
+): CodexSubagentDetails {
+	if (action !== 'spawn_agent' || !result || result.isError) return details;
+	const agentId = resultString(result.content, 'agent_id');
+	const nickname = resultString(result.content, 'nickname');
+	if (!agentId && !nickname) return details;
+	return {
+		...details,
+		...(agentId ? { threadId: details.threadId ?? agentId } : {}),
+		...(nickname && !details.taskName ? { taskName: nickname } : {}),
+	};
+}
+
+function resultString(content: Record<string, unknown>, key: string): string | undefined {
+	const value = content[key];
+	if (typeof value === 'string' && value.trim()) return value.trim();
+	if (typeof content.raw !== 'string') return undefined;
+	try {
+		const parsed: unknown = JSON.parse(content.raw);
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+		const nested = (parsed as Record<string, unknown>)[key];
+		return typeof nested === 'string' && nested.trim() ? nested.trim() : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function createSubagentEntry(
@@ -101,7 +214,7 @@ function createSubagentEntry(
 		id: key,
 		kind: 'subagent',
 		name: displayNameFor(details, message.toolId),
-		path: details.target ?? details.pathPrefix ?? details.taskName,
+		path: preferredPath(details),
 		model: details.model,
 		message: details.message,
 		status: 'running',
@@ -116,15 +229,53 @@ function applySubagentEvent(
 	message: CodexSubagentToolUseMessage,
 	result: ToolResultMessage | undefined,
 	details: CodexSubagentDetails,
+	eventOrder: number,
+	metadata: ReducerEntryMetadata,
 ): void {
-	entry.name = displayNameFor(details, entry.name);
-	entry.path = details.target ?? details.pathPrefix ?? entry.path;
+	entry.name = preferredDisplayName(details, entry.name, entry.id);
+	entry.path = preferredPath(details) ?? entry.path;
 	entry.model = details.model ?? entry.model;
 	entry.lastActionLabel = actionLabelFor(message.action);
 	const agentState = stateForDetails(details);
-	entry.message = agentState?.message ?? details.message ?? entry.message;
-	entry.status = statusFor(message.action, result?.isError === true, agentState);
-	entry.statusLabel = agentState ? statusLabelForAgentState(agentState) : statusLabelFor(entry.status);
+	const nextStatus = statusFor(message.action, result?.isError === true, agentState);
+	const keepExisting = keepsExistingStatus(entry.status, nextStatus, message.action);
+	if (!keepExisting) {
+		entry.status = nextStatus;
+		entry.statusLabel = agentState ? statusLabelForAgentState(agentState) : statusLabelFor(nextStatus);
+		metadata.statusOrder = eventOrder;
+		if (isExplicitResetAction(message.action)) metadata.resetOrder = eventOrder;
+	}
+	const nextMessage = agentState?.message ?? details.message;
+	if (nextMessage !== undefined && (!keepExisting || !isProtectedStatus(entry.status))) {
+		entry.message = nextMessage;
+		metadata.messageOrder = eventOrder;
+	}
+}
+
+function isExplicitResetAction(action: CodexSubagentAction): boolean {
+	return action === 'resume_agent'
+		|| action === 'send_input'
+		|| action === 'send_message'
+		|| action === 'followup_task';
+}
+
+function keepsExistingStatus(
+	current: SubagentManagementStatus,
+	next: SubagentManagementStatus,
+	action: CodexSubagentAction,
+): boolean {
+	if (!isProtectedStatus(current) || isProtectedStatus(next)) return false;
+	return action !== 'resume_agent'
+		&& action !== 'send_input'
+		&& action !== 'send_message'
+		&& action !== 'followup_task';
+}
+
+function isProtectedStatus(status: SubagentManagementStatus): boolean {
+	return status === 'interrupted'
+		|| status === 'completed'
+		|| status === 'closed'
+		|| status === 'error';
 }
 
 function entryDetailsForMessage(message: CodexSubagentToolUseMessage): CodexSubagentDetails[] {
@@ -160,9 +311,87 @@ function resolveEntryKey(
 	}
 
 	const identity = details.target ?? details.pathPrefix ?? details.taskName;
+	if (details.threadId) return normalizeAlias(details.threadId);
 	if (identity) return normalizeAlias(identity);
 	if (action === 'spawn_agent') return normalizeAlias(fallback);
 	return null;
+}
+
+function coalesceAliasedEntries(
+	entry: SubagentManagementEntry,
+	details: CodexSubagentDetails,
+	subagentsByKey: Map<string, SubagentManagementEntry>,
+	aliasToKey: Map<string, string>,
+	orderedSubagents: SubagentManagementEntry[],
+	reducerMetadata: Map<SubagentManagementEntry, ReducerEntryMetadata>,
+): SubagentManagementEntry {
+	const keys = new Set<string>();
+	for (const alias of aliasesFor(details)) {
+		const key = aliasToKey.get(normalizeAlias(alias));
+		if (key) keys.add(key);
+	}
+	keys.add(entry.id);
+	if (keys.size < 2) return entry;
+
+	const entries = orderedSubagents.filter((candidate) => keys.has(candidate.id));
+	const primary = entries[0] ?? entry;
+	for (const duplicate of entries.slice(1)) {
+		mergeSubagentEntry(
+			primary,
+			duplicate,
+			reducerMetadata.get(primary)!,
+			reducerMetadata.get(duplicate)!,
+		);
+		reducerMetadata.delete(duplicate);
+		subagentsByKey.delete(duplicate.id);
+		const index = orderedSubagents.indexOf(duplicate);
+		if (index >= 0) orderedSubagents.splice(index, 1);
+		for (const [alias, key] of aliasToKey) {
+			if (key === duplicate.id) aliasToKey.set(alias, primary.id);
+		}
+	}
+	return primary;
+}
+
+function mergeSubagentEntry(
+	primary: SubagentManagementEntry,
+	duplicate: SubagentManagementEntry,
+	primaryMetadata: ReducerEntryMetadata,
+	duplicateMetadata: ReducerEntryMetadata,
+): void {
+	if (!primary.path || isCanonicalPath(duplicate.path)) primary.path = duplicate.path ?? primary.path;
+	if (isCanonicalPath(duplicate.path)) primary.name = duplicate.name;
+	primary.model ??= duplicate.model;
+	primary.anchorId ??= duplicate.anchorId;
+	if (duplicateMetadata.messageOrder > primaryMetadata.messageOrder) {
+		primary.message = duplicate.message;
+		primaryMetadata.messageOrder = duplicateMetadata.messageOrder;
+	} else {
+		primary.message ??= duplicate.message;
+	}
+	if (
+		isProtectedStatus(duplicate.status)
+		&& (
+			(isProtectedStatus(primary.status) && duplicateMetadata.statusOrder > primaryMetadata.statusOrder)
+			|| (!isProtectedStatus(primary.status) && duplicateMetadata.statusOrder > primaryMetadata.resetOrder)
+		)
+	) {
+		primary.status = duplicate.status;
+		primary.statusLabel = duplicate.statusLabel;
+		primaryMetadata.statusOrder = duplicateMetadata.statusOrder;
+		if (duplicateMetadata.messageOrder >= primaryMetadata.messageOrder) {
+			primary.message = duplicate.message ?? primary.message;
+		}
+	} else if (
+		isProtectedStatus(primary.status)
+		&& !isProtectedStatus(duplicate.status)
+		&& duplicateMetadata.resetOrder > primaryMetadata.statusOrder
+	) {
+		primary.status = duplicate.status;
+		primary.statusLabel = duplicate.statusLabel;
+		primaryMetadata.statusOrder = duplicateMetadata.statusOrder;
+	}
+	primaryMetadata.resetOrder = Math.max(primaryMetadata.resetOrder, duplicateMetadata.resetOrder);
 }
 
 function registerAliases(
@@ -170,16 +399,19 @@ function registerAliases(
 	details: CodexSubagentDetails,
 	aliasToKey: Map<string, string>,
 ): void {
-	const aliases = [
+	for (const alias of aliasesFor(details)) {
+		aliasToKey.set(normalizeAlias(alias), key);
+	}
+}
+
+function aliasesFor(details: CodexSubagentDetails): string[] {
+	return [
 		details.target,
 		details.threadId,
 		details.pathPrefix,
 		details.taskName,
 		details.taskName ? `/root/${details.taskName}` : undefined,
-	];
-	for (const alias of aliases) {
-		if (alias) aliasToKey.set(normalizeAlias(alias), key);
-	}
+	].filter((alias): alias is string => Boolean(alias));
 }
 
 function normalizeAlias(value: string): string {
@@ -192,6 +424,38 @@ function displayNameFor(details: CodexSubagentDetails, fallback: string): string
 	if (details.pathPrefix)
 		return details.pathPrefix.split('/').filter(Boolean).at(-1) ?? details.pathPrefix;
 	return fallback;
+}
+
+function preferredDisplayName(
+	details: CodexSubagentDetails,
+	fallback: string,
+	entryId: string,
+): string {
+	if (details.taskName) return details.taskName;
+	if (details.target && normalizeAlias(details.target) === entryId) return fallback;
+	const path = preferredPath(details);
+	if (path) return path.split('/').filter(Boolean).at(-1) ?? path;
+	if (!isCanonicalPath(fallback) && details.target && !looksLikeThreadId(details.target)) {
+		return displayNameFor(details, fallback);
+	}
+	return fallback;
+}
+
+function preferredPath(details: CodexSubagentDetails): string | undefined {
+	if (isCanonicalPath(details.target)) return details.target;
+	if (isCanonicalPath(details.pathPrefix)) return details.pathPrefix;
+	if (details.pathPrefix) return details.pathPrefix;
+	if (details.taskName?.startsWith('/')) return details.taskName;
+	if (details.target && !looksLikeThreadId(details.target)) return details.target;
+	return undefined;
+}
+
+function isCanonicalPath(value: string | undefined): value is string {
+	return Boolean(value?.startsWith('/root/'));
+}
+
+function looksLikeThreadId(value: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(value) || value.startsWith('worker-thread-');
 }
 
 function actionLabelFor(action: CodexSubagentAction): string {

--- a/web/src/lib/components/chat/SubagentManagementBar.svelte
+++ b/web/src/lib/components/chat/SubagentManagementBar.svelte
@@ -42,6 +42,7 @@
 			case 'interrupted':
 				return 'text-status-warning-muted-foreground';
 			case 'closed':
+			case 'completed':
 			case 'idle':
 			case 'observing':
 				return 'text-muted-foreground';


### PR DESCRIPTION
## Summary

- consume Codex typed collaboration activity instead of dropping it at the app-server boundary
- recognize terminal worker communications from the structured v2 live stream and persisted history, while retaining correlated v1 notification support
- validate structured sender/recipient routing and reject user-authored lifecycle lookalikes
- fold thread IDs and canonical agent paths into one worker entry without allowing late events to resurrect stale state
- show completed, stopped, interrupted, errored, shutdown, and missing workers instead of leaving them marked as running

## Why

Codex reports worker startup and worker termination through different protocol paths. Garcon understood the management tool call but ignored or misclassified later lifecycle events, so a worker that completed, failed, shut down, or disappeared could remain shown as running.

The lifecycle reducer now preserves explicit resume/follow-up transitions, protects newer terminal state from late activity, and marks unresolved workers as stopped once the owning Codex runtime is idle.

## Contract migration note

`codex-subagent-tool-use.details` now optionally carries `threadId`, typed `agentStates`, `lifecycleSource`, and `sourceFingerprint`. The action union adds provider-owned `agent_status` for lifecycle events that are not user-invoked tool calls. Existing payloads remain valid.

## Validation

- 249 focused lifecycle, converter, history, reducer, and contract tests
- `bun run check`
- `bun run test` (all server suites and 2,183 web tests)
- `bun run start --port 0` (production build completed and server started on a random port)
- final independent review: APPROVE, no valid bug findings or BLOCKER/MAJOR findings
