### PR TITLE
Preserve file viewer scroll positions

### DIFF
--- a/web/src/lib/components/files/ImageViewer.svelte
+++ b/web/src/lib/components/files/ImageViewer.svelte
@@ -96,16 +96,16 @@
 		});
 	}
 
-	function persistViewport(): void {
-		if (!viewportElement || correctingScroll) return;
+	function persistViewport(viewport = viewportElement): void {
+		if (!viewport || correctingScroll) return;
 		const anchor = captureViewport();
 		if (!anchor) return;
 		session.image = {
 			...session.image,
 			focalX: anchor.focal.x,
 			focalY: anchor.focal.y,
-			scrollLeft: viewportElement.scrollLeft,
-			scrollTop: viewportElement.scrollTop,
+			scrollLeft: viewport.scrollLeft,
+			scrollTop: viewport.scrollTop,
 		};
 	}
 
@@ -140,6 +140,8 @@
 	$effect(() => {
 		const viewport = viewportElement;
 		if (!viewport) return;
+		let restored = false;
+		correctingScroll = true;
 		const observer = new ResizeObserver(() => {
 			if (session.image.mode === 'fit') fitToWindow();
 		});
@@ -151,17 +153,18 @@
 			if (session.image.mode === 'fit') fitToWindow();
 			else restoreSavedManualFocalPoint();
 			scheduleScrollRelease();
+			restored = true;
 		});
 		return () => {
 			cancelAnimationFrame(frame);
 			cancelPendingManualZoom();
 			if (scrollReleaseFrame !== null) cancelAnimationFrame(scrollReleaseFrame);
 			observer.disconnect();
-			if (viewportElement) {
+			if (restored) {
 				session.image = {
 					...session.image,
-					scrollLeft: viewportElement.scrollLeft,
-					scrollTop: viewportElement.scrollTop,
+					scrollLeft: viewport.scrollLeft,
+					scrollTop: viewport.scrollTop,
 				};
 			}
 		};
@@ -205,7 +208,7 @@
 		bind:this={viewportElement}
 		class="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted p-4"
 		onwheel={handleWheel}
-		onscroll={persistViewport}
+		onscroll={(event) => persistViewport(event.currentTarget)}
 	>
 		{#if session.imageObjectUrl}
 			<img

--- a/web/src/lib/components/files/MarkdownViewer.svelte
+++ b/web/src/lib/components/files/MarkdownViewer.svelte
@@ -17,13 +17,22 @@
 	$effect(() => {
 		const element = contentElement;
 		if (!element) return;
-		requestAnimationFrame(() => {
+		let restored = false;
+		const frame = requestAnimationFrame(() => {
+			element.scrollLeft = session.markdownScrollLeft;
 			element.scrollTop = session.markdownScrollTop;
+			restored = true;
 		});
 		return () => {
-			session.markdownScrollTop = element.scrollTop;
+			cancelAnimationFrame(frame);
+			if (restored) captureScroll(element);
 		};
 	});
+
+	function captureScroll(element: HTMLDivElement): void {
+		session.markdownScrollLeft = element.scrollLeft;
+		session.markdownScrollTop = element.scrollTop;
+	}
 
 	function navigateFileLink(link: MarkdownLinkNavigateEvent): boolean {
 		if (link.kind !== 'file') return false;
@@ -50,6 +59,7 @@
 	aria-label={session.fileName}
 	class="markdown-viewer-content h-full overflow-auto bg-background p-4 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:p-6"
 	style={`--markdown-viewer-font-size: ${markdownFontSize}px;`}
+	onscroll={(event) => captureScroll(event.currentTarget)}
 >
 	<Markdown
 		source={session.content}

--- a/web/src/lib/components/files/__tests__/ImageViewer.test.ts
+++ b/web/src/lib/components/files/__tests__/ImageViewer.test.ts
@@ -29,6 +29,74 @@ describe('ImageViewer', () => {
 		expect(screen.getByText('125%')).toBeTruthy();
 	});
 
+	it('restores manual viewport offsets across presentation remounts', async () => {
+		const session = new FileSession(
+			{
+				canonicalFileRootPath: '/workspace/project',
+				normalizedRelativePath: 'image.png',
+			},
+			'/workspace/project\0image.png',
+		);
+		session.imageObjectUrl = 'blob:image';
+		session.image = {
+			...session.image,
+			mode: 'manual',
+			scale: 2,
+			scrollLeft: 31,
+			scrollTop: 79,
+		};
+		const first = render(ImageViewer, { session });
+		await tick();
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		const firstViewport = screen.getByRole('img').closest('.overflow-auto') as HTMLDivElement;
+		expect(firstViewport.scrollLeft).toBe(31);
+		expect(firstViewport.scrollTop).toBe(79);
+		firstViewport.scrollLeft = 47;
+		firstViewport.scrollTop = 113;
+		await fireEvent.scroll(firstViewport);
+		first.unmount();
+
+		render(ImageViewer, { session });
+		await tick();
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		const restoredViewport = screen.getByRole('img').closest('.overflow-auto') as HTMLDivElement;
+		expect(restoredViewport.scrollLeft).toBe(47);
+		expect(restoredViewport.scrollTop).toBe(113);
+	});
+
+	it('does not overwrite saved dialog offsets when unmounted before restoration', async () => {
+		let nextFrame = 1;
+		const frames = new Map<number, FrameRequestCallback>();
+		vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+			const frame = nextFrame++;
+			frames.set(frame, callback);
+			return frame;
+		});
+		vi.stubGlobal('cancelAnimationFrame', (frame: number) => frames.delete(frame));
+		const session = new FileSession(
+			{
+				canonicalFileRootPath: '/workspace/project',
+				normalizedRelativePath: 'image.png',
+			},
+			'/workspace/project\0image.png',
+		);
+		session.image = {
+			...session.image,
+			mode: 'manual',
+			scrollLeft: 23,
+			scrollTop: 101,
+		};
+
+		const dialog = render(ImageViewer, { session });
+		await tick();
+		dialog.unmount();
+
+		expect(session.image.scrollLeft).toBe(23);
+		expect(session.image.scrollTop).toBe(101);
+	});
+
 	it('keeps the initial cursor focal point stable through a rapid wheel burst', async () => {
 		const session = new FileSession(
 			{

--- a/web/src/lib/components/files/__tests__/MarkdownViewer.test.ts
+++ b/web/src/lib/components/files/__tests__/MarkdownViewer.test.ts
@@ -1,10 +1,14 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileSession } from '$lib/files/sessions/file-session.svelte.js';
 import type { FileOpenRequest } from '$lib/files/sessions/file-session-registry.svelte.js';
 import MarkdownViewerTestHost from './MarkdownViewerTestHost.svelte';
 
-afterEach(cleanup);
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
 
 function markdownSession(content: string): FileSession {
 	const session = new FileSession(
@@ -19,6 +23,67 @@ function markdownSession(content: string): FileSession {
 }
 
 describe('MarkdownViewer', () => {
+	it('restores scroll offsets across main, sidebar, and dialog remounts', async () => {
+		const session = markdownSession('# Read me');
+		const main = render(MarkdownViewerTestHost, {
+			session,
+			presentation: 'main',
+			onOpen: vi.fn(),
+		});
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		const mainContent = screen.getByRole('region', { name: 'current.md' });
+		mainContent.scrollLeft = 11;
+		mainContent.scrollTop = 137;
+		await fireEvent.scroll(mainContent);
+		main.unmount();
+
+		const sidebar = render(MarkdownViewerTestHost, {
+			session,
+			presentation: 'sidebar',
+			onOpen: vi.fn(),
+		});
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		const sidebarContent = screen.getByRole('region', { name: 'current.md' });
+		expect(sidebarContent.scrollLeft).toBe(11);
+		expect(sidebarContent.scrollTop).toBe(137);
+		sidebarContent.scrollTop = 241;
+		await fireEvent.scroll(sidebarContent);
+		sidebar.unmount();
+
+		render(MarkdownViewerTestHost, {
+			session,
+			presentation: 'dialog',
+			onOpen: vi.fn(),
+		});
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		expect(screen.getByRole('region', { name: 'current.md' }).scrollTop).toBe(241);
+	});
+
+	it('does not overwrite saved dialog scroll when unmounted before restoration', async () => {
+		let nextFrame = 1;
+		const frames = new Map<number, FrameRequestCallback>();
+		vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+			const frame = nextFrame++;
+			frames.set(frame, callback);
+			return frame;
+		});
+		vi.stubGlobal('cancelAnimationFrame', (frame: number) => frames.delete(frame));
+		const session = markdownSession('# Read me');
+		session.markdownScrollLeft = 17;
+		session.markdownScrollTop = 193;
+
+		const dialog = render(MarkdownViewerTestHost, {
+			session,
+			presentation: 'dialog',
+			onOpen: vi.fn(),
+		});
+		await tick();
+		dialog.unmount();
+
+		expect(session.markdownScrollLeft).toBe(17);
+		expect(session.markdownScrollTop).toBe(193);
+	});
+
 	it('exposes its scrollable content as the primary focus target', () => {
 		const session = markdownSession('# Read me');
 

--- a/web/src/lib/files/editor/__tests__/code-editor-controller.test.ts
+++ b/web/src/lib/files/editor/__tests__/code-editor-controller.test.ts
@@ -52,21 +52,29 @@ function createController() {
 }
 
 describe('CodeEditorController', () => {
-	it('moves one editor state between hosts and ignores stale cleanup', () => {
+	it('moves one editor state and its scroll position between hosts', async () => {
 		const { session, controller } = createController();
 		const firstParent = parent();
 		const secondParent = parent();
 
 		const firstLease = controller.attach(firstParent);
 		const firstScroller = firstParent.querySelector<HTMLElement>('.cm-scroller');
-		if (firstScroller) firstScroller.scrollTop = 24;
+		if (!firstScroller) throw new Error('Expected CodeMirror scroller');
+		firstScroller.scrollLeft = 9;
+		firstScroller.scrollTop = 24;
+		firstScroller.dispatchEvent(new Event('scroll'));
 		controller.prepareRendererTransfer();
 		const secondLease = controller.attach(secondParent);
 		controller.detach(firstLease);
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+		const secondScroller = secondParent.querySelector<HTMLElement>('.cm-scroller');
 
 		expect(controller.isAttached).toBe(true);
 		expect(firstParent.querySelector('.cm-editor')).toBeNull();
 		expect(secondParent.querySelector('.cm-editor')).not.toBeNull();
+		expect(session.editorScrollSnapshot).not.toBeNull();
+		expect(secondScroller?.scrollLeft).toBe(9);
+		expect(secondScroller?.scrollTop).toBe(24);
 		controller.detach(secondLease);
 		expect(controller.isAttached).toBe(false);
 		expect(session.editorState?.doc.toString()).toBe('first\nsecond\nthird');
@@ -144,9 +152,9 @@ describe('CodeEditorController', () => {
 		scroller.scrollTop = 28;
 
 		controller.replaceContentFromDisk('new');
-		host.querySelector<HTMLElement>('.cm-content')?.dispatchEvent(
-			new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }),
-		);
+		host
+			.querySelector<HTMLElement>('.cm-content')
+			?.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }));
 		await new Promise((resolve) => requestAnimationFrame(resolve));
 
 		expect(controller.currentContent()).toBe('new');

--- a/web/src/lib/files/editor/code-editor-controller.svelte.ts
+++ b/web/src/lib/files/editor/code-editor-controller.svelte.ts
@@ -8,13 +8,7 @@ import {
 	highlightActiveLine,
 	keymap,
 } from '@codemirror/view';
-import {
-	EditorSelection,
-	EditorState,
-	Compartment,
-	Text,
-	type Extension,
-} from '@codemirror/state';
+import { EditorSelection, EditorState, Compartment, Text, type Extension } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
 import {
 	foldGutter,
@@ -52,6 +46,10 @@ export class CodeEditorController {
 	#rendererGeneration = 0;
 	#baselineDocument: Text | null = null;
 	#lineSeparator: '\n' | '\r\n';
+	readonly #handleScroll = (): void => {
+		const view = this.#view;
+		if (view) this.#captureScroll(view);
+	};
 
 	constructor(
 		readonly session: FileSession,
@@ -68,20 +66,40 @@ export class CodeEditorController {
 		if (this.#view) throw new Error('File editor renderer is already attached');
 		const lease = ++this.#rendererGeneration;
 		const editorState = this.session.editorState ?? this.createState(this.session.content);
+		const scrollSnapshot = this.session.editorScrollSnapshot;
+		const scrollLeft = this.session.textScrollLeft;
+		const scrollTop = this.session.textScrollTop;
 		this.#view = new EditorView({
 			state: editorState,
 			parent,
+			scrollTo: scrollSnapshot ?? undefined,
 			dispatchTransactions: (transactions, view) => {
 				view.update(transactions);
-				this.capture(view.state);
+				this.capture(view);
 			},
 		});
+		this.#view.scrollDOM.addEventListener('scroll', this.#handleScroll);
 		this.reconfigure();
 		void this.applyLanguage();
+		const attachedView = this.#view;
+		attachedView.requestMeasure({
+			key: this,
+			read: () => undefined,
+			write: () => {
+				if (this.#view !== attachedView || lease !== this.#rendererGeneration) return;
+				if (!scrollSnapshot || (scrollLeft !== 0 && attachedView.scrollDOM.scrollLeft === 0)) {
+					attachedView.scrollDOM.scrollLeft = scrollLeft;
+				}
+				if (!scrollSnapshot || (scrollTop !== 0 && attachedView.scrollDOM.scrollTop === 0)) {
+					attachedView.scrollDOM.scrollTop = scrollTop;
+				}
+				this.#captureScroll(attachedView);
+			},
+		});
 		requestAnimationFrame(() => {
-			if (!this.#view || lease !== this.#rendererGeneration) return;
-			this.#view.scrollDOM.scrollTop = this.session.textScrollTop;
-			this.applyRequestedLocation();
+			if (this.#view === attachedView && lease === this.#rendererGeneration) {
+				this.applyRequestedLocation();
+			}
 		});
 		return lease;
 	}
@@ -99,9 +117,10 @@ export class CodeEditorController {
 	#detachCurrent(): void {
 		const view = this.#view;
 		if (!view) return;
+		this.#captureScroll(view);
+		view.scrollDOM.removeEventListener('scroll', this.#handleScroll);
 		this.session.editorState = view.state;
 		this.session.content = this.#serializeDocument(view.state.doc);
-		this.session.textScrollTop = view.scrollDOM.scrollTop;
 		view.destroy();
 		this.#view = null;
 	}
@@ -139,6 +158,7 @@ export class CodeEditorController {
 		const nextDocument = normalizedDocument(content);
 		const anchor = Math.min(previousSelection?.anchor ?? 0, nextDocument.length);
 		const head = Math.min(previousSelection?.head ?? anchor, nextDocument.length);
+		const scrollLeft = view?.scrollDOM.scrollLeft ?? this.session.textScrollLeft;
 		const scrollTop = view?.scrollDOM.scrollTop ?? this.session.textScrollTop;
 		const nextState = this.createState(nextDocument, EditorSelection.single(anchor, head));
 
@@ -147,6 +167,7 @@ export class CodeEditorController {
 		this.session.dirty = false;
 		this.#lineSeparator = lineSeparatorFor(content);
 		this.#baselineDocument = nextDocument;
+		this.session.editorScrollSnapshot = null;
 
 		if (!view) {
 			this.session.editorState = previousState ? nextState : null;
@@ -157,10 +178,13 @@ export class CodeEditorController {
 		view.setState(nextState);
 		this.reconfigure();
 		void this.applyLanguage();
+		this.session.textScrollLeft = scrollLeft;
 		this.session.textScrollTop = scrollTop;
 		requestAnimationFrame(() => {
 			if (this.#view !== view) return;
+			view.scrollDOM.scrollLeft = scrollLeft;
 			view.scrollDOM.scrollTop = scrollTop;
+			this.#captureScroll(view);
 		});
 	}
 
@@ -237,10 +261,17 @@ export class CodeEditorController {
 		return extensions;
 	}
 
-	private capture(editorState: EditorState): void {
-		this.session.editorState = editorState;
+	private capture(view: EditorView): void {
+		this.session.editorState = view.state;
 		this.#baselineDocument ??= normalizedDocument(this.session.baseline);
-		this.session.dirty = !editorState.doc.eq(this.#baselineDocument);
+		this.session.dirty = !view.state.doc.eq(this.#baselineDocument);
+		this.#captureScroll(view);
+	}
+
+	#captureScroll(view: EditorView): void {
+		this.session.editorScrollSnapshot = view.scrollSnapshot();
+		this.session.textScrollLeft = view.scrollDOM.scrollLeft;
+		this.session.textScrollTop = view.scrollDOM.scrollTop;
 	}
 
 	#serializeDocument(document: Text): string {

--- a/web/src/lib/files/sessions/file-session.svelte.ts
+++ b/web/src/lib/files/sessions/file-session.svelte.ts
@@ -1,4 +1,4 @@
-import type { EditorState } from '@codemirror/state';
+import type { EditorState, StateEffect } from '@codemirror/state';
 import type { CanonicalFileIdentity, FileRevision } from '$shared/file-contracts';
 import type { CodeEditorController } from '$lib/files/editor/code-editor-controller.svelte.js';
 import { createRandomId } from '$lib/utils/random-id.js';
@@ -58,7 +58,10 @@ export class FileSession {
 
 	loadedRevision: FileRevision | null = null;
 	editorState: EditorState | null = null;
+	editorScrollSnapshot: StateEffect<unknown> | null = null;
+	textScrollLeft = 0;
 	textScrollTop = 0;
+	markdownScrollLeft = 0;
 	markdownScrollTop = 0;
 	editor: CodeEditorController | null = null;
 	loadController: AbortController | null = null;


### PR DESCRIPTION
File views currently jump to the top when their presentation is remounted while switching between main, sidebar, and dialog hosts. This change stores per-session horizontal and vertical positions for code, Markdown, and image viewers, restores them on remount, and prevents rapid dialog transitions from overwriting saved positions before restoration completes.