### PR TITLE
Expand integration coverage and harden chat recovery

### DIFF
--- a/common/chat-list.ts
+++ b/common/chat-list.ts
@@ -53,3 +53,17 @@ export interface SetLastSelectedChatResponse {
   success: true;
   lastSelectedChatId: string | null;
 }
+
+export interface MarkChatsReadEntry {
+  chatId: string;
+  lastReadAt: string;
+}
+
+export interface MarkChatsReadRequest {
+  entries: MarkChatsReadEntry[];
+}
+
+export interface MarkChatsReadResponse {
+  success: true;
+  results: MarkChatsReadEntry[];
+}

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -115,7 +115,7 @@ bun run check
 bun run test
 ```
 
-`bun run test` includes the server integration lane but not the Lightpanda lane. Run `test:integration:e2e` explicitly for SPA workflow changes. The E2E fixture requires a current production build at `web/build/index.html` and an executable `LIGHTPANDA_BIN`. CI pins and verifies the Lightpanda binary in `.github/workflows/integration-tests.yml`.
+`bun run test:integration` runs the server integration lane but not the Lightpanda lane. The root `bun run test` command runs the server and web unit suites, so run the integration commands explicitly while developing cross-boundary changes. The E2E fixture requires a current production build at `web/build/index.html` and an executable `LIGHTPANDA_BIN`. CI pins and verifies the Lightpanda binary in `.github/workflows/integration-tests.yml`.
 
 Focused runs are useful while iterating:
 

--- a/integration-tests/support/garcon-client.ts
+++ b/integration-tests/support/garcon-client.ts
@@ -11,6 +11,8 @@ import type {
   AgentStopResponse,
   CommandAcceptedResponse,
   ForkChatResponse,
+  ForkRunCommandRequest,
+  ForkRunCommandResponse,
   QueueEntryCommandResponse,
   QueueEntryCreateCommandRequest,
   QueueEntryDeleteCommandRequest,
@@ -20,7 +22,12 @@ import type {
   StartChatCommandRequest,
   StartChatCommandResponse,
 } from '../../common/chat-command-contracts.js';
-import type { ChatListResponse } from '../../common/chat-list.js';
+import type {
+  ChatListResponse,
+  MarkChatsReadEntry,
+  MarkChatsReadRequest,
+  MarkChatsReadResponse,
+} from '../../common/chat-list.js';
 import { parseChatViewMessages, type ChatViewMessage } from '../../common/chat-view.js';
 import { normalizePendingUserInput, type PendingUserInput } from '../../common/pending-user-input.js';
 import { parseQueueState, type QueueState } from '../../common/queue-state.js';
@@ -32,13 +39,16 @@ import {
   parseServerWsMessage,
   type AgentRunFailedMessage,
   type AgentRunFinishedMessage,
+  type ChatReloadedMessage,
   type ChatProcessingUpdatedMessage,
   type ChatSubscribedMessage,
+  type ClientRequestErrorMessage,
   type ReconnectStateMessage,
   type ServerWsMessage,
   type WsPongMessage,
 } from '../../common/ws-events.js';
 import {
+  ChatReloadRequest,
   ChatSubscribeRequest,
   ReconnectStateQueryRequest,
   WsPingRequest,
@@ -113,6 +123,13 @@ export class GarconApiError extends Error {
   ) {
     super(`${method} ${path} returned ${status}: ${JSON.stringify(body)}`);
     this.name = 'GarconApiError';
+  }
+}
+
+export class GarconWsRequestError extends Error {
+  constructor(readonly response: ClientRequestErrorMessage) {
+    super(`${response.requestType} failed with ${response.code}: ${response.message}`);
+    this.name = 'GarconWsRequestError';
   }
 }
 
@@ -196,6 +213,10 @@ export class GarconTestClient {
 
   events(): readonly ServerWsMessage[] {
     return this.#eventRecords.map((record) => record.parsed);
+  }
+
+  eventsSince(index: number): readonly ServerWsMessage[] {
+    return this.#eventRecords.slice(index).map((record) => record.parsed);
   }
 
   rawEvents(): readonly unknown[] {
@@ -376,8 +397,17 @@ export class GarconTestClient {
     return this.post<ForkChatResponse>('/api/v1/chats/fork', request);
   }
 
+  forkRunChat(request: ForkRunCommandRequest): Promise<ForkRunCommandResponse> {
+    return this.post<ForkRunCommandResponse>('/api/v1/chats/fork-run', request);
+  }
+
   deleteChat(chatId: string): Promise<{ success: boolean }> {
     return this.delete<{ success: boolean }>('/api/v1/chats', { chatId });
+  }
+
+  markChatsRead(entries: MarkChatsReadEntry[]): Promise<MarkChatsReadResponse> {
+    const request: MarkChatsReadRequest = { entries };
+    return this.post<MarkChatsReadResponse>('/api/v1/chats/read', request);
   }
 
   enqueue(request: QueueEntryCreateCommandRequest): Promise<QueueEntryCommandResponse> {
@@ -493,6 +523,25 @@ export class GarconTestClient {
       `chat-subscribed ${clientRequestId}`,
       { afterIndex },
     );
+  }
+
+  async reloadChat(chatId: string): Promise<ChatReloadedMessage> {
+    const clientRequestId = crypto.randomUUID();
+    const afterIndex = this.markEvents();
+    this.sendWs(new ChatReloadRequest(clientRequestId, chatId));
+    const outcome = await this.waitForEvent(
+      (message): message is ChatReloadedMessage | ClientRequestErrorMessage =>
+        (message.type === 'chat-reloaded' && message.clientRequestId === clientRequestId)
+        || (
+          message.type === 'client-request-error'
+          && message.clientRequestId === clientRequestId
+          && message.requestType === 'chat-reload'
+        ),
+      `chat-reload ${clientRequestId}`,
+      { afterIndex },
+    );
+    if (outcome.type === 'client-request-error') throw new GarconWsRequestError(outcome);
+    return outcome;
   }
 
   async waitForProcessing(

--- a/integration-tests/support/integration-fixture.ts
+++ b/integration-tests/support/integration-fixture.ts
@@ -27,8 +27,11 @@ export interface IntegrationFixtureOptions {
 
 interface IntegrationProcessRunDiagnostics {
   serverLogs: readonly string[];
-  httpExchanges: ReturnType<GarconTestClient['exchanges']>;
-  websocketEvents: ReturnType<GarconTestClient['eventRecords']>;
+  clients: Array<{
+    name: string;
+    httpExchanges: ReturnType<GarconTestClient['exchanges']>;
+    websocketEvents: ReturnType<GarconTestClient['eventRecords']>;
+  }>;
 }
 
 export interface IntegrationDiagnostics {
@@ -44,6 +47,7 @@ export class IntegrationFixture {
   readonly provider: ConfiguredTestProvider;
   garcon: GarconProcess;
   client: GarconTestClient;
+  readonly #clients = new Map<string, GarconTestClient>();
   readonly #completedRuns: IntegrationProcessRunDiagnostics[] = [];
   #disposed = false;
 
@@ -58,6 +62,7 @@ export class IntegrationFixture {
     this.fakeOpenAi = input.fakeOpenAi;
     this.garcon = input.garcon;
     this.client = input.client;
+    this.#clients.set('primary', input.client);
     this.provider = input.provider;
   }
 
@@ -104,15 +109,35 @@ export class IntegrationFixture {
     return String(Date.now() * 1_000 + chatIdSequence);
   }
 
+  async connectObserver(name: string): Promise<GarconTestClient> {
+    const normalizedName = name.trim();
+    if (!normalizedName || normalizedName === 'primary') {
+      throw new Error('Observer name must be non-empty and cannot be "primary".');
+    }
+    if (this.#clients.has(normalizedName)) {
+      throw new Error(`Integration client already exists: ${normalizedName}`);
+    }
+    const observer = await GarconTestClient.connect(this.garcon.baseUrl);
+    try {
+      await observer.ping();
+      this.#clients.set(normalizedName, observer);
+      return observer;
+    } catch (error) {
+      await observer.close().catch(() => undefined);
+      throw error;
+    }
+  }
+
   async restartGarcon(): Promise<void> {
-    await this.client.close();
+    await this.#closeClients();
     await this.garcon.stop();
     this.#archiveCurrentRun();
+    this.#clients.clear();
     await this.#startReplacementGarcon();
   }
 
   async crashAndRestartGarcon(): Promise<void> {
-    await this.client.close();
+    await this.#closeClients();
     await this.garcon.crash();
     const expiredAt = new Date(Date.now() - 60_000);
     await utimes(
@@ -121,6 +146,7 @@ export class IntegrationFixture {
       expiredAt,
     );
     this.#archiveCurrentRun();
+    this.#clients.clear();
     await this.#startReplacementGarcon();
   }
 
@@ -160,7 +186,7 @@ export class IntegrationFixture {
     this.#disposed = true;
     const errors: unknown[] = [];
     try {
-      await this.client.close();
+      await this.#closeClients();
     } catch (error) {
       errors.push(error);
     }
@@ -194,7 +220,13 @@ export class IntegrationFixture {
       homeDir: this.dirs.home,
     });
     this.client = await GarconTestClient.connect(this.garcon.baseUrl);
-    await this.client.ping();
+    this.#clients.set('primary', this.client);
+    try {
+      await this.client.ping();
+    } catch (error) {
+      await this.client.close().catch(() => undefined);
+      throw error;
+    }
   }
 
   #archiveCurrentRun(): void {
@@ -204,9 +236,22 @@ export class IntegrationFixture {
   #currentRunDiagnostics(): IntegrationProcessRunDiagnostics {
     return {
       serverLogs: this.garcon.logs,
-      httpExchanges: this.client.exchanges(),
-      websocketEvents: this.client.eventRecords(),
+      clients: [...this.#clients].map(([name, client]) => ({
+        name,
+        httpExchanges: client.exchanges(),
+        websocketEvents: client.eventRecords(),
+      })),
     };
+  }
+
+  async #closeClients(): Promise<void> {
+    const results = await Promise.allSettled(
+      [...this.#clients.values()].map((client) => client.close()),
+    );
+    const errors = results
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+    if (errors.length > 0) throw new AggregateError(errors, 'Failed to close integration clients.');
   }
 }
 

--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -188,6 +188,33 @@ export class SpaDriver {
     }, text);
   }
 
+  async waitForSidebarPreview(chatText: string, previewText: string): Promise<void> {
+    await this.#page.waitForFunction(
+      (chatMarker, preview) => {
+        const summary = [...document.querySelectorAll<HTMLElement>('[data-slot="sidebar-chat-summary"]')]
+          .find((element) => element.innerText.includes(chatMarker));
+        return summary?.innerText.includes(preview) === true;
+      },
+      { timeout: 20_000 },
+      chatText,
+      previewText,
+    );
+  }
+
+  async waitForSidebarUnread(chatText: string, expected: boolean): Promise<void> {
+    await this.#page.waitForFunction(
+      (chatMarker, shouldBeUnread) => {
+        const summary = [...document.querySelectorAll<HTMLElement>('[data-slot="sidebar-chat-summary"]')]
+          .find((element) => element.innerText.includes(chatMarker));
+        if (!summary) return false;
+        return Boolean(summary.querySelector('[aria-label="Unread"]')) === shouldBeUnread;
+      },
+      { timeout: 20_000 },
+      chatText,
+      expected,
+    );
+  }
+
   async clickQueuedRowAction(content: string, action: QueueRowAction): Promise<void> {
     await this.#page.evaluate(({ content, action }) => {
       const dialog = document.querySelector<HTMLElement>('[role="dialog"]');

--- a/integration-tests/tests/e2e/fork-delete.test.ts
+++ b/integration-tests/tests/e2e/fork-delete.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { ChatSessionDeletedWsMessage } from '../../../common/ws-events.js';
 import { withE2eFixture } from '../../support/e2e-fixture.js';
 import { SpaDriver } from '../../support/spa-driver.js';
 
@@ -30,10 +31,17 @@ describe('Lightpanda fork and delete', () => {
         )}`);
       }
 
+      const deleteCursor = fixture.integration.client.markEvents();
       await app.clickButton('Chat actions');
       await app.clickMenuItem('Delete');
       await app.clickDialogButton('Delete');
       await app.waitForTextAbsent('Delete chat');
+      await fixture.integration.client.waitForEvent(
+        (event): event is ChatSessionDeletedWsMessage =>
+          event.type === 'chat-session-deleted' && event.chatId === fork.id,
+        'observer chat deletion',
+        { afterIndex: deleteCursor },
+      );
 
       const afterDelete = await fixture.integration.client.listChats();
       expect(afterDelete.sessions.map((entry) => entry.id)).toEqual([source.id]);

--- a/integration-tests/tests/e2e/multi-chat.test.ts
+++ b/integration-tests/tests/e2e/multi-chat.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { ChatReadUpdatedV1Message } from '../../../common/ws-events.js';
 import { withE2eFixture } from '../../support/e2e-fixture.js';
 import { SpaDriver } from '../../support/spa-driver.js';
 
