### PR TITLE
fix(codex): retry model capacity failures

### DIFF
--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -1157,6 +1157,72 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it('resumes a blocked goal after a capacity failure without duplicating input', async () => {
+    const nativePath = path.join(tmpDir, 'goal-capacity-retry-thread.jsonl');
+    let fake;
+    let resolveRetryStarted;
+    const retryStarted = new Promise((resolve) => { resolveRetryStarted = resolve; });
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+      setThreadGoalStatus: async (threadId, status) => {
+        const goal = makeGoal(threadId, 'Finish the work', status);
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: { threadId, turnId: null, goal },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: {
+            threadId,
+            turn: makeTurn({ id: 'turn-2', status: 'inProgress', completedAt: null, durationMs: null }),
+          },
+        });
+        resolveRetryStarted({ threadId, status });
+        return { goal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0],
+    });
+    const failures = [];
+    provider.onFailed((_chatId, message) => failures.push(message));
+    await provider.startSession(makeRequest());
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work') },
+    });
+
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work', 'blocked') },
+    });
+    emitCapacityFailure(fake, 'turn-1');
+
+    await expect(retryStarted).resolves.toEqual({ threadId: 'thread-1', status: 'active' });
+    expect(fake.setThreadGoalStatus).toHaveBeenCalledWith('thread-1', 'active');
+    expect(fake.startTurn).toHaveBeenCalledTimes(1);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(failures).toEqual([]);
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-2', goal: makeGoal('thread-1', 'Finish the work', 'complete') },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-2' }) },
+    });
+    await finished;
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
   it('caps capacity retries at three', async () => {
     const nativePath = path.join(tmpDir, 'capacity-exhausted-thread.jsonl');
     let turnNumber = 0;
@@ -1191,6 +1257,70 @@ describe('CodexAppServerRuntime', () => {
       message: 'Selected model is at capacity. Please try a different model.',
     });
     expect(fake.startTurn).toHaveBeenCalledTimes(4);
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails a blocked goal after three capacity retries', async () => {
+    const nativePath = path.join(tmpDir, 'goal-capacity-exhausted-thread.jsonl');
+    let fake;
+    let turnNumber = 1;
+    const retryResolvers = [];
+    const retryStarts = Array.from({ length: 3 }, () => new Promise((resolve) => retryResolvers.push(resolve)));
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+      setThreadGoalStatus: async (threadId, status) => {
+        turnNumber += 1;
+        const goal = makeGoal(threadId, 'Finish the work', status);
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: { threadId, turnId: null, goal },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: {
+            threadId,
+            turn: makeTurn({ id: `turn-${turnNumber}`, status: 'inProgress', completedAt: null, durationMs: null }),
+          },
+        });
+        retryResolvers[turnNumber - 2]?.({ threadId, status });
+        return { goal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0],
+    });
+    const failed = new Promise((resolve) => provider.onFailed((chatId, message) => resolve({ chatId, message })));
+    await provider.startSession(makeRequest());
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work') },
+    });
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const turnId = `turn-${attempt + 1}`;
+      fake.emit('notification', {
+        method: 'thread/goal/updated',
+        params: { threadId: 'thread-1', turnId, goal: makeGoal('thread-1', 'Finish the work', 'blocked') },
+      });
+      emitCapacityFailure(fake, turnId);
+      if (attempt < 3) {
+        await expect(retryStarts[attempt]).resolves.toEqual({ threadId: 'thread-1', status: 'active' });
+      }
+    }
+
+    await expect(failed).resolves.toEqual({
+      chatId: 'chat-1',
+      message: 'Selected model is at capacity. Please try a different model.',
+    });
+    expect(fake.setThreadGoalStatus).toHaveBeenCalledTimes(3);
+    expect(fake.startTurn).toHaveBeenCalledTimes(1);
     expect(provider.isRunning('thread-1')).toBe(false);
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
   });

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -67,6 +67,30 @@ function makeTurn(overrides = {}) {
   };
 }
 
