### PR TITLE
Route Claude login through browser-code flow

### DIFF
--- a/server/agents/__tests__/auth-login.test.js
+++ b/server/agents/__tests__/auth-login.test.js
@@ -1,4 +1,3 @@
-import os from 'os';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 const spawn = mock();
@@ -96,10 +95,12 @@ describe('AgentAuthLoginManager', () => {
     else process.env.CLAUDE_BINARY = originalClaudeBinary;
   });
 
-  it('launches Claude auth login with the configured binary and strips nested Claude env', async () => {
+  it('always launches Claude auth through the browser-code process, even when PTY is available', async () => {
     process.env.CLAUDECODE = '1';
     process.env.CLAUDE_BINARY = '/tmp/custom-claude';
-    const manager = new AgentAuthLoginManager();
+    const browser = createFakeBrowserProcess();
+    const spawnProcess = mock(() => browser.process);
+    const manager = new AgentAuthLoginManager({ spawnProcess });
     const pty = createFakePty();
     spawn.mockImplementation(() => pty);
 
@@ -108,33 +109,37 @@ describe('AgentAuthLoginManager', () => {
       launched: true,
       alreadyRunning: false,
       sessionId: expect.any(String),
+      deviceAuth: {
+        url: 'https://example.test/claude',
+        needsCode: true,
+      },
     });
     expect(await manager.launch('claude')).toEqual({
       launched: false,
       alreadyRunning: true,
       sessionId: first.sessionId,
-      deviceAuth: undefined,
+      deviceAuth: {
+        url: 'https://example.test/claude',
+        needsCode: true,
+      },
     });
 
-    expect(spawn).toHaveBeenCalledTimes(1);
-    const [command, args, options] = spawn.mock.calls[0];
-    expect(command).toBe(process.execPath);
-    expect(args[0]).toBe('-e');
-    expect(args[1]).toContain('delete process.env.CLAUDECODE');
-    expect(args[1]).toContain('process.argv.slice(1)');
-    expect(args[1]).toContain('env: process.env');
-    expect(args.slice(2)).toEqual(['/tmp/custom-claude', 'auth', 'login']);
-    expect(options.cwd).toBe(os.homedir());
-    expect(options.env.CLAUDECODE).toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(spawnProcess).toHaveBeenCalledTimes(1);
+    expect(spawnProcess.mock.calls[0]).toEqual([['/tmp/custom-claude', 'auth', 'login'], 'claude']);
 
-    pty.emitExit({ exitCode: 0, signal: null });
+    await browser.exit();
 
-    const nextPty = createFakePty();
-    spawn.mockImplementationOnce(() => nextPty);
+    const nextBrowser = createFakeBrowserProcess();
+    spawnProcess.mockImplementationOnce(() => nextBrowser.process);
     expect(await manager.launch('claude')).toEqual({
       launched: true,
       alreadyRunning: false,
       sessionId: expect.any(String),
+      deviceAuth: {
+        url: 'https://example.test/claude',
+        needsCode: true,
+      },
     });
   });
 
@@ -333,11 +338,11 @@ describe('AgentAuthLoginManager', () => {
     const pty = createFakePty();
     spawn.mockImplementation(() => pty);
 
-    const launch = await manager.launch('claude');
+    const launch = await manager.launch('cursor');
     pty.emitExit({ exitCode: 7, signal: null });
 
-    expect(manager.status('claude')).toEqual({ state: 'idle', running: false });
-    expect(manager.status('claude', launch.sessionId)).toEqual({
+    expect(manager.status('cursor')).toEqual({ state: 'idle', running: false });
+    expect(manager.status('cursor', launch.sessionId)).toEqual({
       state: 'failed',
       running: false,
       sessionId: launch.sessionId,
@@ -357,16 +362,16 @@ describe('AgentAuthLoginManager', () => {
     const secondPty = createFakePty();
     spawn.mockImplementationOnce(() => firstPty).mockImplementationOnce(() => secondPty);
 
-    const first = await manager.launch('claude');
+    const first = await manager.launch('cursor');
     firstPty.emitExit({ exitCode: 0, signal: null });
-    const second = await manager.launch('claude');
+    const second = await manager.launch('cursor');
 
-    expect(manager.status('claude', first.sessionId)).toEqual({
+    expect(manager.status('cursor', first.sessionId)).toEqual({
       state: 'succeeded',
       running: false,
       sessionId: first.sessionId,
     });
-    expect(manager.status('claude')).toEqual({
+    expect(manager.status('cursor')).toEqual({
       state: 'running',
       running: true,
       sessionId: second.sessionId,
@@ -379,11 +384,11 @@ describe('AgentAuthLoginManager', () => {
     const pty = createFakePty();
     spawn.mockImplementation(() => pty);
 
-    const launch = await manager.launch('claude');
+    const launch = await manager.launch('cursor');
     pty.emitExit({ exitCode: 0, signal: null });
     await new Promise((resolve) => setTimeout(resolve, 5));
 
-    expect(manager.status('claude', launch.sessionId)).toEqual({
+    expect(manager.status('cursor', launch.sessionId)).toEqual({
       state: 'failed',
       running: false,
       sessionId: launch.sessionId,
@@ -416,11 +421,11 @@ describe('AgentAuthLoginManager', () => {
     const pty = createFakePty();
     spawn.mockImplementation(() => pty);
 
-    const launch = await manager.launch('claude');
+    const launch = await manager.launch('cursor');
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(pty.kill).toHaveBeenCalledTimes(1);
-    expect(manager.status('claude', launch.sessionId)).toEqual({
+    expect(manager.status('cursor', launch.sessionId)).toEqual({
       state: 'failed',
       running: false,
       sessionId: launch.sessionId,

--- a/server/agents/auth-login.ts
+++ b/server/agents/auth-login.ts
@@ -33,31 +33,12 @@ interface CachedTerminalAuthLoginStatus {
   status: TerminalAuthLoginStatus;
 }
 
-const CLAUDE_LOGIN_WRAPPER = `
-delete process.env.CLAUDECODE;
-const [binary, ...args] = process.argv.slice(1);
-const child = Bun.spawn({
-  cmd: [binary, ...args],
-  cwd: process.cwd(),
-  env: process.env,
-  stdin: 'inherit',
-  stdout: 'inherit',
-  stderr: 'inherit',
-});
-process.exit(await child.exited);
-`.trim();
-
-function getClaudeLoginCommand(): LoginCommand {
-  // Removes CLAUDECODE inside the spawned process because bun-pty merges its env with the parent env.
-  return [process.execPath, '-e', CLAUDE_LOGIN_WRAPPER, getClaudeBinary(), 'auth', 'login'];
-}
-
 function getClaudePipeLoginCommand(): LoginCommand {
   return [getClaudeBinary(), 'auth', 'login'];
 }
 
 function getLoginCommand(agentId: string): LoginCommand | null {
-  if (agentId === 'claude') return getClaudeLoginCommand();
+  if (agentId === 'claude') return getClaudePipeLoginCommand();
   if (agentId === 'codex') return ['codex', 'login', '--device-auth'];
   if (agentId === 'cursor') return [getCursorBinary(), 'login'];
   return null;
@@ -258,6 +239,13 @@ export class AgentAuthLoginManager {
     this.#sessions.set(agentId, session);
     this.#startWatchdog(agentId, session);
 
+    // Claude prints a browser URL and then waits for a callback code on stdin.
+    // A hidden PTY swallows both handoff steps, so always use the piped flow
+    // that exposes the URL and accepts the code through Garcon's completion API.
+    if (agentId === 'claude') {
+      return this.#launchClaudeBrowserCodeLogin(agentId, session);
+    }
+
     try {
       const proc = await this.#spawnPty(agentId, command, session);
       const useDeviceAuth = DEVICE_AUTH_AGENTS.has(agentId);
@@ -276,17 +264,11 @@ export class AgentAuthLoginManager {
       };
     } catch (error) {
       if (this.#sessions.get(agentId) !== session) throw error;
-      if (agentId !== 'claude') {
-        this.#finishSession(agentId, session, {
-          state: 'failed',
-          error: SESSION_FAILED_ERROR,
-        });
-        throw error;
-      }
-      logger.warn(
-        `agents: Claude PTY login failed, falling back to browser-code flow: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return this.#launchClaudeBrowserCodeLogin(agentId, session);
+      this.#finishSession(agentId, session, {
+        state: 'failed',
+        error: SESSION_FAILED_ERROR,
+      });
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Problem

Claude login first used `bun-pty` and only fell back to Garcon's browser-code flow when PTY startup failed. A successful hidden PTY swallowed Claude's OAuth URL and callback-code prompt, so the web client received no `deviceAuth` handoff and appeared stuck.

This remained after #265 and #303: #265 made browser-code auth a PTY failure fallback, while #303 preserves an already-discovered device-auth handoff. Neither handles a healthy Claude PTY that never exposes the handoff.

## Fix

- Always launch Claude login through the existing piped browser-code flow.
- Return the OAuth URL to Garcon and accept the callback code through the completion endpoint.
- Remove the obsolete Claude PTY wrapper and PTY-failure fallback.
- Keep PTY login behavior unchanged for Codex and Cursor.
- Add a regression test proving Claude bypasses an available PTY and returns `deviceAuth`.

## Testing

- `bun test server/agents/__tests__/auth-login.test.js server/routes/__tests__/providers.test.js` — 37 passed
- `bun run typecheck` — passed
- `bun run check` — passed
- `bun run test` — passed
- `bun run build` — passed