@@ -12,21 +13,58 @@ describe('Lightpanda multi-chat isolation', () => {
       await fixture.waitForSpaWebSocket();
       await app.startDirectChat('ui-multi-a');
       await first.received;
+      const initialReadCursor = fixture.integration.client.markEvents();
       await app.startDirectChat('ui-multi-b');
       await second.received;
 
-      expect((await fixture.integration.client.listChats()).sessions).toHaveLength(2);
+      const chats = (await fixture.integration.client.listChats()).sessions;
+      expect(chats).toHaveLength(2);
+      const chatA = chats.find((chat) => chat.preview.firstMessage === 'ui-multi-a');
+      const chatB = chats.find((chat) => chat.preview.firstMessage === 'ui-multi-b');
+      if (!chatA || !chatB) throw new Error('Concurrent chats were not projected in the sidebar list.');
+      await fixture.integration.client.waitForEvent(
+        (event): event is ChatReadUpdatedV1Message =>
+          event.type === 'chat-read-updated-v1' && event.chatId === chatB.id,
+        'initial selected-chat read receipt',
+        { afterIndex: initialReadCursor },
+      );
       await app.clickSidebarChatContaining('ui-multi-a');
+      await app.waitForSelectedChat(chatA.id);
       await app.waitForExactTextCount('ui-multi-a', 1);
       expect(await app.exactTextCount('ui-multi-b')).toBe(0);
       first.releaseEcho();
       await app.waitForText('echo:ui-multi-a');
 
-      await app.clickSidebarChatContaining('ui-multi-b');
-      await app.waitForExactTextCount('ui-multi-b', 1);
-      expect(await app.exactTextCount('echo:ui-multi-a')).toBe(0);
       second.releaseEcho();
+      await app.waitForSidebarPreview('ui-multi-b', 'echo:ui-multi-b');
+      await app.waitForSidebarUnread('ui-multi-b', true);
+      await app.waitForSidebarUnread('ui-multi-a', false);
+      expect(await app.exactTextCount('echo:ui-multi-b')).toBe(0);
+
+      const readCursor = fixture.integration.client.markEvents();
+      await app.clickSidebarChatContaining('ui-multi-b');
+      await app.waitForSelectedChat(chatB.id);
+      await app.waitForSidebarUnread('ui-multi-b', false);
+      await app.waitForExactTextCount('ui-multi-b', 1);
       await app.waitForText('echo:ui-multi-b');
+      const read = await fixture.integration.client.waitForEvent(
+        (event): event is ChatReadUpdatedV1Message =>
+          event.type === 'chat-read-updated-v1' && event.chatId === chatB.id,
+        'background chat read receipt',
+        { afterIndex: readCursor },
+      );
+      const confirmed = (await fixture.integration.client.listChats()).sessions
+        .find((chat) => chat.id === chatB.id);
+      expect(confirmed?.activity.lastReadAt).toBe(read.lastReadAt);
+      expect(confirmed?.isUnread).toBe(false);
+
+      const beforeReloadConnections = await fixture.spaWebSocketConnectionCount();
+      await fixture.page.reload({ waitUntil: [] });
+      await fixture.waitForSpaWebSocket({ afterConnectionCount: beforeReloadConnections });
+      await app.waitForSelectedChat(chatB.id);
+      await app.waitForSidebarUnread('ui-multi-b', false);
+      await app.waitForExactTextCount('ui-multi-b', 1);
+      await app.waitForExactTextCount('echo:ui-multi-b', 1);
 
       expect(fixture.integration.fakeOpenAi.requests().filter((request) =>
         request.lastUserText === 'ui-multi-a')).toHaveLength(1);

--- a/integration-tests/tests/server/chat-lifecycle.test.ts
+++ b/integration-tests/tests/server/chat-lifecycle.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import type { ChatTitleUpdatedMessage } from '../../../common/ws-events.js';
+import type {
+  ChatMessagesMessage,
+  ChatTitleUpdatedMessage,
+  ServerWsMessage,
+} from '../../../common/ws-events.js';
 import { GarconApiError } from '../../support/garcon-client.js';
 import {
   assistantContents,
@@ -9,22 +13,104 @@ import {
 } from '../../support/chat-assertions.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
 
+function expectSuccessfulTurnContract(
+  events: readonly ServerWsMessage[],
+  input: {
+    chatId: string;
+    content: string;
+    assistantContent: string;
+    clientRequestId: string;
+    clientMessageId: string;
+    turnId: string;
+  },
+): void {
+  expect(events).toContainEqual(expect.objectContaining({
+    type: 'chat-list-refresh-requested',
+    reason: 'chat-added',
+    chatId: input.chatId,
+  }));
+  expect(events).toContainEqual(expect.objectContaining({
+    type: 'pending-user-input-updated',
+    input: expect.objectContaining({
+      chatId: input.chatId,
+      content: input.content,
+      clientRequestId: input.clientRequestId,
+      clientMessageId: input.clientMessageId,
+      turnId: input.turnId,
+      deliveryStatus: 'accepted',
+    }),
+  }));
+  expect(events).toContainEqual(expect.objectContaining({
+    type: 'chat-processing-updated',
+    chatId: input.chatId,
+    isProcessing: true,
+  }));
+
+  const userEvent = events.find((event): event is ChatMessagesMessage =>
+    event.type === 'chat-messages'
+    && event.chatId === input.chatId
+    && event.messages.some((entry) =>
+      entry.message.type === 'user-message' && entry.message.content === input.content));
+  expect(userEvent).toMatchObject({
+    clientRequestId: input.clientRequestId,
+    turnId: input.turnId,
+  });
+  const user = userEvent?.messages.find((entry) =>
+    entry.message.type === 'user-message' && entry.message.content === input.content);
+  expect(user?.message).toMatchObject({
+    metadata: {
+      clientRequestId: input.clientRequestId,
+      turnId: input.turnId,
+      deliveryStatus: 'accepted',
+    },
+  });
+
+  const assistantIndex = events.findIndex((event) =>
+    event.type === 'chat-messages'
+    && event.chatId === input.chatId
+    && event.clientRequestId === input.clientRequestId
+    && event.turnId === input.turnId
+    && event.messages.some((entry) =>
+      entry.message.type === 'assistant-message' && entry.message.content === input.assistantContent));
+  const clearedIndex = events.findIndex((event) =>
+    event.type === 'pending-user-input-cleared'
+    && event.chatId === input.chatId
+    && event.clientRequestId === input.clientRequestId
+    && event.reason === 'persisted');
+  const terminalIndex = events.findIndex((event) =>
+    event.type === 'agent-run-finished'
+    && event.chatId === input.chatId
+    && event.clientRequestId === input.clientRequestId
+    && event.turnId === input.turnId);
+  expect(assistantIndex).toBeGreaterThanOrEqual(0);
+  expect(clearedIndex).toBeGreaterThanOrEqual(0);
+  expect(terminalIndex).toBeGreaterThan(assistantIndex);
+  expect(terminalIndex).toBeGreaterThan(clearedIndex);
+}
+
 describe('chat lifecycle', () => {
   test('starts and completes a direct chat through HTTP, WebSocket, and provider sockets', async () => {
     await withIntegrationFixture('direct-chat-happy-path', async (fixture) => {
       const chatId = fixture.newChatId();
+      const clientRequestId = crypto.randomUUID();
+      const clientMessageId = crypto.randomUUID();
       const held = fixture.fakeOpenAi.holdNext({ lastUserText: 'hello-integration' });
+      const observer = await fixture.connectObserver('turn-observer');
       const eventCursor = fixture.client.markEvents();
+      const observerCursor = observer.markEvents();
 
       const accepted = await fixture.client.startDirectChat({
         chatId,
         content: 'hello-integration',
         projectPath: fixture.dirs.project,
         provider: fixture.provider,
+        clientRequestId,
+        clientMessageId,
       });
       expect(accepted.status).toBe('accepted');
       expect(accepted.chat.id).toBe(chatId);
       expect(accepted.turnId).toBeString();
+      expect(accepted.clientRequestId).toBe(clientRequestId);
 
       const providerRequest = await held.received;
       expect(providerRequest.body.model).toBe('integration-echo');
@@ -34,15 +120,30 @@ describe('chat lifecycle', () => {
       await fixture.client.waitForProcessing(chatId, true, { afterIndex: eventCursor });
 
       held.releaseEcho();
-      const terminal = await fixture.client.waitForTurnTerminal(chatId, accepted.turnId, {
-        afterIndex: eventCursor,
-      });
+      const [terminal] = await Promise.all([
+        fixture.client.waitForTurnTerminal(chatId, accepted.turnId, { afterIndex: eventCursor }),
+        observer.waitForTurnTerminal(chatId, accepted.turnId, { afterIndex: observerCursor }),
+      ]);
       expect(terminal.type).toBe('agent-run-finished');
+      const turnContract = {
+        chatId,
+        content: 'hello-integration',
+        assistantContent: 'echo:hello-integration',
+        clientRequestId,
+        clientMessageId,
+        turnId: accepted.turnId!,
+      };
+      expectSuccessfulTurnContract(fixture.client.eventsSince(eventCursor), turnContract);
+      expectSuccessfulTurnContract(observer.eventsSince(observerCursor), turnContract);
       const transcript = await fixture.client.getMessages(chatId);
       expect(userContents(transcript.messages)).toEqual(['hello-integration']);
       expect(assistantContents(transcript.messages)).toEqual(['echo:hello-integration']);
       expect(countUserContent(transcript.messages, 'hello-integration')).toBe(1);
       expect(userMessages(transcript.messages)[0].metadata?.deliveryStatus).not.toBe('failed');
+      expect(userMessages(transcript.messages)[0].metadata).toMatchObject({
+        clientRequestId,
+        turnId: accepted.turnId,
+      });
       expect(transcript.pendingUserInputs).toEqual([]);
       expect(fixture.fakeOpenAi.requests()).toHaveLength(1);
     });
@@ -176,6 +277,92 @@ describe('chat lifecycle', () => {
         errorCode: 'IDEMPOTENCY_CONFLICT',
       });
       expect(fixture.fakeOpenAi.requests()).toHaveLength(1);
+    });
+  });
+
+  test('rejects a concurrent direct turn before mutating pending or transcript state', async () => {
+    await withIntegrationFixture('same-chat-direct-admission', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const held = fixture.fakeOpenAi.holdNext({ lastUserText: 'admission-first' });
+      const first = await fixture.client.startDirectChat({
+        chatId,
+        content: 'admission-first',
+        projectPath: fixture.dirs.project,
+        provider: fixture.provider,
+      });
+      await held.received;
+
+      const rejectedRequestId = crypto.randomUUID();
+      const rejectedMessageId = crypto.randomUUID();
+      const cursor = fixture.client.markEvents();
+      let rejected: unknown;
+      try {
+        await fixture.client.runDirectChat({
+          chatId,
+          content: 'admission-rejected',
+          provider: fixture.provider,
+          clientRequestId: rejectedRequestId,
+          clientMessageId: rejectedMessageId,
+        });
+      } catch (error) {
+        rejected = error;
+      }
+      expect(rejected).toBeInstanceOf(GarconApiError);
+      expect(rejected).toMatchObject({
+        status: 409,
+        body: { errorCode: 'SESSION_BUSY' },
+      });
+      await fixture.client.ping();
+
+      const rejectedEvents = fixture.client.eventsSince(cursor);
+      expect(rejectedEvents.some((event) =>
+        event.type === 'pending-user-input-updated'
+        && event.input.clientRequestId === rejectedRequestId)).toBe(false);
+      expect(rejectedEvents.some((event) =>
+        event.type === 'chat-messages'
+        && (
+          event.clientRequestId === rejectedRequestId
+          || event.messages.some((entry) =>
+            entry.message.type === 'user-message'
+            && entry.message.content === 'admission-rejected')
+        ))).toBe(false);
+      const whileHeld = await fixture.client.getMessages(chatId);
+      expect(userContents(whileHeld.messages)).toEqual(['admission-first']);
+      expect(whileHeld.pendingUserInputs.map((input) => input.content)).toEqual(['admission-first']);
+      expect(fixture.fakeOpenAi.requests()).toHaveLength(1);
+
+      held.releaseEcho();
+      expect((await fixture.client.waitForTurnTerminal(chatId, first.turnId)).type)
+        .toBe('agent-run-finished');
+      await fixture.client.ping();
+      const afterTerminal = fixture.client.eventsSince(cursor);
+      expect(afterTerminal.some((event) =>
+        event.type === 'pending-user-input-updated'
+        && event.input.clientRequestId === rejectedRequestId)).toBe(false);
+      expect(afterTerminal.some((event) =>
+        event.type === 'chat-messages'
+        && (
+          event.clientRequestId === rejectedRequestId
+          || event.messages.some((entry) =>
+            entry.message.type === 'user-message'
+            && entry.message.content === 'admission-rejected')
+        ))).toBe(false);
+      const afterTerminalMessages = await fixture.client.getMessages(chatId);
+      expect(afterTerminalMessages.pendingUserInputs.some((input) =>
+        input.clientRequestId === rejectedRequestId)).toBe(false);
+      expect(countUserContent(afterTerminalMessages.messages, 'admission-rejected')).toBe(0);
+
+      const later = await fixture.client.runDirectChat({
+        chatId,
+        content: 'admission-later',
+        provider: fixture.provider,
+      });
+      expect((await fixture.client.waitForTurnTerminal(chatId, later.turnId)).type)
+        .toBe('agent-run-finished');
+      expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual([
+        'admission-first',
+        'admission-later',
+      ]);
     });
   });
 });

--- a/integration-tests/tests/server/fork-run.test.ts
+++ b/integration-tests/tests/server/fork-run.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'bun:test';
+import type { ChatMessagesMessage } from '../../../common/ws-events.js';
+import {
+  assistantContents,
+  countUserContent,
+  userContents,
+} from '../../support/chat-assertions.js';
+import { GarconApiError } from '../../support/garcon-client.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+describe('fork-run lifecycle', () => {
+  test('atomically forks provider context, runs once, and survives restart', async () => {
+    await withIntegrationFixture('fork-run-atomic', async (fixture) => {
+      const sourceChatId = fixture.newChatId();
+      const first = await fixture.client.startDirectChat({
+        chatId: sourceChatId,
+        content: 'fork-source-first',
+        projectPath: fixture.dirs.project,
+        provider: fixture.provider,
+      });
+      await fixture.client.waitForTurnTerminal(sourceChatId, first.turnId);
+      const second = await fixture.client.runDirectChat({
+        chatId: sourceChatId,
+        content: 'fork-source-second',
+        provider: fixture.provider,
+      });
+      await fixture.client.waitForTurnTerminal(sourceChatId, second.turnId);
+
+      const targetChatId = fixture.newChatId();
+      const clientRequestId = crypto.randomUUID();
+      const clientMessageId = crypto.randomUUID();
+      const request = {
+        sourceChatId,
+        chatId: targetChatId,
+        command: 'fork-target-new',
+        clientRequestId,
+        clientMessageId,
+        permissionMode: 'default' as const,
+        thinkingMode: 'none' as const,
+        claudeThinkingMode: 'auto' as const,
+        ampAgentMode: 'smart' as const,
+        model: fixture.provider.model,
+        apiProviderId: fixture.provider.providerId,
+        modelEndpointId: fixture.provider.endpointId,
+        modelProtocol: fixture.provider.protocol,
+      };
+      const held = fixture.fakeOpenAi.holdNext({ lastUserText: 'fork-target-new' });
+      const cursor = fixture.client.markEvents();
+      const accepted = await fixture.client.forkRunChat(request);
+      expect(accepted).toMatchObject({
+        status: 'accepted',
+        commandType: 'fork-run',
+        clientRequestId,
+        chatId: targetChatId,
+        chat: { id: targetChatId },
+      });
+      expect(accepted.turnId).toBeString();
+
+      const duplicate = await fixture.client.forkRunChat(request);
+      expect(duplicate).toMatchObject({
+        status: 'duplicate',
+        clientRequestId,
+        chatId: targetChatId,
+        turnId: accepted.turnId,
+        chat: { id: targetChatId },
+      });
+      let conflict: unknown;
+      try {
+        await fixture.client.forkRunChat({ ...request, command: 'fork-target-conflict' });
+      } catch (error) {
+        conflict = error;
+      }
+      expect(conflict).toBeInstanceOf(GarconApiError);
+      expect(conflict).toMatchObject({
+        status: 409,
+        body: { errorCode: 'IDEMPOTENCY_CONFLICT' },
+      });
+
+      const providerRequest = await held.received;
+      expect(providerRequest.body.messages).toEqual([
+        { role: 'user', content: 'fork-source-first' },
+        { role: 'assistant', content: 'echo:fork-source-first' },
+        { role: 'user', content: 'fork-source-second' },
+        { role: 'assistant', content: 'echo:fork-source-second' },
+        { role: 'user', content: 'fork-target-new' },
+      ]);
+      held.releaseEcho();
+      const terminal = await fixture.client.waitForTurnTerminal(targetChatId, accepted.turnId, {
+        afterIndex: cursor,
+      });
+      expect(terminal).toMatchObject({
+        type: 'agent-run-finished',
+        chatId: targetChatId,
+        turnId: accepted.turnId,
+        clientRequestId,
+      });
+
+      const pendingEvent = fixture.client.eventsSince(cursor).find((event) =>
+        event.type === 'pending-user-input-updated'
+        && event.input.chatId === targetChatId
+        && event.input.clientRequestId === clientRequestId);
+      expect(pendingEvent?.type === 'pending-user-input-updated' ? pendingEvent.input : null)
+        .toMatchObject({
+          clientRequestId,
+          clientMessageId,
+          turnId: accepted.turnId,
+          content: 'fork-target-new',
+        });
+
+      const targetUserEvent = fixture.client.eventsSince(cursor).find(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === targetChatId
+          && event.clientRequestId === clientRequestId
+          && event.turnId === accepted.turnId
+          && event.messages.some((entry) =>
+            entry.message.type === 'user-message'
+            && entry.message.content === 'fork-target-new'),
+      );
+      expect(targetUserEvent).toBeDefined();
+      const targetEventUser = targetUserEvent?.messages.find((entry) =>
+        entry.message.type === 'user-message'
+        && entry.message.content === 'fork-target-new');
+      expect(targetEventUser?.message.type === 'user-message'
+        ? targetEventUser.message.metadata
+        : null).toMatchObject({
+        clientRequestId,
+        turnId: accepted.turnId,
+      });
+      expect(fixture.client.eventsSince(cursor)).toContainEqual(expect.objectContaining({
+        type: 'pending-user-input-cleared',
+        chatId: targetChatId,
+        clientRequestId,
+        reason: 'persisted',
+      }));
+
+      const source = await fixture.client.getMessages(sourceChatId);
+      const target = await fixture.client.getMessages(targetChatId);
+      expect(userContents(source.messages)).toEqual(['fork-source-first', 'fork-source-second']);
+      expect(assistantContents(source.messages)).toEqual([
+        'echo:fork-source-first',
+        'echo:fork-source-second',
+      ]);
+      expect(userContents(target.messages)).toEqual([
+        'fork-source-first',
+        'fork-source-second',
+        'fork-target-new',
+      ]);
+      expect(assistantContents(target.messages)).toEqual([
+        'echo:fork-source-first',
+        'echo:fork-source-second',
+        'echo:fork-target-new',
+      ]);
+      expect(countUserContent(target.messages, 'fork-target-new')).toBe(1);
+      const finalTargetUser = target.messages.find((entry) =>
+        entry.message.type === 'user-message'
+        && entry.message.content === 'fork-target-new');
+      expect(finalTargetUser?.message.type === 'user-message'
+        ? finalTargetUser.message.metadata
+        : null).toMatchObject({
+        clientRequestId,
+        turnId: accepted.turnId,
+      });
+      expect(target.pendingUserInputs).toEqual([]);
+      expect(fixture.fakeOpenAi.requests().filter((entry) =>
+        entry.lastUserText === 'fork-target-new')).toHaveLength(1);
+
+      await fixture.restartGarcon();
+      expect((await fixture.client.listChats()).sessions.map((chat) => chat.id).sort()).toEqual(
+        [sourceChatId, targetChatId].sort(),
+      );
+      expect(userContents((await fixture.client.getMessages(sourceChatId)).messages)).toEqual(
+        ['fork-source-first', 'fork-source-second'],
+      );
+      expect(userContents((await fixture.client.getMessages(targetChatId)).messages)).toEqual(
+        ['fork-source-first', 'fork-source-second', 'fork-target-new'],
+      );
+    });
+  });
+});

