### PR TITLE
web: adjust workspace styling and presentation for mobile viewport

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -352,7 +352,7 @@
 	--file-icon-doc: 214 82% 45%;
 	--file-icon-image: 271 76% 53%;
 	--file-icon-folder: 214 82% 45%;
-	--terminal-bg: 0 0% 96%;
+	--terminal-bg: 0 0% 100%;
 
 	--git-action-commit: 214 82% 51%;
 	--git-action-commit-hover: 214 82% 43%;
@@ -548,7 +548,7 @@
 	--file-icon-doc: 214 92% 68%;
 	--file-icon-image: 271 81% 72%;
 	--file-icon-folder: 214 92% 68%;
-	--terminal-bg: 0 0% 12%;
+	--terminal-bg: 0 0% 11.76%;
 
 	--git-action-commit: 214 82% 55%;
 	--git-action-commit-hover: 214 82% 48%;

--- a/web/src/lib/components/files/FileTree.svelte
+++ b/web/src/lib/components/files/FileTree.svelte
@@ -5,6 +5,7 @@
 	import X from '@lucide/svelte/icons/x';
 	import type { FileTreeEntry } from '$shared/file-contracts';
 	import type { FileTreeStore } from '$lib/files/tree/file-tree.svelte.js';
+	import type { HostId } from '$lib/workspace/surface-types.js';
 	import * as m from '$lib/paraglide/messages.js';
 	import FileTreeBreadcrumbs from './FileTreeBreadcrumbs.svelte';
 	import FileTreeToolbar from './FileTreeToolbar.svelte';
@@ -12,11 +13,13 @@
 
 	let {
 		store,
+		presentation,
 		selectedPath = null,
 		onFileSelect,
 		onImageSelect,
 	}: {
 		store: FileTreeStore;
+		presentation: HostId | 'mobile';
 		selectedPath?: string | null;
 		onFileSelect: (file: FileTreeEntry) => void;
 		onImageSelect?: (file: FileTreeEntry) => void;
@@ -116,7 +119,7 @@
 			</div>
 		</div>
 	{:else if store.navigation.kind === 'ready'}
-		<FileTreeVirtualRows {store} {selectedPath} {onFileSelect} {onImageSelect} />
+		<FileTreeVirtualRows {store} {presentation} {selectedPath} {onFileSelect} {onImageSelect} />
 	{:else}
 		<div class="flex min-h-0 flex-1 items-center justify-center text-sm text-muted-foreground">
 			{m.filetree_no_files_found()}

--- a/web/src/lib/components/files/FileTreeVirtualRows.svelte
+++ b/web/src/lib/components/files/FileTreeVirtualRows.svelte
@@ -3,6 +3,7 @@
 	import type { FileTableRow } from '$lib/files/tree/file-tree-rows.js';
 	import { buildFileTreeRenderModel } from '$lib/files/tree/file-tree-render-rows.js';
 	import type { FileTreeStore } from '$lib/files/tree/file-tree.svelte.js';
+	import type { HostId } from '$lib/workspace/surface-types.js';
 	import { isImageFilePath } from '$lib/utils/file-kind.js';
 	import * as m from '$lib/paraglide/messages.js';
 	import FileTreeColumnHeader from './FileTreeColumnHeader.svelte';
@@ -11,11 +12,13 @@
 
 	let {
 		store,
+		presentation,
 		selectedPath = null,
 		onFileSelect,
 		onImageSelect,
 	}: {
 		store: FileTreeStore;
+		presentation: HostId | 'mobile';
 		selectedPath?: string | null;
 		onFileSelect: (entry: FileTreeEntry) => void;
 		onImageSelect?: (entry: FileTreeEntry) => void;
@@ -42,6 +45,9 @@
 		]),
 	);
 	let minimumTableWidth = $derived(store.visibleColumnKeys.length === 1 ? '240px' : '520px');