+function emitCapacityFailure(client, turnId) {
+  const error = {
+    message: 'Selected model is at capacity. Please try a different model.',
+    codexErrorInfo: 'serverOverloaded',
+    additionalDetails: null,
+  };
+  client.emit('notification', {
+    method: 'error',
+    params: {
+      threadId: 'thread-1',
+      turnId,
+      willRetry: false,
+      error,
+    },
+  });
+  client.emit('notification', {
+    method: 'turn/completed',
+    params: {
+      threadId: 'thread-1',
+      turn: makeTurn({ id: turnId, status: 'failed', error }),
+    },
+  });
+}
+
 function makeGoal(threadId, objective, status = 'active') {
   return {
     threadId,
@@ -939,6 +963,83 @@ describe('CodexAppServerRuntime', () => {
       params: { threadId: 'thread-1', turn: makeTurn() },
     });
     await finished;
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a capacity failure without appending another user message', async () => {
+    const nativePath = path.join(tmpDir, 'capacity-retry-thread.jsonl');
+    let turnNumber = 0;
+    let resolveRetryStarted;
+    const retryStarted = new Promise((resolve) => { resolveRetryStarted = resolve; });
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async (params) => {
+        await fs.writeFile(nativePath, '{}\n');
+        turnNumber += 1;
+        if (turnNumber === 2) resolveRetryStarted(params);
+        return { turn: makeTurn({ id: `turn-${turnNumber}`, status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0],
+    });
+    const failures = [];
+    provider.onFailed((_chatId, message) => failures.push(message));
+    await provider.startSession(makeRequest());
+
+    emitCapacityFailure(fake, 'turn-1');
+
+    await expect(retryStarted).resolves.toEqual({ threadId: 'thread-1', input: [] });
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(failures).toEqual([]);
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-2' }) },
+    });
+    await finished;
+    expect(fake.startTurn).toHaveBeenCalledTimes(2);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps capacity retries at three', async () => {
+    const nativePath = path.join(tmpDir, 'capacity-exhausted-thread.jsonl');
+    let turnNumber = 0;
+    const retryResolvers = [];
+    const retryStarts = Array.from({ length: 3 }, () => new Promise((resolve) => retryResolvers.push(resolve)));
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async (params) => {
+        await fs.writeFile(nativePath, '{}\n');
+        turnNumber += 1;
+        retryResolvers[turnNumber - 2]?.(params);
+        return { turn: makeTurn({ id: `turn-${turnNumber}`, status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0, 0],
+    });
+    const failed = new Promise((resolve) => provider.onFailed((chatId, message) => resolve({ chatId, message })));
+    await provider.startSession(makeRequest());
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      emitCapacityFailure(fake, `turn-${attempt + 1}`);
+      if (attempt < 3) {
+        await expect(retryStarts[attempt]).resolves.toEqual({ threadId: 'thread-1', input: [] });
+      }
+    }
+
+    await expect(failed).resolves.toEqual({
+      chatId: 'chat-1',
+      message: 'Selected model is at capacity. Please try a different model.',
+    });
+    expect(fake.startTurn).toHaveBeenCalledTimes(4);
+    expect(provider.isRunning('thread-1')).toBe(false);
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
   });
 

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -881,6 +881,102 @@ describe('CodexAppServerRuntime', () => {
     expect(provider.isRunning('thread-1')).toBe(true);
   });
 
