### PR TITLE
web: hide open files dialog and actions on mobile

### DIFF
--- a/web/src/lib/components/files/FileDialogHost.svelte
+++ b/web/src/lib/components/files/FileDialogHost.svelte
@@ -168,7 +168,7 @@
 </Dialog.Root>
 
 <Dialog.Root
-	open={Boolean(files.thresholdRequest) && !files.openFilesVisible}
+	open={Boolean(files.thresholdRequest) && (!files.openFilesVisible || appShell.isMobile)}
 	requestClose={() => files.resolveThreshold('cancel')}
 >
 	<Dialog.Content class="sm:max-w-md" showCloseButton={false}>
@@ -182,12 +182,16 @@
 			<Button variant="ghost" onclick={() => files.resolveThreshold('cancel')}
 				>{m.file_session_cancel()}</Button
 			>
-			<Button variant="outline" onclick={() => files.resolveThreshold('review')}
-				>{m.file_session_review_open()}</Button
-			>
+			{#if !appShell.isMobile}
+				<Button variant="outline" onclick={() => files.resolveThreshold('review')}
+					>{m.file_session_review_open()}</Button
+				>
+			{/if}
 			<Button onclick={() => files.resolveThreshold('open')}>{m.file_session_open_anyway()}</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>
 
-<OpenFilesDialog />
+{#if !appShell.isMobile}
+	<OpenFilesDialog />
+{/if}

--- a/web/src/lib/components/files/FileSurface.svelte
+++ b/web/src/lib/components/files/FileSurface.svelte
@@ -30,15 +30,16 @@
 	const files = getFileSessions();
 	const compact = $derived(presentation === 'sidebar' || presentation === 'mobile');
 	const toolbarActions = $derived.by<ResponsiveSurfaceAction[]>(() => {
-		const actions: ResponsiveSurfaceAction[] = [
-			{
+		const actions: ResponsiveSurfaceAction[] = [];
+		if (presentation !== 'mobile') {
+			actions.push({
 				id: 'open-files',
 				label: m.file_session_open_files(),
 				icon: FolderOpen,
 				onclick: () => files.showOpenFiles(),
 				priority: 3,
-			},
-		];
+			});
+		}
 		if (session.contentKind === 'markdown') {
 			const showingMarkdown = session.rendererMode === 'markdown';
 			actions.push({

--- a/web/src/lib/components/files/__tests__/FileDialogHost.test.ts
+++ b/web/src/lib/components/files/__tests__/FileDialogHost.test.ts
@@ -28,6 +28,28 @@ describe('FileDialogHost', () => {
 		rendered.unmount();
 	});
 
+	it('does not present File Sessions on mobile', () => {
+		const rendered = render(FileDialogHostTestHost, {
+			request: 'open-files',
+			isMobile: true,
+		});
+
+		expect(screen.queryByRole('dialog')).toBeNull();
+		rendered.unmount();
+	});
+
+	it('omits File Sessions recovery from the mobile threshold dialog', async () => {
+		const rendered = render(FileDialogHostTestHost, {
+			request: 'threshold',
+			isMobile: true,
+		});
+
+		await screen.findByRole('dialog');
+		expect(screen.queryByRole('button', { name: m.file_session_review_open() })).toBeNull();
+		expect(screen.getByRole('button', { name: m.file_session_open_anyway() })).toBeTruthy();
+		rendered.unmount();
+	});
+
 	it('resolves a dirty-file guard as Cancel when Escape dismisses it', async () => {
 		const onResolve = vi.fn();
 		render(FileDialogHostTestHost, { request: 'guard', onResolve });

--- a/web/src/lib/components/files/__tests__/FileDialogHostTestHost.svelte
+++ b/web/src/lib/components/files/__tests__/FileDialogHostTestHost.svelte
@@ -16,7 +16,7 @@
 		onResolve = () => undefined,
 		isMobile = false,
 	}: {
-		request: 'guard' | 'threshold' | 'file';
+		request: 'guard' | 'threshold' | 'file' | 'open-files';
 		onResolve?: (choice: string) => void;
 		isMobile?: boolean;
 	} = $props();
@@ -49,7 +49,7 @@
 				}
 			: null,
 	);
-	let openFilesVisible = $state(false);
+	let openFilesVisible = $state(initialRequest === 'open-files');
 
 	setAppShell({
 		get isMobile() {

--- a/web/src/lib/components/files/__tests__/FileSurface.test.ts
+++ b/web/src/lib/components/files/__tests__/FileSurface.test.ts
@@ -1,0 +1,19 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import FileSurfaceTestHost from './FileSurfaceTestHost.svelte';
+
+afterEach(cleanup);
+
+describe('FileSurface', () => {
+	it('hides File Sessions from mobile file chrome', () => {
+		const { container } = render(FileSurfaceTestHost, { presentation: 'mobile' });
+
+		expect(container.querySelector('[data-surface-action-measure="open-files"]')).toBeNull();
+	});
+
+	it('retains File Sessions in desktop file chrome', () => {
+		const { container } = render(FileSurfaceTestHost, { presentation: 'main' });
+
+		expect(container.querySelector('[data-surface-action-measure="open-files"]')).not.toBeNull();
+	});
+});

--- a/web/src/lib/components/files/__tests__/FileSurfaceTestHost.svelte
+++ b/web/src/lib/components/files/__tests__/FileSurfaceTestHost.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { setFileSessions } from '$lib/context';
+	import { FileSession } from '$lib/files/sessions/file-session.svelte.js';
+	import { FileSessionRegistry } from '$lib/files/sessions/file-session-registry.svelte.js';
+	import FileSurface from '../FileSurface.svelte';
+
+	let {
+		presentation,
+	}: {
+		presentation: 'main' | 'mobile';
+	} = $props();
+
+	const fileSessions = new FileSessionRegistry({
+		getIsMobile: () => presentation === 'mobile',
+		getDefaultPlacement: () => 'dialog',
+		getEditorSettings: () => ({
+			get wordWrap() {
+				return false;
+			},
+			get showLineNumbers() {
+				return true;
+			},
+			get fontSize() {
+				return 12;
+			},
+		}),
+		getPlacement: () => ({
+			async placeFileSession(_sessionId, _target, publication) {
+				publication.publish();
+				return 'placed';
+			},
+			async focusFileSession() {},
+		}),
+		resolveFileIdentity: async ({ relativePath }) => ({
+			success: true,
+			identity: {
+				canonicalFileRootPath: '/workspace',
+				normalizedRelativePath: relativePath,
+			},
+		}),
+		readText: async () => ({ content: '' }),
+		saveText: async () => ({ success: true }),
+		fetchContent: async () => new Response(),
+	});
+	const session = new FileSession(
+		{
+			canonicalFileRootPath: '/workspace',
+			normalizedRelativePath: 'assets/image.png',
+		},
+		'file-surface-test',
+	);
+	session.contentKind = 'image';
+	session.rendererMode = 'image';
+	session.loading = true;
+
+	setFileSessions(fileSessions);
+</script>
+
+<FileSurface {session} {presentation} />

--- a/web/src/lib/components/shared/CommandMenu.svelte
+++ b/web/src/lib/components/shared/CommandMenu.svelte
@@ -102,13 +102,17 @@
 						? workspace.focusMobileSingleton('files')
 						: workspace.openSingleton('files', 'sidebar')),
 			},
-			{
-				id: 'workspace-open-files',
-				label: m.file_session_open_files(),
-				description: m.file_session_open_files_description(),
-				category: categories.workspace,
-				action: () => files.showOpenFiles(),
-			},
+			...(!workspace.isMobile
+				? [
+						{
+							id: 'workspace-open-files',
+							label: m.file_session_open_files(),
+							description: m.file_session_open_files_description(),
+							category: categories.workspace,
+							action: () => files.showOpenFiles(),
+						},
+					]
+				: []),
 			{
 				id: 'workspace-terminal',
 				label: m.command_switch_to_terminal(),

--- a/web/src/lib/components/shared/__tests__/CommandMenu.test.ts
+++ b/web/src/lib/components/shared/__tests__/CommandMenu.test.ts
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as m from '$lib/paraglide/messages.js';
+
+const mocks = vi.hoisted(() => ({
+	workspace: {
+		isMobile: false,
+		focusChat: vi.fn(),
+		focusMobileSingleton: vi.fn(),
+		openSingleton: vi.fn(),
+		focusMostRecentTerminalOrCreate: vi.fn(async () => undefined),
+		createTerminal: vi.fn(async () => undefined),
+	},
+	terminals: {
+		listStatus: 'ready',
+		orderedSessions: [],
+	},
+	files: {
+		showOpenFiles: vi.fn(),
+	},
+	appShell: {
+		openNewChatDialog: vi.fn(),
+		openSettings: vi.fn(),
+	},
+	localSettings: {
+		colorblindMode: false,
+		toggle: vi.fn(),
+	},
+	ghCapability: {
+		available: true,
+		hasChecked: true,
+	},
+	notifications: {
+		error: vi.fn(),
+	},
+	transientLayers: {
+		open: (_modality: string, action: () => void) => action(),
+		register: () => () => undefined,
+	},
+}));
+
+vi.mock('$lib/context', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/context')>()),
+	getWorkspaceCoordinator: () => mocks.workspace,
+	getTerminalRegistry: () => mocks.terminals,
+	getFileSessions: () => mocks.files,
+	getAppShell: () => mocks.appShell,
+	getLocalSettings: () => mocks.localSettings,
+	getGhCapability: () => mocks.ghCapability,
+	getNotifications: () => mocks.notifications,
+	getTransientLayers: () => mocks.transientLayers,
+}));
+
+import CommandMenu from '../CommandMenu.svelte';
+
+afterEach(() => {
+	cleanup();
+	mocks.workspace.isMobile = false;
+	vi.clearAllMocks();
+});
+
+describe('CommandMenu', () => {
+	it('offers File Sessions on desktop', async () => {
+		const { component } = render(CommandMenu);
+		component.toggle();
+
+		expect(await screen.findByText(m.file_session_open_files())).toBeTruthy();
+	});
+
+	it('hides File Sessions on mobile', async () => {
+		mocks.workspace.isMobile = true;
+		const { component } = render(CommandMenu);
+		component.toggle();
+
+		await screen.findByRole('dialog');
+		expect(screen.queryByText(m.file_session_open_files())).toBeNull();
+	});
+});

--- a/web/src/lib/components/workspace/PortableSurfaceFrame.svelte
+++ b/web/src/lib/components/workspace/PortableSurfaceFrame.svelte
@@ -73,22 +73,25 @@
 	{:else if presentation === 'mobile' && (surface.type === 'file' || (surface.type === 'singleton' && surface.kind === 'commit'))}
 		<div class="flex h-full min-h-0 flex-col">
 			<div class="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background px-2">
+				{#if surface.type === 'singleton'}
+					<button
+						type="button"
+						class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+						onclick={() => void workspace.mobileBack()}
+						aria-label={m.workspace_back()}
+						title={m.workspace_back()}
+					>
+						<ArrowLeft class="h-4 w-4" />
+					</button>
+				{/if}
 				<button
 					type="button"
 					class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-					onclick={() => void workspace.mobileBack()}
-					aria-label={m.workspace_back()}
-					title={m.workspace_back()}
-				>
-					<ArrowLeft class="h-4 w-4" />
-				</button>
-				<button
-					type="button"
-					class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+					class:ml-auto={surface.type === 'file'}
 					onclick={() => void workspace.closeSurface(surface.id)}
 					disabled={workspace.isSurfaceCloseBlocked(surface.id)}
-					aria-label={m.workspace_close_view()}
-					title={m.workspace_close_view()}
+					aria-label={surface.type === 'file' ? m.file_session_close() : m.workspace_close_view()}
+					title={surface.type === 'file' ? m.file_session_close() : m.workspace_close_view()}
 				>
 					<X class="h-4 w-4" />
 				</button>

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -179,6 +179,19 @@ function minimalGitSnapshot(): WorkspaceLayoutSnapshot {
 	};
 }
 
+function mobileFileSnapshot(): WorkspaceLayoutSnapshot {
+	const base = canonicalWorkspaceSnapshot();
+	return {
+		...base,
+		surfaces: {
+			...base.surfaces,
+			'file:one': { id: 'file:one', type: 'file', fileSessionId: 'one' },
+		},
+		mobileActiveSurfaceId: 'file:one',
+		mobileOnlySurfaceIds: ['file:one'],
+	};
+}
+
 function createWorkspace(initial: WorkspaceLayoutSnapshot) {
 	const layout = new WorkspaceLayoutStore(initial);
 	const commit = (mutations: readonly WorkspaceLayoutMutation[]): void => {
@@ -364,6 +377,21 @@ describe('PortableSurfaceContent', () => {
 });
 
 describe('WorkspaceRoot', () => {
+	it('offers destructive Close without non-destructive Back for a mobile file', async () => {
+		const { workspace } = installContext(mobileFileSnapshot());
+		workspace.closeSurface.mockResolvedValueOnce(true);
+		render(WorkspaceRoot, {
+			isMobile: true,
+			chatActions,
+		});
+
+		expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
+		await fireEvent.click(await screen.findByRole('button', { name: 'Close file' }));
+
+		expect(workspace.closeSurface).toHaveBeenCalledWith('file:one');
+		expect(workspace.mobileBack).not.toHaveBeenCalled();
+	});
+
 	it('reserves chat content space only while the desktop taskbar is rendered', async () => {
 		installContext(canonicalWorkspaceSnapshot());
 		const rendered = render(WorkspaceRoot, {

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -247,6 +247,38 @@ describe('WorkspaceCoordinator', () => {
 		expect(layout.snapshot.sidebar.order).not.toContain(surfaceId);
 	});
 
+	it('destroys a mobile file session and returns to Chat when it is closed', async () => {
+		const confirmDestructive = vi.fn(async () => true);
+		const { coordinator, files, layout } = createHarness({ confirmDestructive });
+		await coordinator.enterMobilePresentation();
+		await coordinator.placeFileSession('mobile-file');
+		const surfaceId = fileSurfaceId('mobile-file');
+
+		await expect(coordinator.closeSurface(surfaceId)).resolves.toBe(true);
+
+		expect(confirmDestructive).toHaveBeenCalledWith('mobile-file', 'close');
+		expect(files.destroy).toHaveBeenCalledWith('mobile-file');
+		expect(layout.surface(surfaceId)).toBeNull();
+		expect(layout.snapshot.mobileOnlySurfaceIds).not.toContain(surfaceId);
+		expect(layout.snapshot.mobileActiveSurfaceId).toBe(CHAT_SURFACE_ID);
+	});
+
+	it('keeps a dirty mobile file visible when destructive Close is cancelled', async () => {
+		const confirmDestructive = vi.fn(async () => false);
+		const { coordinator, files, layout } = createHarness({ confirmDestructive });
+		await coordinator.enterMobilePresentation();
+		await coordinator.placeFileSession('mobile-file');
+		const surfaceId = fileSurfaceId('mobile-file');
+
+		await expect(coordinator.closeSurface(surfaceId)).resolves.toBe(false);
+
+		expect(confirmDestructive).toHaveBeenCalledWith('mobile-file', 'close');
+		expect(files.destroy).not.toHaveBeenCalled();
+		expect(layout.surface(surfaceId)).not.toBeNull();
+		expect(layout.snapshot.mobileOnlySurfaceIds).toContain(surfaceId);
+		expect(layout.snapshot.mobileActiveSurfaceId).toBe(surfaceId);
+	});
+
 	it('serializes dialog collisions and revalidates the occupant after each guard', async () => {
 		const firstConfirmation = deferred<boolean>();
 		const secondConfirmation = deferred<boolean>();


### PR DESCRIPTION
Omits the open files list, its toolbar action, and command menu item when running in mobile presentation. This also streamlines mobile file surfaces by replacing the dual Back and Close navigation buttons with a single Close button.
