### PR TITLE
Restore legacy direct chat history

### DIFF
--- a/integration-tests/support/integration-fixture.ts
+++ b/integration-tests/support/integration-fixture.ts
@@ -185,11 +185,12 @@ export class IntegrationFixture {
     }
   }
 
-  async restartGarcon(): Promise<void> {
+  async restartGarcon(options: { beforeStart?: () => Promise<void> } = {}): Promise<void> {
     await this.#closeClients();
     await this.garcon.stop();
     this.#archiveCurrentRun();
     this.#clients.clear();
+    await options.beforeStart?.();
     await this.#startReplacementGarcon();
   }
 

--- a/integration-tests/tests/server/direct-session-relocation.test.ts
+++ b/integration-tests/tests/server/direct-session-relocation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import { access, readFile, rename, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  assistantContents,
+  userContents,
+} from '../../support/chat-assertions.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+describe('direct session relocation', () => {
+  test('restores pre-split direct history into agent-scoped storage', async () => {
+    await withIntegrationFixture('direct-session-relocation', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const first = await fixture.client.startDirectChat({
+        chatId,
+        content: 'legacy-a',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAi,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, first.turnId);
+      const second = await fixture.client.runDirectChat({
+        chatId,
+        content: 'legacy-b',
+        agent: fixture.directAgents.openAi,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, second.turnId);
+      const before = await fixture.client.getMessages(chatId);
+
+      const registry = JSON.parse(
+        await readFile(join(fixture.dirs.workspace, 'chats.json'), 'utf8'),
+      ) as { sessions: Record<string, { agentSessionId: string }> };
+      const sessionId = registry.sessions[chatId]?.agentSessionId;
+      if (!sessionId) throw new Error(`Direct chat ${chatId} is missing its agent session ID`);
+
+      const agentDirectory = join(
+        fixture.dirs.workspace,
+        'agent-data',
+        'direct-openai-compatible',
+      );
+      const sessionsLabel = 'openai-compatible-sessions';
+      const legacyDirectory = join(fixture.dirs.workspace, sessionsLabel);
+      const scopedDirectory = join(agentDirectory, sessionsLabel);
+      const sessionFile = join(
+        scopedDirectory,
+        fixture.directAgents.openAi.provider.endpointId,
+        `${sessionId}.jsonl`,
+      );
+      await access(sessionFile);
+
+      await fixture.restartGarcon({
+        beforeStart: async () => {
+          await rename(scopedDirectory, legacyDirectory);
+          await rm(join(agentDirectory, 'migration-state.json'), { force: true });
+        },
+      });
+
+      const restored = await fixture.client.getMessages(chatId);
+      expect(userContents(restored.messages)).toEqual(userContents(before.messages));
+      expect(assistantContents(restored.messages)).toEqual(assistantContents(before.messages));
+      expect(restored.messages.map((entry) => entry.seq)).toEqual(
+        before.messages.map((entry) => entry.seq),
+      );
+      await expect(access(legacyDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+      await access(sessionFile);
+
+      const followUp = await fixture.client.runDirectChat({
+        chatId,
+        content: 'legacy-c',
+        agent: fixture.directAgents.openAi,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, followUp.turnId);
+      expect(
+        fixture.fakeProviders.openAi.requests().at(-1)?.body.messages.map((message) => message.content),
+      ).toEqual([
+        'legacy-a',
+        'echo:legacy-a',
+        'legacy-b',
+        'echo:legacy-b',
+        'legacy-c',
+      ]);
+    });
+  });
+});

--- a/server-agents/claude/src/__tests__/integration.test.js
+++ b/server-agents/claude/src/__tests__/integration.test.js
@@ -13,6 +13,7 @@ function createHost() {
     storage: {
       rootDirectory: '/tmp/garcon-claude-integration-test',
       directory: mock(() => Promise.resolve('/tmp/garcon-claude-integration-test/search')),
+      claimLegacyWorkspaceDirectory: mock(() => Promise.resolve({ moved: 0, skipped: 0 })),
     },
     environment: { get: mock(() => undefined) },
     apiProviders: { resolveCredential: mock(() => Promise.resolve(null)) },

--- a/server-agents/codex/src/__tests__/integration.test.js
+++ b/server-agents/codex/src/__tests__/integration.test.js
@@ -13,6 +13,7 @@ function createHost() {
     storage: {
       rootDirectory: '/tmp/garcon-codex-integration-test',
       directory: mock(() => Promise.resolve('/tmp/garcon-codex-integration-test/search')),
+      claimLegacyWorkspaceDirectory: mock(() => Promise.resolve({ moved: 0, skipped: 0 })),
     },
     environment: { get: mock(() => undefined) },
     apiProviders: { resolveCredential: mock(() => Promise.resolve(null)) },

--- a/server-agents/common/src/direct/__tests__/legacy-session-relocation.test.ts
+++ b/server-agents/common/src/direct/__tests__/legacy-session-relocation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type {
+  AgentHost,
+  AgentMigrationStore,
+} from '@garcon/server-agent-interface';
+import { relocateLegacySessionDirectory } from '../legacy-session-relocation.js';
+
+function createStore(initialVersion = 0) {
+  let version = initialVersion;
+  const commit = mock(async (request: Parameters<AgentMigrationStore['commit']>[0]) => {
+    if (request.expectedVersion !== version) throw new Error('Unexpected migration version');
+    version = request.nextVersion;
+  });
+  const store = {
+    getVersion: async () => version,
+    read: async () => undefined,
+    commit,
+  } satisfies AgentMigrationStore;
+  return { commit, store };
+}
+
+function createHost(
+  claimLegacyWorkspaceDirectory: AgentHost['storage']['claimLegacyWorkspaceDirectory'],
+) {
+  const info = mock(() => undefined);
+  const host = {
+    agentId: 'direct-test',
+    logger: { debug() {}, info, warn() {}, error() {} },
+    storage: {
+      rootDirectory: '/tmp/direct-test',
+      directory: async () => '/tmp/direct-test/sessions',
+      claimLegacyWorkspaceDirectory,
+    },
+    environment: { get: () => undefined },
+    apiProviders: { resolveCredential: async () => null },
+    carryOver: {
+      load: async ({ expectedRevision }) => ({ revision: expectedRevision, messages: [] }),
+    },
+  } satisfies AgentHost;
+  return { host, info };
+}
+
+describe('relocateLegacySessionDirectory', () => {
+  test('claims legacy storage and commits the relocation version', async () => {
+    const claim = mock(async () => ({ moved: 2, skipped: 1 }));
+    const { host, info } = createHost(claim);
+    const { commit, store } = createStore();
+
+    await relocateLegacySessionDirectory(host, store, 'legacy-sessions');
+
+    expect(claim).toHaveBeenCalledWith('legacy-sessions');
+    expect(info).toHaveBeenCalledWith('Relocated legacy legacy-sessions: moved 2, skipped 1');
+    expect(commit).toHaveBeenCalledWith({
+      expectedVersion: 0,
+      nextVersion: 1,
+      set: {},
+      delete: [],
+    });
+  });
+
+  test('does not touch storage after the relocation version is committed', async () => {
+    const claim = mock(async () => ({ moved: 0, skipped: 0 }));
+    const { host } = createHost(claim);
+    const { commit, store } = createStore(1);
+
+    await relocateLegacySessionDirectory(host, store, 'legacy-sessions');
+
+    expect(claim).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  test('does not commit when claiming legacy storage fails', async () => {
+    const claim = mock(async () => {
+      throw new Error('claim failed');
+    });
+    const { host } = createHost(claim);
+    const { commit, store } = createStore();
+
+    await expect(
+      relocateLegacySessionDirectory(host, store, 'legacy-sessions'),
+    ).rejects.toThrow('claim failed');
+    expect(commit).not.toHaveBeenCalled();
+  });
+});

--- a/server-agents/common/src/direct/__tests__/transcript-source.test.js
+++ b/server-agents/common/src/direct/__tests__/transcript-source.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -14,12 +14,13 @@ async function tempDir() {
   return dir;
 }
 
-function source(root) {
+function source(root, logger) {
   const paths = createDirectSessionPaths(root, 'sessions');
   return createDirectCompatibleTranscriptSource({
     agentId: 'direct-openai-compatible',
     sessionLabel: 'Direct (Chat Completions)',
     findSessionFilePath: paths.findSessionFilePath,
+    logger,
   });
 }
 
@@ -197,6 +198,28 @@ describe('Direct compatible transcript source', () => {
       modelEndpointId: 'chat_endpoint',
       nativePath: '!direct-openai-compatible:missing-session',
     })).resolves.toBeNull();
+  });
+
+  it('warns when loading a missing transcript and stays quiet when the file exists', async () => {
+    const root = await tempDir();
+    const warn = mock(() => undefined);
+    const transcript = source(root, { warn });
+    const reference = {
+      agentSessionId: 'session-1',
+      modelEndpointId: 'chat_endpoint',
+    };
+
+    await expect(transcript.loadMessages(reference)).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      'Direct transcript file missing for session session-1 (endpoint chat_endpoint)',
+    );
+
+    warn.mockClear();
+    await writeTranscript(root, 'chat_endpoint', 'session-1', [
+      { role: 'user', content: 'found' },
+    ]);
+    await expect(transcript.loadMessages(reference)).resolves.toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('scans later compatible endpoints when the recorded endpoint has no transcript', async () => {

--- a/server-agents/common/src/direct/legacy-session-relocation.ts
+++ b/server-agents/common/src/direct/legacy-session-relocation.ts
@@ -1,0 +1,25 @@
+import type { AgentHost, AgentMigrationStore } from '@garcon/server-agent-interface';
+
+const RELOCATION_VERSION = 1;
+
+export async function relocateLegacySessionDirectory(
+  host: AgentHost,
+  store: AgentMigrationStore,
+  label: string,
+): Promise<void> {
+  const version = await store.getVersion();
+  if (version >= RELOCATION_VERSION) return;
+
+  const claim = await host.storage.claimLegacyWorkspaceDirectory(label);
+  if (claim.moved > 0 || claim.skipped > 0) {
+    host.logger.info(
+      `Relocated legacy ${label}: moved ${claim.moved}, skipped ${claim.skipped}`,
+    );
+  }
+  await store.commit({
+    expectedVersion: version,
+    nextVersion: RELOCATION_VERSION,
+    set: {},
+    delete: [],
+  });
+}

--- a/server-agents/common/src/direct/transcript-source.ts
+++ b/server-agents/common/src/direct/transcript-source.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import type { ChatMessage } from '@garcon/common/chat-types';
+import type { AgentLogger } from '@garcon/server-agent-interface';
 import { getArtificialAgentSessionId } from '../chats/artificial-native-path.js';
 import {
   getDirectCompatiblePreviewFromSessionId,
@@ -24,6 +25,7 @@ export interface DirectCompatibleTranscriptReader {
 export interface DirectCompatibleTranscriptSourceConfig {
   readonly agentId: string;
   readonly sessionLabel: string;
+  readonly logger?: AgentLogger;
   readonly findSessionFilePath: (
     sessionId: string,
     preferredEndpointId?: string | null,
@@ -48,7 +50,12 @@ export function createDirectCompatibleTranscriptSource(
     const identity = sessionIdentity(reference);
     if (!identity.sessionId) return [];
     const nativePath = await resolve(reference);
-    if (!nativePath) return [];
+    if (!nativePath) {
+      config.logger?.warn(
+        `Direct transcript file missing for session ${identity.sessionId} (endpoint ${identity.endpointId ?? 'unknown'})`,
+      );
+      return [];
+    }
     return loadDirectCompatibleChatMessages(identity.sessionId, {
       getSessionFilePath: () => nativePath,
       isValidSessionId: isSafeDirectPathSegment,

--- a/server-agents/common/src/execution/__tests__/resolve-endpoint.test.ts
+++ b/server-agents/common/src/execution/__tests__/resolve-endpoint.test.ts
@@ -29,6 +29,7 @@ describe('resolveAgentEndpoint', () => {
       storage: {
         rootDirectory: '/tmp',
         directory: async () => '/tmp',
+        claimLegacyWorkspaceDirectory: async () => ({ moved: 0, skipped: 0 }),
       },
       environment: { get: () => undefined },
       apiProviders: { resolveCredential },

--- a/server-agents/cursor/src/__tests__/integration.test.js
+++ b/server-agents/cursor/src/__tests__/integration.test.js
@@ -13,6 +13,7 @@ function createHost() {
     storage: {
       rootDirectory: '/tmp/garcon-cursor-integration-test',
       directory: mock(() => Promise.resolve('/tmp/garcon-cursor-integration-test/search')),
+      claimLegacyWorkspaceDirectory: mock(() => Promise.resolve({ moved: 0, skipped: 0 })),
     },
     environment: { get: mock(() => undefined) },
     apiProviders: { resolveCredential: mock(() => Promise.resolve(null)) },

--- a/server-agents/direct-anthropic-compatible/src/index.ts
+++ b/server-agents/direct-anthropic-compatible/src/index.ts
@@ -12,6 +12,7 @@ import { createModelCatalog } from '@garcon/server-agent-common/catalog/model-ca
 import { resolveAgentStandaloneEntrypoint } from '@garcon/server-agent-common/build/standalone-entrypoint';
 import { classifyDirectIntegrationError } from '@garcon/server-agent-common/direct/errors';
 import { DirectExecution } from '@garcon/server-agent-common/direct/execution';
+import { relocateLegacySessionDirectory } from '@garcon/server-agent-common/direct/legacy-session-relocation';
 import { createDirectAnthropicRuntime } from '@garcon/server-agent-common/direct/router';
 import { createDirectSessionPaths } from '@garcon/server-agent-common/direct/session-paths';
 import {
@@ -24,6 +25,8 @@ import { createIntegrationLifecycle } from '@garcon/server-agent-common/lifecycl
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+
+const SESSIONS_LABEL = 'anthropic-compatible-sessions';
 
 const DESCRIPTOR = {
   id: DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID,
@@ -69,7 +72,7 @@ export default class DirectAnthropicCompatibleIntegration implements AgentIntegr
     );
     const sessionPaths = createDirectSessionPaths(
       host.storage.rootDirectory,
-      'anthropic-compatible-sessions',
+      SESSIONS_LABEL,
     );
     const runtime = createDirectAnthropicRuntime({
       runtimeId: DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID,
@@ -81,6 +84,7 @@ export default class DirectAnthropicCompatibleIntegration implements AgentIntegr
       agentId: DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID,
       sessionLabel: DIRECT_ANTHROPIC_COMPATIBLE_AGENT_LABEL,
       findSessionFilePath: sessionPaths.findSessionFilePath,
+      logger: host.logger,
     });
 
     this.settings = createVersionedSettings({
@@ -148,6 +152,7 @@ export default class DirectAnthropicCompatibleIntegration implements AgentIntegr
       },
     };
     this.lifecycle = createIntegrationLifecycle({
+      migrateOwnedStorage: (store) => relocateLegacySessionDirectory(host, store, SESSIONS_LABEL),
       start: () => runtime.startPurgeTimer(),
       stop: async () => {
         runtime.shutdown();

--- a/server-agents/direct-openai-compatible/src/index.ts
+++ b/server-agents/direct-openai-compatible/src/index.ts
@@ -12,6 +12,7 @@ import { createModelCatalog } from '@garcon/server-agent-common/catalog/model-ca
 import { resolveAgentStandaloneEntrypoint } from '@garcon/server-agent-common/build/standalone-entrypoint';
 import { classifyDirectIntegrationError } from '@garcon/server-agent-common/direct/errors';
 import { DirectExecution } from '@garcon/server-agent-common/direct/execution';
+import { relocateLegacySessionDirectory } from '@garcon/server-agent-common/direct/legacy-session-relocation';
 import { createDirectOpenAiChatRuntime } from '@garcon/server-agent-common/direct/router';
 import { createDirectSessionPaths } from '@garcon/server-agent-common/direct/session-paths';
 import {
@@ -24,6 +25,8 @@ import { createIntegrationLifecycle } from '@garcon/server-agent-common/lifecycl
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+
+const SESSIONS_LABEL = 'openai-compatible-sessions';
 
 const DESCRIPTOR = {
   id: DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
@@ -69,7 +72,7 @@ export default class DirectOpenAiCompatibleIntegration implements AgentIntegrati
     );
     const sessionPaths = createDirectSessionPaths(
       host.storage.rootDirectory,
-      'openai-compatible-sessions',
+      SESSIONS_LABEL,
     );
     const runtime = createDirectOpenAiChatRuntime({
       runtimeId: DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
@@ -81,6 +84,7 @@ export default class DirectOpenAiCompatibleIntegration implements AgentIntegrati
       agentId: DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
       sessionLabel: DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_LABEL,
       findSessionFilePath: sessionPaths.findSessionFilePath,
+      logger: host.logger,
     });
 
     this.settings = createVersionedSettings({
@@ -148,6 +152,7 @@ export default class DirectOpenAiCompatibleIntegration implements AgentIntegrati
       },
     };
     this.lifecycle = createIntegrationLifecycle({
+      migrateOwnedStorage: (store) => relocateLegacySessionDirectory(host, store, SESSIONS_LABEL),
       start: () => runtime.startPurgeTimer(),
       stop: async () => {
         runtime.shutdown();

--- a/server-agents/direct-openai-responses-compatible/src/index.ts
+++ b/server-agents/direct-openai-responses-compatible/src/index.ts
@@ -12,6 +12,7 @@ import { createModelCatalog } from '@garcon/server-agent-common/catalog/model-ca
 import { resolveAgentStandaloneEntrypoint } from '@garcon/server-agent-common/build/standalone-entrypoint';
 import { classifyDirectIntegrationError } from '@garcon/server-agent-common/direct/errors';
 import { DirectExecution } from '@garcon/server-agent-common/direct/execution';
+import { relocateLegacySessionDirectory } from '@garcon/server-agent-common/direct/legacy-session-relocation';
 import { createDirectOpenAiResponsesRuntime } from '@garcon/server-agent-common/direct/router';
 import { createDirectSessionPaths } from '@garcon/server-agent-common/direct/session-paths';
 import {
@@ -24,6 +25,8 @@ import { createIntegrationLifecycle } from '@garcon/server-agent-common/lifecycl
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+
+const SESSIONS_LABEL = 'openai-compatible-responses-sessions';
 
 const DESCRIPTOR = {
   id: DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
@@ -69,7 +72,7 @@ export default class DirectOpenAiResponsesCompatibleIntegration implements Agent
     );
     const sessionPaths = createDirectSessionPaths(
       host.storage.rootDirectory,
-      'openai-compatible-responses-sessions',
+      SESSIONS_LABEL,
     );
     const runtime = createDirectOpenAiResponsesRuntime({
       runtimeId: DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
@@ -81,6 +84,7 @@ export default class DirectOpenAiResponsesCompatibleIntegration implements Agent
       agentId: DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
       sessionLabel: DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_LABEL,
       findSessionFilePath: sessionPaths.findSessionFilePath,
+      logger: host.logger,
     });
 
     this.settings = createVersionedSettings({
@@ -148,6 +152,7 @@ export default class DirectOpenAiResponsesCompatibleIntegration implements Agent
       },
     };
     this.lifecycle = createIntegrationLifecycle({
+      migrateOwnedStorage: (store) => relocateLegacySessionDirectory(host, store, SESSIONS_LABEL),
       start: () => runtime.startPurgeTimer(),
       stop: async () => {
         runtime.shutdown();

--- a/server-agents/interface/src/contracts/host.ts
+++ b/server-agents/interface/src/contracts/host.ts
@@ -18,6 +18,12 @@ export interface AgentHostFactory {
 export interface AgentScopedStorage {
   readonly rootDirectory: string;
   directory(namespace: string): Promise<string>;
+  claimLegacyWorkspaceDirectory(name: string): Promise<AgentLegacyDirectoryClaim>;
+}
+
+export interface AgentLegacyDirectoryClaim {
+  readonly moved: number;
+  readonly skipped: number;
 }
 
 export interface AgentLogger {

--- a/server-agents/opencode/src/__tests__/integration.test.js
+++ b/server-agents/opencode/src/__tests__/integration.test.js
@@ -13,6 +13,7 @@ function createHost() {
     storage: {
       rootDirectory: '/tmp/opencode-test',
       directory: mock(() => Promise.resolve('/tmp/opencode-test/search')),
+      claimLegacyWorkspaceDirectory: mock(() => Promise.resolve({ moved: 0, skipped: 0 })),
     },
     environment: { get: mock(() => undefined) },
     apiProviders: { resolveCredential: mock(() => Promise.resolve(null)) },

--- a/server-agents/pi/src/__tests__/integration.test.js
+++ b/server-agents/pi/src/__tests__/integration.test.js
@@ -13,6 +13,7 @@ function createHost() {
     storage: {
       rootDirectory: '/tmp/garcon-pi-integration-test',
       directory: mock(() => Promise.resolve('/tmp/garcon-pi-integration-test/search')),
+      claimLegacyWorkspaceDirectory: mock(() => Promise.resolve({ moved: 0, skipped: 0 })),
     },
     environment: { get: mock(() => undefined) },
     apiProviders: { resolveCredential: mock(() => Promise.resolve(null)) },

--- a/server/agents/__tests__/integration-host-storage.test.js
+++ b/server/agents/__tests__/integration-host-storage.test.js
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { AgentIntegrationError } from '@garcon/server-agent-interface';
+import { IntegrationHostFactory } from '../integration-host.ts';
+
+const createdDirectories = [];
+
+async function createStorage() {
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'garcon-agent-storage-'));
+  createdDirectories.push(workspaceDir);
+  const factory = new IntegrationHostFactory({
+    workspaceDir,
+    resolveCredential: async () => null,
+    loadCarryOver: async ({ expectedRevision }) => ({ revision: expectedRevision, messages: [] }),
+    loggerFactory: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
+  });
+  return { storage: factory.forAgent('alpha').storage, workspaceDir };
+}
+
+async function expectAbsent(candidate) {
+  await expect(access(candidate)).rejects.toMatchObject({ code: 'ENOENT' });
+}
+
+describe('IntegrationHostFactory legacy storage claims', () => {
+  afterEach(async () => {
+    for (const directory of createdDirectories.splice(0)) {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test('moves a nested legacy directory into agent-scoped storage', async () => {
+    const { storage, workspaceDir } = await createStorage();
+    const source = path.join(workspaceDir, 'legacy-sessions');
+    await mkdir(path.join(source, 'endpoint'), { recursive: true });
+    await writeFile(path.join(source, 'root.jsonl'), 'root');
+    await writeFile(path.join(source, 'endpoint', 'nested.jsonl'), 'nested');
+
+    await expect(storage.claimLegacyWorkspaceDirectory('legacy-sessions')).resolves.toEqual({
+      moved: 2,
+      skipped: 0,
+    });
+    const destination = path.join(storage.rootDirectory, 'legacy-sessions');
+    await expect(readFile(path.join(destination, 'root.jsonl'), 'utf8')).resolves.toBe('root');
+    await expect(readFile(path.join(destination, 'endpoint', 'nested.jsonl'), 'utf8')).resolves.toBe('nested');
+    await expectAbsent(source);
+  });
+
+  test('does nothing when the legacy directory is absent', async () => {
+    const { storage } = await createStorage();
+
+    await expect(storage.claimLegacyWorkspaceDirectory('legacy-sessions')).resolves.toEqual({
+      moved: 0,
+      skipped: 0,
+    });
+  });
+
+  test('leaves an existing destination file and its legacy copy untouched', async () => {
+    const { storage, workspaceDir } = await createStorage();
+    const sourceFile = path.join(workspaceDir, 'legacy-sessions', 'session.jsonl');
+    const destinationFile = path.join(storage.rootDirectory, 'legacy-sessions', 'session.jsonl');
+    await mkdir(path.dirname(sourceFile), { recursive: true });
+    await mkdir(path.dirname(destinationFile), { recursive: true });
+    await writeFile(sourceFile, 'legacy');
+    await writeFile(destinationFile, 'current');
+
+    await expect(storage.claimLegacyWorkspaceDirectory('legacy-sessions')).resolves.toEqual({
+      moved: 0,
+      skipped: 1,
+    });
+    await expect(readFile(sourceFile, 'utf8')).resolves.toBe('legacy');
+    await expect(readFile(destinationFile, 'utf8')).resolves.toBe('current');
+  });
+
+  test('completes the remainder after a partially completed claim', async () => {
+    const { storage, workspaceDir } = await createStorage();
+    const source = path.join(workspaceDir, 'legacy-sessions');
+    const destination = path.join(storage.rootDirectory, 'legacy-sessions');
+    await mkdir(path.join(source, 'endpoint'), { recursive: true });
+    await mkdir(path.join(destination, 'endpoint'), { recursive: true });
+    await writeFile(path.join(source, 'endpoint', 'remaining.jsonl'), 'remaining');
+    await writeFile(path.join(destination, 'endpoint', 'moved.jsonl'), 'moved');
+
+    await expect(storage.claimLegacyWorkspaceDirectory('legacy-sessions')).resolves.toEqual({
+      moved: 1,
+      skipped: 0,
+    });
+    await expect(readFile(path.join(destination, 'endpoint', 'moved.jsonl'), 'utf8')).resolves.toBe('moved');
+    await expect(readFile(path.join(destination, 'endpoint', 'remaining.jsonl'), 'utf8')).resolves.toBe('remaining');
+    await expectAbsent(source);
+  });
+
+  test('skips symlinked entries without traversing them', async () => {
+    const { storage, workspaceDir } = await createStorage();
+    const source = path.join(workspaceDir, 'legacy-sessions');
+    const outside = path.join(workspaceDir, 'outside');
+    await mkdir(source);
+    await mkdir(outside);
+    await writeFile(path.join(outside, 'session.jsonl'), 'outside');
+    await symlink(outside, path.join(source, 'linked'));
+
+    await expect(storage.claimLegacyWorkspaceDirectory('legacy-sessions')).resolves.toEqual({
+      moved: 0,
+      skipped: 1,
+    });
+    await expect(readFile(path.join(outside, 'session.jsonl'), 'utf8')).resolves.toBe('outside');
+    await expectAbsent(path.join(storage.rootDirectory, 'legacy-sessions', 'linked'));
+  });
+
+  test('rejects unsafe names and symlinked legacy directories', async () => {
+    const { storage, workspaceDir } = await createStorage();
+    await expect(storage.claimLegacyWorkspaceDirectory('../evil')).rejects.toBeInstanceOf(
+      AgentIntegrationError,
+    );
+    const outside = path.join(workspaceDir, 'outside');
+    await mkdir(outside);
+    await symlink(outside, path.join(workspaceDir, 'legacy-sessions'));
+
+    await expect(storage.claimLegacyWorkspaceDirectory('legacy-sessions')).rejects.toBeInstanceOf(
+      AgentIntegrationError,
+    );
+  });
+});

--- a/server/agents/integration-host.ts
+++ b/server/agents/integration-host.ts
@@ -1,4 +1,14 @@
-import { lstat, mkdir, realpath } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  realpath,
+  rename,
+  rmdir,
+  unlink,
+} from 'node:fs/promises';
 import path from 'node:path';
 import type {
   AgentApiProviderReader,
@@ -6,6 +16,7 @@ import type {
   AgentEnvironmentReader,
   AgentHost,
   AgentHostFactory,
+  AgentLegacyDirectoryClaim,
   AgentLogger,
   AgentResolvedCredential,
   AgentScopedStorage,
@@ -67,9 +78,11 @@ class BoundEnvironmentReader implements AgentEnvironmentReader {
 
 class ScopedStorage implements AgentScopedStorage {
   readonly rootDirectory: string;
+  readonly #workspaceDir: string;
 
   constructor(workspaceDir: string, agentId: string) {
-    this.rootDirectory = path.resolve(workspaceDir, 'agent-data', agentId);
+    this.#workspaceDir = path.resolve(workspaceDir);
+    this.rootDirectory = path.join(this.#workspaceDir, 'agent-data', agentId);
   }
 
   async directory(namespace: string): Promise<string> {
@@ -92,28 +105,114 @@ class ScopedStorage implements AgentScopedStorage {
     }
     return resolved;
   }
+
+  async claimLegacyWorkspaceDirectory(name: string): Promise<AgentLegacyDirectoryClaim> {
+    assertNamespace(name);
+    const source = path.join(this.#workspaceDir, name);
+    const sourceStats = await lstatOrNull(source);
+    if (!sourceStats) return { moved: 0, skipped: 0 };
+    assertDirectoryWithoutSymlink(source, sourceStats);
+
+    const destination = await this.directory(name);
+    const claim = { moved: 0, skipped: 0 };
+    await moveDirectoryContents(source, destination, claim);
+    return claim;
+  }
 }
 
 async function ensureDirectoryWithoutSymlink(directory: string): Promise<void> {
-  const existing = await lstat(directory).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === 'ENOENT') return null;
-    throw error;
-  });
-  if (existing?.isSymbolicLink()) {
+  const existing = await lstatOrNull(directory);
+  if (existing) {
+    assertDirectoryWithoutSymlink(directory, existing);
+    return;
+  }
+  await mkdir(directory);
+}
+
+function assertDirectoryWithoutSymlink(
+  directory: string,
+  stats: Awaited<ReturnType<typeof lstat>>,
+): void {
+  if (stats.isSymbolicLink()) {
     throw new AgentIntegrationError(
       'INVALID_SETTINGS',
       `Agent storage path must not be a symbolic link: ${directory}`,
       false,
     );
   }
-  if (existing && !existing.isDirectory()) {
+  if (!stats.isDirectory()) {
     throw new AgentIntegrationError(
       'INVALID_SETTINGS',
       `Agent storage path is not a directory: ${directory}`,
       false,
     );
   }
-  if (!existing) await mkdir(directory);
+}
+
+async function lstatOrNull(candidate: string): Promise<Awaited<ReturnType<typeof lstat>> | null> {
+  return lstat(candidate).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  });
+}
+
+async function moveDirectoryContents(
+  source: string,
+  destination: string,
+  claim: { moved: number; skipped: number },
+): Promise<void> {
+  const entries = await readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+    const sourceStats = await lstatOrNull(sourcePath);
+    if (!sourceStats) continue;
+
+    if (sourceStats.isSymbolicLink()) {
+      claim.skipped += 1;
+      continue;
+    }
+    if (sourceStats.isDirectory()) {
+      await ensureDirectoryWithoutSymlink(destinationPath);
+      await moveDirectoryContents(sourcePath, destinationPath, claim);
+      continue;
+    }
+    if (!sourceStats.isFile()) {
+      claim.skipped += 1;
+      continue;
+    }
+    if (await lstatOrNull(destinationPath)) {
+      claim.skipped += 1;
+      continue;
+    }
+    await moveFile(sourcePath, destinationPath, claim);
+  }
+  await rmdir(source).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== 'ENOENT' && error.code !== 'ENOTEMPTY') throw error;
+  });
+}
+
+async function moveFile(
+  source: string,
+  destination: string,
+  claim: { moved: number; skipped: number },
+): Promise<void> {
+  try {
+    await rename(source, destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EXDEV') throw error;
+    try {
+      await copyFile(source, destination, constants.COPYFILE_EXCL);
+    } catch (copyError) {
+      if ((copyError as NodeJS.ErrnoException).code === 'EEXIST') {
+        claim.skipped += 1;
+        return;
+      }
+      throw copyError;
+    }
+    await unlink(source);
+  }
+  claim.moved += 1;
 }
 
 function assertNamespace(namespace: string): void {


### PR DESCRIPTION
Direct chats created before server-agent storage isolation still have transcripts in workspace-root directories, while current loaders only scan agent-scoped storage. This change adds a symlink-safe, collision-preserving one-time relocation owned by each direct integration, warns when a transcript file is missing, and adds restart coverage proving legacy history is restored and remains usable.