+  it('keeps the turn running when Codex reports a retryable stream error', async () => {
+    const nativePath = path.join(tmpDir, 'retryable-error-thread.jsonl');
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+    const emitted = [];
+    const failures = [];
+    const processing = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    provider.onFailed((chatId, message) => failures.push({ chatId, message }));
+    provider.onProcessing((_chatId, value) => processing.push(value));
+    await provider.startSession(makeRequest());
+
+    fake.emit('notification', {
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        willRetry: true,
+        error: {
+          message: 'Reconnecting... 1/5',
+          additionalDetails: 'Request to upstream timed out',
+        },
+      },
+    });
+    fake.emit('notification', {
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        willRetry: true,
+        error: {
+          message: 'Reconnecting... 2/5',
+          additionalDetails: 'Request to upstream timed out',
+        },
+      },
+    });
+
+    expect(emitted.map((message) => message.content)).toEqual([
+      'Reconnecting... 1/5',
+      'Reconnecting... 2/5',
+    ]);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(processing.at(-1)).toBe(true);
+    expect(failures).toEqual([]);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn() },
+    });
+    await finished;
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the turn when Codex reports a non-retryable error', async () => {
+    const nativePath = path.join(tmpDir, 'terminal-error-thread.jsonl');
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+    const emitted = [];
+    const failed = new Promise((resolve) => provider.onFailed((chatId, message) => resolve({ chatId, message })));
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    await provider.startSession(makeRequest());
+
+    fake.emit('notification', {
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: {
+          message: 'Codex turn failed',
+          additionalDetails: null,
+        },
+      },
+    });
+
+    await expect(failed).resolves.toEqual({ chatId: 'chat-1', message: 'Codex turn failed' });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ type: 'error', content: 'Codex turn failed' });
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
   it('streams raw Code Mode calls and their paired outputs through the shared contract', async () => {
     const nativePath = path.join(tmpDir, 'live-exec-thread.jsonl');
     const fake = new FakeClient({

--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -931,6 +931,7 @@ describe('CodexAppServerRuntime', () => {
         willRetry: true,
         error: {
           message: 'Reconnecting... 1/5',
+          codexErrorInfo: null,
           additionalDetails: 'Request to upstream timed out',
         },
       },
@@ -943,6 +944,7 @@ describe('CodexAppServerRuntime', () => {
         willRetry: true,
         error: {
           message: 'Reconnecting... 2/5',
+          codexErrorInfo: null,
           additionalDetails: 'Request to upstream timed out',
         },
       },
@@ -964,6 +966,156 @@ describe('CodexAppServerRuntime', () => {
     });
     await finished;
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores lifecycle notifications emitted by a stale app-server client', async () => {
+    const nativePath = path.join(tmpDir, 'stale-client-error-thread.jsonl');
+    const staleClient = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ id: 'old-turn', status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const activeClient = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ id: 'active-turn', status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const clients = [staleClient, activeClient];
+    const provider = new CodexAppServerRuntime({ createClient: () => clients.shift(), materializationTimeoutMs: 20 });
+    const emitted = [];
+    const failures = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    provider.onFailed((_chatId, message) => failures.push(message));
+
+    await provider.startSession(makeRequest());
+    const oldFinished = new Promise((resolve) => provider.onFinished(resolve));
+    staleClient.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'old-turn' }) },
+    });
+    await oldFinished;
+    await provider.startSession(makeRequest());
+
+    staleClient.emit('notification', {
+      method: 'turn/started',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'stale-started-turn', status: 'inProgress' }) },
+    });
+    staleClient.emit('notification', {
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'active-turn',
+        item: { type: 'agentMessage', id: 'stale-message', text: 'Message from stale client', phase: null, memoryCitation: null },
+      },
+    });
+    staleClient.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'active-turn',
+        item: { type: 'custom_tool_call', call_id: 'stale-call', name: 'exec', input: 'text("stale")' },
+      },
+    });
+    staleClient.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'active-turn', goal: makeGoal('thread-1', 'Stale goal') },
+    });
+    staleClient.emit('notification', {
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'active-turn',
+        willRetry: false,
+        error: {
+          message: 'Error from stale client',
+          codexErrorInfo: null,
+          additionalDetails: null,
+        },
+      },
+    });
+    staleClient.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'active-turn' }) },
+    });
+
+    expect(emitted).toEqual([]);
+    expect(failures).toEqual([]);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(activeClient.shutdown).not.toHaveBeenCalled();
+
+    const activeFinished = new Promise((resolve) => provider.onFinished(resolve));
+    activeClient.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'active-turn' }) },
+    });
+    await activeFinished;
+  });
+
+  it('ignores lifecycle notifications for a turn that is no longer active', async () => {
+    const nativePath = path.join(tmpDir, 'stale-turn-error-thread.jsonl');
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ id: 'active-turn', status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+    const emitted = [];
+    const failures = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    provider.onFailed((_chatId, message) => failures.push(message));
+    await provider.startSession(makeRequest());
+
+    fake.emit('notification', {
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'stale-turn',
+        willRetry: false,
+        error: {
+          message: 'Error from stale turn',
+          codexErrorInfo: null,
+          additionalDetails: null,
+        },
+      },
+    });
+    fake.emit('notification', {
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'stale-turn',
+        item: { type: 'agentMessage', id: 'stale-message', text: 'Message from stale turn', phase: null, memoryCitation: null },
+      },
+    });
+    fake.emit('notification', {
+      method: 'rawResponseItem/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'stale-turn',
+        item: { type: 'custom_tool_call', call_id: 'stale-call', name: 'exec', input: 'text("stale")' },
+      },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'stale-turn' }) },
+    });
+
+    expect(emitted).toEqual([]);
+    expect(failures).toEqual([]);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'active-turn' }) },
+    });
+    await finished;
   });
 
   it('retries a capacity failure without appending another user message', async () => {
@@ -1066,6 +1218,7 @@ describe('CodexAppServerRuntime', () => {
         willRetry: false,
         error: {
           message: 'Codex turn failed',
+          codexErrorInfo: null,
           additionalDetails: null,
         },
       },
@@ -2859,7 +3012,12 @@ describe('CodexAppServerRuntime', () => {
     }), async () => {
       fake.emit('notification', {
         method: 'error',
-        params: { threadId: 'thread-1', error: { message: 'terminal failure' } },
+        params: {
+          threadId: 'thread-1',
+          turnId: 'goal-turn',
+          willRetry: false,
+          error: { message: 'terminal failure', codexErrorInfo: null, additionalDetails: null },
+        },
       });
     });
     await expect(first).rejects.toThrow('terminal failure');
@@ -3366,7 +3524,7 @@ describe('CodexAppServerRuntime', () => {
     listedPath = secondResolvedPath;
     fake.emit('notification', {
       method: 'turn/completed',
-      params: { threadId: 'thread-1', turn: { status: 'completed', error: null } },
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-1' }) },
     });
     await finished;
     const after = await provider.resolveNativePath(session);

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -58,12 +58,38 @@ export type CodexThreadStatus =
   | { type: 'systemError' }
   | { type: 'active'; activeFlags: string[] };
 
+type CodexHttpErrorInfo = { httpStatusCode: number | null };
+
+export type CodexErrorInfo =
+  | 'contextWindowExceeded'
+  | 'sessionBudgetExceeded'
+  | 'usageLimitExceeded'
+  | 'serverOverloaded'
+  | 'cyberPolicy'
+  | 'internalServerError'
+  | 'unauthorized'
+  | 'badRequest'
+  | 'threadRollbackFailed'
+  | 'sandboxError'
+  | 'other'
+  | { httpConnectionFailed: CodexHttpErrorInfo }
+  | { responseStreamConnectionFailed: CodexHttpErrorInfo }
+  | { responseStreamDisconnected: CodexHttpErrorInfo }
+  | { responseTooManyFailedAttempts: CodexHttpErrorInfo }
+  | { activeTurnNotSteerable: { turnKind: 'review' | 'compact' } };
+
+export interface CodexTurnError {
+  message: string;
+  codexErrorInfo?: CodexErrorInfo | null;
+  additionalDetails?: string | null;
+}
+
 export interface CodexTurn {
   id: string;
   items: CodexThreadItem[];
   itemsView: 'notLoaded' | 'summary' | 'full';
   status: 'completed' | 'interrupted' | 'failed' | 'inProgress';
-  error: { message: string; codexErrorInfo: unknown; additionalDetails: string | null } | null;
+  error: CodexTurnError | null;
   startedAt: number | null;
   completedAt: number | null;
   durationMs: number | null;
@@ -230,10 +256,7 @@ export interface ErrorNotification {
   threadId: string;
   turnId: string;
   willRetry: boolean;
-  error: {
-    message: string;
-    additionalDetails: string | null;
-  };
+  error: CodexTurnError;
 }
 
 export interface CommandExecutionRequestApprovalParams {

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -227,11 +227,12 @@ export interface RawResponseItemCompletedNotification {
 }
 
 export interface ErrorNotification {
-  threadId?: string;
-  turnId?: string;
-  error?: {
-    message?: string;
-    additionalDetails?: string | null;
+  threadId: string;
+  turnId: string;
+  willRetry: boolean;
+  error: {
+    message: string;
+    additionalDetails: string | null;
   };
 }
 

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -958,39 +958,39 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #handleNotification(client: CodexAppServerClient, notification: JsonRpcNotification): void {
     switch (notification.method) {
       case 'turn/started':
-        this.#handleTurnStarted(notification.params as TurnStartedNotification);
+        this.#handleTurnStarted(client, notification.params as TurnStartedNotification);
         break;
       case 'item/completed':
-        this.#handleItemCompleted(notification.params as ItemCompletedNotification);
+        this.#handleItemCompleted(client, notification.params as ItemCompletedNotification);
         break;
       case 'rawResponseItem/completed':
-        this.#handleRawResponseItemCompleted(notification.params as RawResponseItemCompletedNotification);
+        this.#handleRawResponseItemCompleted(client, notification.params as RawResponseItemCompletedNotification);
         break;
       case 'turn/completed':
-        this.#handleTurnCompleted(notification.params as TurnCompletedNotification);
+        this.#handleTurnCompleted(client, notification.params as TurnCompletedNotification);
         break;
       case 'thread/goal/updated':
-        this.#handleGoalUpdated(notification.params as ThreadGoalUpdatedNotification);
+        this.#handleGoalUpdated(client, notification.params as ThreadGoalUpdatedNotification);
         break;
       case 'thread/goal/cleared':
-        this.#handleGoalCleared(notification.params as ThreadGoalClearedNotification);
+        this.#handleGoalCleared(client, notification.params as ThreadGoalClearedNotification);
         break;
       case 'error':
-        this.#handleErrorNotification(notification.params as ErrorNotification);
+        this.#handleErrorNotification(client, notification.params as ErrorNotification);
         break;
     }
   }
 
-  #handleTurnStarted(params: TurnStartedNotification): void {
-    const session = this.#sessions.get(params.threadId);
+  #handleTurnStarted(client: CodexAppServerClient, params: TurnStartedNotification): void {
+    const session = this.#sessionForClientThread(client, params.threadId);
     if (!session) return;
     session.activeTurnId = params.turn.id;
     session.status = 'running';
     for (const waiter of session.turnStartWaiters) waiter.resolve(params.turn.id);
   }
 
-  #handleGoalUpdated(params: ThreadGoalUpdatedNotification): void {
-    const session = this.#sessions.get(params.threadId);
+  #handleGoalUpdated(client: CodexAppServerClient, params: ThreadGoalUpdatedNotification): void {
+    const session = this.#sessionForClientThread(client, params.threadId);
     if (!session) return;
     session.goal = params.goal;
     if (params.goal.status === 'active') session.managesGoalLifecycle = true;
@@ -1004,8 +1004,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     }
   }
 
-  #handleGoalCleared(params: ThreadGoalClearedNotification): void {
-    const session = this.#sessions.get(params.threadId);
+  #handleGoalCleared(client: CodexAppServerClient, params: ThreadGoalClearedNotification): void {
+    const session = this.#sessionForClientThread(client, params.threadId);
     if (!session) return;
     if (session.ignoredGoalClears > 0) {
       session.ignoredGoalClears -= 1;
@@ -1096,8 +1096,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (session.ignoredGoalClears > 0) session.ignoredGoalClears -= 1;
   }
 
-  #handleItemCompleted(params: ItemCompletedNotification): void {
-    const session = this.#sessions.get(params.threadId);
+  #handleItemCompleted(client: CodexAppServerClient, params: ItemCompletedNotification): void {
+    const session = this.#sessionForClientTurn(client, params.threadId, params.turnId);
     if (!session) return;
     // A contextCompaction item is 'manual' only when this session was started by
     // /compact; otherwise the app-server auto-compacted to free context.
@@ -1110,8 +1110,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (messages.length) this.emitMessages(session.chatId, messages);
   }
 
-  #handleRawResponseItemCompleted(params: RawResponseItemCompletedNotification): void {
-    const session = this.#sessions.get(params.threadId);
+  #handleRawResponseItemCompleted(client: CodexAppServerClient, params: RawResponseItemCompletedNotification): void {
+    const session = this.#sessionForClientTurn(client, params.threadId, params.turnId);
     if (!session) return;
     const messages = convertCodexRawCodeModeItem(
       params.item,
@@ -1121,17 +1121,20 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (messages.length) this.emitMessages(session.chatId, messages);
   }
 
-  #handleTurnCompleted(params: TurnCompletedNotification): void {
-    void this.#completeTurn(params).catch((error) => {
-      const session = this.#sessions.get(params.threadId);
-      if (!session) return;
+  #handleTurnCompleted(client: CodexAppServerClient, params: TurnCompletedNotification): void {
+    const session = this.#sessionForClientTurn(client, params.threadId, params.turn.id);
+    if (!session) return;
+    void this.#completeTurn(session, params).catch((error) => {
+      if (
+        this.#sessions.get(session.threadId) !== session
+        || isTerminalSessionStatus(session.status)
+        || hasTerminalPendingFinish(session)
+      ) return;
       this.#finishSession(session, { failedMessage: humanizeCodexAppServerError(error) });
     });
   }
 
