### PR TITLE
[codex] retry queue creation after transport failures

### DIFF
--- a/web/src/lib/api/__tests__/chats-contract.test.ts
+++ b/web/src/lib/api/__tests__/chats-contract.test.ts
@@ -478,6 +478,56 @@ describe('chats API contract', () => {
 		});
 	});
 
+	it('retries queue creation after a transport failure with the same command identity', async () => {
+		const queue = {
+			entries: [],
+			dispatchingEntryId: null,
+			recentlyDispatched: [],
+			pause: null,
+			version: 1,
+			updatedAt: '2026-07-18T00:00:00.000Z',
+		};
+		fetchMock
+			.mockRejectedValueOnce(new DOMException('', 'NetworkError'))
+			.mockResolvedValueOnce(jsonResponse({ success: true, chatId: 'c-1', queue }));
+
+		await expect(
+			createQueuedInput({
+				clientRequestId: 'req-retry',
+				chatId: 'c-1',
+				content: 'queue safely',
+			}),
+		).resolves.toMatchObject({ queue });
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/chats/queue/entries');
+		expect(fetchMock.mock.calls[1][0]).toBe('/api/v1/chats/queue/entries');
+		expect(fetchMock.mock.calls[1][1].body).toBe(fetchMock.mock.calls[0][1].body);
+	});
+
+	it('does not retry queue creation after an HTTP error response', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(
+				{
+					success: false,
+					error: 'Session not found',
+					errorCode: 'SESSION_NOT_FOUND',
+					retryable: false,
+				},
+				404,
+			),
+		);
+
+		await expect(
+			createQueuedInput({
+				clientRequestId: 'req-http-error',
+				chatId: 'missing',
+				content: 'do not retry',
+			}),
+		).rejects.toMatchObject({ message: 'Session not found' });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it('settings, model, project path, and history helpers use REST endpoints', async () => {
 		fetchMock.mockImplementation((url: string) =>
 			Promise.resolve(

--- a/web/src/lib/api/chats.ts
+++ b/web/src/lib/api/chats.ts
@@ -1,6 +1,6 @@
 // Chat session API for listing, starting, messaging, and managing chats.
 
-import { apiGet, apiPost, apiPatch, apiDelete, apiPut, type ApiFetchOptions } from './client.js';
+import { ApiError, apiGet, apiPost, apiPatch, apiDelete, apiPut, type ApiFetchOptions } from './client.js';
 import type { SessionAgentId } from '$lib/types/app.js';
 import {
 	normalizeAmpAgentMode,
@@ -63,6 +63,15 @@ import type { QueueState } from '$shared/queue-state';
 import type { AgentCommandImage } from '$shared/ws-requests';
 
 const CHAT_TITLE_GENERATION_TIMEOUT_MS = 120_000;
+
+async function retryTransportFailure<T>(request: () => Promise<T>): Promise<T> {
+	try {
+		return await request();
+	} catch (error) {
+		if (error instanceof ApiError) throw error;
+		return request();
+	}
+}
 
 export interface StartChatParams {
 	clientRequestId: string;
@@ -165,7 +174,9 @@ export async function sendPermissionDecision(
 export async function createQueuedInput(
 	params: QueueEntryCreateCommandRequest,
 ): Promise<QueueEntryCommandResponse> {
-	return apiPost<QueueEntryCommandResponse>('/api/v1/chats/queue/entries', params);
+	return retryTransportFailure(() =>
+		apiPost<QueueEntryCommandResponse>('/api/v1/chats/queue/entries', params),
+	);
 }
 
 export async function replaceQueuedInput(

--- a/web/src/lib/chat/conversation/__tests__/conversation-submission-helpers.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-submission-helpers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { errorDetail } from '../conversation-submission-helpers.js';
+
+describe('conversation submission helpers', () => {
+	it('uses the error name when the browser omits the message', () => {
+		expect(errorDetail(new DOMException('', 'NetworkError'))).toBe('NetworkError');
+	});
+
+	it('never returns an empty error detail', () => {
+		expect(errorDetail(new Error(''))).toBe('Unknown error');
+		expect(errorDetail('')).toBe('Unknown error');
+	});
+});

--- a/web/src/lib/chat/conversation/conversation-submission-helpers.ts
+++ b/web/src/lib/chat/conversation/conversation-submission-helpers.ts
@@ -3,7 +3,14 @@ import type { PendingUserInput } from '$shared/pending-user-input';
 import { mimeTypeForChatAttachment } from '$lib/chat/composer/image-attachment.svelte.js';
 
 export function errorDetail(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+	if (error instanceof Error) {
+		const message = error.message.trim();
+		if (message) return message;
+		if (error.name && error.name !== 'Error') return error.name;
+		return 'Unknown error';
+	}
+	const detail = String(error).trim();
+	return detail || 'Unknown error';
 }
 
 export async function prepareChatImages(files: readonly File[]): Promise<ChatImage[]> {


### PR DESCRIPTION
## What changed

- Retry queue-entry creation once when the browser fails before receiving an HTTP response.
- Reuse the same `clientRequestId` and payload so the server's durable command ledger safely deduplicates a response-loss retry.
- Do not retry typed HTTP errors such as validation or session-not-found responses.
- Ensure browser exceptions with an empty message still render a non-empty diagnostic.

## Root cause

The reported queue attempt for chat `1784183164006599` never created a `queue-entry-create` ledger record. The queue route writes that record before mutating queue state, while all server-side rejection paths return a non-empty JSON error. The UI showed an empty error detail, which identifies a transport-level `fetch` rejection before a server response rather than a queue admission failure.

PR #324 was the deployed regression boundary, but its final diff did not change queue-entry admission, and both direct HTTP and browser tests against that deployment queued successfully during an active turn. The reliability gap was that queue creation already had a durable idempotency key but the web client did not use it to recover from a transient request/response failure.

## Impact

A transient connection reset or lost response no longer forces the user to manually re-enter a queued message. If both attempts fail, the composer still restores the unsent content and now shows a non-empty error name.

## Validation

- `bun run test -- src/lib/api/__tests__/chats-contract.test.ts src/lib/chat/conversation/__tests__/conversation-submission-helpers.test.ts`
- `bun run check`
- `bun run lint`
- `TZ=UTC bun run test` — 2,603 tests passed
- `bun test server/routes/__tests__/files.test.js` — 30 tests passed on retry after one unrelated flaky concurrency failure in the broader server loop
- `bun run start --port 0` startup/build smoke
- Dogfood: ran an isolated local Garcon instance, forced Playwright to connection-reset the first queue POST, observed exactly two POST attempts, and verified the second attempt created the durable queued entry

## Existing unrelated validation issues

- Repository-wide `prettier --check .` is already red on 99 files.
- Server typecheck is already blocked by missing declarations for `mime-types`.
