### PR TITLE
Speed up transcript search result hydration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build-exe": "bun run check && bun run test && bun run build && bun run build-exe:compile && bun run build-exe:smoke",
     "server": "bun server/main.ts",
     "start": "bun scripts/start.js",
+    "bench:search": "bun scripts/benchmark-chat-search.js",
     "test": "for f in server/**/__tests__/*.test.js; do bun test \"$f\" || exit 1; done && bun run --cwd web test",
     "lint": "bun run --cwd web lint",
     "check": "bun run lint && bun run --cwd web check",

--- a/scripts/benchmark-chat-search.js
+++ b/scripts/benchmark-chat-search.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
-import { rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { performance } from "node:perf_hooks";
@@ -13,22 +14,14 @@ const measuredIterations = readPositiveInteger(
   "GARCON_SEARCH_BENCH_ITERATIONS",
   80,
 );
-const dbPath = path.join(
-  "/tmp",
-  `garcon-search-benchmark-${process.pid}.sqlite`,
-);
 const moduleUrl = pathToFileURL(
   path.join(repoPath, "server/chats/chat-search-index.ts"),
 ).href;
 const { ChatSearchIndex } = await import(moduleUrl);
-
-const index = new ChatSearchIndex({
-  dbPath,
-  registry: { listAllChats: () => ({}) },
-  loadNativeMessages: async () => [],
-  now: () => new Date("2026-07-16T00:00:00.000Z"),
-});
-await index.init();
+const benchmarkDir = await mkdtemp(
+  path.join(os.tmpdir(), "garcon-search-benchmark-"),
+);
+const dbPath = path.join(benchmarkDir, "search.sqlite");
 
 const allowedChatIds = Array.from(
   { length: chatCount },
@@ -39,8 +32,17 @@ const workloads = [
   { name: "rare", query: "rareterm" },
   { name: "cross-message", query: "alphaterm betaterm" },
 ];
+let index;
 
 try {
+  index = new ChatSearchIndex({
+    dbPath,
+    registry: { listAllChats: () => ({}) },
+    loadNativeMessages: async () => [],
+    now: () => new Date("2026-07-16T00:00:00.000Z"),
+  });
+  await index.init();
+
   const indexingStarted = performance.now();
   for (let chatIndex = 0; chatIndex < chatCount; chatIndex += 1) {
     index.replaceMessages(`chat-${chatIndex}`, messagesForChat(chatIndex), {
@@ -71,8 +73,11 @@ try {
     ),
   );
 } finally {
-  for (const suffix of ["", "-shm", "-wal"]) {
-    await rm(`${dbPath}${suffix}`, { force: true });
+  if (!index || typeof index.close === "function") {
+    index?.close();
+    await rm(benchmarkDir, { recursive: true, force: true });
+  } else {
+    deferCleanupUntilExit(benchmarkDir);
   }
 }
 
@@ -132,4 +137,32 @@ function readPositiveInteger(name, fallback) {
     throw new Error(`${name} must be a positive integer`);
   }
   return value;
+}
+
+function deferCleanupUntilExit(directory) {
+  // Defers deletion for comparison targets that predate the explicit close lifecycle.
+  const cleaner = Bun.spawn(
+    [
+      process.execPath,
+      "-e",
+      `
+        import { rm } from "node:fs/promises";
+        const [parentPidValue, directory] = process.argv.slice(1);
+        const parentPid = Number(parentPidValue);
+        while (true) {
+          try {
+            process.kill(parentPid, 0);
+          } catch {
+            break;
+          }
+          await Bun.sleep(50);
+        }
+        await rm(directory, { recursive: true, force: true });
+      `,
+      String(process.pid),
+      directory,
+    ],
+    { detached: true, stdio: ["ignore", "ignore", "ignore"] },
+  );
+  cleaner.unref();
 }

--- a/scripts/benchmark-chat-search.js
+++ b/scripts/benchmark-chat-search.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const repoPath = path.resolve(process.argv[2] ?? ".");
+const chatCount = readPositiveInteger("GARCON_SEARCH_BENCH_CHATS", 3_000);
+const messagesPerChat = readPositiveInteger("GARCON_SEARCH_BENCH_MESSAGES", 40);
+const warmupIterations = readPositiveInteger("GARCON_SEARCH_BENCH_WARMUPS", 8);
+const measuredIterations = readPositiveInteger(
+  "GARCON_SEARCH_BENCH_ITERATIONS",
+  80,
+);
+const dbPath = path.join(
+  "/tmp",
+  `garcon-search-benchmark-${process.pid}.sqlite`,
+);
+const moduleUrl = pathToFileURL(
+  path.join(repoPath, "server/chats/chat-search-index.ts"),
+).href;
+const { ChatSearchIndex } = await import(moduleUrl);
+
+const index = new ChatSearchIndex({
+  dbPath,
+  registry: { listAllChats: () => ({}) },
+  loadNativeMessages: async () => [],
+  now: () => new Date("2026-07-16T00:00:00.000Z"),
+});
+await index.init();
+
+const allowedChatIds = Array.from(
+  { length: chatCount },
+  (_, chatIndex) => `chat-${chatIndex}`,
+);
+const workloads = [
+  { name: "common", query: "commonterm" },
+  { name: "rare", query: "rareterm" },
+  { name: "cross-message", query: "alphaterm betaterm" },
+];
+
+try {
+  const indexingStarted = performance.now();
+  for (let chatIndex = 0; chatIndex < chatCount; chatIndex += 1) {
+    index.replaceMessages(`chat-${chatIndex}`, messagesForChat(chatIndex), {
+      sourceKey: "benchmark",
+    });
+  }
+  const indexingMs = performance.now() - indexingStarted;
+
+  for (let iteration = 0; iteration < warmupIterations; iteration += 1) {
+    for (const workload of workloads) runSearch(workload.query);
+  }
+
+  const results = workloads.map((workload) => measureWorkload(workload));
+  console.log(
+    JSON.stringify(
+      {
+        repoPath,
+        chatCount,
+        messagesPerChat,
+        indexedMessages: chatCount * messagesPerChat,
+        indexingMs,
+        warmupIterations,
+        measuredIterations,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  for (const suffix of ["", "-shm", "-wal"]) {
+    await rm(`${dbPath}${suffix}`, { force: true });
+  }
+}
+
+function messagesForChat(chatIndex) {
+  return Array.from({ length: messagesPerChat }, (_, messageIndex) => {
+    const terms = [
+      "commonterm",
+      `chatword${chatIndex % 97}`,
+      `messageword${messageIndex % 31}`,
+    ];
+    if (chatIndex % 50 === 0 && messageIndex === 0) terms.push("rareterm");
+    if (chatIndex % 10 === 0 && messageIndex === 1) terms.push("alphaterm");
+    if (chatIndex % 10 === 0 && messageIndex === 2) terms.push("betaterm");
+    return {
+      type: messageIndex % 2 === 0 ? "user-message" : "assistant-message",
+      timestamp: `2026-07-16T00:${String(messageIndex % 60).padStart(2, "0")}:00.000Z`,
+      content: `${terms.join(" ")} synthetic transcript payload ${"context ".repeat(12)}`,
+    };
+  });
+}
+
+function runSearch(query) {
+  return index.search({ query, allowedChatIds, limit: 20 });
+}
+
+function measureWorkload(workload) {
+  const samples = [];
+  let resultCount = 0;
+  for (let iteration = 0; iteration < measuredIterations; iteration += 1) {
+    const started = performance.now();
+    const result = runSearch(workload.query);
+    samples.push(performance.now() - started);
+    resultCount = result.results.length;
+  }
+  const sorted = [...samples].sort((left, right) => left - right);
+  return {
+    name: workload.name,
+    resultCount,
+    meanMs:
+      samples.reduce((total, sample) => total + sample, 0) / samples.length,
+    p50Ms: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+    minMs: sorted[0],
+    maxMs: sorted.at(-1),
+  };
+}
+
+function percentile(sorted, fraction) {
+  return sorted[
+    Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))
+  ];
+}
+
+function readPositiveInteger(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}

--- a/server/chats/__tests__/chat-search-index.test.js
+++ b/server/chats/__tests__/chat-search-index.test.js
@@ -262,6 +262,43 @@ describe('ChatSearchIndex', () => {
     expect(index.indexStatus(['c1'])).toEqual({ indexedChatCount: 1, pendingChatCount: 0 });
   });
 
+  it('closes idempotently while pending reindex work settles', async () => {
+    const loadStarted = deferred();
+    const releaseLoad = deferred();
+    const index = new ChatSearchIndex({
+      dbPath: path.join(tempDir, 'search.sqlite'),
+      registry: registry({
+        c1: {
+          agentId: 'claude',
+          agentSessionId: 's1',
+          nativePath: null,
+          projectPath: '/tmp/project',
+          tags: [],
+          model: 'sonnet',
+        },
+      }),
+      loadNativeMessages: async () => {
+        loadStarted.resolve();
+        return releaseLoad.promise;
+      },
+    });
+    await index.init();
+
+    const reindexing = index.reindexStaleChats();
+    await loadStarted.promise;
+    index.close();
+    index.close();
+    releaseLoad.resolve([
+      new AssistantMessage('2026-07-08T00:00:00.000Z', 'ignored-after-close'),
+    ]);
+
+    await expect(reindexing).resolves.toBeUndefined();
+    expect(() => index.search({ query: 'ignored', allowedChatIds: ['c1'] }))
+      .toThrow('ChatSearchIndex not initialized');
+    await fs.rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
   it('matches query terms across messages and returns representative snippets', async () => {
     const index = await createIndex({
       c1: [

--- a/server/chats/__tests__/chat-search-index.test.js
+++ b/server/chats/__tests__/chat-search-index.test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -295,6 +296,26 @@ describe('ChatSearchIndex', () => {
     await expect(reindexing).resolves.toBeUndefined();
     expect(() => index.search({ query: 'ignored', allowedChatIds: ['c1'] }))
       .toThrow('ChatSearchIndex not initialized');
+    await fs.rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  it('closes the database when initialization fails after opening it', async () => {
+    const dbPath = path.join(tempDir, 'search.sqlite');
+    const malformedDb = new Database(dbPath);
+    malformedDb.exec('CREATE TABLE chat_search_meta (key TEXT PRIMARY KEY)');
+    malformedDb.close();
+    const index = new ChatSearchIndex({
+      dbPath,
+      registry: registry({}),
+      loadNativeMessages: async () => [],
+    });
+
+    await expect(index.init()).rejects.toThrow('no such column: value');
+    expect(() => index.search({ query: 'ignored', allowedChatIds: ['c1'] }))
+      .toThrow('ChatSearchIndex not initialized');
+    index.close();
+    expect((await fs.readdir(tempDir)).sort()).toEqual(['search.sqlite']);
     await fs.rm(tempDir, { recursive: true, force: true });
     tempDir = null;
   });

--- a/server/chats/__tests__/chat-search-index.test.js
+++ b/server/chats/__tests__/chat-search-index.test.js
@@ -298,6 +298,7 @@ describe('ChatSearchIndex', () => {
 
     expect(new Set(result.results.map((entry) => entry.chatId))).toEqual(new Set(['c1', 'c2']));
     expect(result.results.find((entry) => entry.chatId === 'c1')?.snippets).toHaveLength(3);
+    expect(result.results.find((entry) => entry.chatId === 'c1')?.matchedMessageCount).toBe(40);
     expect(result.results.find((entry) => entry.chatId === 'c2')?.snippets).toHaveLength(1);
   });
 

--- a/server/chats/chat-search-index.ts
+++ b/server/chats/chat-search-index.ts
@@ -142,9 +142,21 @@ export class ChatSearchIndex {
   async #reindexStaleChats(): Promise<void> {
     const sessions = this.#deps.registry.listAllChats();
     for (const [chatId, session] of Object.entries(sessions)) {
+      if (!this.#db) return;
       await this.#startReindex(chatId, session);
     }
+    if (!this.#db) return;
     this.#pruneMissingChats();
+  }
+
+  close(): void {
+    for (const timer of this.#reindexTimers.values()) clearTimeout(timer);
+    this.#reindexTimers.clear();
+    this.#activeReindexes.clear();
+    this.#appendRevisions.clear();
+    const db = this.#db;
+    this.#db = null;
+    db?.close();
   }
 
   #startReindex(chatId: string, session: ChatRegistryEntry): Promise<void> {

--- a/server/chats/chat-search-index.ts
+++ b/server/chats/chat-search-index.ts
@@ -86,48 +86,53 @@ export class ChatSearchIndex {
       await fs.mkdir(path.dirname(this.#deps.dbPath), { recursive: true });
     }
     const db = new Database(this.#deps.dbPath);
-    db.exec('PRAGMA journal_mode = WAL');
-    db.exec('PRAGMA synchronous = NORMAL');
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS chat_search_meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS chat_search_state (
-        chat_id TEXT PRIMARY KEY,
-        source_key TEXT NOT NULL,
-        indexed_at TEXT NOT NULL
-      );
-      CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_chunks USING fts5(
-        chat_id UNINDEXED,
-        message_ordinal UNINDEXED,
-        role UNINDEXED,
-        timestamp UNINDEXED,
-        body,
-        tokenize = 'unicode61'
-      );
-      CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_documents USING fts5(
-        chat_id UNINDEXED,
-        body,
-        tokenize = 'unicode61'
-      );
-    `);
-    const storedSchemaVersion = db.query<{ value: string }, []>(`
-      SELECT value FROM chat_search_meta WHERE key = 'schema_version'
-    `).get()?.value;
-    if (storedSchemaVersion !== String(SCHEMA_VERSION)) {
+    try {
+      db.exec('PRAGMA journal_mode = WAL');
+      db.exec('PRAGMA synchronous = NORMAL');
       db.exec(`
-        DELETE FROM chat_search_state;
-        DELETE FROM chat_search_chunks;
-        DELETE FROM chat_search_documents;
+        CREATE TABLE IF NOT EXISTS chat_search_meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS chat_search_state (
+          chat_id TEXT PRIMARY KEY,
+          source_key TEXT NOT NULL,
+          indexed_at TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_chunks USING fts5(
+          chat_id UNINDEXED,
+          message_ordinal UNINDEXED,
+          role UNINDEXED,
+          timestamp UNINDEXED,
+          body,
+          tokenize = 'unicode61'
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_documents USING fts5(
+          chat_id UNINDEXED,
+          body,
+          tokenize = 'unicode61'
+        );
       `);
+      const storedSchemaVersion = db.query<{ value: string }, []>(`
+        SELECT value FROM chat_search_meta WHERE key = 'schema_version'
+      `).get()?.value;
+      if (storedSchemaVersion !== String(SCHEMA_VERSION)) {
+        db.exec(`
+          DELETE FROM chat_search_state;
+          DELETE FROM chat_search_chunks;
+          DELETE FROM chat_search_documents;
+        `);
+      }
+      db.query(`
+        INSERT INTO chat_search_meta (key, value)
+        VALUES ('schema_version', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `).run(String(SCHEMA_VERSION));
+      this.#db = db;
+    } catch (error) {
+      db.close();
+      throw error;
     }
-    db.query(`
-      INSERT INTO chat_search_meta (key, value)
-      VALUES ('schema_version', ?)
-      ON CONFLICT(key) DO UPDATE SET value = excluded.value
-    `).run(String(SCHEMA_VERSION));
-    this.#db = db;
   }
 
   reindexStaleChats(): Promise<void> {

--- a/server/chats/chat-search-index.ts
+++ b/server/chats/chat-search-index.ts
@@ -46,9 +46,16 @@ interface IndexedMessageChunk {
 }
 
 interface SearchRow {
+  rowId: number;
+  chatId: string;
   messageOrdinal: number;
   role: ChatSearchSnippetRole;
   timestamp: string | null;
+  matchedMessageCount: number;
+}
+
+interface SnippetRow {
+  rowId: number;
   snippet: string;
 }
 
@@ -265,27 +272,25 @@ export class ChatSearchIndex {
     if (allowedChatIds.length === 0) {
       return { results: [], index: { indexedChatCount: 0, pendingChatCount: 0 } };
     }
-    const index = this.#withAllowedChats(allowedChatIds, () => this.#indexStatusForAllowed(allowedChatIds.length));
-    const matchQuery = buildFtsQuery(options.textTokens?.length ? options.textTokens : [options.query]);
-    if (!matchQuery) return { results: [], index };
+    return this.#withAllowedChats(allowedChatIds, () => {
+      const index = this.#indexStatusForAllowed(allowedChatIds.length);
+      const tokens = options.textTokens?.length ? options.textTokens : [options.query];
+      const matchQuery = buildFtsQuery(tokens);
+      if (!matchQuery) return { results: [], index };
 
-    const limit = clampLimit(options.limit);
-    const chatRows = this.#withAllowedChats(allowedChatIds, () => this.#requireDb().query<ChatMatchRow, [string, number]>(`
-      SELECT
-        chat_search_documents.chat_id AS chatId,
-        bm25(chat_search_documents) AS rank
-      FROM chat_search_documents
-      JOIN temp_search_allowed ON temp_search_allowed.chat_id = chat_search_documents.chat_id
-      WHERE chat_search_documents MATCH ?
-      ORDER BY rank
-      LIMIT ?
-    `).all(matchQuery, limit));
-
-    const snippetQuery = buildSnippetFtsQuery(
-      options.textTokens?.length ? options.textTokens : [options.query],
-    );
-    const results = chatRows.map((row) => this.#buildResult(row, snippetQuery));
-    return { results, index };
+      const chatRows = this.#requireDb().query<ChatMatchRow, [string, number]>(`
+        SELECT
+          chat_search_documents.chat_id AS chatId,
+          bm25(chat_search_documents) AS rank
+        FROM chat_search_documents
+        JOIN temp_search_allowed ON temp_search_allowed.chat_id = chat_search_documents.chat_id
+        WHERE chat_search_documents MATCH ?
+        ORDER BY rank
+        LIMIT ?
+      `).all(matchQuery, clampLimit(options.limit));
+      const results = this.#buildResults(chatRows, buildSnippetFtsQuery(tokens));
+      return { results, index };
+    });
   }
 
   indexStatus(allowedChatIds: string[]): ChatSearchIndexStatus {
@@ -341,35 +346,79 @@ export class ChatSearchIndex {
     this.#replaceDocument(chatId, body);
   }
 
-  #buildResult(row: ChatMatchRow, snippetQuery: string): ChatSearchResult {
+  #buildResults(chatRows: ChatMatchRow[], snippetQuery: string): ChatSearchResult[] {
+    if (chatRows.length === 0) return [];
     const db = this.#requireDb();
-    const matchedMessageCount = db.query<{ count: number }, [string, string]>(`
-      SELECT COUNT(*) AS count
-      FROM chat_search_chunks
-      WHERE chat_search_chunks MATCH ? AND chat_id = ?
-    `).get(snippetQuery, row.chatId)?.count ?? 0;
-    const snippets = db.query<SearchRow, [string, string, number]>(`
+    db.exec(`
+      CREATE TEMP TABLE IF NOT EXISTS temp_search_matches (
+        chat_id TEXT PRIMARY KEY
+      ) WITHOUT ROWID
+    `);
+    db.query('DELETE FROM temp_search_matches').run();
+    const insert = db.query('INSERT INTO temp_search_matches (chat_id) VALUES (?)');
+    for (const row of chatRows) insert.run(row.chatId);
+
+    // Bounds snippet generation and JS row materialization for common terms.
+    const rows = db.query<SearchRow, [string, number]>(`
+      SELECT rowId, chatId, messageOrdinal, role, timestamp, matchedMessageCount
+      FROM (
+        SELECT
+          chat_search_chunks.rowid AS rowId,
+          chat_search_chunks.chat_id AS chatId,
+          CAST(message_ordinal AS INTEGER) AS messageOrdinal,
+          role,
+          timestamp,
+          COUNT(*) OVER (PARTITION BY chat_search_chunks.chat_id) AS matchedMessageCount,
+          ROW_NUMBER() OVER (
+            PARTITION BY chat_search_chunks.chat_id
+            ORDER BY rank, CAST(message_ordinal AS INTEGER)
+          ) AS snippetRank
+        FROM chat_search_chunks
+        JOIN temp_search_matches ON temp_search_matches.chat_id = chat_search_chunks.chat_id
+        WHERE chat_search_chunks MATCH ?
+      )
+      WHERE snippetRank <= ?
+      ORDER BY chatId, snippetRank
+    `).all(snippetQuery, SNIPPETS_PER_CHAT);
+
+    db.exec(`
+      CREATE TEMP TABLE IF NOT EXISTS temp_search_snippet_rows (
+        row_id INTEGER PRIMARY KEY
+      )
+    `);
+    db.query('DELETE FROM temp_search_snippet_rows').run();
+    const insertSnippetRow = db.query('INSERT INTO temp_search_snippet_rows (row_id) VALUES (?)');
+    for (const row of rows) insertSnippetRow.run(row.rowId);
+    const snippets = db.query<SnippetRow, [string]>(`
       SELECT
-        CAST(message_ordinal AS INTEGER) AS messageOrdinal,
-        role,
-        timestamp,
+        chat_search_chunks.rowid AS rowId,
         snippet(chat_search_chunks, 4, '', '', ' ... ', 32) AS snippet
       FROM chat_search_chunks
-      WHERE chat_search_chunks MATCH ? AND chat_id = ?
-      ORDER BY bm25(chat_search_chunks), CAST(message_ordinal AS INTEGER)
-      LIMIT ?
-    `).all(snippetQuery, row.chatId, SNIPPETS_PER_CHAT);
-    return {
+      JOIN temp_search_snippet_rows ON temp_search_snippet_rows.row_id = chat_search_chunks.rowid
+      WHERE chat_search_chunks MATCH ?
+    `).all(snippetQuery);
+    const snippetTextByRow = new Map(
+      snippets.map((row) => [Number(row.rowId), normalizeSnippet(row.snippet)]),
+    );
+    const snippetsByChat = new Map<string, ChatSearchSnippet[]>();
+    const matchedMessageCounts = new Map<string, number>();
+    for (const row of rows) {
+      matchedMessageCounts.set(row.chatId, Number(row.matchedMessageCount));
+      const snippets = snippetsByChat.get(row.chatId) ?? [];
+      snippets.push({
+        messageOrdinal: Number(row.messageOrdinal),
+        role: row.role,
+        timestamp: row.timestamp,
+        text: snippetTextByRow.get(Number(row.rowId)) ?? '',
+      });
+      snippetsByChat.set(row.chatId, snippets);
+    }
+    return chatRows.map((row) => ({
       chatId: row.chatId,
       score: -Number(row.rank || 0),
-      matchedMessageCount,
-      snippets: snippets.map((snippet) => ({
-        messageOrdinal: Number(snippet.messageOrdinal),
-        role: snippet.role,
-        timestamp: snippet.timestamp,
-        text: normalizeSnippet(snippet.snippet),
-      } satisfies ChatSearchSnippet)),
-    };
+      matchedMessageCount: matchedMessageCounts.get(row.chatId) ?? 0,
+      snippets: snippetsByChat.get(row.chatId) ?? [],
+    }));
   }
 
   #upsertState(chatId: string, sourceKey: string, indexedAt: string): void {


### PR DESCRIPTION
## Summary

- batches transcript-result count and snippet hydration across the top-ranked chats
- limits snippet materialization to the existing three snippets per chat
- reuses one allowed-chat filter setup for status and ranking
- adds a reproducible synthetic search benchmark

The API response contract and search ranking/snippet behavior are unchanged.

## Diagnosis

Bun CPU profiles on the merged transcript-search implementation showed search result hydration as the bottleneck:

- `search` consumed 80.2% of the full benchmark profile
- the per-chat snippet query consumed 41.5%
- the per-chat matched-message count query consumed 38.6%
- allowed-chat filter setup consumed 0.5%

Each result previously ran two FTS queries constrained by an unindexed `chat_id`, so a 20-result common-term search repeatedly scanned the global FTS match set.

This change selects the top chats first, counts and ranks matching chunks for all selected chats in a single windowed query, and generates snippets only for the top three row IDs per chat.

## Methodology

- Bun 1.3.14, same host and worktree parent for both runs
- 3,000 chats × 40 messages = 120,000 indexed messages
- 20-result limit
- 8 warmup iterations, then 80 measured iterations per workload
- common term: matches every message
- rare term: matches one message in every 50th chat
- cross-message terms: requires two terms found in separate messages
- sampled with Bun's 1 ms CPU profiler; kernel `perf` was unavailable in the environment

Reproduce from this branch, passing either a base or head worktree:

```bash
bun --cpu-prof --cpu-prof-md scripts/benchmark-chat-search.js <repo-path>
```

## Results

| Workload | Mean before | Mean after | Speedup | p50 before → after | p95 before → after |
| --- | ---: | ---: | ---: | ---: | ---: |
| Common | 2,421.65 ms | 85.38 ms | 28.4× | 2,244.90 → 84.84 ms | 3,803.17 → 90.21 ms |
| Rare | 8.77 ms | 3.53 ms | 2.5× | 7.56 → 3.38 ms | 8.64 → 4.04 ms |
| Cross-message | 19.68 ms | 5.19 ms | 3.8× | 19.34 → 5.07 ms | 21.30 → 5.99 ms |

Index construction was not changed: 49.30 s before and 47.02 s after in these runs. After the query optimization, index construction accounts for 84.5% of the full head profile.

## Validation

- `bun run check`
- `bun run test` (all server suites; 258 web files / 2,178 tests)
- `bun run bench:search` smoke workload
- `bun run start --port 0` startup smoke on an isolated random port