-  async #completeTurn(params: TurnCompletedNotification): Promise<void> {
-    const session = this.#sessions.get(params.threadId);
-    if (!session) return;
+  async #completeTurn(session: RunningCodexSession, params: TurnCompletedNotification): Promise<void> {
     session.liveCodeModeCallIds.clear();
     if (params.turn.status === 'failed') {
       if (session.managesGoalLifecycle && session.goal && session.goal.status !== 'active') {
@@ -1169,10 +1172,10 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     this.#finishSession(session, { aborted });
   }
 
-  #handleErrorNotification(params: ErrorNotification): void {
-    const message = params.error.message || params.error.additionalDetails || 'Codex app-server error';
-    const session = this.#sessions.get(params.threadId);
+  #handleErrorNotification(client: CodexAppServerClient, params: ErrorNotification): void {
+    const session = this.#sessionForClientTurn(client, params.threadId, params.turnId);
     if (!session) return;
+    const message = params.error.message || params.error.additionalDetails || 'Codex app-server error';
     this.emitMessages(session.chatId, [new ErrorMessage(new Date().toISOString(), message)]);
     if (params.willRetry) return;
     if (isCapacityError(params.error)) {
@@ -1196,6 +1199,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       threadId: session.threadId,
       input: [],
     });
+    if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
     session.activeTurnId = turn.turn.id;
     return true;
   }
