### PR TITLE
Update sidebar, grouping, and pin-insert defaults

### DIFF
--- a/common/settings.ts
+++ b/common/settings.ts
@@ -17,6 +17,7 @@ import { isAgentId } from './agents';
 import type { ApiProtocol } from './api-providers';
 
 export type PinnedInsertPosition = 'top' | 'bottom';
+export const DEFAULT_PINNED_INSERT_POSITION: PinnedInsertPosition = 'bottom';
 export const DEFAULT_APP_TITLE = 'Garcon';
 export const APP_TITLE_MAX_LENGTH = 120;
 

--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -217,6 +217,20 @@ export class SpaDriver {
   }
 
   async clickButton(name: string, options: ClickOptions = {}): Promise<void> {
+    const params = { name, contains: options.contains === true, last: options.last === true };
+    // A button can render a beat after navigation or a WebSocket-driven update
+    // (the open sidebar adds initial render work), so wait for it before clicking
+    // rather than failing on the first probe.
+    await this.#page.waitForFunction(
+      ({ name, contains }) =>
+        [...document.querySelectorAll('button')].some((element) => {
+          if (element.closest('[aria-hidden="true"]')) return false;
+          const accessibleName = element.getAttribute('aria-label') || element.textContent?.trim() || '';
+          return contains ? accessibleName.includes(name) : accessibleName === name;
+        }),
+      { timeout: 20_000 },
+      params,
+    );
     try {
       await this.#page.evaluate(({ name, contains, last }) => {
         const buttons = [...document.querySelectorAll('button')].filter((element) => {
@@ -228,7 +242,7 @@ export class SpaDriver {
         if (!button) throw new Error(`Missing button: ${name}`);
         if (button.disabled) throw new Error(`Button is disabled: ${name}`);
         button.click();
-      }, { name, contains: options.contains === true, last: options.last === true });
+      }, params);
     } catch (error) {
       // Lightpanda may collect the CDP evaluation promise when a click replaces
       // the document. The next positive product milestone still verifies it.

--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -71,9 +71,12 @@ export class SpaDriver {
     waitForRequest: () => Promise<TRequest>;
   }): Promise<TRequest> {
     await this.clickButton('New Chat');
+    // Modal dialogs are matched by the shared Dialog component's data-slot rather
+    // than role="dialog": the workspace sidebar overlay is also a role="dialog"
+    // and, now open by default, would otherwise be selected instead of the modal.
     await this.#page.waitForFunction(
       () => {
-        const dialog = document.querySelector('[role="dialog"]');
+        const dialog = document.querySelector('[data-slot="dialog-content"]');
         return dialog !== null
           && dialog.querySelector('[role="status"][aria-label="Loading chat defaults..."]') === null;
       },
@@ -81,12 +84,12 @@ export class SpaDriver {
     );
     await this.#page.waitForFunction(
       () => document.activeElement?.matches(
-        '[role="dialog"] textarea[placeholder="How can I help you today?"]',
+        '[data-slot="dialog-content"] textarea[placeholder="How can I help you today?"]',
       ) === true,
       { timeout: 20_000 },
     );
     const directProviderSelected = await this.#page.evaluate(({ agentLabel, modelLabel }) => {
-      const dialog = document.querySelector('[role="dialog"]');
+      const dialog = document.querySelector('[data-slot="dialog-content"]');
       return [...(dialog?.querySelectorAll('button') ?? [])].some((element) => {
         const name = element.getAttribute('aria-label') || element.textContent?.trim() || '';
         return name.includes(agentLabel) && name.includes(modelLabel);
@@ -104,21 +107,21 @@ export class SpaDriver {
     }
 
     const projectPath = await this.#page.$eval(
-      '[role="dialog"] input[aria-label="Project Path"]',
+      '[data-slot="dialog-content"] input[aria-label="Project Path"]',
       (element) => (element as HTMLInputElement).value,
     );
     if (projectPath !== this.#integration.dirs.project) {
       await this.fill(
-        '[role="dialog"] input[aria-label="Project Path"]',
+        '[data-slot="dialog-content"] input[aria-label="Project Path"]',
         this.#integration.dirs.project,
       );
     }
-    await this.fill('[role="dialog"] textarea[placeholder="How can I help you today?"]', input.content);
+    await this.fill('[data-slot="dialog-content"] textarea[placeholder="How can I help you today?"]', input.content);
     await this.waitForDialogButtonEnabled('Start session');
     await this.clickButton('Start session');
     const request = await input.waitForRequest();
     await this.#page.waitForFunction(
-      () => document.querySelector('[role="dialog"]') === null,
+      () => document.querySelector('[data-slot="dialog-content"]') === null,
       { timeout: 20_000 },
     );
     return request;
