### PR TITLE
Fix Codex fork-at-message validation

### DIFF
--- a/integration-tests/support/integration-fixture.ts
+++ b/integration-tests/support/integration-fixture.ts
@@ -42,6 +42,7 @@ export interface IntegrationDirectories {
 
 export interface IntegrationFixtureOptions {
   chatTitleEnabled?: boolean;
+  prepareWorkspace?: (directories: IntegrationDirectories) => Promise<void>;
 }
 
 interface IntegrationProcessRunDiagnostics {
@@ -114,6 +115,7 @@ export class IntegrationFixture {
     let garcon: GarconProcess | null = null;
     let client: GarconTestClient | null = null;
     try {
+      await options.prepareWorkspace?.(dirs);
       garcon = await GarconProcess.start({
         repoRoot: REPO_ROOT,
         configDir: dirs.config,

--- a/integration-tests/tests/server/codex-fork-at-message.test.ts
+++ b/integration-tests/tests/server/codex-fork-at-message.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { CURRENT_WORKSPACE_VERSION } from '../../../server/migrations/index.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+describe('Codex fork at message', () => {
+  test('preserves a selected prefix when suppressed native entries are filtered', async () => {
+    const sourceChatId = String(Date.now() * 1_000 + 1);
+    const sourceAgentSessionId = randomUUID();
+    let sourceNativePath = '';
+
+    await withIntegrationFixture('codex-fork-at-message', async (fixture) => {
+      const source = await fixture.client.getMessages(sourceChatId);
+      expect(source.messages.map((entry) => [entry.seq, entry.message.type])).toEqual([
+        [1, 'user-message'],
+        [2, 'assistant-message'],
+      ]);
+
+      const targetChatId = fixture.newChatId();
+      const fork = await fixture.client.forkChat({
+        sourceChatId,
+        chatId: targetChatId,
+        upToSeq: 2,
+      });
+      expect(fork.chat.id).toBe(targetChatId);
+
+      const forked = await fixture.client.getMessages(targetChatId);
+      expect(forked.messages.map((entry) => entry.message))
+        .toEqual(source.messages.map((entry) => entry.message));
+
+      const registry = JSON.parse(
+        await readFile(join(fixture.dirs.workspace, 'chats.json'), 'utf8'),
+      ) as {
+        sessions: Record<string, { nativeSession: { value: { path: string } } }>;
+      };
+      const targetNativePath = registry.sessions[targetChatId]!.nativeSession.value.path;
+      const targetLines = (await readFile(targetNativePath, 'utf8')).trimEnd().split('\n');
+      expect(JSON.parse(targetLines[1]!)).toEqual({ type: 'garcon_fork_filtered' });
+      expect(targetNativePath).not.toBe(sourceNativePath);
+    }, {
+      async prepareWorkspace(directories) {
+        sourceNativePath = join(
+          directories.home,
+          '.codex',
+          'sessions',
+          '2026',
+          '07',
+          '20',
+          `rollout-${sourceAgentSessionId}.jsonl`,
+        );
+        await mkdir(dirname(sourceNativePath), { recursive: true });
+        const timestamp = '2026-07-20T00:00:00.000Z';
+        await writeFile(sourceNativePath, [
+          JSON.stringify({
+            timestamp,
+            type: 'session_meta',
+            payload: { id: sourceAgentSessionId, cwd: directories.project },
+          }),
+          JSON.stringify({
+            timestamp,
+            type: 'response_item',
+            payload: {
+              type: 'message',
+              role: 'user',
+              content: [{ type: 'input_text', text: 'hello' }],
+            },
+          }),
+          JSON.stringify({
+            timestamp,
+            type: 'event_msg',
+            payload: { type: 'user_message', message: 'hello' },
+          }),
+          JSON.stringify({
+            timestamp,
+            type: 'response_item',
+            payload: {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'world' }],
+            },
+          }),
+          '',
+        ].join('\n'));
+        await writeFile(
+          join(directories.workspace, 'workspace-version.json'),
+          JSON.stringify({ version: CURRENT_WORKSPACE_VERSION }),
+        );
+        await writeFile(join(directories.workspace, 'chats.json'), JSON.stringify({
+          version: 3,
+          sessions: {
+            [sourceChatId]: {
+              agentId: 'codex',
+              nativeSession: {
+                ownerId: 'codex',
+                schemaVersion: 1,
+                value: {
+                  path: sourceNativePath,
+                  agentSessionId: sourceAgentSessionId,
+                },
+              },
+              agentOwnershipEpoch: randomUUID(),
+              agentSettingsById: {},
+              projectPath: directories.project,
+              tags: [],
+              agentSessionId: sourceAgentSessionId,
+              nextForkOrdinal: 1,
+              model: 'gpt-5.6-sol',
+              apiProviderId: null,
+              modelEndpointId: null,
+              modelProtocol: null,
+              lastReadAt: null,
+              permissionMode: 'default',
+              thinkingMode: 'none',
+            },
+          },
+        }));
+      },
+    });
+  });
+});

--- a/server-agents/common/src/forking/__tests__/jsonl-forking.test.ts
+++ b/server-agents/common/src/forking/__tests__/jsonl-forking.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { UserMessage, type ChatMessage } from '@garcon/common/chat-types';
+import {
+  attachNativeMessageSource,
+  computeAgentTranscriptRevision,
+  getNativeMessageRevisionSource,
+  type AgentForkRequest,
+  type AgentHost,
+  type AgentTranscript,
+} from '@garcon/server-agent-interface';
+import { createPathNativeSessionCodec } from '../../native-session/path-native-session.js';
+import { createJsonlForking } from '../jsonl-forking.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('createJsonlForking', () => {
+  it('validates rewritten forks by ordered message content rather than native offsets', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'garcon-jsonl-forking-'));
+    roots.push(root);
+    const sourcePath = path.join(root, 'source.jsonl');
+    const sourceAgentSessionId = '11111111-1111-1111-1111-111111111111';
+    await writeFile(sourcePath, [
+      JSON.stringify({ type: 'session', sessionId: sourceAgentSessionId }),
+      JSON.stringify({ type: 'fallback', content: 'suppressed duplicate' }),
+      JSON.stringify({ type: 'message', content: 'first' }),
+      JSON.stringify({ type: 'message', content: 'second' }),
+      '',
+    ].join('\n'));
+
+    const nativeSessions = createPathNativeSessionCodec('test');
+    const loadMessages = async (nativePath: string): Promise<ChatMessage[]> => {
+      const content = await readFile(nativePath, 'utf8');
+      const messages: ChatMessage[] = [];
+      let byteOffset = 0;
+      for (const [index, line] of content.split('\n').entries()) {
+        if (line) {
+          const entry = JSON.parse(line) as { type?: string; content?: string };
+          if (entry.type === 'message' && entry.content) {
+            messages.push(attachNativeMessageSource(
+              new UserMessage('2026-07-20T00:00:00.000Z', entry.content),
+              { lineNumber: index + 1, byteOffset, withinSourceOrdinal: 0 },
+            ));
+          }
+        }
+        byteOffset += Buffer.byteLength(line) + 1;
+      }
+      return messages;
+    };
+    const transcript = {
+      async resolveNativeSession({ chat }) {
+        return chat.nativeSession;
+      },
+      async load({ chat }) {
+        const native = nativeSessions.decode(chat.nativeSession);
+        const messages = await loadMessages(native.path!);
+        return { messages, revision: computeAgentTranscriptRevision(messages) };
+      },
+      async revision({ chat }) {
+        const native = nativeSessions.decode(chat.nativeSession);
+        return computeAgentTranscriptRevision(await loadMessages(native.path!));
+      },
+    } satisfies Pick<AgentTranscript, 'load' | 'revision' | 'resolveNativeSession'>;
+    const host = {
+      carryOver: {
+        async load() {
+          return { revision: 'carry-over', messages: [] };
+        },
+      },
+    } satisfies Pick<AgentHost, 'carryOver'>;
+    const sourceMessages = await loadMessages(sourcePath);
+    const sourceRevision = computeAgentTranscriptRevision(sourceMessages);
+    const settings = { ownerId: 'test', schemaVersion: 1, values: {} } as const;
+    const sourceNativeSession = nativeSessions.encode({
+      path: sourcePath,
+      agentSessionId: sourceAgentSessionId,
+      modelEndpointId: null,
+    });
+    const request = {
+      chatId: 'target-chat',
+      projectPath: root,
+      model: 'test-model',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      settings,
+      endpoint: null,
+      operation: {
+        commandType: 'fork-run',
+        clientRequestId: null,
+        clientMessageId: null,
+        turnId: 'turn-1',
+      },
+      admission: {
+        signal: new AbortController().signal,
+        markStarted() {},
+        markAbortable() {},
+      },
+      source: {
+        chatId: 'source-chat',
+        agentId: 'test',
+        agentSessionId: sourceAgentSessionId,
+        projectPath: root,
+        model: 'test-model',
+        nativeSession: sourceNativeSession,
+        carryOverRevision: 'carry-over',
+        settings,
+      },
+      point: {
+        messageSequence: 2,
+        sourceRevision: { native: sourceRevision, carryOver: 'carry-over' },
+      },
+    } satisfies AgentForkRequest;
+
+    const forking = createJsonlForking({
+      host,
+      supportsWhileRunning: true,
+      transcript,
+      nativeSessions,
+      rewriteEntry(entry, context) {
+        const record = entry as Record<string, unknown>;
+        if (record.type === 'session') {
+          return { ...record, sessionId: context.targetAgentSessionId };
+        }
+        if (record.type === 'fallback' && context.retainedMessageCount === 0) {
+          return { type: 'filtered' };
+        }
+        return entry;
+      },
+    });
+    const forked = await forking.fork(request);
+    const forkedNative = nativeSessions.decode(forked.nativeSession);
+    const forkedMessages = await loadMessages(forkedNative.path!);
+
+    expect(forkedMessages).toEqual(sourceMessages);
+    expect(getNativeMessageRevisionSource(forkedMessages[0])?.byteOffset)
+      .not.toBe(getNativeMessageRevisionSource(sourceMessages[0])?.byteOffset);
+  });
+});