@@ -1330,6 +1334,20 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       messages.push(new PermissionCancelledMessage(new Date().toISOString(), permissionRequestId, reason));
     }
     this.emitMessages(chatId, messages);
+  }
+
+  #sessionForClientThread(client: CodexAppServerClient, threadId: string): RunningCodexSession | null {
+    const session = this.#sessions.get(threadId);
+    return session?.client === client ? session : null;
+  }
+
+  #sessionForClientTurn(
+    client: CodexAppServerClient,
+    threadId: string,
+    turnId: string,
+  ): RunningCodexSession | null {
+    const session = this.#sessionForClientThread(client, threadId);
+    return session?.activeTurnId === turnId ? session : null;
   }
 
   #sessionForClient(client: CodexAppServerClient): RunningCodexSession | null {

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -24,6 +24,7 @@ import type {
   ThreadGoalUpdatedNotification,
   ThreadGoalSetResponse,
   RawResponseItemCompletedNotification,
+  CodexTurnError,
   TurnCompletedNotification,
   TurnStartedNotification,
 } from './protocol.js';
@@ -52,6 +53,8 @@ type GoalCommandOptions = {
 };
 const GOAL_TURN_START_TIMEOUT_MS = 30_000;
 const MAX_ACTIVE_INPUT_DELIVERY_TRANSITIONS = 8;
