### PR TITLE
perf(ws): accelerate reconnect recovery

### DIFF
--- a/web/src/lib/ws/__tests__/connection.test.ts
+++ b/web/src/lib/ws/__tests__/connection.test.ts
@@ -249,7 +249,7 @@ describe('WsConnection', () => {
 		connection.disconnect();
 	});
 
-	it('retries an established socket immediately, then backs off repeated failures', async () => {
+	it('retries an established socket quickly, then backs off repeated failures', async () => {
 		vi.setSystemTime(1_000);
 		const connection = new WsConnection();
 
@@ -291,6 +291,54 @@ describe('WsConnection', () => {
 
 		await vi.advanceTimersByTimeAsync(1);
 		expect(mockSockets).toHaveLength(3);
+
+		connection.disconnect();
+	});
+
+	it('keeps retry progression when a reconnect opens but closes before becoming stable', async () => {
+		const connection = new WsConnection();
+
+		connection.connect('token');
+		mockSockets[0].open();
+		mockSockets[0].closeFromServer();
+
+		await vi.advanceTimersByTimeAsync(250);
+		mockSockets[1].open();
+		expect(connection.connectionStatus.reconnectAttempt).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(9_999);
+		mockSockets[1].closeFromServer();
+		expect(connection.connectionStatus).toMatchObject({
+			phase: 'reconnecting',
+			reconnectAttempt: 2,
+		});
+
+		await vi.advanceTimersByTimeAsync(800);
+		expect(mockSockets).toHaveLength(3);
+
+		connection.disconnect();
+	});
+
+	it('resets retry progression after the replacement socket remains stable', async () => {
+		vi.setSystemTime(0);
+		const connection = new WsConnection();
+
+		connection.connect('token');
+		mockSockets[0].open();
+		mockSockets[0].closeFromServer();
+		await vi.advanceTimersByTimeAsync(250);
+
+		mockSockets[1].open();
+		expect(connection.connectionStatus.reconnectAttempt).toBe(1);
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(connection.connectionStatus.reconnectAttempt).toBe(0);
+
+		mockSockets[1].closeFromServer();
+		expect(connection.connectionStatus).toMatchObject({
+			phase: 'reconnecting',
+			reconnectAttempt: 1,
+			nextRetryAt: 10_500,
+		});
 
 		connection.disconnect();
 	});

--- a/web/src/lib/ws/__tests__/connection.test.ts
+++ b/web/src/lib/ws/__tests__/connection.test.ts
@@ -185,7 +185,7 @@ describe('WsConnection', () => {
 			episodeId: 1,
 			reconnectAttempt: 1,
 			lastDisconnectedAt: 2_000,
-			nextRetryAt: 5_000,
+			nextRetryAt: 2_250,
 		});
 
 		connection.disconnect();
@@ -249,7 +249,8 @@ describe('WsConnection', () => {
 		connection.disconnect();
 	});
 
-	it('lets socket close own reconnect scheduling when a heartbeat request is in flight', async () => {
+	it('retries an established socket immediately, then backs off repeated failures', async () => {
+		vi.setSystemTime(1_000);
 		const connection = new WsConnection();
 
 		connection.connect('token');
@@ -267,14 +268,29 @@ describe('WsConnection', () => {
 			phase: 'reconnecting',
 			reason: 'socket-close',
 			reconnectAttempt: 1,
+			nextRetryAt: 16_250,
 		});
 		expect(mockSockets).toHaveLength(1);
 
-		await vi.advanceTimersByTimeAsync(2_999);
+		await vi.advanceTimersByTimeAsync(249);
 		expect(mockSockets).toHaveLength(1);
 
 		await vi.advanceTimersByTimeAsync(1);
 		expect(mockSockets).toHaveLength(2);
+
+		mockSockets[1].closeFromServer();
+		expect(connection.connectionStatus).toMatchObject({
+			phase: 'reconnecting',
+			reason: 'socket-close',
+			reconnectAttempt: 2,
+			nextRetryAt: 17_050,
+		});
+
+		await vi.advanceTimersByTimeAsync(799);
+		expect(mockSockets).toHaveLength(2);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(mockSockets).toHaveLength(3);
 
 		connection.disconnect();
 	});

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -213,6 +213,32 @@ describe('ChatReconnectCoordinator', () => {
 		await reconnect;
 	});
 
+	it('completes global reconciliation while the selected resume is pending', async () => {
+		const selectedSubscribe = deferred<Record<string, unknown>>();
+		const deps = createReconnectDeps({ runningIds: ['chat-1'] });
+		(deps.ws.sendRequest as ReturnType<typeof vi.fn>).mockImplementation(
+			async (request: Record<string, unknown>) => {
+				if (request.type === 'chats-running-query') return runningResponse(['chat-1']);
+				if (request.type === 'chat-subscribe') return selectedSubscribe.promise;
+				throw new Error(`Unexpected request: ${String(request.type)}`);
+			},
+		);
+
+		const coordinator = new ChatReconnectCoordinator(deps);
+		await coordinator.handleConnectionState(true);
+		await coordinator.handleConnectionState(false);
+		const reconnect = coordinator.handleConnectionState(true);
+
+		await flushUntil(() => deps.getQueue.mock.calls.length === 1);
+		expect(deps.reconcileProcessing).toHaveBeenCalledWith(new Set(['chat-1']));
+		expect(deps.quietRefreshChats).toHaveBeenCalledOnce();
+		expect(deps.getQueue).toHaveBeenCalledWith('chat-1');
+		expect(deps.getVisibleChatIds).not.toHaveBeenCalled();
+
+		selectedSubscribe.resolve(deltaResponse('chat-1'));
+		await reconnect;
+	});
+
 	it('falls back to selected snapshot on snapshot-required subscribe response', async () => {
 		const deps = createReconnectDeps({
 			subscribeResponses: {

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -183,6 +183,36 @@ describe('ChatReconnectCoordinator', () => {
 		);
 	});
 
+	it('resumes the selected chat without waiting for running-session reconciliation', async () => {
+		const running = deferred<Record<string, unknown>>();
+		const deps = createReconnectDeps();
+		(deps.ws.sendRequest as ReturnType<typeof vi.fn>).mockImplementation(
+			async (request: Record<string, unknown>) => {
+				if (request.type === 'chats-running-query') return running.promise;
+				if (request.type === 'chat-subscribe') {
+					return deltaResponse('chat-1', 'generation-selected', [messageJson(3, 'missed')]);
+				}
+				throw new Error(`Unexpected request: ${String(request.type)}`);
+			},
+		);
+
+		const coordinator = new ChatReconnectCoordinator(deps);
+		await coordinator.handleConnectionState(true);
+		await coordinator.handleConnectionState(false);
+		const reconnect = coordinator.handleConnectionState(true);
+
+		await flushUntil(() => deps.chatState.transcriptCache.markValidated.mock.calls.length === 1);
+		expect(deps.reconcileProcessing).not.toHaveBeenCalled();
+		expect(deps.chatState.applyMessages).toHaveBeenCalledWith(
+			'chat-1',
+			'generation-selected',
+			expect.arrayContaining([expect.objectContaining({ seq: 3 })]),
+		);
+
+		running.resolve(runningResponse([]));
+		await reconnect;
+	});
+
 	it('falls back to selected snapshot on snapshot-required subscribe response', async () => {
 		const deps = createReconnectDeps({
 			subscribeResponses: {

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -74,6 +74,7 @@ async function flushUntil(predicate: () => boolean): Promise<void> {
 function createReconnectDeps(
 	options: {
 		selectedChatId?: string | null;
+		selectedStatus?: 'idle' | 'running';
 		runningIds?: string[];
 		subscribeResponses?: Record<string, Record<string, unknown>>;
 		backgroundCursors?: Array<{ chatId: string; generationId: string; lastSeq: number }>;
@@ -120,7 +121,11 @@ function createReconnectDeps(
 		ws: { isConnected: true, sendRequest },
 		chatState,
 		conversationUi,
-		getSelectedChat: vi.fn(() => (selectedChatId ? { id: selectedChatId, status: 'idle' } : null)),
+		getSelectedChat: vi.fn(() =>
+			selectedChatId
+				? { id: selectedChatId, status: options.selectedStatus ?? 'idle' }
+				: null,
+		),
 		getSelectedChatId: vi.fn(() => selectedChatId),
 		getQueue: vi.fn(async () => ({ queue: { entries: [], paused: false } })),
 		reconcileProcessing: vi.fn(),
@@ -488,16 +493,24 @@ describe('ChatReconnectCoordinator', () => {
 
 	it('discards a stale queue refresh after a newer reconnect begins', async () => {
 		const firstQueue = deferred<{ queue: { entries: never[]; paused: boolean } }>();
-		const deps = createReconnectDeps({ runningIds: ['chat-1'] });
+		const deps = createReconnectDeps({
+			selectedStatus: 'running',
+			runningIds: ['chat-1'],
+		});
 		deps.getQueue
+			.mockResolvedValueOnce({ queue: { entries: [], paused: false } })
 			.mockImplementationOnce(async () => firstQueue.promise)
 			.mockResolvedValueOnce({ queue: { entries: [], paused: true } });
 
 		const coordinator = new ChatReconnectCoordinator(deps);
 		await coordinator.handleConnectionState(true);
+		await flushUntil(
+			() => deps.conversationUi.setMessageQueueFromRefresh.mock.calls.length === 1,
+		);
+		deps.conversationUi.setMessageQueueFromRefresh.mockClear();
 		await coordinator.handleConnectionState(false);
 		const first = coordinator.handleConnectionState(true);
-		await flushUntil(() => deps.getQueue.mock.calls.length === 1);
+		await flushUntil(() => deps.getQueue.mock.calls.length === 2);
 
 		await coordinator.handleConnectionState(false);
 		const second = coordinator.handleConnectionState(true);

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -485,4 +485,35 @@ describe('ChatReconnectCoordinator', () => {
 			expect.any(Array),
 		);
 	});
+
+	it('discards a stale queue refresh after a newer reconnect begins', async () => {
+		const firstQueue = deferred<{ queue: { entries: never[]; paused: boolean } }>();
+		const deps = createReconnectDeps({ runningIds: ['chat-1'] });
+		deps.getQueue
+			.mockImplementationOnce(async () => firstQueue.promise)
+			.mockResolvedValueOnce({ queue: { entries: [], paused: true } });
+
+		const coordinator = new ChatReconnectCoordinator(deps);
+		await coordinator.handleConnectionState(true);
+		await coordinator.handleConnectionState(false);
+		const first = coordinator.handleConnectionState(true);
+		await flushUntil(() => deps.getQueue.mock.calls.length === 1);
+
+		await coordinator.handleConnectionState(false);
+		const second = coordinator.handleConnectionState(true);
+		await second;
+
+		expect(deps.conversationUi.setMessageQueueFromRefresh).toHaveBeenCalledExactlyOnceWith(
+			'chat-1',
+			{ entries: [], paused: true },
+		);
+
+		firstQueue.resolve({ queue: { entries: [], paused: false } });
+		await first;
+
+		expect(deps.conversationUi.setMessageQueueFromRefresh).toHaveBeenCalledExactlyOnceWith(
+			'chat-1',
+			{ entries: [], paused: true },
+		);
+	});
 });

--- a/web/src/lib/ws/__tests__/reconnect-policy.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-policy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { reconnectDelayMs } from '../reconnect-policy';
+
+describe('reconnectDelayMs', () => {
+	it('uses an exact 250ms first retry', () => {
+		expect(reconnectDelayMs(0, () => 0)).toBe(250);
+		expect(reconnectDelayMs(0, () => 1)).toBe(250);
+	});
+
+	it('applies injected jitter between 80% and 100%', () => {
+		expect(reconnectDelayMs(1, () => 0)).toBe(800);
+		expect(reconnectDelayMs(1, () => 1)).toBe(1_000);
+	});
+
+	it('progresses exponentially after the first retry', () => {
+		expect([1, 2, 3, 4].map((attempt) => reconnectDelayMs(attempt, () => 1))).toEqual([
+			1_000, 2_000, 4_000, 8_000,
+		]);
+	});
+
+	it('caps the unjittered backoff at 30 seconds', () => {
+		expect(reconnectDelayMs(20, () => 1)).toBe(30_000);
+		expect(reconnectDelayMs(20, () => 0)).toBe(24_000);
+	});
+});

--- a/web/src/lib/ws/connection.svelte.ts
+++ b/web/src/lib/ws/connection.svelte.ts
@@ -10,11 +10,17 @@ import { createRandomId } from '$lib/utils/random-id';
 // past this many entries. Keeps memory bounded on long-running sessions.
 const TRIM_THRESHOLD = 500;
 
-// Base delay for exponential backoff reconnection (ms).
-const RECONNECT_BASE_MS = 3000;
+// Short first delay lets transient drops recover quickly without creating a tight retry loop.
+const RECONNECT_FIRST_MS = 250;
+
+// Base delay for exponential backoff after the fast recovery attempt (ms).
+const RECONNECT_BASE_MS = 1000;
 
 // Maximum reconnection delay (ms).
 const RECONNECT_MAX_MS = 30000;
+
+// Spreads sustained-outage retries without making any client wait longer than the backoff target.
+const RECONNECT_JITTER_FLOOR = 0.8;
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const HEARTBEAT_TIMEOUT_MS = 6_000;
@@ -90,6 +96,13 @@ function buildWebSocketUrl(): string {
 
 function generateRequestId() {
 	return createRandomId();
+}
+
+function reconnectDelayMs(failedAttempts: number): number {
+	if (failedAttempts === 0) return RECONNECT_FIRST_MS;
+	const backoff = Math.min(RECONNECT_BASE_MS * Math.pow(2, failedAttempts - 1), RECONNECT_MAX_MS);
+	const jitter = RECONNECT_JITTER_FLOOR + Math.random() * (1 - RECONNECT_JITTER_FLOOR);
+	return Math.round(backoff * jitter);
 }
 
 export class WsConnection {
@@ -518,10 +531,7 @@ export class WsConnection {
 		if (this.#destroyed) return;
 		this.#clearReconnectTimeout();
 
-		const delay = Math.min(
-			RECONNECT_BASE_MS * Math.pow(2, this.#reconnectAttempts),
-			RECONNECT_MAX_MS,
-		);
+		const delay = reconnectDelayMs(this.#reconnectAttempts);
 		const attempt = this.#reconnectAttempts + 1;
 		const nextRetryAt = Date.now() + delay;
 		this.#reconnectAttempts = attempt;

--- a/web/src/lib/ws/connection.svelte.ts
+++ b/web/src/lib/ws/connection.svelte.ts
@@ -5,27 +5,17 @@
 import { getAuthToken } from '$lib/api/client';
 import { webSocketProtocolsForAuth } from '$shared/ws-auth';
 import { createRandomId } from '$lib/utils/random-id';
+import { reconnectDelayMs } from './reconnect-policy';
 
 // Trims the message log once all registered consumers have drained
 // past this many entries. Keeps memory bounded on long-running sessions.
 const TRIM_THRESHOLD = 500;
 
-// Short first delay lets transient drops recover quickly without creating a tight retry loop.
-const RECONNECT_FIRST_MS = 250;
-
-// Base delay for exponential backoff after the fast recovery attempt (ms).
-const RECONNECT_BASE_MS = 1000;
-
-// Maximum reconnection delay (ms).
-const RECONNECT_MAX_MS = 30000;
-
-// Spreads sustained-outage retries without making any client wait longer than the backoff target.
-const RECONNECT_JITTER_FLOOR = 0.8;
-
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const HEARTBEAT_TIMEOUT_MS = 6_000;
 const HEARTBEAT_IMMEDIATE_PROBE_MS = 250;
 const HEARTBEAT_JITTER_MS = 1_500;
+const CONNECTION_STABILITY_MS = 10_000;
 
 export interface WsMessage {
 	data: Record<string, unknown>;
@@ -98,13 +88,6 @@ function generateRequestId() {
 	return createRandomId();
 }
 
-function reconnectDelayMs(failedAttempts: number): number {
-	if (failedAttempts === 0) return RECONNECT_FIRST_MS;
-	const backoff = Math.min(RECONNECT_BASE_MS * Math.pow(2, failedAttempts - 1), RECONNECT_MAX_MS);
-	const jitter = RECONNECT_JITTER_FLOOR + Math.random() * (1 - RECONNECT_JITTER_FLOOR);
-	return Math.round(backoff * jitter);
-}
-
 export class WsConnection {
 	#ws: WebSocket | null = null;
 	#activeSocket: WebSocket | null = null;
@@ -116,6 +99,7 @@ export class WsConnection {
 	#cursors = new Set<DrainCursor>();
 	#trimOffset = 0;
 	#reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+	#stabilityTimeout: ReturnType<typeof setTimeout> | null = null;
 	#reconnectAttempts = 0;
 	#destroyed = false;
 	#pendingRequests = new Map<string, PendingRequest>();
@@ -202,15 +186,15 @@ export class WsConnection {
 				this.isConnected = true;
 				this.#hasEverConnected = true;
 				this.#ws = websocket;
-				this.#reconnectAttempts = 0;
 				this.#setConnectionStatus({
 					phase: 'connected',
 					reason: null,
-					reconnectAttempt: 0,
+					reconnectAttempt: this.#reconnectAttempts,
 					nextRetryAt: null,
 					lastConnectedAt: now,
 				});
 				this.#resolveAllWaiters();
+				this.#scheduleStabilityReset(websocket);
 				this.#scheduleHeartbeat(this.#nextHeartbeatDelay());
 			};
 
@@ -278,6 +262,7 @@ export class WsConnection {
 			nextRetryAt: null,
 		});
 		this.#clearReconnectTimeout();
+		this.#clearStabilityTimeout();
 		this.#clearHeartbeatTimer();
 		this.#rejectAllWaiters('WebSocket destroyed');
 		this.#rejectAllPending();
@@ -323,6 +308,7 @@ export class WsConnection {
 
 	#handleSocketClosed(reason: WsConnectionIssue): void {
 		const episodeId = this.#beginOutage();
+		this.#clearStabilityTimeout();
 		this.#clearHeartbeatTimer();
 		this.#heartbeatInFlight = false;
 		this.isConnected = false;
@@ -422,6 +408,7 @@ export class WsConnection {
 
 	#closeExisting(options: { rejectPending?: boolean } = {}): void {
 		this.#clearReconnectTimeout();
+		this.#clearStabilityTimeout();
 		this.#clearHeartbeatTimer();
 		this.#heartbeatInFlight = false;
 		if (options.rejectPending) this.#rejectAllPending();
@@ -514,7 +501,6 @@ export class WsConnection {
 
 	#connectNow(reason: WsConnectionIssue): void {
 		if (this.#destroyed) return;
-		this.#reconnectAttempts = 0;
 		this.#clearReconnectTimeout();
 		this.#nextConnectReason = reason;
 		this.connect(getAuthToken(), this.#authDisabled);
@@ -560,6 +546,23 @@ export class WsConnection {
 		if (this.#reconnectTimeout !== null) {
 			clearTimeout(this.#reconnectTimeout);
 			this.#reconnectTimeout = null;
+		}
+	}
+
+	#scheduleStabilityReset(socket: WebSocket): void {
+		this.#clearStabilityTimeout();
+		this.#stabilityTimeout = setTimeout(() => {
+			this.#stabilityTimeout = null;
+			if (!this.#isCurrentSocket(socket) || socket.readyState !== WebSocket.OPEN) return;
+			this.#reconnectAttempts = 0;
+			this.#setConnectionStatus({ reconnectAttempt: 0 });
+		}, CONNECTION_STABILITY_MS);
+	}
+
+	#clearStabilityTimeout(): void {
+		if (this.#stabilityTimeout !== null) {
+			clearTimeout(this.#stabilityTimeout);
+			this.#stabilityTimeout = null;
 		}
 	}
 

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -111,7 +111,17 @@ export class ChatReconnectCoordinator {
 	}
 
 	async #reconcileAfterReconnect(selectedChatId: string | null, epoch: number): Promise<void> {
-		const runningChatIds = await this.#requestRunningChatIds();
+		let selectedResume = Promise.resolve();
+		if (selectedChatId) {
+			this.options.chatState.transcriptCache.markStale(selectedChatId);
+			selectedResume = this.#resumeSelectedChat(selectedChatId, epoch);
+		}
+
+		const runningChatIdsRequest = this.#requestRunningChatIds();
+		await selectedResume;
+		if (epoch !== this.#reconnectEpoch) return;
+
+		const runningChatIds = await runningChatIdsRequest;
 		if (epoch !== this.#reconnectEpoch) return;
 
 		this.options.reconcileProcessing(runningChatIds);
@@ -120,11 +130,6 @@ export class ChatReconnectCoordinator {
 
 		if (selectedChatId && runningChatIds.has(selectedChatId)) {
 			await this.#refreshQueue(selectedChatId);
-		}
-
-		if (selectedChatId) {
-			this.options.chatState.transcriptCache.markStale(selectedChatId);
-			await this.#resumeSelectedChat(selectedChatId, epoch);
 		}
 
 		const visibleChatIds = this.#visibleChatIds(selectedChatId);

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -140,7 +140,7 @@ export class ChatReconnectCoordinator {
 		if (epoch !== this.#reconnectEpoch) return runningChatIds;
 
 		if (selectedChatId && runningChatIds.has(selectedChatId)) {
-			await this.#refreshQueue(selectedChatId);
+			await this.#refreshQueue(selectedChatId, epoch);
 		}
 		return runningChatIds;
 	}
@@ -158,9 +158,15 @@ export class ChatReconnectCoordinator {
 		}
 	}
 
-	async #refreshQueue(chatId: string): Promise<void> {
+	async #refreshQueue(chatId: string, expectedEpoch?: number): Promise<void> {
 		try {
 			const result = await this.options.getQueue(chatId);
+			if (
+				expectedEpoch !== undefined &&
+				(expectedEpoch !== this.#reconnectEpoch || this.options.getSelectedChatId() !== chatId)
+			) {
+				return;
+			}
 			this.options.conversationUi.setMessageQueueFromRefresh(chatId, result.queue);
 		} catch {
 			// Later queue broadcasts will converge the visible queue state.

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -117,20 +117,9 @@ export class ChatReconnectCoordinator {
 			selectedResume = this.#resumeSelectedChat(selectedChatId, epoch);
 		}
 
-		const runningChatIdsRequest = this.#requestRunningChatIds();
-		await selectedResume;
+		const globalReconciliation = this.#reconcileGlobalState(selectedChatId, epoch);
+		const [, runningChatIds] = await Promise.all([selectedResume, globalReconciliation]);
 		if (epoch !== this.#reconnectEpoch) return;
-
-		const runningChatIds = await runningChatIdsRequest;
-		if (epoch !== this.#reconnectEpoch) return;
-
-		this.options.reconcileProcessing(runningChatIds);
-		await this.options.quietRefreshChats();
-		if (epoch !== this.#reconnectEpoch) return;
-
-		if (selectedChatId && runningChatIds.has(selectedChatId)) {
-			await this.#refreshQueue(selectedChatId);
-		}
 
 		const visibleChatIds = this.#visibleChatIds(selectedChatId);
 		await this.#resumeVisibleChats(visibleChatIds, epoch);
@@ -140,6 +129,20 @@ export class ChatReconnectCoordinator {
 			...(selectedChatId ? [selectedChatId] : []),
 		]);
 		await this.#resumeBackgroundChats(excludedBackgroundChatIds, runningChatIds, epoch);
+	}
+
+	async #reconcileGlobalState(selectedChatId: string | null, epoch: number): Promise<Set<string>> {
+		const runningChatIds = await this.#requestRunningChatIds();
+		if (epoch !== this.#reconnectEpoch) return runningChatIds;
+
+		this.options.reconcileProcessing(runningChatIds);
+		await this.options.quietRefreshChats();
+		if (epoch !== this.#reconnectEpoch) return runningChatIds;
+
+		if (selectedChatId && runningChatIds.has(selectedChatId)) {
+			await this.#refreshQueue(selectedChatId);
+		}
+		return runningChatIds;
 	}
 
 	async #requestRunningChatIds(): Promise<Set<string>> {

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -97,12 +97,11 @@ export class ChatReconnectCoordinator {
 		const selected = this.options.getSelectedChat();
 		const chatId = this.options.getSelectedChatId();
 
-		if (selected?.status === 'running') {
-			void this.#refreshQueue(selected.id);
-		}
-
 		if (!this.#hasConnectedBefore) {
 			this.#hasConnectedBefore = true;
+			if (selected?.status === 'running') {
+				void this.#refreshQueue(selected.id);
+			}
 			return;
 		}
 

--- a/web/src/lib/ws/reconnect-policy.ts
+++ b/web/src/lib/ws/reconnect-policy.ts
@@ -1,0 +1,17 @@
+const FIRST_RETRY_MS = 250;
+const EXPONENTIAL_BASE_MS = 1_000;
+const MAX_RETRY_MS = 30_000;
+const JITTER_FLOOR = 0.8;
+
+export type RandomSource = () => number;
+
+export function reconnectDelayMs(
+	failedAttempts: number,
+	random: RandomSource = Math.random,
+): number {
+	if (failedAttempts === 0) return FIRST_RETRY_MS;
+
+	const backoff = Math.min(EXPONENTIAL_BASE_MS * Math.pow(2, failedAttempts - 1), MAX_RETRY_MS);
+	const jitter = JITTER_FLOOR + random() * (1 - JITTER_FLOOR);
+	return Math.round(backoff * jitter);
+}


### PR DESCRIPTION
## Before
- An observed WebSocket close waited 3,000 ms before constructing the first replacement socket.
- After the replacement opened, selected-chat catch-up waited behind running-session and chat-list reconciliation.

```mermaid
flowchart LR
  A[Socket closes] --> B[Wait 3,000 ms]
  B --> C[Open replacement]
  C --> D[Reconcile global state]
  D --> E[Resume selected chat]
```

## After

```mermaid
flowchart LR
  A[Socket closes] --> B[Wait 250 ms]
  B --> C[Open replacement]
  C --> D[Resume selected chat]
  C --> E[Reconcile global state]
  F[Repeated failures] --> G[Jittered exponential backoff]
```

The first replacement attempt now starts after 250 ms, a 91.7% reduction in client-side reconnect scheduling latency. Sustained failures back off from 0.8-1.0 seconds and remain capped at 30 seconds, with jitter to spread retries. Retry progression resets only after a socket remains stable for 10 seconds. Selected-chat replay starts before and runs concurrently with global reconciliation, while reconnect epochs prevent stale queue responses from overwriting newer state.

## Files
- `web/src/lib/ws/connection.svelte.ts` adds fast-first reconnects and stability-qualified backoff resets.
- `web/src/lib/ws/reconnect-policy.ts` owns the deterministic jittered backoff policy.
- `web/src/lib/ws/reconnect-coordinator.svelte.ts` prioritizes selected-chat catch-up and guards stale reconciliation.
- WebSocket tests cover timing boundaries, jitter/cap behavior, unstable opens, concurrency, and stale-response races.

## Tests
- Targeted reconnect tests: 33/33 passed.
- `bun run check`: passed with 0 Svelte errors and 0 warnings.
- `bun run test`: passed; all server suites plus 259 web test files / 2,187 web tests.
- `bun run start --port 0`: production build completed and server started on an ephemeral port.
- GitHub checks: server-tests, web-tests, and build-exe passed.
- Review/fix loop: four review rounds; final verdict APPROVE with no valid bugs or BLOCKER/MAJOR findings.

Prompted by: yk (@chiayong)