--- a/server-agents/common/src/forking/jsonl-forking.ts
+++ b/server-agents/common/src/forking/jsonl-forking.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from 'node:fs';
+import type { ChatMessage } from '@garcon/common/chat-types';
 import {
   AgentIntegrationError,
-  computeAgentTranscriptRevision,
   getNativeMessageRevisionSource,
+  orderedTranscriptDigest,
   type AgentForkRequest,
   type AgentForking,
   type AgentHost,
@@ -16,9 +17,9 @@ import {
 } from './fork-jsonl.js';
 
 export interface JsonlForkingOptions {
-  readonly host: AgentHost;
+  readonly host: Pick<AgentHost, 'carryOver'>;
   readonly supportsWhileRunning: boolean;
-  readonly transcript: AgentTranscript;
+  readonly transcript: Pick<AgentTranscript, 'load' | 'revision' | 'resolveNativeSession'>;
   readonly nativeSessions: PathNativeSessionCodec;
   readonly rewriteEntry?: (
     entry: unknown,
@@ -64,7 +65,7 @@ async function forkJsonlAtPoint(
   let cutoffLine: number | null = null;
   let leadingLineCount = 0;
   let retainedMessageCounts: ReadonlyMap<number, number> | undefined;
-  let expectedForkRevision: string | null = null;
+  let expectedForkDigest: string | null = null;
   if (request.point) {
     if (request.point.sourceRevision.carryOver !== request.source.carryOverRevision) {
       throw sourceRevisionChanged();
@@ -103,7 +104,7 @@ async function forkJsonlAtPoint(
       ? Math.max(0, Math.min(...sourceLines) - 1)
       : 0;
     const retainedMessages = native.messages.slice(0, nativeSequence);
-    expectedForkRevision = computeAgentTranscriptRevision(retainedMessages);
+    expectedForkDigest = forkTranscriptDigest(retainedMessages);
     const retainedCounts = new Map<number, number>();
     for (const message of retainedMessages) {
       const sourcePosition = getNativeMessageRevisionSource(message);
@@ -157,7 +158,7 @@ async function forkJsonlAtPoint(
         },
         signal: request.admission.signal,
       });
-      if (forked.revision !== expectedForkRevision) {
+      if (forkTranscriptDigest(forked.messages) !== expectedForkDigest) {
         throw new AgentIntegrationError(
           'TRANSCRIPT_UNAVAILABLE',
           'The provider-native fork did not preserve the selected message prefix',
@@ -170,6 +171,13 @@ async function forkJsonlAtPoint(
     }
   }
   return { agentSessionId: result.agentSessionId, nativeSession };
+}
+
+function forkTranscriptDigest(messages: readonly ChatMessage[]): string {
+  return orderedTranscriptDigest(messages.map((message, index) => ({
+    seq: index + 1,
+    message,
+  })));
 }
 
 async function resolveSourceReference(


### PR DESCRIPTION
Codex forks can rewrite or filter provider-native JSONL entries, changing physical byte offsets without changing the selected transcript. This updates fork verification to compare an ordered content digest while retaining source-position revisions for concurrent-change detection, and adds unit and black-box coverage for suppressed Codex fallback entries.