+const MAX_CAPACITY_RETRIES = 3;
+const CAPACITY_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
 
 interface TurnStartWaiter {
   resolve: (turnId: string) => void;
@@ -87,6 +90,8 @@ interface RunningCodexSession {
   activeDeliveryReservations: number;
   pendingFinish: FinishSessionOptions | null;
   liveCodeModeCallIds: Set<string>;
+  capacityRetryCount: number;
+  pendingCapacityFailure: { turnId: string; message: string } | null;
 }
 
 interface CodexForkSessionRequest {
@@ -98,6 +103,7 @@ interface CodexForkSessionRequest {
 export interface CodexAppServerRuntimeOptions {
   createClient?: (options?: CodexAppServerClientOptions) => CodexAppServerClient;
   materializationTimeoutMs?: number;
+  capacityRetryDelaysMs?: readonly number[];
 }
 
 export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
@@ -110,6 +116,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #threadListCaches = new Map<boolean, Promise<Map<string, CodexThread>>>();
   #createClient: (options?: CodexAppServerClientOptions) => CodexAppServerClient;
   #materializationTimeoutMs: number;
+  #capacityRetryDelaysMs: readonly number[];
   #idlePurger = new IdleSessionPurger<RunningCodexSession>({
     sessions: () => this.#sessions.entries(),
     isRunning: (session) => session.status === 'running' || session.status === 'completing',
@@ -125,6 +132,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     super();
     this.#createClient = options.createClient ?? ((clientOptions) => new CodexAppServerClient(clientOptions));
     this.#materializationTimeoutMs = options.materializationTimeoutMs ?? 10_000;
+    this.#capacityRetryDelaysMs = (options.capacityRetryDelaysMs ?? CAPACITY_RETRY_DELAYS_MS)
+      .slice(0, MAX_CAPACITY_RETRIES);
   }
 
   // Resolves available skills only when the command opens with a "/<name>"
@@ -885,6 +894,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       activeDeliveryReservations: 0,
       pendingFinish: null,
       liveCodeModeCallIds: new Set(),
+      capacityRetryCount: 0,
+      pendingCapacityFailure: null,
     };
     this.#sessions.set(args.threadId, session);
     return session;
@@ -1129,12 +1140,22 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         this.#finishSession(session);
         return;
       }