--- a/integration-tests/tests/server/provider-failures.test.ts
+++ b/integration-tests/tests/server/provider-failures.test.ts
@@ -3,7 +3,7 @@ import type {
   AgentRunFailedMessage,
   QueueStateUpdatedMessage,
 } from '../../../common/ws-events.js';
-import { countUserContent } from '../../support/chat-assertions.js';
+import { countUserContent, userMessages } from '../../support/chat-assertions.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
 
 describe('provider failures', () => {
@@ -39,6 +39,8 @@ describe('provider failures', () => {
 
       for (const [index, failure] of failures.entries()) {
         failure.configure();
+        const clientRequestId = crypto.randomUUID();
+        const clientMessageId = crypto.randomUUID();
         const cursor = fixture.client.markEvents();
         const accepted = index === 0
           ? await fixture.client.startDirectChat({
@@ -46,19 +48,57 @@ describe('provider failures', () => {
               content: failure.content,
               projectPath: fixture.dirs.project,
               provider: fixture.provider,
+              clientRequestId,
+              clientMessageId,
             })
           : await fixture.client.runDirectChat({
               chatId,
               content: failure.content,
               provider: fixture.provider,
+              clientRequestId,
+              clientMessageId,
             });
-        expect(accepted.status).toBe('accepted');
+        expect(accepted).toMatchObject({ status: 'accepted', clientRequestId });
+        expect(accepted.turnId).toBeString();
         const terminal = await fixture.client.waitForTurnTerminal(chatId, accepted.turnId, {
           afterIndex: cursor,
         });
-        expect(terminal.type).toBe('agent-run-failed');
+        expect(terminal).toMatchObject({
+          type: 'agent-run-failed',
+          chatId,
+          clientRequestId,
+          turnId: accepted.turnId,
+        });
         expect((terminal as AgentRunFailedMessage).error).toBeString();
-        expect(countUserContent((await fixture.client.getMessages(chatId)).messages, failure.content)).toBe(1);
+        const transcript = await fixture.client.getMessages(chatId);
+        expect(countUserContent(transcript.messages, failure.content)).toBe(1);
+        const failedUser = userMessages(transcript.messages).find((message) =>
+          message.content === failure.content);
+        expect(failedUser?.metadata).toMatchObject({
+          clientRequestId,
+          turnId: accepted.turnId,
+        });
+        expect(transcript.pendingUserInputs).toEqual([]);
+        const events = fixture.client.eventsSince(cursor);
+        expect(events).toContainEqual(expect.objectContaining({
+          type: 'pending-user-input-updated',
+          input: expect.objectContaining({
+            chatId,
+            clientRequestId,
+            clientMessageId,
+            turnId: accepted.turnId,
+          }),
+        }));
+        const clearedIndex = events.findIndex((event) =>
+          event.type === 'pending-user-input-cleared'
+          && event.clientRequestId === clientRequestId
+          && event.reason === 'persisted');
+        const terminalIndex = events.findIndex((event) =>
+          event.type === 'agent-run-failed'
+          && event.clientRequestId === clientRequestId
+          && event.turnId === accepted.turnId);
+        expect(clearedIndex).toBeGreaterThanOrEqual(0);
+        expect(terminalIndex).toBeGreaterThan(clearedIndex);
       }
       expect(fixture.fakeOpenAi.requests()).toHaveLength(failures.length);
     });
@@ -118,6 +158,18 @@ describe('provider failures', () => {
         { afterIndex: failureCursor },
       );
       const failureEvents = fixture.client.events().slice(failureCursor);
+      const failedPending = failureEvents.find((event) =>
+        event.type === 'pending-user-input-updated'
+        && event.input.content === 'failure-b');
+      if (failedPending?.type !== 'pending-user-input-updated') {
+        throw new Error('Missing failed queued input identity.');
+      }
+      if (!failed.turnId || !failed.clientRequestId) {
+        throw new Error('Missing failed queued delivery identity.');
+      }
+      expect(failedPending.input.clientRequestId).toBe(failed.clientRequestId);
+      expect(failedPending.input.turnId).toBe(failed.turnId);
+      expect(failedPending.input.clientMessageId).toBeString();
       const pauseEventIndex = failureEvents.findIndex((event) => (
         event.type === 'queue-state-updated'
         && event.chatId === chatId
@@ -167,9 +219,19 @@ describe('provider failures', () => {
       ]);
       heldEdited.releaseEcho();
       await heldC.received;
+      const pendingC = (await fixture.client.getMessages(chatId)).pendingUserInputs.find(
+        (input) => input.content === 'failure-c',
+      );
+      if (!pendingC) throw new Error('Missing pending identity for failure-c.');
+      expect(pendingC.clientRequestId).toBeString();
+      expect(pendingC.clientMessageId).toBeString();
+      expect(pendingC.turnId).toBeString();
+      const pendingCTurnId = pendingC.turnId;
       const completionCursor = fixture.client.markEvents();
       heldC.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: completionCursor });
+      await fixture.client.waitForTurnTerminal(chatId, pendingCTurnId, {
+        afterIndex: completionCursor,
+      });
 
       expect((await fixture.client.getQueue(chatId)).entries).toEqual([]);
       expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual([
@@ -233,12 +295,21 @@ describe('provider failures', () => {
       expect(failedIndex).toBeGreaterThanOrEqual(0);
       expect(dispatchIndex).toBeGreaterThan(failedIndex);
       const inFlight = await fixture.client.getMessages(chatId);
-      expect(inFlight.pendingUserInputs.find((input) => input.content === 'failure-fence-b'))
-        .toMatchObject({ deliveryStatus: 'accepted' });
+      const successorInput = inFlight.pendingUserInputs.find(
+        (input) => input.content === 'failure-fence-b',
+      );
+      if (!successorInput) throw new Error('Missing pending successor identity.');
+      expect(successorInput.deliveryStatus).toBe('accepted');
+      expect(successorInput.clientRequestId).toBeString();
+      expect(successorInput.clientMessageId).toBeString();
+      expect(successorInput.turnId).toBeString();
+      const successorTurnId = successorInput.turnId;
 
       const terminalCursor = fixture.client.markEvents();
       successor.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: terminalCursor });
+      await fixture.client.waitForTurnTerminal(chatId, successorTurnId, {
+        afterIndex: terminalCursor,
+      });
       const settled = await fixture.client.getMessages(chatId);
       expect(countUserContent(settled.messages, 'failure-fence-b')).toBe(1);
       expect(settled.pendingUserInputs).toEqual([]);

--- a/integration-tests/tests/server/queue-lifecycle.test.ts
+++ b/integration-tests/tests/server/queue-lifecycle.test.ts
@@ -2,14 +2,38 @@ import { describe, expect, test } from 'bun:test';
 import type {
   ChatMessagesMessage,
   PendingUserInputClearedMessage,
+  PendingUserInputUpdatedMessage,
 } from '../../../common/ws-events.js';
-import { GarconApiError } from '../../support/garcon-client.js';
+import { GarconApiError, type GarconTestClient } from '../../support/garcon-client.js';
 import {
   assistantContents,
   countUserContent,
   userContents,
 } from '../../support/chat-assertions.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+async function waitForQueuedTurnIdentity(
+  client: GarconTestClient,
+  chatId: string,
+  content: string,
+  afterIndex = 0,
+) {
+  const event = await client.waitForEvent(
+    (message): message is PendingUserInputUpdatedMessage =>
+      message.type === 'pending-user-input-updated'
+      && message.input.chatId === chatId
+      && message.input.content === content,
+    `queued turn identity for ${content}`,
+    { afterIndex },
+  );
+  expect(event.input.clientRequestId).toBeString();
+  expect(event.input.clientMessageId).toBeString();
+  expect(event.input.turnId).toBeString();
+  return event.input as typeof event.input & {
+    clientMessageId: string;
+    turnId: string;
+  };
+}
 
 describe('queue lifecycle', () => {
   test('dispatches queued entries in FIFO order', async () => {
@@ -26,7 +50,30 @@ describe('queue lifecycle', () => {
       });
       await heldA.received;
 
-      const queuedB = await fixture.client.enqueueNew(chatId, 'fifo-b');
+      const queueRequestId = crypto.randomUUID();
+      const queueRequest = {
+        chatId,
+        content: 'fifo-b',
+        clientRequestId: queueRequestId,
+      };
+      const queuedB = await fixture.client.enqueue(queueRequest);
+      const duplicateB = await fixture.client.enqueue(queueRequest);
+      expect(duplicateB).toMatchObject({
+        status: 'duplicate',
+        entryId: queuedB.entryId,
+      });
+      expect(duplicateB.queue.entries.map((entry) => entry.id)).toEqual([queuedB.entryId]);
+      let queueConflict: unknown;
+      try {
+        await fixture.client.enqueue({ ...queueRequest, content: 'fifo-conflict' });
+      } catch (error) {
+        queueConflict = error;
+      }
+      expect(queueConflict).toBeInstanceOf(GarconApiError);
+      expect(queueConflict).toMatchObject({
+        status: 409,
+        body: { errorCode: 'IDEMPOTENCY_CONFLICT' },
+      });
       const queuedC = await fixture.client.enqueueNew(chatId, 'fifo-c');
       expect(queuedB.entryId).not.toBe(queuedC.entryId);
       expect(queuedC.queue.entries.map((entry) => [entry.id, entry.content])).toEqual([
@@ -40,9 +87,10 @@ describe('queue lifecycle', () => {
       await heldB.received;
       heldB.releaseEcho();
       await heldC.received;
+      const queuedTurnC = await waitForQueuedTurnIdentity(fixture.client, chatId, 'fifo-c');
       const finalCursor = fixture.client.markEvents();
       heldC.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: finalCursor });
+      await fixture.client.waitForTurnTerminal(chatId, queuedTurnC.turnId, { afterIndex: finalCursor });
 
       expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual([
         'fifo-a',
@@ -116,9 +164,10 @@ describe('queue lifecycle', () => {
       const heldEdited = fixture.fakeOpenAi.holdNext({ lastUserText: 'edited-b' });
       heldA.releaseEcho();
       await heldEdited.received;
+      const editedTurn = await waitForQueuedTurnIdentity(fixture.client, chatId, 'edited-b');
       const cursor = fixture.client.markEvents();
       heldEdited.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: cursor });
+      await fixture.client.waitForTurnTerminal(chatId, editedTurn.turnId, { afterIndex: cursor });
       expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual([
         'edit-a',
         'edited-b',
@@ -167,9 +216,10 @@ describe('queue lifecycle', () => {
       const heldB = fixture.fakeOpenAi.holdNext({ lastUserText: 'pause-b' });
       await fixture.client.resumeQueue(chatId, secondPause.queue.pause!.id);
       await heldB.received;
+      const queuedTurnB = await waitForQueuedTurnIdentity(fixture.client, chatId, 'pause-b');
       const cursor = fixture.client.markEvents();
       heldB.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: cursor });
+      await fixture.client.waitForTurnTerminal(chatId, queuedTurnB.turnId, { afterIndex: cursor });
       expect((await fixture.client.getQueue(chatId)).pause).toBeNull();
     });
   });
@@ -188,12 +238,25 @@ describe('queue lifecycle', () => {
       await fixture.client.enqueueNew(chatId, 'stop-b');
 
       const activeAborted = heldA.expectAbort();
-      const stopped = await fixture.client.stopChat({
+      const stopCursor = fixture.client.markEvents();
+      const stopRequest = {
         chatId,
         clientRequestId: crypto.randomUUID(),
-      });
+      };
+      const stopped = await fixture.client.stopChat(stopRequest);
       await activeAborted;
+      const duplicateStop = await fixture.client.stopChat(stopRequest);
       expect(stopped.stopped).toBe(true);
+      expect(duplicateStop).toMatchObject({
+        status: 'duplicate',
+        stopped: true,
+        queue: stopped.queue,
+      });
+      await fixture.client.ping();
+      expect(fixture.client.eventsSince(stopCursor).filter((event) =>
+        event.type === 'chat-session-stopped'
+        && event.chatId === chatId
+        && event.intent === 'stop')).toHaveLength(1);
       expect(stopped.queue.pause).not.toBeNull();
       expect(stopped.queue.entries.map((entry) => entry.content)).toEqual(['stop-b']);
       expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual(['stop-a']);
@@ -201,9 +264,10 @@ describe('queue lifecycle', () => {
       const heldB = fixture.fakeOpenAi.holdNext({ lastUserText: 'stop-b' });
       await fixture.client.resumeQueue(chatId, stopped.queue.pause!.id);
       await heldB.received;
+      const queuedTurnB = await waitForQueuedTurnIdentity(fixture.client, chatId, 'stop-b');
       const cursor = fixture.client.markEvents();
       heldB.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: cursor });
+      await fixture.client.waitForTurnTerminal(chatId, queuedTurnB.turnId, { afterIndex: cursor });
       expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual([
         'stop-a',
         'stop-b',
@@ -266,9 +330,12 @@ describe('queue lifecycle', () => {
       const heldC = fixture.fakeOpenAi.holdNext({ lastUserText: 'drain-stop-c' });
       await fixture.client.resumeQueue(chatId, stopped.queue.pause!.id);
       await heldC.received;
+      const queuedTurnC = await waitForQueuedTurnIdentity(fixture.client, chatId, 'drain-stop-c');
       const completionCursor = fixture.client.markEvents();
       heldC.releaseEcho();
-      await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: completionCursor });
+      await fixture.client.waitForTurnTerminal(chatId, queuedTurnC.turnId, {
+        afterIndex: completionCursor,
+      });
 
       expect(fixture.fakeOpenAi.requests().map((request) => request.lastUserText)).toEqual([
         'drain-stop-seed',
@@ -300,13 +367,29 @@ describe('queue lifecycle', () => {
       const heldB = fixture.fakeOpenAi.holdNext({ lastUserText: 'interrupt-b' });
 
       const activeAborted = heldA.expectAbort();
-      const interrupted = await fixture.client.interruptAndSend({
+      const interruptRequest = {
         chatId,
         clientRequestId: crypto.randomUUID(),
-      });
+      };
+      const interrupted = await fixture.client.interruptAndSend(interruptRequest);
       await activeAborted;
+      const duplicateInterrupt = await fixture.client.interruptAndSend(interruptRequest);
       expect(interrupted.stopped).toBe(true);
+      expect(duplicateInterrupt).toMatchObject({
+        status: 'duplicate',
+        stopped: true,
+      });
       await heldB.received;
+      await fixture.client.ping();
+      const interruptEvents = fixture.client.eventsSince(eventCursor);
+      expect(interruptEvents.filter((event) =>
+        event.type === 'chat-session-stopped'
+        && event.chatId === chatId
+        && event.intent === 'interrupt-and-send')).toHaveLength(1);
+      expect(interruptEvents.filter((event) =>
+        event.type === 'queue-dispatching'
+        && event.chatId === chatId
+        && event.content === 'interrupt-b')).toHaveLength(1);
 
       const successorMessageEvent = await fixture.client.waitForEvent(
         (event): event is ChatMessagesMessage =>
@@ -319,10 +402,23 @@ describe('queue lifecycle', () => {
       );
       const successor = successorMessageEvent.messages.find((entry) =>
         entry.message.type === 'user-message' && entry.message.content === 'interrupt-b');
+      const successorIdentity = await waitForQueuedTurnIdentity(
+        fixture.client,
+        chatId,
+        'interrupt-b',
+        eventCursor,
+      );
       const clientRequestId = successor?.message.type === 'user-message'
         ? successor.message.metadata?.clientRequestId
         : undefined;
-      expect(clientRequestId).toBeString();
+      expect(clientRequestId).toBe(successorIdentity.clientRequestId);
+      expect(successor?.message.type === 'user-message'
+        ? successor.message.metadata?.turnId
+        : undefined).toBe(successorIdentity.turnId);
+      expect(successorMessageEvent).toMatchObject({
+        clientRequestId: successorIdentity.clientRequestId,
+        turnId: successorIdentity.turnId,
+      });
       expect(fixture.client.events().slice(eventCursor).filter((event) =>
         event.type === 'pending-user-input-status-updated'
         && event.chatId === chatId
@@ -332,15 +428,20 @@ describe('queue lifecycle', () => {
       heldA.releaseText('stale response must be ignored');
       const finalCursor = fixture.client.markEvents();
       heldB.releaseEcho();
-      await fixture.client.waitForEvent(
-        (event): event is PendingUserInputClearedMessage =>
-          event.type === 'pending-user-input-cleared'
-          && event.chatId === chatId
-          && event.clientRequestId === clientRequestId
-          && event.reason === 'persisted',
-        'interrupt successor persistence',
-        { afterIndex: finalCursor },
-      );
+      await Promise.all([
+        fixture.client.waitForEvent(
+          (event): event is PendingUserInputClearedMessage =>
+            event.type === 'pending-user-input-cleared'
+            && event.chatId === chatId
+            && event.clientRequestId === clientRequestId
+            && event.reason === 'persisted',
+          'interrupt successor persistence',
+          { afterIndex: finalCursor },
+        ),
+        fixture.client.waitForTurnTerminal(chatId, successorIdentity.turnId, {
+          afterIndex: finalCursor,
+        }),
+      ]);
       const transcript = await fixture.client.getMessages(chatId);
       expect(countUserContent(transcript.messages, 'interrupt-b')).toBe(1);
       expect(transcript.pendingUserInputs).toEqual([]);

--- a/integration-tests/tests/server/reconnect-transcript.test.ts
+++ b/integration-tests/tests/server/reconnect-transcript.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, test } from 'bun:test';
-import { applyChatViewMessages } from '../../../common/chat-view.js';
+import { applyChatViewMessages, type ChatViewMessage } from '../../../common/chat-view.js';
+import type { ChatGenerationResetMessage } from '../../../common/ws-events.js';
 import { countUserContent, userContents } from '../../support/chat-assertions.js';
+import { GarconWsRequestError } from '../../support/garcon-client.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+function transcriptProjection(messages: readonly ChatViewMessage[]): Array<{
+  seq: number;
+  type: string;
+  content?: string;
+}> {
+  return messages.map((entry) => ({
+    seq: entry.seq,
+    type: entry.message.type,
+    ...('content' in entry.message && typeof entry.message.content === 'string'
+      ? { content: entry.message.content }
+      : {}),
+  }));
+}
 
 describe('reconnect and transcript stability', () => {
   test('reconnects while processing with correlated processing, queue, and pending snapshots', async () => {
@@ -71,6 +87,7 @@ describe('reconnect and transcript stability', () => {
         expect(page.pendingUserInputs[0].deliveryStatus).toBe('accepted');
       }
       expect(fixture.fakeOpenAi.requests()).toHaveLength(1);
+      await fixture.client.ping();
       expect(fixture.client.events().slice(eventCursor).filter((event) =>
         event.type === 'chat-generation-reset' && event.chatId === chatId)).toEqual([]);
 
@@ -148,5 +165,115 @@ describe('reconnect and transcript stability', () => {
       expect(subscribed.messages).toEqual([]);
     });
   });
-});
 
+  test('scopes manual reload responses and preserves a paged transcript across generations', async () => {
+    await withIntegrationFixture('manual-reload-contract', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const observer = await fixture.connectObserver('reload-observer');
+      const first = await fixture.client.startDirectChat({
+        chatId,
+        content: 'reload-first',
+        projectPath: fixture.dirs.project,
+        provider: fixture.provider,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, first.turnId);
+      const second = await fixture.client.runDirectChat({
+        chatId,
+        content: 'reload-second',
+        provider: fixture.provider,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, second.turnId);
+
+      const held = fixture.fakeOpenAi.holdNext({ lastUserText: 'reload-third' });
+      const third = await fixture.client.runDirectChat({
+        chatId,
+        content: 'reload-third',
+        provider: fixture.provider,
+      });
+      await held.received;
+      const failedObserverCursor = observer.markEvents();
+
+      let reloadFailure: unknown;
+      try {
+        await fixture.client.reloadChat(chatId);
+      } catch (error) {
+        reloadFailure = error;
+      }
+      expect(reloadFailure).toBeInstanceOf(GarconWsRequestError);
+      const requestError = (reloadFailure as GarconWsRequestError).response;
+      expect(requestError).toMatchObject({
+        type: 'client-request-error',
+        requestType: 'chat-reload',
+        code: 'CHAT_RUNNING',
+        retryable: true,
+        chatId,
+      });
+      expect(requestError.clientRequestId).toBeString();
+      await Promise.all([fixture.client.ping(), observer.ping()]);
+      expect(observer.eventsSince(failedObserverCursor).some((event) =>
+        event.type === 'chat-generation-reset' && event.chatId === chatId)).toBe(false);
+
+      held.releaseEcho();
+      await Promise.all([
+        fixture.client.waitForTurnTerminal(chatId, third.turnId),
+        observer.waitForTurnTerminal(chatId, third.turnId),
+      ]);
+      const beforeReload = await fixture.client.getMessages(chatId);
+      expect(beforeReload.pendingUserInputs).toEqual([]);
+      const observerCursor = observer.markEvents();
+
+      const reloaded = await fixture.client.reloadChat(chatId);
+      expect(reloaded).toMatchObject({
+        type: 'chat-reloaded',
+        chatId,
+        hasMore: false,
+      });
+      expect(reloaded.generationId).not.toBe(beforeReload.generationId);
+      expect(transcriptProjection(reloaded.messages)).toEqual(
+        transcriptProjection(beforeReload.messages),
+      );
+      const reset = await observer.waitForEvent(
+        (event): event is ChatGenerationResetMessage =>
+          event.type === 'chat-generation-reset'
+          && event.chatId === chatId
+          && event.generationId === reloaded.generationId,
+        'manual reload generation reset',
+        { afterIndex: observerCursor },
+      );
+      expect(reset).toMatchObject({ reason: 'manual-reload', lastSeq: reloaded.lastSeq });
+      expect(observer.eventsSince(observerCursor).some((event) =>
+        event.type === 'chat-reloaded'
+        && event.clientRequestId === reloaded.clientRequestId)).toBe(false);
+
+      const stale = await observer.subscribe(
+        chatId,
+        beforeReload.generationId,
+        beforeReload.lastSeq,
+      );
+      expect(stale.mode).toBe('snapshot-required');
+      expect(stale.generationId).toBe(reloaded.generationId);
+
+      let page = await fixture.client.getMessages(chatId, { limit: 2 });
+      let reconstructed = [...page.messages];
+      let pageCount = 1;
+      while (page.hasMore) {
+        page = await fixture.client.getMessages(chatId, {
+          limit: 2,
+          beforeSeq: page.pageOldestSeq,
+        });
+        expect(page.pendingUserInputs).toEqual([]);
+        reconstructed = [...page.messages, ...reconstructed];
+        pageCount += 1;
+        if (pageCount > 10) throw new Error('Transcript pagination did not converge.');
+      }
+      expect(pageCount).toBeGreaterThan(1);
+      expect(reconstructed.map((entry) => entry.seq)).toEqual(
+        Array.from({ length: reconstructed.length }, (_, index) => index + 1),
+      );
+      expect(transcriptProjection(reconstructed)).toEqual(transcriptProjection(beforeReload.messages));
+      for (const content of ['reload-first', 'reload-second', 'reload-third']) {
+        expect(countUserContent(reconstructed, content)).toBe(1);
+      }
+    });
+  });
+});

--- a/server/chats/__tests__/fork-chat.test.js
+++ b/server/chats/__tests__/fork-chat.test.js
@@ -42,6 +42,11 @@ function createRegistry(sessions) {
       store[chatId] = { ...store[chatId], ...patch };
       return { id: chatId, ...store[chatId] };
     },
+    removeChat(chatId) {
+      if (!store[chatId]) return false;
+      delete store[chatId];
+      return true;
+    },
   };
 }
 
@@ -55,6 +60,11 @@ function createSettings(initialTitles = {}) {
     async setSessionName(chatId, title) {
       titles.set(chatId, title);
     },
+    removeFromAllOrderLists: mock(() => Promise.resolve(undefined)),
+    removeSessionName: mock((chatId) => {
+      titles.delete(chatId);
+      return Promise.resolve(undefined);
+    }),
   };
 }
 
@@ -728,5 +738,42 @@ describe('forkChatFileCopy', () => {
     })).rejects.toThrow(/missing source entry missing-entry/);
 
     expect(registry.getChat('601')).toBeNull();
+  });
+
+  it('rolls back every durable target side effect idempotently', async () => {
+    const agentSessionId = '77777777-7777-7777-7777-777777777777';
+    const nativePath = await createSourceNativeFile(agentSessionId);
+    const registry = createRegistry({
+      '950': {
+        agentId: 'claude',
+        model: 'sonnet',
+        projectPath: '/proj',
+        nativePath,
+        tags: [],
+        agentSessionId,
+        nextForkOrdinal: 3,
+      },
+    });
+    const settings = createSettings({ '950': 'Rollback source' });
+    const metadata = createMetadata({ '950': { firstMessage: 'Rollback prompt' } });
+    const result = await forkChatFileCopy({
+      sourceSession: registry.getChat('950'),
+      sourceChatId: '950',
+      targetChatId: '951',
+      registry,
+      settings,
+      metadata,
+    });
+
+    expect(registry.getChat('951')).not.toBeNull();
+    expect(registry.getChat('950')?.nextForkOrdinal).toBe(4);
+    await result.rollback();
+    await result.rollback();
+
+    expect(registry.getChat('951')).toBeNull();
+    expect(registry.getChat('950')?.nextForkOrdinal).toBe(3);
+    expect(settings.removeFromAllOrderLists).toHaveBeenCalledOnce();
+    expect(settings.removeSessionName).toHaveBeenCalledOnce();
+    await expect(fs.stat(result.nativePath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/server/chats/fork-chat.ts
+++ b/server/chats/fork-chat.ts
@@ -21,6 +21,8 @@ interface ForkChatSettings {
   getChatName(chatId: string): string | null | undefined;
   ensureInNormal(chatId: string): Promise<unknown>;
   setSessionName(chatId: string, title: string): Promise<unknown>;
+  removeFromAllOrderLists(chatId: string): Promise<unknown>;
+  removeSessionName(chatId: string): Promise<unknown>;
 }
 
 interface ForkChatMetadata {
@@ -61,6 +63,45 @@ export interface ForkChatFileCopyResult {
   agentId: string;
   agentSessionId: string;
   nativePath: string;
+  sourceNextForkOrdinal: number;
+  rollback(): Promise<void>;
+}
+
+export interface ForkTargetRollbackInput {
+  sourceChatId: string;
+  targetChatId: string;
+  registry: IChatRegistry;
+  settings: ForkChatSettings;
+  nativePath?: string | null;
+  sourceNextForkOrdinal?: number;
+}
+
+export async function rollbackForkTarget({
+  sourceChatId,
+  targetChatId,
+  registry,
+  settings,
+  nativePath,
+  sourceNextForkOrdinal,
+}: ForkTargetRollbackInput): Promise<void> {
+  const target = registry.getChat(targetChatId);
+  const targetNativePath = nativePath ?? target?.nativePath ?? null;
+  const source = registry.getChat(sourceChatId);
+  await Promise.all([
+    settings.removeFromAllOrderLists(targetChatId),
+    settings.removeSessionName(targetChatId),
+  ]);
+  if (targetNativePath && targetNativePath !== source?.nativePath) {
+    await fs.unlink(targetNativePath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'ENOENT') throw error;
+    });
+  }
+  if (source && sourceNextForkOrdinal !== undefined) {
+    registry.updateChat(sourceChatId, {
+      nextForkOrdinal: sourceNextForkOrdinal,
+    });
+  }
+  registry.removeChat(targetChatId);
 }
 
 export interface NormalizedForkJsonl {
@@ -342,19 +383,42 @@ export async function forkChatFileCopy({
     throw new Error(`Chat ID collision: ${targetChatId}`);
   }
 
-  // Carry-over segments hold prior-agent history for a switched chat; a fork must
-  // inherit them so the forked chat renders the same continuation.
-  carryOver?.copy(sourceChatId, targetChatId);
+  let rolledBack = false;
+  const rollback = async () => {
+    if (rolledBack) return;
+    await rollbackForkTarget({
+      sourceChatId,
+      targetChatId,
+      registry,
+      settings,
+      nativePath: destinationNativePath,
+      sourceNextForkOrdinal: nextForkOrdinal,
+    });
+    rolledBack = true;
+  };
 
-  registry.updateChat(sourceChatId, { nextForkOrdinal: nextForkOrdinal + 1 });
-  await settings.ensureInNormal(targetChatId);
+  try {
+    // Carry-over segments hold prior-agent history for a switched chat; a fork must
+    // inherit them so the forked chat renders the same continuation.
+    carryOver?.copy(sourceChatId, targetChatId);
 
-  const sourceMeta = metadata.getChatMetadata(sourceChatId);
-  if (sourceMeta?.firstMessage) {
-    metadata.addNewChatMetadata(targetChatId, sourceMeta.firstMessage);
+    registry.updateChat(sourceChatId, { nextForkOrdinal: nextForkOrdinal + 1 });
+    await settings.ensureInNormal(targetChatId);
+
+    const sourceMeta = metadata.getChatMetadata(sourceChatId);
+    if (sourceMeta?.firstMessage) {
+      metadata.addNewChatMetadata(targetChatId, sourceMeta.firstMessage);
+    }
+
+    await settings.setSessionName(targetChatId, forkTitle);
+  } catch (error) {
+    try {
+      await rollback();
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], `Failed to create and roll back fork ${targetChatId}`);
+    }
+    throw error;
   }
-
-  await settings.setSessionName(targetChatId, forkTitle);
 
   return {
     sourceChatId,
@@ -362,5 +426,7 @@ export async function forkChatFileCopy({
     agentId: sourceAgentId,
     agentSessionId: newAgentSessionId,
     nativePath: destinationNativePath,
+    sourceNextForkOrdinal: nextForkOrdinal,
+    rollback,
   };
 }

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -243,6 +243,8 @@ function makeService(overrides = {}) {
     agentId: 'claude',
     agentSessionId: 'agent-2',
     nativePath: '/tmp/agent-2.jsonl',
+    sourceNextForkOrdinal: 1,
+    rollback: mock(() => Promise.resolve(undefined)),
   }));
   const ledger = overrides.ledger ?? new CommandLedger(workspaceDir);
   const chatListProjector = {
@@ -997,6 +999,83 @@ describe('ChatCommandService', () => {
     expect(retry.status).toBe('accepted');
     expect(queue.registerPendingUserInput).toHaveBeenCalledTimes(2);
     expect(queue.runReservedTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back a fork target before admitting a pre-schedule retry', async () => {
+    const rollbacks = [];
+    const forkChatFileCopy = mock(async () => {
+      const rollback = mock(async () => undefined);
+      rollbacks.push(rollback);
+      return {
+        sourceChatId: SOURCE_CHAT_ID,
+        chatId: TARGET_CHAT_ID,
+        agentId: 'claude',
+        agentSessionId: 'agent-2',
+        nativePath: '/tmp/agent-2.jsonl',
+        sourceNextForkOrdinal: 1,
+        rollback,
+      };
+    });
+    const { service, queue } = makeService({ forkChatFileCopy });
+    const input = {
+      sourceChatId: SOURCE_CHAT_ID,
+      chatId: TARGET_CHAT_ID,
+      command: 'continue in fork',
+      clientRequestId: 'req-fork-retry',
+      clientMessageId: 'msg-fork-retry',
+    };
+    queue.registerPendingUserInput
+      .mockRejectedValueOnce(new Error('fork append failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(service.submitForkRun(input)).rejects.toThrow('fork append failed');
+    const retry = await service.submitForkRun(input);
+
+    expect(retry.status).toBe('accepted');
+    expect(forkChatFileCopy).toHaveBeenCalledTimes(2);
+    expect(rollbacks[0]).toHaveBeenCalledOnce();
+    expect(rollbacks[1]).not.toHaveBeenCalled();
+    expect(queue.registerPendingUserInput).toHaveBeenCalledTimes(2);
+    expect(queue.runReservedTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains durable fork recovery when immediate compensation fails', async () => {
+    const rollback = mock(async () => {
+      throw new Error('rollback failed');
+    });
+    const forkChatFileCopy = mock(async () => ({
+      sourceChatId: SOURCE_CHAT_ID,
+      chatId: TARGET_CHAT_ID,
+      agentId: 'claude',
+      agentSessionId: 'agent-2',
+      nativePath: '/tmp/agent-2.jsonl',
+      sourceNextForkOrdinal: 1,
+      rollback,
+    }));
+    const { service, queue, ledger } = makeService({ forkChatFileCopy });
+    queue.registerPendingUserInput.mockRejectedValueOnce(new Error('append failed'));
+
+    await expect(service.submitForkRun({
+      sourceChatId: SOURCE_CHAT_ID,
+      chatId: TARGET_CHAT_ID,
+      command: 'continue in fork',
+      clientRequestId: 'req-fork-recovery',
+      clientMessageId: 'msg-fork-recovery',
+    })).rejects.toThrow('Failed to prepare and roll back fork-run');
+
+    expect(rollback).toHaveBeenCalledOnce();
+    await expect(ledger.listForkPreparationsPendingRecovery()).resolves.toEqual([
+      expect.objectContaining({
+        chatId: TARGET_CHAT_ID,
+        status: 'failed',
+        forkPreparation: {
+          phase: 'created',
+          sourceChatId: SOURCE_CHAT_ID,
+          nativePath: '/tmp/agent-2.jsonl',
+          sourceNextForkOrdinal: 1,
+        },
+      }),
+    ]);
   });
 
   it('applies shared fork validation before copying', async () => {

--- a/server/commands/__tests__/command-ledger.test.js
+++ b/server/commands/__tests__/command-ledger.test.js
@@ -162,6 +162,43 @@ describe('CommandLedger', () => {
     await expect(third.listPendingInputRecoveries()).resolves.toEqual([]);
   });
 
+  it('retains interrupted fork preparation until startup compensation settles it', async () => {
+    const first = new CommandLedger(workspaceDir);
+    const accepted = await first.accept({
+      commandType: 'fork-run',
+      chatId: 'fork-target',
+      clientRequestId: 'req-fork-interrupted',
+      payload: { sourceChatId: 'fork-source', command: 'continue' },
+    });
+    await first.update(accepted.record.key, {
+      forkPreparation: {
+        phase: 'created',
+        sourceChatId: 'fork-source',
+        nativePath: '/tmp/fork-target.jsonl',
+        sourceNextForkOrdinal: 2,
+      },
+    });
+
+    const restarted = new CommandLedger(workspaceDir);
+    const interrupted = await restarted.listForkPreparationsPendingRecovery();
+
+    expect(interrupted).toEqual([
+      expect.objectContaining({
+        key: accepted.record.key,
+        status: 'failed',
+        errorCode: SERVER_RESTART_INTERRUPTED_ERROR_CODE,
+        forkPreparation: {
+          phase: 'created',
+          sourceChatId: 'fork-source',
+          nativePath: '/tmp/fork-target.jsonl',
+          sourceNextForkOrdinal: 2,
+        },
+      }),
+    ]);
+    await expect(restarted.settleForkPreparationRecovery(accepted.record.key)).resolves.toBe(true);
+    await expect(restarted.listForkPreparationsPendingRecovery()).resolves.toEqual([]);
+  });
+
   it('does not trim unresolved restart recovery records', async () => {
     const recoveryRecord = {
       ...makeLedgerRecord(-1),

--- a/server/commands/chat-command-service.ts
+++ b/server/commands/chat-command-service.ts
@@ -185,6 +185,11 @@ interface ForkTruncatePoint {
   lineNumber?: number;
 }
 
+interface AcceptedRunPreparation {
+  prepare(): Promise<void>;
+  compensate(): Promise<void>;
+}
+
 interface SubmitRunInput {
   chatId: string;
   command: string;
@@ -1586,21 +1591,35 @@ export class ChatCommandService {
       };
     }
 
-    try {
-      await this.#forkChatFromContext(this.#validateFork(input));
-    } catch (error: unknown) {
-      await this.deps.ledger.update(ledger.record.key, {
-        status: 'failed',
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
-
+    const forkContext = this.#validateFork(input);
+    let forkResult: ForkChatFileCopyResult | null = null;
     const result = await this.#scheduleAcceptedHttpRun(ledger, input, {
       clientRequestId,
       clientMessageId,
       turnId,
-    }, 'fork-run');
+    }, 'fork-run', {
+      prepare: async () => {
+        await this.deps.ledger.update(ledger.record.key, {
+          forkPreparation: {
+            phase: 'creating',
+            sourceChatId: forkContext.sourceChatId,
+          },
+        });
+        forkResult = await this.#forkChatFromContext(forkContext);
+        await this.deps.ledger.update(ledger.record.key, {
+          forkPreparation: {
+            phase: 'created',
+            sourceChatId: forkContext.sourceChatId,
+            nativePath: forkResult.nativePath,
+            sourceNextForkOrdinal: forkResult.sourceNextForkOrdinal,
+          },
+        });
+      },
+      compensate: async () => {
+        if (forkResult) await forkResult.rollback();
+        forkResult = null;
+      },
+    });
     return { ...result, chat: await this.#projectCommandChat(input.chatId) };
   }
 
@@ -1609,6 +1628,7 @@ export class ChatCommandService {
     input: NormalizedSubmitRunInput,
     ids: { clientRequestId: string; clientMessageId: string; turnId: string },
     commandType: Extract<AgentExecutionCommandType, 'agent-run' | 'fork-run'>,
+    preparation?: AcceptedRunPreparation,
   ): Promise<CommandAcceptedResponse> {
     if (ledger.kind === 'conflict') {
       throw new CommandValidationError(
@@ -1641,12 +1661,15 @@ export class ChatCommandService {
       reservation.executionAdmission.signal.throwIfAborted();
       await this.#assertDirectExecutionQueueAvailable(input.chatId);
       reservation.executionAdmission.signal.throwIfAborted();
+      await preparation?.prepare();
+      reservation.executionAdmission.signal.throwIfAborted();
       await this.#registerPendingInput(input.chatId, input.command, options);
       reservation.executionAdmission.signal.throwIfAborted();
       const scheduled = await this.deps.ledger.update(ledger.record.key, {
         status: 'scheduled',
         turnId: options.turnId,
         pendingInputRecovery: 'required',
+        forkPreparation: undefined,
       });
       this.#runReservedTurn(reservation, input.command, options);
       return commandResultFromRecord(scheduled ?? ledger.record);
@@ -1656,8 +1679,29 @@ export class ChatCommandService {
         options.clientRequestId!,
       );
       await this.deps.queue.releaseDirectTurn(reservation);
-      await this.#markPreScheduleFailure(ledger.record.key, error, pendingRegistered);
-      throw error;
+      let failure: unknown = error;
+      let retryable = true;
+      let forkRecoveryRequired = false;
+      if (preparation) {
+        try {
+          await preparation.compensate();
+        } catch (compensationError) {
+          retryable = false;
+          forkRecoveryRequired = true;
+          failure = new AggregateError(
+            [error, compensationError],
+            `Failed to prepare and roll back ${commandType} for ${input.chatId}`,
+          );
+        }
+      }
+      await this.#markPreScheduleFailure(
+        ledger.record.key,
+        failure,
+        pendingRegistered,
+        retryable,
+        forkRecoveryRequired,
+      );
+      throw failure;
     }
   }
 
@@ -1665,13 +1709,17 @@ export class ChatCommandService {
     ledgerKey: string,
     error: unknown,
     pendingRegistered = false,
+    retryable = true,
+    preserveForkPreparation = false,
   ): Promise<void> {
-    await this.deps.ledger.update(ledgerKey, {
+    const patch: Partial<Omit<CommandLedgerRecord, 'key'>> = {
       status: 'failed',
       error: error instanceof Error ? error.message : String(error),
-      errorCode: PRE_SCHEDULE_FAILURE_ERROR_CODE,
+      errorCode: retryable ? PRE_SCHEDULE_FAILURE_ERROR_CODE : undefined,
       ...(pendingRegistered ? { pendingInputRecovery: 'required' as const } : {}),
-    });
+    };
+    if (!preserveForkPreparation) patch.forkPreparation = undefined;
+    await this.deps.ledger.update(ledgerKey, patch);
   }
 
   async #assertDirectExecutionQueueAvailable(chatId: string): Promise<void> {

--- a/server/commands/command-ledger.ts
+++ b/server/commands/command-ledger.ts
@@ -13,6 +13,13 @@ export type CommandLedgerStatus =
 
 export type PendingInputRecoveryStatus = 'required' | 'settled';
 
+export interface ForkPreparationState {
+  phase: 'creating' | 'created';
+  sourceChatId: string;
+  nativePath?: string;
+  sourceNextForkOrdinal?: number;
+}
+
 export interface CommandLedgerRecord {
   key: string;
   commandType: string;
@@ -28,6 +35,7 @@ export interface CommandLedgerRecord {
   error?: string;
   errorCode?: string;
   pendingInputRecovery?: PendingInputRecoveryStatus;
+  forkPreparation?: ForkPreparationState;
 }
 
 export interface LedgerAcceptInput {
@@ -134,6 +142,38 @@ function parseLedgerRecord(value: unknown, index: number): CommandLedgerRecord {
   ) {
     throw new Error(`Invalid command ledger records[${index}].pendingInputRecovery`);
   }
+  let forkPreparation: ForkPreparationState | undefined;
+  if (value.forkPreparation !== undefined) {
+    if (!isPlainRecord(value.forkPreparation)) {
+      throw new Error(`Invalid command ledger records[${index}].forkPreparation`);
+    }
+    const phase = value.forkPreparation.phase;
+    const sourceChatId = value.forkPreparation.sourceChatId;
+    const nativePath = value.forkPreparation.nativePath;
+    const sourceNextForkOrdinal = value.forkPreparation.sourceNextForkOrdinal;
+    if (
+      (phase !== 'creating' && phase !== 'created')
+      || typeof sourceChatId !== 'string'
+      || sourceChatId.length === 0
+      || (nativePath !== undefined && (typeof nativePath !== 'string' || nativePath.length === 0))
+      || (
+        sourceNextForkOrdinal !== undefined
+        && (
+          typeof sourceNextForkOrdinal !== 'number'
+          || !Number.isInteger(sourceNextForkOrdinal)
+          || sourceNextForkOrdinal < 1
+        )
+      )
+    ) {
+      throw new Error(`Invalid command ledger records[${index}].forkPreparation`);
+    }
+    forkPreparation = {
+      phase,
+      sourceChatId,
+      ...(nativePath !== undefined ? { nativePath } : {}),
+      ...(sourceNextForkOrdinal !== undefined ? { sourceNextForkOrdinal } : {}),
+    };
+  }
   return {
     key,
     commandType,
@@ -159,6 +199,7 @@ function parseLedgerRecord(value: unknown, index: number): CommandLedgerRecord {
     ...(value.pendingInputRecovery !== undefined
       ? { pendingInputRecovery: value.pendingInputRecovery as PendingInputRecoveryStatus }
       : {}),
+    ...(forkPreparation ? { forkPreparation } : {}),
   };
 }
 
@@ -275,6 +316,7 @@ export class CommandLedger {
             entryId: input.entryId,
             error: undefined,
             errorCode: undefined,
+            forkPreparation: undefined,
           };
           const nextRecords = new Map(this.#records);
           nextRecords.set(key, record);
@@ -398,6 +440,32 @@ export class CommandLedger {
         ...record,
         payload: { ...record.payload },
       }));
+  }
+
+  async listForkPreparationsPendingRecovery(): Promise<CommandLedgerRecord[]> {
+    await this.#load();
+    return [...this.#records.values()]
+      .filter((record) => (
+        record.commandType === 'fork-run'
+        && record.forkPreparation !== undefined
+      ))
+      .map((record) => ({ ...record, payload: { ...record.payload } }));
+  }
+
+  async settleForkPreparationRecovery(key: string): Promise<boolean> {
+    return this.#withMutationLock(async () => {
+      await this.#load();
+      const existing = this.#records.get(key);
+      if (!existing?.forkPreparation) return false;
+      const nextRecords = new Map(this.#records);
+      nextRecords.set(key, {
+        ...existing,
+        forkPreparation: undefined,
+        updatedAt: new Date().toISOString(),
+      });
+      await this.#commit(nextRecords);
+      return true;
+    });
   }
 
   async settlePendingInputRecovery(chatId: string, clientRequestId: string): Promise<boolean> {
@@ -531,6 +599,7 @@ export class CommandLedger {
             && record.errorCode === SERVER_RESTART_INTERRUPTED_ERROR_CODE;
           return TERMINAL_COMMAND_STATUSES.has(record.status)
             && record.pendingInputRecovery !== 'required'
+            && record.forkPreparation === undefined
             && !interruptedExecution;
         })?.[0];
       if (!oldest) return;

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -20,6 +20,8 @@ import type {
   ChatListEntry,
   ChatListResponse,
   ChatOrderGroup,
+  MarkChatsReadRequest,
+  MarkChatsReadResponse,
   SetLastSelectedChatRequest,
   SetLastSelectedChatResponse,
 } from '../../common/chat-list.js';
@@ -655,11 +657,13 @@ export default function createChatRoutes({
     }
   }
 
-  async function postMarkRead(body: Record<string, unknown>): Promise<Response> {
+  async function postMarkRead(
+    body: MarkChatsReadRequest & Record<string, unknown>,
+  ): Promise<Response> {
     try {
       const entries = Array.isArray(body.entries) ? body.entries : [];
       if (entries.length === 0) {
-        return Response.json({ success: true, results: [] });
+        return Response.json({ success: true, results: [] } satisfies MarkChatsReadResponse);
       }
 
       const now = new Date().toISOString();
@@ -680,7 +684,7 @@ export default function createChatRoutes({
         results.push({ chatId, lastReadAt: merged });
       }
 
-      return Response.json({ success: true, results });
+      return Response.json({ success: true, results } satisfies MarkChatsReadResponse);
     } catch (error: unknown) {
       return jsonErrorFromUnknown(error);
     }

--- a/server/server.ts
+++ b/server/server.ts
@@ -14,7 +14,7 @@ import {
   webSocketUpgradeHeaders,
 } from './lib/websocket-auth.js';
 import { init as initAuthStore } from './auth/store.js';
-import { forkChatFileCopy } from './chats/fork-chat.js';
+import { forkChatFileCopy, rollbackForkTarget } from './chats/fork-chat.js';
 import { wireServerEvents } from './server-event-wiring.js';
 import { startExecutionControlPlane } from './execution-control-plane.js';
 
@@ -328,6 +328,35 @@ export async function startServer(): Promise<void> {
     );
     chatExecutionActivity.attachReservedExecutions(queue);
     const commandLedger = new CommandLedger(workspaceDir);
+    const forkPreparations = await commandLedger.listForkPreparationsPendingRecovery();
+    for (const record of forkPreparations) {
+      const preparation = record.forkPreparation!;
+      const sourceChatId = preparation.sourceChatId;
+      pendingInputs.clearChat(record.chatId, 'chat-removed');
+      await queue.deleteChatQueueFile(record.chatId).catch(() => undefined);
+      const target = chatRegistry.getChat(record.chatId);
+      if (target && preparation.phase === 'creating') {
+        const recoveredPreparation = {
+          phase: 'created' as const,
+          sourceChatId,
+          ...(target.nativePath ? { nativePath: target.nativePath } : {}),
+        };
+        await commandLedger.update(record.key, { forkPreparation: recoveredPreparation });
+        record.forkPreparation = recoveredPreparation;
+      }
+      if (target || record.forkPreparation?.phase === 'created') {
+        await rollbackForkTarget({
+          sourceChatId,
+          targetChatId: record.chatId,
+          registry: chatRegistry,
+          settings,
+          nativePath: record.forkPreparation?.nativePath,
+          sourceNextForkOrdinal: record.forkPreparation?.sourceNextForkOrdinal,
+        });
+      }
+      await commandLedger.settleForkPreparationRecovery(record.key);
+      logger.warn(`fork-run: removed interrupted pre-schedule target ${record.chatId}`);
+    }
     const pendingRecovery = new PendingUserInputRecoveryCoordinator(
       {
         ledger: commandLedger,

--- a/web/src/lib/api/chats.ts
+++ b/web/src/lib/api/chats.ts
@@ -16,6 +16,9 @@ import type { ApiProtocol } from '$shared/api-providers';
 import { parseChatViewMessages, type ChatViewMessage } from '$shared/chat-view';
 import type {
 	ChatListResponse,
+	MarkChatsReadEntry,
+	MarkChatsReadRequest,
+	MarkChatsReadResponse,
 	SetLastSelectedChatRequest,
 	SetLastSelectedChatResponse,
 } from '$shared/chat-list';
@@ -354,16 +357,12 @@ export async function toggleArchive(chatId: string): Promise<ToggleArchiveRespon
 	return apiPost<ToggleArchiveResponse>('/api/v1/chats/archive', { chatId });
 }
 
-export interface MarkReadBatchResponse {
-	success: boolean;
-	results: Array<{ chatId: string; lastReadAt: string }>;
-}
-
 /** Marks chats as read in a single batched request. */
 export async function markChatsReadBatch(
-	entries: Array<{ chatId: string; lastReadAt: string }>,
-): Promise<MarkReadBatchResponse> {
-	return apiPost<MarkReadBatchResponse>('/api/v1/chats/read', { entries });
+	entries: MarkChatsReadEntry[],
+): Promise<MarkChatsReadResponse> {
+	const request: MarkChatsReadRequest = { entries };
+	return apiPost<MarkChatsReadResponse>('/api/v1/chats/read', request);
 }
 
 export type ValidateStartErrorCode =

--- a/web/src/lib/chat/conversation/__tests__/conversation-router-adapter.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-router-adapter.test.ts
@@ -56,7 +56,7 @@ function depsFor(selectedChat: ChatSessionRecord | null): ConversationRouterStor
 			patchLastReadAt: vi.fn(),
 			removeChat: vi.fn(),
 			setSelectedChatId: vi.fn(),
-			setChatProcessing: vi.fn(),
+			applyProcessingEvent: vi.fn(),
 			reconcileProcessing: vi.fn(),
 			quietRefreshChats: vi.fn(),
 		},

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -247,7 +247,6 @@ function createDeps(chat = createRunningChat()) {
 			patchLastReadAt: vi.fn(),
 			applyStartEntry: vi.fn(),
 			upsertServerChat: vi.fn(),
-			setChatProcessing: vi.fn(),
 			setSelectedChatId: vi.fn(),
 			renameChat: vi.fn().mockResolvedValue(true),
 		},
@@ -679,7 +678,6 @@ describe('ConversationSessionController', () => {
 
 		expect(deps.conversationUi.setMessageQueue).toHaveBeenCalledWith('chat-1', queue);
 		expect(deps.lifecycle.clearTurnStatus).toHaveBeenCalledOnce();
-		expect(deps.sessions.setChatProcessing).toHaveBeenCalledWith('chat-1', false);
 	});
 
 	it('uses the distinct interrupt command without invoking Stop', async () => {
@@ -729,7 +727,6 @@ describe('ConversationSessionController', () => {
 
 		expect(loadingStatus).toEqual(previousStatus);
 		expect(deps.lifecycle.clearTurnStatus).not.toHaveBeenCalled();
-		expect(deps.sessions.setChatProcessing).not.toHaveBeenCalledWith('chat-1', false);
 		expect(deps.chatState.localNotices).toEqual([
 			expect.objectContaining({
 				noticeType: 'error',
@@ -762,7 +759,6 @@ describe('ConversationSessionController', () => {
 
 		expect(loadingStatus).toEqual(previousStatus);
 		expect(deps.lifecycle.clearTurnStatus).not.toHaveBeenCalled();
-		expect(deps.sessions.setChatProcessing).not.toHaveBeenCalledWith('chat-1', false);
 		expect(deps.chatState.localNotices).toEqual([
 			expect.objectContaining({
 				noticeType: 'error',
@@ -1037,7 +1033,6 @@ describe('ConversationSessionController', () => {
 		const acceptedInput = deps.chatState.pendingUserInputs[0];
 		expect(acceptedInput.deliveryStatus).toBe('accepted');
 		expect(deps.lifecycle.beginTurn).toHaveBeenCalledWith('chat-1');
-		expect(deps.sessions.setChatProcessing).toHaveBeenCalledWith('chat-1', true);
 	});
 
 	it('submits follow-up messages with the current Claude thinking mode', async () => {
@@ -1284,7 +1279,6 @@ describe('ConversationSessionController', () => {
 		});
 		expect(deps.composerState.inputText).toBe('please send');
 		expect(deps.composerState.saveDraft).toHaveBeenCalledWith('chat-1');
-		expect(deps.sessions.setChatProcessing).toHaveBeenCalledWith('chat-1', false);
 	});
 
 	it('queues text while a turn is processing without adding a transcript user message', async () => {

--- a/web/src/lib/chat/conversation/__tests__/conversation-slash-command-service.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-slash-command-service.test.ts
@@ -104,7 +104,6 @@ function createDeps(chat = createChat()) {
 			renameChat: vi.fn().mockResolvedValue(true),
 			upsertServerChat: vi.fn(),
 			setSelectedChatId: vi.fn(),
-			setChatProcessing: vi.fn(),
 		},
 		chatState: {
 			activeChatId: chat.id,
@@ -271,7 +270,6 @@ describe('ConversationSlashCommandService', () => {
 		expect(deps.sessions.setSelectedChatId).toHaveBeenCalledWith('chat-2');
 		expect(deps.navigation.navigateToChat).toHaveBeenCalledWith('chat-2');
 		expect(deps.lifecycle.beginTurn).toHaveBeenCalledWith('chat-2');
-		expect(deps.sessions.setChatProcessing).toHaveBeenCalledWith('chat-2', true);
 	});
 
 	it('forks without a message and preserves the requested sequence', async () => {

--- a/web/src/lib/chat/conversation/conversation-router-adapter.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-router-adapter.svelte.ts
@@ -32,7 +32,7 @@ export interface ConversationRouterStoreDeps {
 		patchLastReadAt: (chatId: string, lastReadAt: string) => void;
 		removeChat: (chatId: string) => void;
 		setSelectedChatId: (id: string | null) => void;
-		setChatProcessing: (chatId: string, isProcessing: boolean) => void;
+		applyProcessingEvent: (chatId: string, isProcessing: boolean) => void;
 		reconcileProcessing: (activeChatIds: Set<string>) => void;
 		quietRefreshChats: () => Promise<void> | void;
 	};
@@ -148,7 +148,7 @@ export function buildRouterStores(deps: ConversationRouterStoreDeps): EventRoute
 			setSelectedChatId: (id) => deps.sessions.setSelectedChatId(id),
 			reconcileProcessing: (activeChatIds) => deps.sessions.reconcileProcessing(activeChatIds),
 			setChatProcessing: (chatId, isProcessing) =>
-				deps.sessions.setChatProcessing(chatId, isProcessing),
+				deps.sessions.applyProcessingEvent(chatId, isProcessing),
 			patchChatPreview: (chatId, content, timestamp) => {
 				deps.sessions.patchPreview(chatId, content, timestamp);
 			},

--- a/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
@@ -141,8 +141,7 @@ export interface SessionControllerDeps {
 		patchLastReadAt: (chatId: string, lastReadAt: string) => void;
 		applyStartEntry: (entry: ChatListEntry) => void;
 		upsertServerChat: (entry: ChatListEntry) => void;
-		setChatProcessing: (chatId: string, isProcessing: boolean) => void;
-		setSelectedChatId: (id: string | null) => void;
+	setSelectedChatId: (id: string | null) => void;
 		renameChat: (chatId: string, newTitle: string) => Promise<boolean>;
 	};
 	chatState: SessionTranscriptState;
@@ -699,7 +698,6 @@ export class ConversationSessionController {
 				this.#markPendingUserInputDelivery(clientRequestId, 'accepted');
 				if (response.status === 'accepted') {
 					deps.lifecycle.beginTurn(chatId);
-					deps.sessions.setChatProcessing(chatId, true);
 				} else {
 					deps.startupCoordinator.completeStartup(chatId);
 				}
@@ -708,7 +706,6 @@ export class ConversationSessionController {
 				this.#markPendingUserInputDelivery(clientRequestId, 'failed');
 				deps.startupCoordinator.completeStartup(chatId);
 				deps.lifecycle.clearTurnStatus();
-				deps.sessions.setChatProcessing(chatId, false);
 				if (restoreComposerOnFailure) {
 					deps.composerState.inputText = previousText;
 					deps.composerState.images = previousImages;
@@ -745,11 +742,9 @@ export class ConversationSessionController {
 				});
 				this.#markPendingUserInputDelivery(clientRequestId, 'accepted');
 				deps.lifecycle.beginTurn(chatId);
-				deps.sessions.setChatProcessing(chatId, true);
 			} catch (err) {
 				this.#markPendingUserInputDelivery(clientRequestId, 'failed');
 				deps.lifecycle.clearTurnStatus();
-				deps.sessions.setChatProcessing(chatId, false);
 				if (restoreComposerOnFailure) {
 					deps.composerState.inputText = previousText;
 					deps.composerState.images = previousImages;
@@ -822,7 +817,6 @@ export class ConversationSessionController {
 					return;
 				}
 				deps.lifecycle.clearTurnStatus();
-				deps.sessions.setChatProcessing(chatId, false);
 			})
 			.catch((error) => {
 				restorePreviousStatus();
@@ -900,7 +894,6 @@ export class ConversationSessionController {
 			})
 				.then(() => {
 					deps.lifecycle.beginTurn(chatId);
-					deps.sessions.setChatProcessing(chatId, true);
 				})
 				.catch((error) => {
 					deps.chatState.appendLocalNotice(

--- a/web/src/lib/chat/conversation/conversation-slash-command-service.ts
+++ b/web/src/lib/chat/conversation/conversation-slash-command-service.ts
@@ -25,7 +25,6 @@ interface SlashCommandSessions {
 	renameChat(chatId: string, newTitle: string): Promise<boolean>;
 	upsertServerChat(entry: ChatListEntry): void;
 	setSelectedChatId(chatId: string | null): void;
-	setChatProcessing(chatId: string, isProcessing: boolean): void;
 }
 
 interface SlashCommandChatState {
@@ -269,7 +268,6 @@ export class ConversationSlashCommandService {
 			deps.navigation.navigateToChat?.(response.chat.id);
 			if (response.status === 'accepted') {
 				deps.lifecycle.beginTurn(response.chat.id);
-				deps.sessions.setChatProcessing(response.chat.id, true);
 			}
 		} catch (error) {
 			this.#restoreComposer(sourceChatId, previousText, previousImages, clearComposer);

--- a/web/src/lib/chat/sessions/__tests__/chat-sessions.test.ts
+++ b/web/src/lib/chat/sessions/__tests__/chat-sessions.test.ts
@@ -221,6 +221,26 @@ describe('ChatSessionsStore', () => {
 		expect(store.byId['a']?.lastActivityAt).toBe('2026-02-25T12:00:00.000Z');
 	});
 
+	it('patchPreview derives unread state when live activity advances past the read receipt', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({
+			id: 'a',
+			activity: {
+				createdAt: null,
+				lastActivityAt: '2026-02-25T10:00:00.000Z',
+				lastReadAt: '2026-02-25T10:00:00.000Z',
+			},
+			isUnread: false,
+		})]);
+
+		store.patchPreview('a', 'Background reply', '2026-02-25T12:00:00.000Z');
+
+		expect(store.byId['a']?.lastActivityAt).toBe('2026-02-25T12:00:00.000Z');
+		expect(store.byId['a']?.isUnread).toBe(true);
+		store.patchLastReadAt('a', '2026-02-25T12:00:00.000Z');
+		expect(store.byId['a']?.isUnread).toBe(false);
+	});
+
 	it('upsertFromServer does not erase a non-empty preview with a blank payload', () => {
 		const store = new ChatSessionsStore();
 
@@ -233,6 +253,91 @@ describe('ChatSessionsStore', () => {
 
 		expect(store.byId['a']).toBe(ref);
 		expect(store.byId['a']?.lastMessage).toBe('Persisted preview');
+	});
+
+	it('upsertFromServer does not let a stale list snapshot overwrite live activity', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({
+			id: 'a',
+			activity: {
+				createdAt: null,
+				lastActivityAt: '2026-02-25T10:00:00.000Z',
+				lastReadAt: '2026-02-25T10:00:00.000Z',
+			},
+			preview: { lastMessage: 'Initial message' },
+		})]);
+		store.patchPreview('a', 'Live background reply', '2026-02-25T12:00:00.000Z');
+
+		store.upsertFromServer([makeServerSession({
+			id: 'a',
+			activity: {
+				createdAt: null,
+				lastActivityAt: '2026-02-25T11:00:00.000Z',
+				lastReadAt: '2026-02-25T10:00:00.000Z',
+			},
+			preview: { lastMessage: 'Stale server preview' },
+			isUnread: false,
+		})]);
+
+		expect(store.byId['a']).toMatchObject({
+			lastMessage: 'Live background reply',
+			lastActivityAt: '2026-02-25T12:00:00.000Z',
+			lastReadAt: '2026-02-25T10:00:00.000Z',
+			isUnread: true,
+		});
+	});
+
+	it('upsertFromServer preserves a newer local read receipt while accepting newer activity', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({
+			id: 'a',
+			activity: {
+				createdAt: null,
+				lastActivityAt: '2026-02-25T10:00:00.000Z',
+				lastReadAt: '2026-02-25T10:00:00.000Z',
+			},
+		})]);
+		store.patchLastReadAt('a', '2026-02-25T12:00:00.000Z');
+
+		store.upsertFromServer([makeServerSession({
+			id: 'a',
+			activity: {
+				createdAt: null,
+				lastActivityAt: '2026-02-25T11:00:00.000Z',
+				lastReadAt: '2026-02-25T10:00:00.000Z',
+			},
+			isUnread: true,
+		})]);
+
+		expect(store.byId['a']).toMatchObject({
+			lastActivityAt: '2026-02-25T11:00:00.000Z',
+			lastReadAt: '2026-02-25T12:00:00.000Z',
+			isUnread: false,
+		});
+	});
+
+	it('ignores preview and read updates older than the current projection', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({
+			id: 'a',
+			activity: {
+				createdAt: null,
+				lastActivityAt: '2026-02-25T12:00:00.000Z',
+				lastReadAt: '2026-02-25T11:00:00.000Z',
+			},
+			preview: { lastMessage: 'Current preview' },
+			isUnread: true,
+		})]);
+
+		store.patchPreview('a', 'Older preview', '2026-02-25T10:00:00.000Z');
+		store.patchLastReadAt('a', '2026-02-25T09:00:00.000Z');
+
+		expect(store.byId['a']).toMatchObject({
+			lastMessage: 'Current preview',
+			lastActivityAt: '2026-02-25T12:00:00.000Z',
+			lastReadAt: '2026-02-25T11:00:00.000Z',
+			isUnread: true,
+		});
 	});
 
 	it('upsertFromServer clears startup config for all chats now owned by the server', () => {
@@ -415,23 +520,32 @@ describe('ChatSessionsStore', () => {
 		expect(store.byId['draft-1']?.isProcessing).toBe(false);
 	});
 
-	it('setChatProcessing updates a single chat', () => {
+	it('applyProcessingEvent updates a single chat', () => {
 		const store = new ChatSessionsStore();
 
 		store.upsertFromServer([makeServerSession({ id: 'a' })]);
 		expect(store.byId['a']?.isProcessing).toBe(false);
 
-		store.setChatProcessing('a', true);
+		store.applyProcessingEvent('a', true);
 		expect(store.byId['a']?.isProcessing).toBe(true);
 
-		store.setChatProcessing('a', false);
+		store.applyProcessingEvent('a', false);
 		expect(store.byId['a']?.isProcessing).toBe(false);
+	});
+
+	it('upsertFromServer observes processing changes before a WS baseline exists', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({ id: 'a', isActive: false })]);
+
+		store.upsertFromServer([makeServerSession({ id: 'a', isActive: true })]);
+
+		expect(store.byId['a']?.isProcessing).toBe(true);
 	});
 
 	it('applies an early processing event when an external chat enters the snapshot', () => {
 		const store = new ChatSessionsStore();
 
-		store.setChatProcessing('scheduled-chat', true);
+		store.applyProcessingEvent('scheduled-chat', true);
 		const ref = store.byId;
 
 		expect(store.byId).toBe(ref);
@@ -446,8 +560,8 @@ describe('ChatSessionsStore', () => {
 	it('cancels an early processing event when completion arrives before the snapshot', () => {
 		const store = new ChatSessionsStore();
 
-		store.setChatProcessing('scheduled-chat', true);
-		store.setChatProcessing('scheduled-chat', false);
+		store.applyProcessingEvent('scheduled-chat', true);
+		store.applyProcessingEvent('scheduled-chat', false);
 		store.upsertFromServer([makeServerSession({ id: 'scheduled-chat', isActive: false })]);
 
 		expect(store.byId['scheduled-chat']?.isProcessing).toBe(false);
@@ -456,20 +570,20 @@ describe('ChatSessionsStore', () => {
 	it('clears an early processing event when its chat is deleted', () => {
 		const store = new ChatSessionsStore();
 
-		store.setChatProcessing('scheduled-chat', true);
+		store.applyProcessingEvent('scheduled-chat', true);
 		store.removeChat('scheduled-chat');
 		store.upsertFromServer([makeServerSession({ id: 'scheduled-chat', isActive: false })]);
 
 		expect(store.byId['scheduled-chat']?.isProcessing).toBe(false);
 	});
 
-	it('setChatProcessing is a no-op when value unchanged', () => {
+	it('applyProcessingEvent is a no-op when value unchanged', () => {
 		const store = new ChatSessionsStore();
 
 		store.upsertFromServer([makeServerSession({ id: 'a' })]);
 		const ref = store.byId;
 
-		store.setChatProcessing('a', false);
+		store.applyProcessingEvent('a', false);
 
 		expect(store.byId).toBe(ref);
 	});
@@ -497,8 +611,8 @@ describe('ChatSessionsStore', () => {
 			makeServerSession({ id: 'a' }),
 			makeServerSession({ id: 'b', title: 'B' }),
 		]);
-		store.setChatProcessing('a', true);
-		store.setChatProcessing('b', true);
+		store.applyProcessingEvent('a', true);
+		store.applyProcessingEvent('b', true);
 
 		store.reconcileProcessing(new Set(['b']));
 
@@ -509,7 +623,7 @@ describe('ChatSessionsStore', () => {
 	it('reconcileProcessing replaces early processing events with its authoritative snapshot', () => {
 		const store = new ChatSessionsStore();
 
-		store.setChatProcessing('stale-chat', true);
+		store.applyProcessingEvent('stale-chat', true);
 		store.reconcileProcessing(new Set(['active-chat']));
 		store.upsertFromServer([
 			makeServerSession({ id: 'stale-chat', isActive: false }),
@@ -527,7 +641,7 @@ describe('ChatSessionsStore', () => {
 			makeServerSession({ id: 'a' }),
 			makeServerSession({ id: 'b', title: 'B' }),
 		]);
-		store.setChatProcessing('a', true);
+		store.applyProcessingEvent('a', true);
 
 		const ref = store.byId;
 		store.reconcileProcessing(new Set(['a']));
@@ -539,12 +653,59 @@ describe('ChatSessionsStore', () => {
 		const store = new ChatSessionsStore();
 
 		store.upsertFromServer([makeServerSession({ id: 'a' })]);
-		store.setChatProcessing('a', true);
+		store.applyProcessingEvent('a', true);
 
 		store.upsertFromServer([makeServerSession({ id: 'a', title: 'Updated' })]);
 
 		expect(store.byId['a']?.isProcessing).toBe(true);
 		expect(store.byId['a']?.title).toBe('Updated');
+	});
+
+	it('upsertFromServer preserves a terminal WS event over a stale active REST snapshot', () => {
+		const store = new ChatSessionsStore();
+
+		store.upsertFromServer([makeServerSession({ id: 'a', isActive: true })]);
+		store.applyProcessingEvent('a', false);
+		store.upsertFromServer([makeServerSession({ id: 'a', title: 'Updated', isActive: true })]);
+
+		expect(store.byId['a']?.isProcessing).toBe(false);
+		expect(store.byId['a']?.title).toBe('Updated');
+	});
+
+	it('invalidateProcessingAuthority lets the next REST snapshot converge processing', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({ id: 'a', isActive: true })]);
+		store.reconcileProcessing(new Set(['a']));
+		store.applyProcessingEvent('a', true);
+
+		store.invalidateProcessingAuthority();
+		store.upsertFromServer([makeServerSession({ id: 'a', isActive: false })]);
+
+		expect(store.byId['a']?.isProcessing).toBe(false);
+	});
+
+	it('prunes processing authority for a known chat removed from the server list', () => {
+		const store = new ChatSessionsStore();
+		store.upsertFromServer([makeServerSession({ id: 'a' })]);
+		store.applyProcessingEvent('a', true);
+
+		store.upsertFromServer([]);
+		store.upsertFromServer([makeServerSession({ id: 'a', isActive: false })]);
+
+		expect(store.byId['a']?.isProcessing).toBe(false);
+	});
+
+	it('reconnect processing baseline governs chats arriving in later list responses', () => {
+		const store = new ChatSessionsStore();
+
+		store.reconcileProcessing(new Set(['active-chat']));
+		store.upsertFromServer([
+			makeServerSession({ id: 'active-chat', isActive: false }),
+			makeServerSession({ id: 'stale-chat', title: 'Stale', isActive: true }),
+		]);
+
+		expect(store.byId['active-chat']?.isProcessing).toBe(true);
+		expect(store.byId['stale-chat']?.isProcessing).toBe(false);
 	});
 
 	it('reconcileProcessing after upsertFromServer correctly sets processing state', () => {

--- a/web/src/lib/chat/sessions/__tests__/read-receipt-outbox.test.ts
+++ b/web/src/lib/chat/sessions/__tests__/read-receipt-outbox.test.ts
@@ -8,6 +8,7 @@ vi.mock('$lib/api/chats', () => ({
 import { ReadReceiptOutboxStore } from '../read-receipt-outbox.svelte';
 import { ChatSessionsStore } from '../chat-sessions.svelte';
 import { markChatsReadBatch } from '$lib/api/chats';
+import type { MarkChatsReadResponse } from '$shared/chat-list';
 
 const mockMarkBatch = vi.mocked(markChatsReadBatch);
 
@@ -82,10 +83,7 @@ describe('ReadReceiptOutboxStore', () => {
 	it('flushes pending receipts that arrive while a batch is already in flight', async () => {
 		const { outbox } = createTestStore();
 		let resolveFirstBatch:
-			| ((value: {
-					success: boolean;
-					results: Array<{ chatId: string; lastReadAt: string }>;
-			  }) => void)
+			| ((value: MarkChatsReadResponse) => void)
 			| undefined;
 
 		mockMarkBatch.mockImplementationOnce(

--- a/web/src/lib/chat/sessions/chat-sessions.svelte.ts
+++ b/web/src/lib/chat/sessions/chat-sessions.svelte.ts
@@ -108,6 +108,7 @@ function sameRecord(a: ChatSessionRecord, b: ChatSessionRecord): boolean {
 		a.lastReadAt === b.lastReadAt &&
 		a.isPinned === b.isPinned &&
 		a.isArchived === b.isArchived &&
+		a.isProcessing === b.isProcessing &&
 		a.isUnread === b.isUnread &&
 		a.status === b.status &&
 		a.lastMessage === b.lastMessage &&
@@ -116,9 +117,30 @@ function sameRecord(a: ChatSessionRecord, b: ChatSessionRecord): boolean {
 	);
 }
 
-function preserveLocalPreview(prev: ChatSessionRecord | undefined, next: ChatSessionRecord): void {
-	if (prev?.lastMessage && !next.lastMessage) {
-		next.lastMessage = prev.lastMessage;
+function reconcileActivityProjection(
+	previous: ChatSessionRecord | undefined,
+	next: ChatSessionRecord,
+): void {
+	if (!previous) return;
+	let preservedLocalTimestamp = false;
+
+	if (previous.lastActivityAt && (!next.lastActivityAt || previous.lastActivityAt > next.lastActivityAt)) {
+		next.lastActivityAt = previous.lastActivityAt;
+		next.lastMessage = previous.lastMessage;
+		preservedLocalTimestamp = true;
+	} else if (previous.lastMessage && !next.lastMessage) {
+		next.lastMessage = previous.lastMessage;
+	}
+
+	if (previous.lastReadAt && (!next.lastReadAt || previous.lastReadAt > next.lastReadAt)) {
+		next.lastReadAt = previous.lastReadAt;
+		preservedLocalTimestamp = true;
+	}
+
+	if (preservedLocalTimestamp) {
+		next.isUnread = Boolean(
+			next.lastActivityAt && (!next.lastReadAt || next.lastActivityAt > next.lastReadAt),
+		);
 	}
 }
 
@@ -198,7 +220,8 @@ export class ChatSessionsStore {
 	#selectionWriteInFlight = false;
 	#selectionWritePending: string | null | undefined = undefined;
 	#selectionWriteAcked: string | null = null;
-	readonly #pendingProcessingChatIds = new Set<string>();
+	#processingSnapshot: Set<string> | null = null;
+	readonly #processingOverrides = new Map<string, boolean>();
 
 	#selectedChat = $derived.by(() => {
 		if (!this.selectedChatId) return null;
@@ -365,6 +388,11 @@ export class ChatSessionsStore {
 	upsertFromServer(sessions: ChatSession[]): void {
 		const nextById: Record<string, ChatSessionRecord> = {};
 		const nextOrder: string[] = [];
+		const previousServerChatIds = new Set(
+			Object.values(this.byId)
+				.filter((record) => record.status !== 'draft')
+				.map((record) => record.id),
+		);
 
 		// Preserve drafts that the server doesn't know about yet.
 		for (const [id, record] of Object.entries(this.byId)) {
@@ -377,19 +405,12 @@ export class ChatSessionsStore {
 
 		for (const session of sessions) {
 			const next = toRecord(session);
-			if (this.#pendingProcessingChatIds.delete(next.id)) {
-				next.isProcessing = true;
-			}
+			next.isProcessing = this.#resolveProcessing(next.id, next.isProcessing);
 			const prev = this.byId[next.id];
-			preserveLocalPreview(prev, next);
+			reconcileActivityProjection(prev, next);
 			if (prev && sameRecord(prev, next)) {
 				nextById[next.id] = prev;
 			} else {
-				// Preserve WS-authoritative isProcessing flag; the REST
-				// isActive snapshot can lag behind real-time WS events.
-				if (prev?.isProcessing && !next.isProcessing) {
-					next.isProcessing = true;
-				}
 				nextById[next.id] = next;
 			}
 			nextOrder.push(next.id);
@@ -410,6 +431,11 @@ export class ChatSessionsStore {
 
 		// Prepend draft IDs that aren't in the server order.
 		const serverIdSet = new Set(nextOrder);
+		for (const chatId of previousServerChatIds) {
+			if (serverIdSet.has(chatId)) continue;
+			this.#processingOverrides.delete(chatId);
+			this.#processingSnapshot?.delete(chatId);
+		}
 		const draftOrder: string[] = [];
 		for (const id of this.order) {
 			if (nextById[id]?.status === 'draft' && !serverIdSet.has(id)) {
@@ -487,10 +513,8 @@ export class ChatSessionsStore {
 	#mergeServerEntry(entry: ChatListEntry, clearStartup: boolean): void {
 		const next = toRecord(entry);
 		const previous = this.byId[entry.id];
-		preserveLocalPreview(previous, next);
-		if (this.#pendingProcessingChatIds.delete(entry.id) || previous?.isProcessing) {
-			next.isProcessing = true;
-		}
+		reconcileActivityProjection(previous, next);
+		next.isProcessing = this.#resolveProcessing(entry.id, next.isProcessing);
 		const nextById = { ...this.byId, [entry.id]: next };
 		const nextOrder = insertServerEntry(this.order, nextById, entry.id, entry.orderGroup, previous);
 		this.byId = nextById;
@@ -503,7 +527,8 @@ export class ChatSessionsStore {
 	}
 
 	removeChat(chatId: string): void {
-		this.#pendingProcessingChatIds.delete(chatId);
+		this.#processingOverrides.delete(chatId);
+		this.#processingSnapshot?.delete(chatId);
 		if (!this.byId[chatId]) return;
 
 		const nextById = { ...this.byId };
@@ -525,11 +550,19 @@ export class ChatSessionsStore {
 	patchPreview(chatId: string, content: string, timestamp?: string): void {
 		const chat = this.byId[chatId];
 		if (!chat) return;
+		if (timestamp && chat.lastActivityAt && timestamp < chat.lastActivityAt) return;
 		const lastActivityAt = timestamp ?? chat.lastActivityAt;
-		if ((chat.lastMessage || '') === content && chat.lastActivityAt === lastActivityAt) return;
+		const isUnread = timestamp
+			? Boolean(lastActivityAt && (!chat.lastReadAt || lastActivityAt > chat.lastReadAt))
+			: chat.isUnread;
+		if (
+			(chat.lastMessage || '') === content
+			&& chat.lastActivityAt === lastActivityAt
+			&& chat.isUnread === isUnread
+		) return;
 		this.byId = {
 			...this.byId,
-			[chatId]: { ...chat, lastMessage: content, lastActivityAt },
+			[chatId]: { ...chat, lastMessage: content, lastActivityAt, isUnread },
 		};
 	}
 
@@ -554,25 +587,25 @@ export class ChatSessionsStore {
 	patchLastReadAt(chatId: string, lastReadAt: string): void {
 		const chat = this.byId[chatId];
 		if (!chat) return;
-		const isUnread = Boolean(chat.lastActivityAt && chat.lastActivityAt > lastReadAt);
-		if (chat.lastReadAt === lastReadAt && chat.isUnread === isUnread) return;
+		const reconciledLastReadAt = chat.lastReadAt && chat.lastReadAt > lastReadAt
+			? chat.lastReadAt
+			: lastReadAt;
+		const isUnread = Boolean(
+			chat.lastActivityAt && chat.lastActivityAt > reconciledLastReadAt,
+		);
+		if (chat.lastReadAt === reconciledLastReadAt && chat.isUnread === isUnread) return;
 		this.byId = {
 			...this.byId,
-			[chatId]: { ...chat, lastReadAt, isUnread },
+			[chatId]: { ...chat, lastReadAt: reconciledLastReadAt, isUnread },
 		};
 	}
 
-	/** Sets the processing flag for a single chat. Processing events can arrive
-	 *  before an external chat appears in the latest server snapshot. */
-	setChatProcessing(chatId: string, isProcessing: boolean): void {
+	/** Applies a WebSocket-authoritative processing event for one chat. */
+	applyProcessingEvent(chatId: string, isProcessing: boolean): void {
+		this.#processingOverrides.set(chatId, isProcessing);
 		const chat = this.byId[chatId];
-		if (!chat) {
-			if (isProcessing) this.#pendingProcessingChatIds.add(chatId);
-			else this.#pendingProcessingChatIds.delete(chatId);
-			return;
-		}
+		if (!chat) return;
 
-		this.#pendingProcessingChatIds.delete(chatId);
 		if (chat.isProcessing === isProcessing) return;
 		this.byId = {
 			...this.byId,
@@ -580,19 +613,17 @@ export class ChatSessionsStore {
 		};
 	}
 
-	/** Reconciles processing state from a server-authoritative snapshot.
-	 *  Only mutates records whose isProcessing value actually differs
-	 *  from the snapshot to avoid unnecessary Svelte reactivity triggers.
-	 *
-	 *  NOTE: A narrow race exists where a snapshot arrives slightly after
-	 *  a turn_complete event, briefly re-setting isProcessing=true for a
-	 *  just-finished chat. This is self-healing -- the next lifecycle
-	 *  event corrects it. */
+	/** Drops authority retained from a previous socket so REST can converge state. */
+	invalidateProcessingAuthority(): void {
+		this.#processingSnapshot = null;
+		this.#processingOverrides.clear();
+	}
+
+	/** Replaces processing state from a reconnect snapshot. Later WebSocket
+	 *  events override this baseline; REST list responses never do. */
 	reconcileProcessing(activeChatIds: Set<string>): void {
-		this.#pendingProcessingChatIds.clear();
-		for (const chatId of activeChatIds) {
-			if (!this.byId[chatId]) this.#pendingProcessingChatIds.add(chatId);
-		}
+		this.#processingSnapshot = new Set(activeChatIds);
+		this.#processingOverrides.clear();
 
 		let changed = false;
 		const nextById = { ...this.byId };
@@ -608,6 +639,13 @@ export class ChatSessionsStore {
 		if (changed) {
 			this.byId = nextById;
 		}
+	}
+
+	#resolveProcessing(chatId: string, restValue: boolean): boolean {
+		const override = this.#processingOverrides.get(chatId);
+		if (override !== undefined) return override;
+		if (this.#processingSnapshot) return this.#processingSnapshot.has(chatId);
+		return restValue;
 	}
 }
 

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -148,6 +148,7 @@
 		getSelectedChatId: () => sessions.selectedChatId,
 		getQueue: getChatQueue,
 		reconcileProcessing: (activeChatIds) => sessions.reconcileProcessing(activeChatIds),
+		invalidateProcessingAuthority: () => sessions.invalidateProcessingAuthority(),
 		quietRefreshChats: () => sessions.quietRefreshChats(),
 		getBackgroundCursors: () => transcriptCache.listCursors(20),
 		getVisibleChatIds: () => getVisibleChatIds?.() ?? [],

--- a/web/src/lib/components/chat/__tests__/ConversationWorkspaceEscapeHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationWorkspaceEscapeHost.svelte
@@ -74,8 +74,9 @@
 		upsertServerChat: () => {},
 		removeChat: () => {},
 		setSelectedChatId: () => {},
-		setChatProcessing: () => {},
+		applyProcessingEvent: () => {},
 		reconcileProcessing: () => {},
+		invalidateProcessingAuthority: () => {},
 		quietRefreshChats: () => Promise.resolve(),
 	};
 

--- a/web/src/lib/events/__tests__/router-integration.test.ts
+++ b/web/src/lib/events/__tests__/router-integration.test.ts
@@ -274,6 +274,24 @@ describe('event router integration', () => {
 		expect(stores.chatState.applyChatMessages).not.toHaveBeenCalled();
 	});
 
+	it('does not invent an authoritative activity timestamp for queue dispatch previews', () => {
+		const stores = createStores();
+		renderRouterWithRawMessages(
+			[{
+				type: 'queue-dispatching',
+				chatId: 'chat-a',
+				entryId: 'entry-1',
+				content: 'queued message',
+			}],
+			stores,
+		);
+
+		expect(stores.sessions.patchChatPreview).toHaveBeenCalledWith(
+			'chat-a',
+			'queued message',
+		);
+	});
+
 	it('warms visible split-pane previews before background chat filtering skips them', () => {
 		const defaults = createStores();
 		const stores = createStores({

--- a/web/src/lib/events/router.svelte.ts
+++ b/web/src/lib/events/router.svelte.ts
@@ -75,7 +75,7 @@ export interface EventRouterAgentSettings {
 export interface EventRouterSessionsStore {
 	selectedChat: () => ChatSessionRouterView | null;
 	setSelectedChatId: (chatId: string | null) => void;
-	patchChatPreview: (chatId: string, content: string, timestamp: string) => void;
+	patchChatPreview: (chatId: string, content: string, timestamp?: string) => void;
 	refreshChats: () => void;
 	navigateToChat: (chatId: string) => void;
 	removeChat: (chatId: string) => void;
@@ -391,7 +391,6 @@ function buildDispatch(
 				stores.sessions.patchChatPreview(
 					sendChatId,
 					String(msg.content).slice(0, 200),
-					new Date().toISOString(),
 				);
 			}
 		},

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -167,6 +167,7 @@ function createReconnectDeps(
 			queue: queueState(false),
 		})),
 		reconcileProcessing: vi.fn(),
+		invalidateProcessingAuthority: vi.fn(),
 		quietRefreshChats: vi.fn(async () => undefined),
 		getBackgroundCursors: vi.fn(() => options.backgroundCursors ?? []),
 		getVisibleChatIds: vi.fn(() => options.visibleChatIds ?? []),
@@ -192,6 +193,7 @@ function clearConnectionCalls(deps: ReturnType<typeof createReconnectDeps>): voi
 		deps.getSelectedChatId,
 		deps.getQueue,
 		deps.reconcileProcessing,
+		deps.invalidateProcessingAuthority,
 		deps.quietRefreshChats,
 		deps.getBackgroundCursors,
 		deps.getVisibleChatIds,
@@ -494,7 +496,7 @@ describe('ChatReconnectCoordinator', () => {
 		);
 	});
 
-	it('preserves processing while applying queues when processing is unavailable', async () => {
+	it('invalidates stale processing authority while applying queues when processing is unavailable', async () => {
 		const deps = createReconnectDeps({
 			selectedChatId: 'chat-1',
 			queueChatIds: ['chat-2', 'chat-3'],
@@ -523,6 +525,7 @@ describe('ChatReconnectCoordinator', () => {
 		await reconnectAfterFirstConnection(deps);
 
 		expect(deps.reconcileProcessing).not.toHaveBeenCalled();
+		expect(deps.invalidateProcessingAuthority).toHaveBeenCalledTimes(2);
 		expect(deps.conversationUi.setMessageQueueFromRefresh).toHaveBeenCalledWith(
 			'chat-1',
 			queueState(true),
@@ -530,6 +533,28 @@ describe('ChatReconnectCoordinator', () => {
 		expect(deps.conversationUi.removeMessageQueue).toHaveBeenCalledWith('chat-2');
 		expect(deps.getQueue).toHaveBeenCalledOnce();
 		expect(deps.getQueue).toHaveBeenCalledWith('chat-3');
+	});
+
+	it('invalidates processing authority when the reconnect-state request fails', async () => {
+		const deps = createReconnectDeps();
+		const coordinator = new ChatReconnectCoordinator(deps);
+		await coordinator.handleConnectionState(true);
+		clearConnectionCalls(deps);
+
+		await coordinator.handleConnectionState(false);
+		deps.ws.sendRequest.mockImplementation(async (request: object) => {
+			if (!('type' in request)) throw new Error('Request is missing a type');
+			if (request.type === 'reconnect-state-query') {
+				throw new Error('reconnect state unavailable');
+			}
+			if (request.type === 'chat-subscribe') return deltaResponse('chat-1');
+			throw new Error(`Unexpected request: ${String(request.type)}`);
+		});
+		await coordinator.handleConnectionState(true);
+
+		expect(deps.invalidateProcessingAuthority).toHaveBeenCalledTimes(2);
+		expect(deps.reconcileProcessing).not.toHaveBeenCalled();
+		expect(deps.quietRefreshChats).toHaveBeenCalledOnce();
 	});
 
 	it('falls back queue reads but preserves processing state when reconnect control data is malformed', async () => {

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -41,6 +41,7 @@ export interface ChatReconnectCoordinatorOptions {
 	getSelectedChatId: () => string | null;
 	getQueue: (chatId: string) => Promise<{ queue: QueueState }>;
 	reconcileProcessing: (activeChatIds: Set<string>) => void;
+	invalidateProcessingAuthority: () => void;
 	quietRefreshChats: () => Promise<void> | void;
 	getBackgroundCursors: () => ChatTranscriptCursor[];
 	getVisibleChatIds?: () => string[];
@@ -84,6 +85,7 @@ export class ChatReconnectCoordinator {
 		if (!connected) {
 			this.#wasConnected = false;
 			this.#reconnectEpoch += 1;
+			this.options.invalidateProcessingAuthority();
 			return;
 		}
 		if (this.#wasConnected) return;
@@ -144,7 +146,11 @@ export class ChatReconnectCoordinator {
 			return { queueRefresh: Promise.resolve() };
 		}
 
-		if (runningChatIds !== null) this.options.reconcileProcessing(runningChatIds);
+		if (runningChatIds !== null) {
+			this.options.reconcileProcessing(runningChatIds);
+		} else {
+			this.options.invalidateProcessingAuthority();
+		}
 		await this.#refreshChatsQuietly();
 		if (epoch !== this.#reconnectEpoch) {
 			return { queueRefresh: Promise.resolve() };


### PR DESCRIPTION
## Summary

- expand black-box server integration coverage for direct chat lifecycle, queue dispatch, reconnect and transcript stability, provider failures, concurrent admission, and fork-and-run recovery
- extend Lightpanda coverage for multi-chat isolation, unread/read projections, transcript reload, and deletion events
- make WebSocket processing events and reconnect snapshots authoritative over lagging HTTP projections
- durably compensate and recover interrupted fork-and-run preparation
- centralize the shared chat read-receipt request and response contract

## Contract Notes

The chat read-receipt request and response types now live in the shared contract used by the server, SPA, and integration client. The wire shape is unchanged. Processing state now treats WebSocket events and reconnect snapshots as authoritative until socket authority is invalidated.

## Validation

- `bun run test:integration:server` - 45 passed
- `LIGHTPANDA_BIN=/home/ubuntu/.local/bin/lightpanda bun run test:integration:e2e` - 7 passed
- server unit suite - passed
- web unit suite - 2,704 passed
- `bun run check` - passed
- `bun run typecheck` - passed
- `bun run build` - passed
- isolated `bun run start --port 0` startup - passed
