### PR TITLE
Test queued processing indicator lifecycle

### DIFF
--- a/integration-tests/support/e2e-fixture.ts
+++ b/integration-tests/support/e2e-fixture.ts
@@ -7,6 +7,7 @@ import {
   type BrowserContext,
   type Page,
 } from 'puppeteer-core';
+import type { ServerWsMessage } from '../../common/ws-events.js';
 import { createIntegrationFixture, type IntegrationFixture } from './integration-fixture.js';
 import { LightpandaProcess } from './lightpanda-process.js';
 import { withTimeout } from './deferred.js';
@@ -58,10 +59,12 @@ export class E2eFixture {
       await page.evaluateOnNewDocument(() => {
         const scope = globalThis as typeof globalThis & {
           __garconSpaWsOpenCount?: number;
+          __garconSpaWsEvents?: unknown[];
         };
         const storageKey = '__garconSpaWsOpenCount';
         const NativeWebSocket = globalThis.WebSocket;
         scope.__garconSpaWsOpenCount = Number(globalThis.sessionStorage.getItem(storageKey)) || 0;
+        scope.__garconSpaWsEvents = [];
         globalThis.WebSocket = new Proxy(NativeWebSocket, {
           construct(Target, args: ConstructorParameters<typeof WebSocket>) {
             const socket = new Target(...args);
@@ -73,6 +76,13 @@ export class E2eFixture {
                   storageKey,
                   String(scope.__garconSpaWsOpenCount),
                 );
+              });
+              socket.addEventListener('message', (event) => {
+                try {
+                  scope.__garconSpaWsEvents?.push(JSON.parse(String(event.data)));
+                } catch {
+                  // Product code owns protocol validation; the fixture only records parseable events.
+                }
               });
             }
             return socket;
@@ -137,6 +147,36 @@ export class E2eFixture {
       this.integration.garcon.describeLogs(),
       this.lightpanda.describeLogs(),
     ].join('\n'));
+  }
+
+  async spaWebSocketEventCount(): Promise<number> {
+    return await this.page.evaluate(() => {
+      const scope = globalThis as typeof globalThis & {
+        __garconSpaWsEvents?: unknown[];
+      };
+      return scope.__garconSpaWsEvents?.length ?? 0;
+    });
+  }
+
+  async waitForSpaWebSocketEvent(input: {
+    afterIndex: number;
+    type: ServerWsMessage['type'];
+    chatId?: string;
+  }): Promise<void> {
+    await this.page.waitForFunction(
+      ({ afterIndex, type, chatId }) => {
+        const scope = globalThis as typeof globalThis & {
+          __garconSpaWsEvents?: unknown[];
+        };
+        return (scope.__garconSpaWsEvents ?? []).slice(afterIndex).some((event) => {
+          if (!event || typeof event !== 'object' || Array.isArray(event)) return false;
+          const record = event as Record<string, unknown>;
+          return record.type === type && (chatId === undefined || record.chatId === chatId);
+        });
+      },
+      { timeout: 20_000 },
+      input,
+    );
   }
 
   async writeDiagnostics(testName: string, error: unknown): Promise<string> {

--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -412,6 +412,16 @@ export class SpaDriver {
     );
   }
 
+  async waitForChatProcessing(expected: boolean, timeout = 20_000): Promise<void> {
+    await this.#page.waitForFunction(
+      (shouldBeProcessing) =>
+        (document.querySelector('[data-slot="chat-processing-status"]') !== null)
+          === shouldBeProcessing,
+      { timeout },
+      expected,
+    );
+  }
+
   async waitForTextAbsent(text: string, timeout = 20_000): Promise<void> {
     await this.#page.waitForFunction(
       (expected) => !document.body.innerText.includes(expected),

--- a/integration-tests/tests/e2e/processing-indicator.test.ts
+++ b/integration-tests/tests/e2e/processing-indicator.test.ts
@@ -1,0 +1,46 @@
+import { describe, test } from 'bun:test';
+import { withE2eFixture } from '../../support/e2e-fixture.js';
+import { SpaDriver } from '../../support/spa-driver.js';
+
+describe('Lightpanda processing indicator', () => {
+  test('keeps the Anthropic successor indicator visible after the predecessor terminal arrives', async () => {
+    await withE2eFixture('anthropic-processing-indicator', async (fixture) => {
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      const predecessor = fixture.integration.fakeProviders.anthropic.holdNext({
+        lastUserText: 'ui-processing-a',
+      });
+      const successor = fixture.integration.fakeProviders.anthropic.holdNext({
+        lastUserText: 'ui-processing-b',
+      });
+
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startAnthropicDirectChat('ui-processing-a');
+      await predecessor.received;
+      await app.waitForChatProcessing(true);
+
+      const chat = (await fixture.integration.client.listChats()).sessions.find(
+        (entry) => entry.preview.firstMessage === 'ui-processing-a',
+      );
+      if (!chat) throw new Error('Started Anthropic chat was not listed.');
+
+      await app.sendComposer('ui-processing-b');
+      await app.waitForQueuedPreview('ui-processing-b');
+      const predecessorTerminalCursor = await fixture.spaWebSocketEventCount();
+
+      predecessor.releaseEcho();
+      await successor.received;
+      await fixture.waitForSpaWebSocketEvent({
+        afterIndex: predecessorTerminalCursor,
+        type: 'agent-run-finished',
+        chatId: chat.id,
+      });
+      await app.waitForChatProcessing(true);
+
+      successor.releaseEcho();
+      await app.waitForText('echo:ui-processing-b');
+      await app.waitForChatProcessing(false);
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});

--- a/web/src/lib/components/chat/LoadingStatus.svelte
+++ b/web/src/lib/components/chat/LoadingStatus.svelte
@@ -121,7 +121,12 @@
 
 {#if isVisible}
 	<div class={statusTrayClass}>
-		<div class={statusPanelClass} role="status" aria-live="polite">
+		<div
+			class={statusPanelClass}
+			role="status"
+			aria-live="polite"
+			data-slot="chat-processing-status"
+		>
 			<div class="flex min-w-0 items-center gap-1.5">
 				<span
 					class="flex-shrink-0 text-sm text-status-processing transition-all {animationPhase % 2 ===


### PR DESCRIPTION
Adds a full-stack Lightpanda regression for Anthropic chats that verifies a delayed predecessor terminal cannot hide the processing indicator while a queued successor is running, with stable SPA WebSocket and status-panel test hooks that synchronize the assertion without timing sleeps.