-      this.#finishSession(session, {
-        failedMessage: params.turn.error?.message || 'Codex turn failed',
-      });
+      const pendingCapacityFailure = session.pendingCapacityFailure?.turnId === params.turn.id
+        ? session.pendingCapacityFailure
+        : null;
+      session.pendingCapacityFailure = null;
+      const failedMessage = pendingCapacityFailure?.message
+        ?? params.turn.error?.message
+        ?? 'Codex turn failed';
+      if ((pendingCapacityFailure || isCapacityError(params.turn.error)) && await this.#retryCapacityFailure(session)) {
+        return;
+      }
+      this.#finishSession(session, { failedMessage });
       return;
     }
     const aborted = params.turn.status === 'interrupted' || session.status === 'aborted';
+    session.capacityRetryCount = 0;
+    session.pendingCapacityFailure = null;
     session.status = 'completing';
     session.activeTurnId = null;
     this.#threadListCaches.clear();
@@ -1154,7 +1175,29 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (!session) return;
     this.emitMessages(session.chatId, [new ErrorMessage(new Date().toISOString(), message)]);
     if (params.willRetry) return;
+    if (isCapacityError(params.error)) {
+      session.pendingCapacityFailure = { turnId: params.turnId, message };
+      return;
+    }
     this.#finishSession(session, { failedMessage: message });
+  }
+
+  async #retryCapacityFailure(session: RunningCodexSession): Promise<boolean> {
+    const delayMs = this.#capacityRetryDelaysMs[session.capacityRetryCount];
+    if (delayMs === undefined) return false;
+
+    session.capacityRetryCount += 1;
+    session.activeTurnId = null;
+    session.status = 'running';
+    await delay(delayMs);
+    if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
+
+    const turn = await session.client.startTurn({
+      threadId: session.threadId,
+      input: [],
+    });
+    session.activeTurnId = turn.turn.id;
+    return true;
   }
 
   #handleServerRequest(client: CodexAppServerClient, request: JsonRpcServerRequest): void {