+	let tableMinimumWidth = $derived(
+		presentation === 'mobile' ? `min(${minimumTableWidth}, 100%)` : minimumTableWidth,
+	);
 
 	function activateEntry(row: FileTableRow): void {
 		if (row.entry.type === 'directory') {
@@ -90,7 +96,7 @@
 	class="file-tree-virtual-grid min-h-0 flex-1 overflow-auto overscroll-contain"
 	data-file-tree-grid
 >
-	<div role="presentation" style={`min-width: ${minimumTableWidth}`}>
+	<div role="presentation" style:min-width={tableMinimumWidth}>
 		<FileTreeColumnHeader {store} ariaRowIndex={1} />
 		{#if model.rows.length > 0}
 			<div

--- a/web/src/lib/components/files/FilesPanel.svelte
+++ b/web/src/lib/components/files/FilesPanel.svelte
@@ -2,6 +2,9 @@
 	import FileTree from './FileTree.svelte';
 	import type { FileTreeEntry } from '$shared/file-contracts';
 	import { getFileSessions, getSingletonSurfaces } from '$lib/context';
+	import type { HostId } from '$lib/workspace/surface-types.js';
+
+	let { presentation }: { presentation: HostId | 'mobile' } = $props();
 
 	const files = getFileSessions();
 	const tree = getSingletonSurfaces().files().tree;
@@ -20,6 +23,11 @@
 
 <div class="flex h-full min-h-0 flex-col overflow-hidden">
 	<div class="min-h-0 flex-1">
-		<FileTree store={tree} onFileSelect={handleFileSelect} onImageSelect={handleFileSelect} />
+		<FileTree
+			store={tree}
+			{presentation}
+			onFileSelect={handleFileSelect}
+			onImageSelect={handleFileSelect}
+		/>
 	</div>
 </div>

--- a/web/src/lib/components/files/__tests__/FileTree.test.ts
+++ b/web/src/lib/components/files/__tests__/FileTree.test.ts
@@ -54,7 +54,12 @@ function renderReady(entries: FileTreeEntry[]) {
 	const store = new FileTreeStore();
 	store.navigation = { kind: 'ready', response: response(entries) };
 	const onFileSelect = vi.fn();
-	const result = render(FileTree, { store, onFileSelect, onImageSelect: onFileSelect });
+	const result = render(FileTree, {
+		store,
+		presentation: 'main',
+		onFileSelect,
+		onImageSelect: onFileSelect,
+	});
 	return { ...result, store, onFileSelect };
 }
 
@@ -251,7 +256,7 @@ describe('FileTree', () => {
 			previous: response([]),
 			error: { message: 'Directory not found', retryable: false },
 		};
-		render(FileTree, { store, onFileSelect: vi.fn() });
+		render(FileTree, { store, presentation: 'main', onFileSelect: vi.fn() });
 
 		expect(screen.getByRole('alert')).toBeTruthy();
 		expect(screen.getByText('Could not open this directory')).toBeTruthy();

--- a/web/src/lib/components/files/__tests__/FileTreeVirtualRows.test.ts
+++ b/web/src/lib/components/files/__tests__/FileTreeVirtualRows.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { tick } from 'svelte';
 import type { FileTreeEntry, FileTreeResponse } from '$shared/file-contracts';
 import { FileTreeStore } from '$lib/files/tree/file-tree.svelte.js';
+import type { HostId } from '$lib/workspace/surface-types.js';
 import FileTreeVirtualRows from '../FileTreeVirtualRows.svelte';
 
 function entries(count: number): FileTreeEntry[] {
@@ -33,11 +34,12 @@ function response(items: FileTreeEntry[]): FileTreeResponse {
 	};
 }
 
-function renderRows(count: number) {
+function renderRows(count: number, presentation: HostId | 'mobile' = 'main') {
 	const store = new FileTreeStore();
 	store.navigation = { kind: 'ready', response: response(entries(count)) };
 	const result = render(FileTreeVirtualRows, {
 		store,
+		presentation,
 		onFileSelect: vi.fn(),
 	});
 	return { ...result, store };
@@ -46,6 +48,35 @@ function renderRows(count: number) {
 describe('FileTreeVirtualRows', () => {
 	beforeEach(() => localStorage.clear());
 	afterEach(cleanup);
+
+	it('caps the table minimum width at the available mobile panel width', () => {
+		const { container } = renderRows(1, 'mobile');
+		const table = container.querySelector<HTMLElement>('[data-file-tree-grid] > div');
+
+		expect(table?.style.minWidth).toBe('min(520px, 100%)');
+	});
+
+	it('preserves the scrollable table minimum width in desktop presentations', () => {
+		const { container } = renderRows(1, 'sidebar');
+		const table = container.querySelector<HTMLElement>('[data-file-tree-grid] > div');
+
+		expect(table?.style.minWidth).toBe('520px');
+	});
+
+	it('caps the single-column mobile table at the available panel width', () => {
+		const store = new FileTreeStore();
+		store.navigation = { kind: 'ready', response: response(entries(1)) };
+		store.setColumnVisible('size', false);
+		store.setColumnVisible('modified', false);
+		const { container } = render(FileTreeVirtualRows, {
+			store,
+			presentation: 'mobile',
+			onFileSelect: vi.fn(),
+		});
+		const table = container.querySelector<HTMLElement>('[data-file-tree-grid] > div');
+
+		expect(table?.style.minWidth).toBe('min(240px, 100%)');
+	});
 
 	it('keeps a 100,000-row directory to a bounded mounted window with absolute ARIA positions', async () => {
 		const { container } = renderRows(100_000);
@@ -117,7 +148,11 @@ describe('FileTreeVirtualRows', () => {
 		const items = entries(3);
 		const store = new FileTreeStore();
 		store.navigation = { kind: 'ready', response: response(items) };
-		const { container } = render(FileTreeVirtualRows, { store, onFileSelect: vi.fn() });
+		const { container } = render(FileTreeVirtualRows, {
+			store,
+			presentation: 'main',
+			onFileSelect: vi.fn(),
+		});
 		const removedPath = items[1]!.path;
 		const predecessorPath = items[0]!.path;
 		const removed = await waitFor(() => {
@@ -138,7 +173,11 @@ describe('FileTreeVirtualRows', () => {
 		const items = entries(100);
 		const store = new FileTreeStore();
 		store.navigation = { kind: 'ready', response: response(items) };
-		const { container } = render(FileTreeVirtualRows, { store, onFileSelect: vi.fn() });
+		const { container } = render(FileTreeVirtualRows, {
+			store,
+			presentation: 'main',
+			onFileSelect: vi.fn(),
+		});
 		const treegrid = container.querySelector<HTMLElement>('[data-file-tree-grid]');
 		const first = await waitFor(() => {
 			const row = container.querySelector<HTMLElement>(
@@ -172,7 +211,11 @@ describe('FileTreeVirtualRows', () => {
 		const items = entries(100);
 		const store = new FileTreeStore();
 		store.navigation = { kind: 'ready', response: response(items) };
-		const { container } = render(FileTreeVirtualRows, { store, onFileSelect: vi.fn() });
+		const { container } = render(FileTreeVirtualRows, {
+			store,
+			presentation: 'main',
+			onFileSelect: vi.fn(),
+		});
 		const treegrid = container.querySelector<HTMLElement>('[data-file-tree-grid]');
 		if (!treegrid) throw new Error('Expected file treegrid');
 		await waitFor(() =>
@@ -211,7 +254,11 @@ describe('FileTreeVirtualRows', () => {
 		store.navigation = { kind: 'ready', response: response([directory]) };
 		store.expandedDirs = new Set([directory.path]);
 		store.loadingDirs = new Set([directory.path]);
-		const { container } = render(FileTreeVirtualRows, { store, onFileSelect: vi.fn() });
+		const { container } = render(FileTreeVirtualRows, {
+			store,
+			presentation: 'main',
+			onFileSelect: vi.fn(),
+		});
 		const status = await screen.findByRole('status');
 		const loadingRow = status.closest<HTMLElement>('[role="row"]');
 
@@ -236,7 +283,11 @@ describe('FileTreeVirtualRows', () => {
 		const store = new FileTreeStore();
 		store.navigation = { kind: 'ready', response: response(entries(1_000)) };
 		const sortEntries = vi.spyOn(store, 'sortEntries');
-		const { container } = render(FileTreeVirtualRows, { store, onFileSelect: vi.fn() });
+		const { container } = render(FileTreeVirtualRows, {
+			store,
+			presentation: 'main',
+			onFileSelect: vi.fn(),
+		});
 		const treegrid = container.querySelector<HTMLElement>('[data-file-tree-grid]');
 		if (!treegrid) throw new Error('Expected file treegrid');
 		await waitFor(() =>

--- a/web/src/lib/components/files/__tests__/FileTreeVirtualRowsBenchmarkHost.svelte
+++ b/web/src/lib/components/files/__tests__/FileTreeVirtualRowsBenchmarkHost.svelte
@@ -94,5 +94,5 @@
 </script>
 
 <div class="flex h-screen w-screen flex-col bg-card" data-file-tree-benchmark-host>
-	<FileTreeVirtualRows {store} onFileSelect={() => {}} />
+	<FileTreeVirtualRows {store} presentation="main" onFileSelect={() => {}} />
 </div>

--- a/web/src/lib/components/files/__tests__/FilesPanelTestHost.svelte
+++ b/web/src/lib/components/files/__tests__/FilesPanelTestHost.svelte
@@ -8,4 +8,4 @@
 	setSingletonSurfaces(singletonSurfaces);
 </script>
 
-<FilesPanel />
+<FilesPanel presentation="main" />

--- a/web/src/lib/components/terminal/TerminalSurface.svelte
+++ b/web/src/lib/components/terminal/TerminalSurface.svelte
@@ -279,7 +279,11 @@
 				{m.terminal_earlier_output_unavailable()}
 			</div>
 		{/if}
-		<div bind:this={terminalHost} class="min-h-0 flex-1 bg-background"></div>
+		<div
+			bind:this={terminalHost}
+			data-terminal-host
+			class={`min-h-0 flex-1 ${host === 'mobile' ? 'mobile-terminal-host bg-terminal-bg' : 'bg-background'}`}
+		></div>
 		{#if runtime && showInputControls}
 			<div class="flex shrink-0 items-center gap-1 overflow-x-auto border-t border-border p-1">
 				<button
@@ -307,3 +311,10 @@
 		{/if}
 	{/if}
 </div>
+
+<style>
+	.mobile-terminal-host :global(.xterm) {
+		padding-inline-start: max(0.5rem, var(--safe-area-inset-left, 0px));
+		padding-inline-end: max(0.5rem, var(--safe-area-inset-right, 0px));
+	}
+</style>

--- a/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
@@ -69,6 +69,21 @@ describe('TerminalSurface', () => {
 		expect(onClose).toHaveBeenCalledWith('terminal:terminal-1');
 	});
 
+	it('adds the mobile renderer inset only in mobile presentation', async () => {
+		const { container, rerender } = render(TerminalSurfaceTestHost, { host: 'main' });
+		const terminalHost = container.querySelector<HTMLElement>('[data-terminal-host]');
+
+		expect(terminalHost?.classList.contains('mobile-terminal-host')).toBe(false);
+		expect(terminalHost?.classList.contains('bg-background')).toBe(true);
+		expect(terminalHost?.classList.contains('bg-terminal-bg')).toBe(false);
+
+		await rerender({ host: 'mobile' });
+
+		expect(terminalHost?.classList.contains('mobile-terminal-host')).toBe(true);
+		expect(terminalHost?.classList.contains('bg-background')).toBe(false);
+		expect(terminalHost?.classList.contains('bg-terminal-bg')).toBe(true);
+	});
+
 	it('terminates the session only from the explicit toolbar action', async () => {
 		const onTerminate = vi.fn();
 		render(TerminalSurfaceTestHost, { host: 'main', onTerminate });

--- a/web/src/lib/components/workspace/PortableSurfaceContent.svelte
+++ b/web/src/lib/components/workspace/PortableSurfaceContent.svelte
@@ -98,7 +98,7 @@
 			retainedEffectiveProjectKey={controller.tree.effectiveProjectKey}
 		>
 			{#await filesRenderer() then FilesPanel}
-				<FilesPanel />
+				<FilesPanel presentation={presentation} />
 			{/await}
 		</ProjectSurfaceGate>
 	{:else if surface.type === 'singleton' && surface.kind === 'git'}


### PR DESCRIPTION
Pass the presentation host type down to file and terminal components to allow optimized rendering for mobile viewports.

* Constrain the minimum width of the file tree table on mobile displays to prevent clipping while retaining horizontal scroll behavior on desktop.
* Apply a custom background color and safe-area horizontal insets to the terminal renderer in the mobile presentation.
* Slightly adjust the terminal background color variable under light and dark themes.

## Summary

Describe what changed and why.

## Checklist

- [ ] Scope is focused and behavior is covered by tests
- [ ] API/WS contract changes include type and test updates