@@ -127,7 +130,7 @@ export class SpaDriver {
   async #clickNewChatModelSelector(): Promise<void> {
     await this.#page.waitForFunction(
       () => {
-        const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+        const dialog = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
         const button = dialog
           ? [...dialog.querySelectorAll<HTMLButtonElement>('button')].find((element) =>
               (element.getAttribute('aria-label') ?? '').includes(' / '))
@@ -137,7 +140,7 @@ export class SpaDriver {
       { timeout: 20_000 },
     );
     await this.#page.evaluate(() => {
-      const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+      const dialog = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
       const button = dialog
         ? [...dialog.querySelectorAll<HTMLButtonElement>('button')].find((element) =>
             (element.getAttribute('aria-label') ?? '').includes(' / '))
@@ -293,7 +296,7 @@ export class SpaDriver {
 
   async clickDialogButton(name: string): Promise<void> {
     await this.#page.evaluate((expected) => {
-      const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+      const dialog = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
       const button = dialog
         ? [...dialog.querySelectorAll<HTMLButtonElement>('button')].find((element) =>
             (element.getAttribute('aria-label') || element.textContent?.trim()) === expected)
@@ -343,7 +346,7 @@ export class SpaDriver {
 
   async clickQueuedRowAction(content: string, action: QueueRowAction): Promise<void> {
     await this.#page.evaluate(({ content, action }) => {
-      const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+      const dialog = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
       if (!dialog) throw new Error('Queued messages dialog is not open.');
       const message = [...dialog.querySelectorAll<HTMLElement>('p')].find((element) =>
         element.textContent?.trim() === content);
@@ -359,7 +362,7 @@ export class SpaDriver {
   }
 
   async fillQueuedEditor(value: string): Promise<void> {
-    await this.fill('[role="dialog"] textarea', value);
+    await this.fill('[data-slot="dialog-content"] textarea', value);
   }
 
   async waitForButton(name: string, options: { timeout?: number } = {}): Promise<void> {
@@ -385,7 +388,7 @@ export class SpaDriver {
 
   async waitForDialogButtonEnabled(name: string): Promise<void> {
     await this.#page.waitForFunction(
-      (expected) => [...document.querySelectorAll('[role="dialog"] button')].some((element) => {
+      (expected) => [...document.querySelectorAll('[data-slot="dialog-content"] button')].some((element) => {
         const button = element as HTMLButtonElement;
         return (button.getAttribute('aria-label') || button.textContent?.trim()) === expected
           && !button.disabled;

--- a/server/settings/__tests__/store.test.js
+++ b/server/settings/__tests__/store.test.js
@@ -215,11 +215,11 @@ describe('settings store', () => {
       });
 
       const loaded = await store.getUiSettings();
-      expect(loaded.pinnedInsertPosition).toBe('top');
+      expect(loaded.pinnedInsertPosition).toBe('bottom');
 
-      await store.setUiSettings({ pinnedInsertPosition: 'bottom' });
+      await store.setUiSettings({ pinnedInsertPosition: 'top' });
       const saved = await store.getUiSettings();
-      expect(saved.pinnedInsertPosition).toBe('bottom');
+      expect(saved.pinnedInsertPosition).toBe('top');
     });
 
     it('getPathSettings returns empty object by default', async () => {
@@ -717,6 +717,24 @@ describe('settings store', () => {
 
       const settings = await store.loadSettings();
       expect(settings.pinnedChatIds).toEqual(['x', 'a']);
+    });
+
+    it('defaults to bottom insertion when pinnedInsertPosition is unset', async () => {
+      await writeRaw({ ui: {}, paths: {}, chatNames: {}, pinnedChatIds: ['x'], normalChatIds: ['a'], archivedChatIds: [] });
+
+      await store.togglePin('a');
+
+      const settings = await store.loadSettings();
+      expect(settings.pinnedChatIds).toEqual(['x', 'a']);
+    });
+
+    it('respects pinnedInsertPosition=top', async () => {
+      await writeRaw({ ui: { pinnedInsertPosition: 'top' }, paths: {}, chatNames: {}, pinnedChatIds: ['x'], normalChatIds: ['a'], archivedChatIds: [] });
+
+      await store.togglePin('a');
+
+      const settings = await store.loadSettings();
+      expect(settings.pinnedChatIds).toEqual(['a', 'x']);
     });
   });
 

--- a/server/settings/domain-stores.ts
+++ b/server/settings/domain-stores.ts
@@ -3,6 +3,7 @@ import { createLogger } from '../lib/log.js';
 
 const logger = createLogger('settings:domain-stores');
 import {
+  DEFAULT_PINNED_INSERT_POSITION,
   DEFAULT_REMOTE_FEATURE_SETTINGS,
   normalizeRemoteFeatureSettings,
 } from '../../common/settings.js';
@@ -528,7 +529,7 @@ export class ChatOrderStore {
         s.pinnedChatIds = pinned.filter((id) => id !== chatId);
         s.normalChatIds = [chatId, ...(s.normalChatIds || []).filter((id) => id !== chatId)];
       } else {
-        const position = (s.ui?.pinnedInsertPosition === 'bottom') ? 'bottom' : 'top';
+        const position = s.ui?.pinnedInsertPosition ?? DEFAULT_PINNED_INSERT_POSITION;
         s.normalChatIds = (s.normalChatIds || []).filter((id) => id !== chatId);
         s.archivedChatIds = (s.archivedChatIds || []).filter((id) => id !== chatId);
         s.pinnedChatIds = position === 'bottom' ? [...pinned, chatId] : [chatId, ...pinned];

--- a/server/settings/settings-shared.ts
+++ b/server/settings/settings-shared.ts
@@ -1,5 +1,5 @@
 import type { FolderFilter, UiSettings } from './types.js';
-import { APP_TITLE_MAX_LENGTH } from '../../common/settings.js';
+import { APP_TITLE_MAX_LENGTH, DEFAULT_PINNED_INSERT_POSITION } from '../../common/settings.js';
 
 function normalizeAppIdentitySettings(value: unknown): { title: string } | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
@@ -20,7 +20,10 @@ export function normalizeUiSettings(ui: unknown): UiSettings {
     delete normalized.appIdentity;
   }
   if ('pinnedInsertPosition' in normalized) {
-    normalized.pinnedInsertPosition = normalized.pinnedInsertPosition === 'bottom' ? 'bottom' : 'top';
+    normalized.pinnedInsertPosition =
+      normalized.pinnedInsertPosition === 'top' || normalized.pinnedInsertPosition === 'bottom'
+        ? normalized.pinnedInsertPosition
+        : DEFAULT_PINNED_INSERT_POSITION;
   }
   const commitMessage = normalized.commitMessage;
   if (commitMessage && typeof commitMessage === 'object' && !Array.isArray(commitMessage)) {

--- a/web/src/lib/components/settings/RemoteSettingsSection.svelte
+++ b/web/src/lib/components/settings/RemoteSettingsSection.svelte
@@ -2,7 +2,7 @@
      are available; never renders guessed defaults. -->
 <script lang="ts">
 	import { getRemoteSettings } from '$lib/context';
-	import type { PinnedInsertPosition } from '$lib/types/session.js';
+	import { DEFAULT_PINNED_INSERT_POSITION, type PinnedInsertPosition } from '$shared/settings';
 	import * as m from '$lib/paraglide/messages.js';
 	import RemoteGenerationSettingsCard from './RemoteGenerationSettingsCard.svelte';
 	import AppTitleSettingsCard from './AppTitleSettingsCard.svelte';
@@ -54,7 +54,7 @@
 				<select
 					class="text-sm bg-muted border border-border rounded-md px-2 py-1 text-foreground"
 					aria-label={m.sidebar_chats_pinned_insert_position()}
-					value={remoteSettings.snapshot?.ui.pinnedInsertPosition ?? 'top'}
+					value={remoteSettings.snapshot?.ui.pinnedInsertPosition ?? DEFAULT_PINNED_INSERT_POSITION}
 					onchange={(e) =>
 						onPinnedInsertPositionChange(
 							(e.currentTarget as HTMLSelectElement).value as PinnedInsertPosition,

--- a/web/src/lib/stores/__tests__/local-settings.test.ts
+++ b/web/src/lib/stores/__tests__/local-settings.test.ts
@@ -12,7 +12,7 @@ describe('LocalSettingsStore', () => {
 
 		expect(store.chatMaxWidth).toBe('none');
 		expect(store.overlayBackdropEffects).toBe(true);
-		expect(store.sidebarGroupByProject).toBe(true);
+		expect(store.sidebarGroupByProject).toBe(false);
 		expect(store.sidebarGroupNestedProjectPaths).toBe(false);
 		expect(store.sidebarCompactChatItems).toBe(false);
 		expect(store.sidebarSortMode).toBe('manual');
@@ -288,7 +288,7 @@ describe('LocalSettingsStore', () => {
 		const store = createLocalSettingsStore();
 
 		store.set('chatMaxWidth', 'medium');
-		store.set('sidebarGroupByProject', false);
+		store.set('sidebarGroupByProject', true);
 		store.set('sidebarGroupNestedProjectPaths', true);
 		store.set('sidebarCompactChatItems', true);
 		store.set('showQuickCommitTray', false);
@@ -297,7 +297,7 @@ describe('LocalSettingsStore', () => {
 			JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.localSettings) ?? '{}'),
 		).toMatchObject({
 			chatMaxWidth: 'medium',
-			sidebarGroupByProject: false,
+			sidebarGroupByProject: true,
 			sidebarGroupNestedProjectPaths: true,
 			sidebarCompactChatItems: true,
 			showQuickCommitTray: false,

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -136,7 +136,7 @@ const DEFAULTS: LocalSettingsSnapshot = {
 	hideChatListWhenGitInMain: false,
 	sidebarVisible: true,
 	sidebarWidth: 320,
-	sidebarGroupByProject: true,
+	sidebarGroupByProject: false,
 	sidebarGroupNestedProjectPaths: false,
 	sidebarCompactChatItems: false,
 	sidebarSortMode: 'manual',

--- a/web/src/lib/types/session.ts
+++ b/web/src/lib/types/session.ts
@@ -1,3 +1,1 @@
 export type { ChatListEntry as ChatSession } from '$shared/chat-list';
-
-export type PinnedInsertPosition = 'top' | 'bottom';

--- a/web/src/lib/workspace/__tests__/visible-presentations.test.ts
+++ b/web/src/lib/workspace/__tests__/visible-presentations.test.ts
@@ -28,6 +28,7 @@ describe('visiblePortablePresentations', () => {
 	it('omits a hidden sidebar and projects exactly one portable mobile surface', () => {
 		const desktop = reduceWorkspaceLayout(canonicalWorkspaceSnapshot(), [
 			{ type: 'focus-host', host: 'main', surfaceId: 'singleton:git' },
+			{ type: 'set-sidebar-open', open: false },
 		]);
 		expect(visiblePortablePresentations(desktop, false)).toEqual([
 			{ surfaceId: 'singleton:git', presentation: 'main' },

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -45,12 +45,21 @@ function createHarness(
 		pendingGitSurfaceIds?: readonly string[];
 		terminalPrepareRendererTransfer?: (terminalId: string) => void;
 		initialMainSurfaceId?: string;
+		sidebarClosed?: boolean;
 		onLayoutChanged?: () => void;
 		onTerminalLauncherDismissed?: () => void;
 		failLayoutPublishAt?: number;
 	} = {},
 ) {
 	const layout = createWorkspaceLayoutStore();
+	// The canonical default opens the sidebar; tests exercising sidebar-reveal or
+	// hidden-sidebar behavior opt into a closed sidebar.
+	if (options.sidebarClosed) {
+		layout.publish(
+			layout.revision,
+			reduceWorkspaceLayout(layout.snapshot, [{ type: 'set-sidebar-open', open: false }]),
+		);
+	}
 	if (options.initialMainSurfaceId) {
 		layout.publish(
 			layout.revision,
@@ -147,7 +156,7 @@ function createHarness(
 
 describe('WorkspaceCoordinator', () => {
 	it('opens a new sidebar file through the overlay modality transition', async () => {
-		const { coordinator, layout, transientLayers } = createHarness();
+		const { coordinator, layout, transientLayers } = createHarness({ sidebarClosed: true });
 		const open = vi
 			.spyOn(transientLayers, 'open')
 			.mockImplementation((_modality, commitOpen) => commitOpen());
@@ -516,6 +525,7 @@ describe('WorkspaceCoordinator', () => {
 		const { coordinator, layout } = createHarness({
 			surfaceFrames: frames,
 			initialMainSurfaceId: 'singleton:git',
+			sidebarClosed: true,
 		});
 		const gitAttachment = deferred<void>();
 		const attachGit = vi.fn(() => gitAttachment.promise);
@@ -598,7 +608,9 @@ describe('WorkspaceCoordinator', () => {
 	});
 
 	it('does not route shortcuts through a stale hidden surface owner', () => {
-		const { coordinator, transientLayers, appShell, files } = createHarness();
+		const { coordinator, transientLayers, appShell, files } = createHarness({
+			sidebarClosed: true,
+		});
 		coordinator.focusOwner = { kind: 'surface', surfaceId: 'singleton:files' };
 		const dispatcher = new WorkspaceShortcutDispatcher({
 			workspace: coordinator,
@@ -664,7 +676,7 @@ describe('WorkspaceCoordinator', () => {
 	});
 
 	it('focuses an existing sidebar surface by revealing its host', async () => {
-		const { coordinator, layout } = createHarness();
+		const { coordinator, layout } = createHarness({ sidebarClosed: true });
 		expect(layout.snapshot.sidebarOpen).toBe(false);
 
 		await coordinator.focusSurface('singleton:files');
@@ -707,7 +719,7 @@ describe('WorkspaceCoordinator', () => {
 	});
 
 	it('toggles focus between active main and sidebar surfaces only while the sidebar is open', async () => {
-		const { coordinator } = createHarness();
+		const { coordinator } = createHarness({ sidebarClosed: true });
 		const focusSurface = vi.spyOn(coordinator, 'focusSurface').mockResolvedValue();
 
 		coordinator.toggleFocusBetweenMainAndSidebar();
@@ -1129,6 +1141,7 @@ describe('WorkspaceCoordinator', () => {
 		const { coordinator, layout, appShell } = createHarness({
 			surfaceFrames: frames,
 			fileEditor: editor,
+			sidebarClosed: true,
 		});
 		const surfaceId = fileSurfaceId('dialog');
 		const open = coordinator.placeFileSession('dialog', 'dialog');

--- a/web/src/lib/workspace/__tests__/workspace-layout.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-layout.test.ts
@@ -35,7 +35,7 @@ describe('workspace layout reducers', () => {
 			'singleton:pull-requests',
 		]);
 		expect(snapshot.sidebar.order).toEqual(['singleton:files', 'singleton:commit']);
-		expect(snapshot.sidebarOpen).toBe(false);
+		expect(snapshot.sidebarOpen).toBe(true);
 		expect(snapshot.desiredSidebarWidth).toBe(480);
 		expect(() => assertWorkspaceLayoutInvariants(snapshot)).not.toThrow();
 	});

--- a/web/src/lib/workspace/canonical-layout.ts
+++ b/web/src/lib/workspace/canonical-layout.ts
@@ -49,7 +49,7 @@ export function canonicalWorkspaceSnapshot(): WorkspaceLayoutSnapshot {
 			mru: [...CANONICAL_SIDEBAR_SURFACE_IDS],
 		},
 		surfaces: { ...CANONICAL_SURFACES },
-		sidebarOpen: false,
+		sidebarOpen: true,
 		desiredSidebarWidth: DEFAULT_RIGHT_SIDEBAR_WIDTH,
 		dialogFileSurfaceId: null,
 		manualFullscreen: false,
@@ -84,7 +84,7 @@ export function isCanonicalFirstRunLayout(snapshot: WorkspaceLayoutSnapshot): bo
 		snapshot.main.activeId === CHAT_SURFACE_ID &&
 		hasExactOrder(snapshot.sidebar.order, CANONICAL_SIDEBAR_SURFACE_IDS) &&
 		snapshot.sidebar.activeId === CANONICAL_SIDEBAR_SURFACE_IDS[0] &&
-		!snapshot.sidebarOpen &&
+		snapshot.sidebarOpen &&
 		!snapshot.dialogFileSurfaceId &&
 		snapshot.mobileOnlySurfaceIds.length === 0 &&
 		snapshot.unplacedTerminalIds.length === 0


### PR DESCRIPTION
Updates a few workspace defaults to match common usage. The workspace sidebar (with the Files tab first) now opens by default so secondary surfaces are visible immediately; sidebar chats are no longer grouped by project path by default in favor of a flat list; and newly pinned chats are inserted at the bottom of the pinned list rather than the top, so existing pin order stays stable. All three remain user-configurable—only the defaults change.