@@ -1415,6 +1458,11 @@ function isUtilityOverload(error: unknown): boolean {
   const record = error && typeof error === 'object' ? error as Record<string, unknown> : {};
   if (record.code === -32001) return true;
   return /overloaded/i.test(String((error as Error)?.message || error || ''));
+}
+
+function isCapacityError(error: CodexTurnError | null | undefined): boolean {
+  return error?.codexErrorInfo === 'serverOverloaded'
+    || /selected model is at capacity/i.test(error?.message ?? '');
 }
 
 function isNoActiveTurnError(error: unknown): boolean {

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -1137,12 +1137,6 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   async #completeTurn(session: RunningCodexSession, params: TurnCompletedNotification): Promise<void> {
     session.liveCodeModeCallIds.clear();
     if (params.turn.status === 'failed') {
-      if (session.managesGoalLifecycle && session.goal && session.goal.status !== 'active') {
-        session.activeTurnId = null;
-        session.completedGoalTurn = true;
-        this.#finishSession(session);
-        return;
-      }
       const pendingCapacityFailure = session.pendingCapacityFailure?.turnId === params.turn.id
         ? session.pendingCapacityFailure
         : null;
@@ -1150,7 +1144,15 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       const failedMessage = pendingCapacityFailure?.message
         ?? params.turn.error?.message
         ?? 'Codex turn failed';
-      if ((pendingCapacityFailure || isCapacityError(params.turn.error)) && await this.#retryCapacityFailure(session)) {
+      if (pendingCapacityFailure || isCapacityError(params.turn.error)) {
+        if (await this.#retryCapacityFailure(session)) return;
+        this.#finishSession(session, { failedMessage });
+        return;
+      }
+      if (session.managesGoalLifecycle && session.goal && session.goal.status !== 'active') {
+        session.activeTurnId = null;
+        session.completedGoalTurn = true;
+        this.#finishSession(session);
         return;
       }
       this.#finishSession(session, { failedMessage });
@@ -1188,12 +1190,23 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   async #retryCapacityFailure(session: RunningCodexSession): Promise<boolean> {
     const delayMs = this.#capacityRetryDelaysMs[session.capacityRetryCount];
     if (delayMs === undefined) return false;
+    const resumesBlockedGoal = session.managesGoalLifecycle && session.goal?.status === 'blocked';
+    if (session.managesGoalLifecycle && !resumesBlockedGoal) return false;
 
     session.capacityRetryCount += 1;
     session.activeTurnId = null;
     session.status = 'running';
     await delay(delayMs);
     if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
+
+    if (resumesBlockedGoal) {
+      const response = await session.client.setThreadGoalStatus(session.threadId, 'active');
+      if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
+      session.goal = response.goal;
+      if (response.goal.status !== 'active') return false;
+      await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
+      return true;
+    }
 
     const turn = await session.client.startTurn({
       threadId: session.threadId,

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -965,7 +965,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         this.#handleGoalCleared(notification.params as ThreadGoalClearedNotification);
         break;
       case 'error':
-        this.#handleErrorNotification(client, notification.params as ErrorNotification);
+        this.#handleErrorNotification(notification.params as ErrorNotification);
         break;
     }
   }
@@ -1148,11 +1148,12 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     this.#finishSession(session, { aborted });
   }
 
-  #handleErrorNotification(client: CodexAppServerClient, params: ErrorNotification): void {
-    const message = params.error?.message || params.error?.additionalDetails || 'Codex app-server error';
-    const session = params.threadId ? this.#sessions.get(params.threadId) : this.#sessionForClient(client);
+  #handleErrorNotification(params: ErrorNotification): void {
+    const message = params.error.message || params.error.additionalDetails || 'Codex app-server error';
+    const session = this.#sessions.get(params.threadId);
     if (!session) return;
     this.emitMessages(session.chatId, [new ErrorMessage(new Date().toISOString(), message)]);
+    if (params.willRetry) return;
     this.#finishSession(session, { failedMessage: message });
   }
 


### PR DESCRIPTION
## Before
- Codex-native retry notifications remained active, but terminal model-capacity errors ended the turn immediately.
- Retrying manually could append another user message instead of continuing the failed turn cleanly.

```mermaid
flowchart LR
  A[Codex error] --> B{willRetry}
  B -->|true| C[Keep native retry alive]
  B -->|false| D[End turn]
```

## After

```mermaid
flowchart LR
  A[Codex error] --> B{willRetry}
  B -->|true| C[Keep native retry alive]
  B -->|false| D{Model at capacity}
  D -->|no| E[End turn]
  D -->|yes| F[Wait 1s, 2s, or 4s]
  F --> G[Start empty continuation turn]
  G --> H{Capacity failure again}
  H -->|yes, fewer than 3 retries| F
  H -->|no| I[Complete normally]
  H -->|retry budget exhausted| E
```

The runtime now recognizes the typed `serverOverloaded` error and waits for the failed turn boundary. Ordinary chats start an empty continuation turn, while blocked native goals resume through their goal lifecycle. Both paths preserve the original prompt without appending a duplicate user message. Retries use 1s, 2s, and 4s intervals and stop after three attempts; other terminal errors retain their prior behavior. Client and turn ownership checks prevent delayed app-server events from affecting replacement sessions.

## Files
- `server/agents/codex/app-server/protocol.ts` — types Codex error metadata used to identify capacity failures.
- `server/agents/codex/app-server/runtime.ts` — adds bounded chat/goal capacity retries and guards stale lifecycle events.
- `server/agents/codex/app-server/__tests__/app-server.test.js` — covers native retry, chat and goal recovery, exhaustion, terminal errors, and stale events.

## Tests
- Focused Codex app-server suite: 106 passed
- Full server and web suites: 2,178 passed
- `bun run check`
- `bun run start --port 0` startup smoke test
- `git diff --check`

## Migration note
The Codex error-notification contract now consumes `willRetry` and typed `codexErrorInfo` metadata. `serverOverloaded` failures may keep processing active for up to three continuation attempts before emitting the terminal failure.

Prompted by: yk (@chiayong)
