### PR TITLE
Fix runtime permission reply binding

### DIFF
--- a/server/agents/__tests__/runtime-router-permissions.test.js
+++ b/server/agents/__tests__/runtime-router-permissions.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { AgentRuntimeRouter } from '../runtime-router.ts';
+
+function makeRouter(execution) {
+  const integration = {
+    descriptor: { id: 'test' },
+    execution,
+  };
+  return new AgentRuntimeRouter({
+    registry: {
+      getChat: mock(() => ({ agentId: 'test' })),
+    },
+    directory: {
+      get: mock((agentId) => agentId === 'test' ? integration : null),
+    },
+    endpointResolver: {},
+    events: {},
+    getCarryOverRevision: () => 'carry-1',
+    loadCarryOver: () => [],
+  });
+}
+
+describe('AgentRuntimeRouter permission replies', () => {
+  it('invokes the integration permission handler with its execution receiver', async () => {
+    const resolvePermission = mock(async () => undefined);
+    const execution = {
+      runtime: { resolvePermission },
+      async respondToPermission(permissionRequestId, decision) {
+        await this.runtime.resolvePermission(permissionRequestId, decision);
+      },
+    };
+    const router = makeRouter(execution);
+    const decision = { allow: true };
+
+    router.resolvePermission('chat-1', 'permission-1', decision);
+    await Promise.resolve();
+
+    expect(resolvePermission).toHaveBeenCalledWith('permission-1', decision);
+  });
+});

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -313,9 +313,9 @@ export class AgentRuntimeRouter {
 
   resolvePermission(chatId: string, permissionRequestId: string, decision: PermissionDecisionPayload): void {
     const entry = this.#registry.getChat(chatId);
-    const respond = entry ? this.#directory.get(entry.agentId)?.execution.respondToPermission : null;
-    if (!respond || !permissionRequestId) return;
-    Promise.resolve(respond(permissionRequestId, decision)).catch((error) => {
+    const execution = entry ? this.#directory.get(entry.agentId)?.execution : null;
+    if (!execution?.respondToPermission || !permissionRequestId) return;
+    Promise.resolve(execution.respondToPermission(permissionRequestId, decision)).catch((error) => {
       logger.warn('agents: permission reply failed:', error instanceof Error ? error.message : String(error));
     });
   }


### PR DESCRIPTION
Permission replies lost the provider execution object as their method receiver, causing handlers that access their runtime to reject with an undefined receiver. Keep the execution object attached when dispatching replies and add a focused regression test that exercises the runtime-backed handler path.