### PR TITLE
fix(codex): serialize capacity retry recovery

### DIFF
--- a/server/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server/agents/codex/app-server/__tests__/app-server.test.js
@@ -91,6 +91,26 @@ function emitCapacityFailure(client, turnId) {
   });
 }
 
+function createControlledDelay() {
+  let release;
+  let resolveStarted;
+  const started = new Promise((resolve) => { resolveStarted = resolve; });
+  return {
+    started,
+    wait: (delayMs) => {
+      resolveStarted(delayMs);
+      return new Promise((resolve) => { release = resolve; });
+    },
+    release: () => release(),
+  };
+}
+
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((settle) => { resolve = settle; });
+  return { promise, resolve };
+}
+
 function makeGoal(threadId, objective, status = 'active') {
   return {
     threadId,
@@ -1164,6 +1184,80 @@ describe('CodexAppServerRuntime', () => {
     expect(provider.isRunning('thread-1')).toBe(true);
   });
 
+  it('does not restore a managed goal turn that completes before its start response', async () => {
+    const nativePath = path.join(tmpDir, 'completed-before-start-response-goal-thread.jsonl');
+    let fake;
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'turn-1',
+            goal: makeGoal('thread-1', 'Ship the feature', 'active'),
+          },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ status: 'inProgress' }) },
+        });
+        fake.emit('notification', {
+          method: 'turn/completed',
+          params: { threadId: 'thread-1', turn: makeTurn() },
+        });
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake, materializationTimeoutMs: 20 });
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.startSession(makeRequest());
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        goal: makeGoal('thread-1', 'Ship the feature', 'complete'),
+      },
+    });
+    await finished;
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes a resumed unmanaged turn that completes before its start response', async () => {
+    let fake;
+    fake = new FakeClient({
+      startTurn: async () => {
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn: makeTurn({ status: 'inProgress' }) },
+        });
+        fake.emit('notification', {
+          method: 'turn/completed',
+          params: { threadId: 'thread-1', turn: makeTurn() },
+        });
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      nativePath: null,
+    }));
+    await finished;
+
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the turn running when Codex reports a retryable stream error', async () => {
     const nativePath = path.join(tmpDir, 'retryable-error-thread.jsonl');
     const fake = new FakeClient({
@@ -1480,6 +1574,506 @@ describe('CodexAppServerRuntime', () => {
     });
     await finished;
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the initial unmanaged turn fails before its start response resolves', async () => {
+    const nativePath = path.join(tmpDir, 'initial-same-chunk-capacity-retry-thread.jsonl');
+    let fake;
+    let turnNumber = 0;
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        turnNumber += 1;
+        const turn = makeTurn({
+          id: `turn-${turnNumber}`,
+          status: 'inProgress',
+          completedAt: null,
+          durationMs: null,
+        });
+        if (turnNumber === 1) {
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn },
+          });
+          emitCapacityFailure(fake, turn.id);
+        }
+        return { turn };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0],
+      capacityRetryDelay: () => Promise.resolve(),
+    });
+
+    await provider.startSession(makeRequest());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fake.startTurn).toHaveBeenCalledTimes(2);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-2' }) },
+    });
+    await finished;
+  });
+
+  it('retries when an ordinary managed turn fails before its start response resolves', async () => {
+    const retryStarted = createDeferred();
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        const goal = makeGoal(threadId, params.objective);
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: { threadId, turnId: 'goal-turn', goal },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        });
+        return { goal };
+      },
+      steerTurn: async () => { throw new Error('no active turn to steer'); },
+      startTurn: async () => {
+        const turn = makeTurn({ id: 'user-turn', status: 'inProgress' });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId: 'thread-1', turn },
+        });
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: turn.id,
+            goal: makeGoal('thread-1', 'Long-running work', 'blocked'),
+          },
+        });
+        emitCapacityFailure(fake, turn.id);
+        return { turn };
+      },
+      setThreadGoalStatus: async (threadId, status) => {
+        const goal = makeGoal(threadId, 'Long-running work', status);
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: { threadId, turnId: 'retry-turn', goal },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'retry-turn', status: 'inProgress' }) },
+        });
+        retryStarted.resolve();
+        return { goal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      capacityRetryDelaysMs: [0, 0, 0],
+      capacityRetryDelay: () => Promise.resolve(),
+    });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Continue through capacity recovery',
+      nativePath: null,
+    }))).resolves.toBe(true);
+    await retryStarted.promise;
+
+    expect(fake.startTurn).toHaveBeenCalledTimes(1);
+    expect(fake.setThreadGoalStatus).toHaveBeenCalledTimes(1);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'retry-turn',
+        goal: makeGoal('thread-1', 'Long-running work', 'complete'),
+      },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'retry-turn' }) },
+    });
+    await finished;
+  });
+
+  it('retries a resumed goal when its turn fails before the status response resolves', async () => {
+    const retryStarted = createDeferred();
+    let fake;
+    let statusCallCount = 0;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: makeGoal('thread-1', 'Long-running work', 'blocked') }),
+      setThreadGoalStatus: async (threadId, status) => {
+        statusCallCount += 1;
+        const turnId = `goal-turn-${statusCallCount}`;
+        const activeGoal = makeGoal(threadId, 'Long-running work', status);
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: { threadId, turnId, goal: activeGoal },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: turnId, status: 'inProgress' }) },
+        });
+        if (statusCallCount === 1) {
+          fake.emit('notification', {
+            method: 'thread/goal/updated',
+            params: {
+              threadId,
+              turnId,
+              goal: makeGoal(threadId, 'Long-running work', 'blocked'),
+            },
+          });
+          emitCapacityFailure(fake, turnId);
+        } else {
+          retryStarted.resolve();
+        }
+        return { goal: activeGoal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      capacityRetryDelaysMs: [0, 0, 0],
+      capacityRetryDelay: () => Promise.resolve(),
+    });
+
+    const running = provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'resume' },
+      nativePath: null,
+    }));
+    await retryStarted.promise;
+    await running;
+
+    expect(fake.setThreadGoalStatus).toHaveBeenCalledTimes(2);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'goal-turn-2',
+        goal: makeGoal('thread-1', 'Long-running work', 'complete'),
+      },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn-2' }) },
+    });
+    await finished;
+  });
+
+  it('continues an unmanaged retry when its turn fails before the retry response resolves', async () => {
+    const nativePath = path.join(tmpDir, 'same-chunk-capacity-retry-thread.jsonl');
+    let fake;
+    let turnNumber = 0;
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        turnNumber += 1;
+        const turn = makeTurn({
+          id: `turn-${turnNumber}`,
+          status: 'inProgress',
+          completedAt: null,
+          durationMs: null,
+        });
+        if (turnNumber === 2) {
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn },
+          });
+          emitCapacityFailure(fake, turn.id);
+        }
+        return { turn };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0],
+      capacityRetryDelay: () => Promise.resolve(),
+    });
+    await provider.startSession(makeRequest());
+
+    emitCapacityFailure(fake, 'turn-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fake.startTurn).toHaveBeenCalledTimes(3);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-3' }) },
+    });
+    await finished;
+  });
+
+  it('continues a managed retry when its turn fails before the goal response resolves', async () => {
+    const nativePath = path.join(tmpDir, 'same-chunk-goal-capacity-retry-thread.jsonl');
+    let fake;
+    let goalRetryCount = 0;
+    fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+      setThreadGoalStatus: async (threadId, status) => {
+        goalRetryCount += 1;
+        const turnId = `turn-${goalRetryCount + 1}`;
+        const activeGoal = makeGoal(threadId, 'Finish the work', status);
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: { threadId, turnId: null, goal: activeGoal },
+        });
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: {
+            threadId,
+            turn: makeTurn({ id: turnId, status: 'inProgress', completedAt: null, durationMs: null }),
+          },
+        });
+        if (goalRetryCount === 1) {
+          fake.emit('notification', {
+            method: 'thread/goal/updated',
+            params: { threadId, turnId, goal: makeGoal(threadId, 'Finish the work', 'blocked') },
+          });
+          emitCapacityFailure(fake, turnId);
+        }
+        return { goal: activeGoal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [0, 0, 0],
+      capacityRetryDelay: () => Promise.resolve(),
+    });
+    await provider.startSession(makeRequest());
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work') },
+    });
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work', 'blocked') },
+    });
+
+    emitCapacityFailure(fake, 'turn-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fake.setThreadGoalStatus).toHaveBeenCalledTimes(2);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-3', goal: makeGoal('thread-1', 'Finish the work', 'complete') },
+    });
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-3' }) },
+    });
+    await finished;
+  });
+
+  it('serializes buffered capacity retries after resumed initial input delivery', async () => {
+    for (const goalStatus of ['blocked', null]) {
+      const controlledDelay = createControlledDelay();
+      const initialDelivery = createDeferred();
+      const initialDeliveryStarted = createDeferred();
+      let fake;
+      fake = new FakeClient({
+        resumeThread: async () => {
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'restored-turn', status: 'inProgress' }) },
+          });
+          if (goalStatus) {
+            fake.emit('notification', {
+              method: 'thread/goal/updated',
+              params: {
+                threadId: 'thread-1',
+                turnId: 'restored-turn',
+                goal: makeGoal('thread-1', 'Finish the work', goalStatus),
+              },
+            });
+          }
+          emitCapacityFailure(fake, 'restored-turn');
+          return { thread: makeThread(), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' };
+        },
+        getThreadGoal: async () => ({
+          goal: goalStatus ? makeGoal('thread-1', 'Finish the work') : null,
+        }),
+        startTurn: async (params) => {
+          if (params.input.length === 0) {
+            return { turn: makeTurn({ id: 'empty-retry-turn', status: 'inProgress' }) };
+          }
+          initialDeliveryStarted.resolve(params);
+          await initialDelivery.promise;
+          return { turn: makeTurn({ id: 'user-turn', status: 'inProgress' }) };
+        },
+        setThreadGoalStatus: async (threadId, status) => ({
+          goal: makeGoal(threadId, 'Finish the work', status),
+        }),
+      });
+      const provider = new CodexAppServerRuntime({
+        createClient: () => fake,
+        capacityRetryDelaysMs: [25],
+        capacityRetryDelay: controlledDelay.wait,
+      });
+
+      const running = provider.runTurn(makeRequest({
+        agentSessionId: 'thread-1',
+        command: 'Deliver this before retrying',
+        nativePath: null,
+      }));
+      await expect(initialDeliveryStarted.promise).resolves.toMatchObject({
+        threadId: 'thread-1',
+        input: [{ type: 'text', text: 'Deliver this before retrying', text_elements: [] }],
+      });
+      await expect(controlledDelay.started).resolves.toBe(25);
+
+      controlledDelay.release();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fake.startTurn).toHaveBeenCalledTimes(1);
+      expect(fake.setThreadGoalStatus).not.toHaveBeenCalled();
+
+      initialDelivery.resolve();
+      await running;
+      await Promise.resolve();
+      expect(fake.startTurn).toHaveBeenCalledTimes(1);
+      expect(fake.setThreadGoalStatus).not.toHaveBeenCalled();
+
+      const finished = new Promise((resolve) => provider.onFinished(resolve));
+      fake.emit('notification', {
+        method: 'turn/completed',
+        params: { threadId: 'thread-1', turn: makeTurn({ id: 'user-turn' }) },
+      });
+      await finished;
+    }
+  });
+
+  it('does not reactivate a blocked goal after pause or clear is accepted during capacity backoff', async () => {
+    for (const control of ['pause', 'clear']) {
+      const nativePath = path.join(tmpDir, `${control}-during-capacity-backoff.jsonl`);
+      const controlledDelay = createControlledDelay();
+      const goalCalls = [];
+      const fake = new FakeClient({
+        startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+        startTurn: async () => {
+          await fs.writeFile(nativePath, '{}\n');
+          return { turn: makeTurn({ status: 'inProgress', completedAt: null, durationMs: null }) };
+        },
+        setThreadGoalStatus: async (threadId, status) => {
+          goalCalls.push(status);
+          return { goal: makeGoal(threadId, 'Finish the work', status) };
+        },
+        clearThreadGoal: async () => {
+          goalCalls.push('clear');
+          return { cleared: true };
+        },
+      });
+      const provider = new CodexAppServerRuntime({
+        createClient: () => fake,
+        materializationTimeoutMs: 20,
+        capacityRetryDelaysMs: [25],
+        capacityRetryDelay: controlledDelay.wait,
+      });
+      await provider.startSession(makeRequest());
+      fake.emit('notification', {
+        method: 'thread/goal/updated',
+        params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work') },
+      });
+      fake.emit('notification', {
+        method: 'thread/goal/updated',
+        params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work', 'blocked') },
+      });
+      emitCapacityFailure(fake, 'turn-1');
+      await expect(controlledDelay.started).resolves.toBe(25);
+
+      await expect(provider.submitActiveInput(makeRequest({
+        agentSessionId: 'thread-1',
+        command: `/goal ${control}`,
+        codexGoalCommand: { kind: control },
+        nativePath: null,
+      }))).resolves.toBe(true);
+
+      controlledDelay.release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(goalCalls).toEqual([control === 'pause' ? 'paused' : 'clear']);
+      expect(provider.isRunning('thread-1')).toBe(false);
+      expect(fake.shutdown).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('does not retry a blocked goal after ordinary input starts a turn during capacity backoff', async () => {
+    const nativePath = path.join(tmpDir, 'input-during-capacity-backoff.jsonl');
+    const controlledDelay = createControlledDelay();
+    let turnNumber = 0;
+    const fake = new FakeClient({
+      startThread: async () => ({ thread: makeThread({ path: nativePath }), model: 'gpt', modelProvider: 'openai', serviceTier: null, cwd: '/repo' }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        turnNumber += 1;
+        return { turn: makeTurn({ id: `turn-${turnNumber}`, status: 'inProgress', completedAt: null, durationMs: null }) };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      materializationTimeoutMs: 20,
+      capacityRetryDelaysMs: [25],
+      capacityRetryDelay: controlledDelay.wait,
+    });
+    await provider.startSession(makeRequest());
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work') },
+    });
+    fake.emit('notification', {
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-1', turnId: 'turn-1', goal: makeGoal('thread-1', 'Finish the work', 'blocked') },
+    });
+    emitCapacityFailure(fake, 'turn-1');
+    await expect(controlledDelay.started).resolves.toBe(25);
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Investigate the next failure',
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    controlledDelay.release();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fake.setThreadGoalStatus).not.toHaveBeenCalled();
+    expect(fake.startTurn).toHaveBeenCalledTimes(2);
+    expect(fake.startTurn).toHaveBeenLastCalledWith(expect.objectContaining({
+      threadId: 'thread-1',
+      input: [{ type: 'text', text: 'Investigate the next failure', text_elements: [] }],
+    }));
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
   });
 
   it('caps capacity retries at three', async () => {
@@ -3268,6 +3862,168 @@ describe('CodexAppServerRuntime', () => {
 
     expect(steeredTurnIds).toEqual(['old-turn', 'new-turn']);
     expect(fake.startTurn).not.toHaveBeenCalled();
+  });
+
+  it('retries a mismatch once when steer observes an ordinary turn boundary', async () => {
+    const steeredTurnIds = [];
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async ({ expectedTurnId }) => {
+        steeredTurnIds.push(expectedTurnId);
+        if (expectedTurnId === 'old-turn') {
+          fake.emit('notification', {
+            method: 'turn/completed',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'old-turn' }) },
+          });
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'new-turn', status: 'inProgress' }) },
+          });
+          throw new Error('expected active turn id `old-turn` but found `new-turn`');
+        }
+        return { turnId: expectedTurnId };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Deliver across the boundary',
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(steeredTurnIds).toEqual(['old-turn', 'new-turn']);
+    expect(fake.steerTurn.mock.calls.map(([params]) => params.input)).toEqual([
+      [{ type: 'text', text: 'Deliver across the boundary', text_elements: [] }],
+      [{ type: 'text', text: 'Deliver across the boundary', text_elements: [] }],
+    ]);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('retries a no-active error once when a continuation starts at the turn boundary', async () => {
+    const steeredTurnIds = [];
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async ({ expectedTurnId }) => {
+        steeredTurnIds.push(expectedTurnId);
+        if (expectedTurnId === 'old-turn') {
+          fake.emit('notification', {
+            method: 'turn/completed',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'old-turn' }) },
+          });
+          fake.emit('notification', {
+            method: 'turn/started',
+            params: { threadId: 'thread-1', turn: makeTurn({ id: 'new-turn', status: 'inProgress' }) },
+          });
+          throw new Error('no active turn to steer');
+        }
+        return { turnId: expectedTurnId };
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Deliver to the continuation',
+      nativePath: null,
+    }))).resolves.toBe(true);
+
+    expect(steeredTurnIds).toEqual(['old-turn', 'new-turn']);
+    expect(fake.steerTurn.mock.calls.map(([params]) => params.input)).toEqual([
+      [{ type: 'text', text: 'Deliver to the continuation', text_elements: [] }],
+      [{ type: 'text', text: 'Deliver to the continuation', text_elements: [] }],
+    ]);
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+  });
+
+  it('rejects accepted input when a nested capacity retry advances two generations', async () => {
+    const controlledDelay = createControlledDelay();
+    const retryStarted = createDeferred();
+    let fake;
+    fake = new FakeClient({
+      getThreadGoal: async () => ({ goal: null }),
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'old-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async () => {
+        fake.emit('notification', {
+          method: 'thread/goal/updated',
+          params: {
+            threadId: 'thread-1',
+            turnId: 'old-turn',
+            goal: makeGoal('thread-1', 'Long-running work', 'blocked'),
+          },
+        });
+        emitCapacityFailure(fake, 'old-turn');
+        throw new Error('expected active turn id `old-turn` but found `capacity-turn`');
+      },
+      setThreadGoalStatus: async (threadId, status) => {
+        const goal = makeGoal(threadId, 'Long-running work', status);
+        fake.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'retry-turn', status: 'inProgress' }) },
+        });
+        retryStarted.resolve();
+        return { goal };
+      },
+    });
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      capacityRetryDelaysMs: [25],
+      capacityRetryDelay: controlledDelay.wait,
+    });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      codexGoalCommand: { kind: 'set', objective: 'Long-running work' },
+      nativePath: null,
+    }));
+
+    await expect(provider.submitActiveInput(makeRequest({
+      agentSessionId: 'thread-1',
+      command: 'Do not drop this input',
+      nativePath: null,
+    }))).rejects.toThrow('expected active turn id `old-turn` but found `capacity-turn`');
+    await expect(controlledDelay.started).resolves.toBe(25);
+    expect(fake.steerTurn).toHaveBeenCalledTimes(1);
+    expect(provider.isRunning('thread-1')).toBe(true);
+
+    controlledDelay.release();
+    await retryStarted.promise;
+    expect(fake.setThreadGoalStatus).toHaveBeenCalledWith('thread-1', 'active');
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(fake.shutdown).not.toHaveBeenCalled();
   });
 
   it('retains accepted input across non-steerable goal turns and delivers it to the next turn', async () => {

--- a/server/agents/codex/app-server/protocol.ts
+++ b/server/agents/codex/app-server/protocol.ts
@@ -62,7 +62,6 @@ type CodexHttpErrorInfo = { httpStatusCode: number | null };
 
 export type CodexErrorInfo =
   | 'contextWindowExceeded'
-  | 'sessionBudgetExceeded'
   | 'usageLimitExceeded'
   | 'serverOverloaded'
   | 'cyberPolicy'
@@ -80,8 +79,8 @@ export type CodexErrorInfo =
 
 export interface CodexTurnError {
   message: string;
-  codexErrorInfo?: CodexErrorInfo | null;
-  additionalDetails?: string | null;
+  codexErrorInfo: CodexErrorInfo | null;
+  additionalDetails: string | null;
 }
 
 export interface CodexTurn {

--- a/server/agents/codex/app-server/runtime.ts
+++ b/server/agents/codex/app-server/runtime.ts
@@ -91,6 +91,7 @@ interface RunningCodexSession {
   pendingFinish: FinishSessionOptions | null;
   liveCodeModeCallIds: Set<string>;
   capacityRetryCount: number;
+  turnAttemptGeneration: number;
   pendingCapacityFailure: { turnId: string; message: string } | null;
 }
 
@@ -104,6 +105,7 @@ export interface CodexAppServerRuntimeOptions {
   createClient?: (options?: CodexAppServerClientOptions) => CodexAppServerClient;
   materializationTimeoutMs?: number;
   capacityRetryDelaysMs?: readonly number[];
+  capacityRetryDelay?: (delayMs: number) => Promise<void>;
 }
 
 export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
@@ -117,6 +119,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #createClient: (options?: CodexAppServerClientOptions) => CodexAppServerClient;
   #materializationTimeoutMs: number;
   #capacityRetryDelaysMs: readonly number[];
+  #capacityRetryDelay: (delayMs: number) => Promise<void>;
   #idlePurger = new IdleSessionPurger<RunningCodexSession>({
     sessions: () => this.#sessions.entries(),
     isRunning: (session) => session.status === 'running' || session.status === 'completing',
@@ -134,6 +137,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     this.#materializationTimeoutMs = options.materializationTimeoutMs ?? 10_000;
     this.#capacityRetryDelaysMs = (options.capacityRetryDelaysMs ?? CAPACITY_RETRY_DELAYS_MS)
       .slice(0, MAX_CAPACITY_RETRIES);
+    this.#capacityRetryDelay = options.capacityRetryDelay ?? delay;
   }
 
   // Resolves available skills only when the command opens with a "/<name>"
@@ -166,6 +170,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     const attachments = await writeAttachmentsToTempFiles(request.images);
     session.cleanupAttachments = attachments.cleanup;
     const skills = await this.#resolveTurnSkills(request.command, request.projectPath);
+    const turnAttemptGeneration = session.turnAttemptGeneration;
     const turn = await client.startTurn(buildTurnStartParams({
       threadId: session.threadId,
       command: request.command,
@@ -178,6 +183,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       clientMessageId: request.clientMessageId,
       skills,
     }));
+    if (!this.#canApplyTurnAttempt(session, turnAttemptGeneration)) return;
     session.activeTurnId = turn.turn.id;
 
   }
@@ -253,7 +259,9 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         }
         case 'resume': {
           const previouslyManaged = session.managesGoalLifecycle;
+          const turnAttemptGeneration = session.turnAttemptGeneration;
           const response = await client.setThreadGoalStatus(session.threadId, 'active');
+          if (!this.#canApplyTurnAttempt(session, turnAttemptGeneration)) return;
           session.goal = response.goal;
           if (response.goal.status === 'active') {
             session.managesGoalLifecycle = true;
@@ -405,8 +413,12 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (!turnId && session.goal?.status === 'active') {
       turnId = await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
     }
+    let turnAttemptGeneration = session.turnAttemptGeneration;
 
     while (transitions < MAX_ACTIVE_INPUT_DELIVERY_TRANSITIONS) {
+      if (session.turnAttemptGeneration !== turnAttemptGeneration) {
+        throw new TurnStartWaitCancelledError('Codex turn changed before active input delivery');
+      }
       if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
         throw new TurnStartWaitCancelledError('Codex session ended before active input delivery');
       }
@@ -416,15 +428,28 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         const previousTurnId = session.activeTurnId;
         try {
           const turn = await session.client.startTurn(startParams);
+          if (!this.#canApplyTurnAttempt(session, turnAttemptGeneration)) return;
           session.activeTurnId = turn.turn.id;
           return;
         } catch (error) {
-          if (!isActiveTurnConflictError(error) && !isActiveTurnNotSteerableError(error)) throw error;
+          const isTurnTransition = isActiveTurnConflictError(error) || isActiveTurnNotSteerableError(error);
+          if (session.turnAttemptGeneration !== turnAttemptGeneration) {
+            const nextGeneration = isTurnTransition
+              ? this.#generationAcrossTurnBoundary(session, turnAttemptGeneration)
+              : null;
+            if (nextGeneration === null) throw error;
+            turnAttemptGeneration = nextGeneration;
+          }
+          if (!this.#canApplyTurnAttempt(session, turnAttemptGeneration)) throw error;
+          if (!isTurnTransition) throw error;
           turnId = await this.#waitForDifferentTurnStart(
             session,
             previousTurnId,
             GOAL_TURN_START_TIMEOUT_MS,
           );
+          const nextGeneration = this.#generationAcrossTurnBoundary(session, turnAttemptGeneration);
+          if (nextGeneration === null) throw error;
+          turnAttemptGeneration = nextGeneration;
           transitions += 1;
           continue;
         }
@@ -437,9 +462,21 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           input,
           ...(request.clientMessageId ? { clientUserMessageId: request.clientMessageId } : {}),
         });
+        if (!this.#canApplyTurnAttempt(session, turnAttemptGeneration)) return;
         return;
       } catch (error) {
+        const isNonSteerable = isActiveTurnNotSteerableError(error);
         const actualTurnId = actualTurnIdFromSteerMismatch(error);
+        const noActiveTurn = isNoActiveTurnError(error);
+        const isTurnTransition = isNonSteerable || actualTurnId !== null || noActiveTurn;
+        if (session.turnAttemptGeneration !== turnAttemptGeneration) {
+          const nextGeneration = isTurnTransition
+            ? this.#generationAcrossTurnBoundary(session, turnAttemptGeneration)
+            : null;
+          if (nextGeneration === null) throw error;
+          turnAttemptGeneration = nextGeneration;
+        }
+        if (!this.#canApplyTurnAttempt(session, turnAttemptGeneration)) throw error;
         if (actualTurnId && actualTurnId !== turnId) {
           session.activeTurnId = actualTurnId;
           turnId = actualTurnId;
@@ -447,16 +484,19 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           continue;
         }
         if (actualTurnId) throw error;
-        if (isActiveTurnNotSteerableError(error)) {
+        if (isNonSteerable) {
           turnId = await this.#waitForDifferentTurnStart(
             session,
             turnId,
             GOAL_TURN_START_TIMEOUT_MS,
           );
+          const nextGeneration = this.#generationAcrossTurnBoundary(session, turnAttemptGeneration);
+          if (nextGeneration === null) throw error;
+          turnAttemptGeneration = nextGeneration;
           transitions += 1;
           continue;
         }
-        if (isNoActiveTurnError(error)) {
+        if (noActiveTurn) {
           if (session.activeTurnId === turnId) session.activeTurnId = null;
           turnId = null;
           transitions += 1;
@@ -540,32 +580,36 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
           throw new Error('Codex session ended while resuming the thread');
         }
         await this.#synchronizeRestoredGoal(client, session);
-        this.#releaseBufferedClientEvents(client);
-        if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
-          throw new TurnStartWaitCancelledError('Codex session ended while synchronizing the restored goal');
-        }
-        this.emitProcessing(request.chatId, true);
-        if (!request.codexGoalCommand) {
-          if (session.managesGoalLifecycle) {
-            await this.#deliverReservedActiveInput(session, request);
-          } else {
-            await this.#startRequestedTurn(client, session, request);
+        const initialDelivery = session.activeInputChain.then(async () => {
+          if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
+            throw new TurnStartWaitCancelledError('Codex session ended while synchronizing the restored goal');
           }
-        } else {
-          await this.#handleGoalCommand(
-            client,
-            session,
-            request.codexGoalCommand,
-            request,
-            {
-              keepSession: session.managesGoalLifecycle,
-              goalSynchronized: true,
-            },
-          );
-        }
-        if (session.activeTurnId && !hasTerminalPendingFinish(session)) {
-          session.pendingFinish = null;
-        }
+          this.emitProcessing(request.chatId, true);
+          if (!request.codexGoalCommand) {
+            if (session.managesGoalLifecycle) {
+              await this.#deliverReservedActiveInput(session, request);
+            } else {
+              await this.#startRequestedTurn(client, session, request);
+            }
+          } else {
+            await this.#handleGoalCommand(
+              client,
+              session,
+              request.codexGoalCommand,
+              request,
+              {
+                keepSession: session.managesGoalLifecycle,
+                goalSynchronized: true,
+              },
+            );
+          }
+          if (session.activeTurnId && !hasTerminalPendingFinish(session)) {
+            session.pendingFinish = null;
+          }
+        });
+        session.activeInputChain = initialDelivery.then(() => undefined, () => undefined);
+        this.#releaseBufferedClientEvents(client);
+        await initialDelivery;
       } finally {
         session.activeDeliveryReservations -= 1;
         this.#flushPendingFinish(session);
@@ -895,6 +939,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       pendingFinish: null,
       liveCodeModeCallIds: new Set(),
       capacityRetryCount: 0,
+      turnAttemptGeneration: 0,
       pendingCapacityFailure: null,
     };
     this.#sessions.set(args.threadId, session);
@@ -1135,6 +1180,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   }
 
   async #completeTurn(session: RunningCodexSession, params: TurnCompletedNotification): Promise<void> {
+    session.turnAttemptGeneration += 1;
     session.liveCodeModeCallIds.clear();
     if (params.turn.status === 'failed') {
       const pendingCapacityFailure = session.pendingCapacityFailure?.turnId === params.turn.id
@@ -1194,27 +1240,76 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     if (session.managesGoalLifecycle && !resumesBlockedGoal) return false;
 
     session.capacityRetryCount += 1;
+    const retryGeneration = ++session.turnAttemptGeneration;
     session.activeTurnId = null;
     session.status = 'running';
-    await delay(delayMs);
-    if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
+    await this.#capacityRetryDelay(delayMs);
 
-    if (resumesBlockedGoal) {
-      const response = await session.client.setThreadGoalStatus(session.threadId, 'active');
-      if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
-      session.goal = response.goal;
-      if (response.goal.status !== 'active') return false;
-      await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
-      return true;
-    }
+    const retry = session.activeInputChain.then(async () => {
+      if (
+        this.#sessions.get(session.threadId) !== session
+        || session.status !== 'running'
+        || hasTerminalPendingFinish(session)
+        || session.turnAttemptGeneration !== retryGeneration
+      ) return true;
 
-    const turn = await session.client.startTurn({
-      threadId: session.threadId,
-      input: [],
+      session.activeDeliveryReservations += 1;
+      try {
+        if (resumesBlockedGoal) {
+          if (
+            !session.managesGoalLifecycle
+            || session.goal?.status !== 'blocked'
+            || session.activeTurnId
+          ) return true;
+          const response = await session.client.setThreadGoalStatus(session.threadId, 'active');
+          if (
+            this.#sessions.get(session.threadId) !== session
+            || session.status !== 'running'
+            || hasTerminalPendingFinish(session)
+            || session.turnAttemptGeneration !== retryGeneration
+          ) return true;
+          session.goal = response.goal;
+          if (response.goal.status !== 'active') return false;
+          await this.#waitForTurnStart(session, GOAL_TURN_START_TIMEOUT_MS);
+          return true;
+        }
+
+        if (session.activeTurnId) return true;
+        const turn = await session.client.startTurn({
+          threadId: session.threadId,
+          input: [],
+        });
+        if (
+          this.#sessions.get(session.threadId) !== session
+          || session.status !== 'running'
+          || hasTerminalPendingFinish(session)
+          || session.turnAttemptGeneration !== retryGeneration
+        ) return true;
+        session.activeTurnId = turn.turn.id;
+        return true;
+      } finally {
+        session.activeDeliveryReservations -= 1;
+        this.#flushPendingFinish(session);
+      }
     });
-    if (this.#sessions.get(session.threadId) !== session || session.status !== 'running') return true;
-    session.activeTurnId = turn.turn.id;
-    return true;
+    session.activeInputChain = retry.then(() => undefined, () => undefined);
+    return retry;
+  }
+
+  #canApplyTurnAttempt(session: RunningCodexSession, generation: number): boolean {
+    return this.#sessions.get(session.threadId) === session
+      && (session.status === 'running' || session.status === 'completing')
+      && !hasTerminalPendingFinish(session)
+      && session.turnAttemptGeneration === generation;
+  }
+
+  #generationAcrossTurnBoundary(session: RunningCodexSession, generation: number): number | null {
+    const currentGeneration = session.turnAttemptGeneration;
+    // Allows an accepted delivery to cross one ordinary turn boundary while a
+    // second generation advance keeps ownership with a nested capacity retry.
+    return currentGeneration === generation || currentGeneration === generation + 1
+      ? currentGeneration
+      : null;
   }
 
   #handleServerRequest(client: CodexAppServerClient, request: JsonRpcServerRequest): void {


### PR DESCRIPTION
## Summary

- Align Codex app-server error types with the pinned Codex 0.142.2 protocol.
- Serialize retry recovery with initial and active input delivery.
- Track turn-attempt ownership so delayed RPC continuations cannot restore completed or failed turns.
- Revalidate goal, turn, and session state after retry backoff before resuming work.
- Preserve retryable error visibility, terminal failure behavior, and the three-attempt retry cap.
- Add deterministic coverage for same-response event ordering, nested retries, goal controls, input delivery, stale clients, and successful turn boundaries.

This follows up on #314 by covering the asynchronous turn-boundary races exposed during review.

## Validation

- Focused Codex app-server suite: 130 passed
- `bun run check`
- `bun run test` (all server suites; web: 259 files / 2,204 tests passed)
- `bun run start --port 0` isolated startup smoke test
- `git diff --check`
- Five-round isolated review-fix loop: approved with no findings on current main

## Migration note

The internal Codex error-notification contract now matches the pinned 0.142.2 generated schema: `willRetry`, `threadId`, `turnId`, and all `TurnError` fields are required, with nullable values retained where defined by Codex. No external API migration is required.

## Checklist

- [x] Scope is focused and behavior is covered by tests
- [x] API/WS contract changes include type and test updates