### PR TITLE
Fix long chat titles in project path dialog

### DIFF
--- a/web/src/lib/components/sidebar/SidebarProjectPathDialog.svelte
+++ b/web/src/lib/components/sidebar/SidebarProjectPathDialog.svelte
@@ -150,13 +150,15 @@
 {:else}
 	<Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
 		<Dialog.Content
-			class="h-dvh w-full max-w-full rounded-none border-0 p-0 sm:h-auto sm:max-w-lg sm:rounded-lg sm:border"
+			class="h-dvh w-full max-w-full overflow-hidden rounded-none border-0 p-0 sm:h-auto sm:max-w-lg sm:rounded-lg sm:border"
 			onOpenAutoFocus={handleOpenAutoFocus}
 		>
-			<div class="flex h-full flex-col sm:h-auto">
-				<Dialog.Header class="border-b border-border px-5 py-4">
+			<div class="flex h-full min-w-0 max-w-full flex-col sm:h-auto">
+				<Dialog.Header
+					class="min-w-0 max-w-full overflow-hidden border-b border-border px-5 py-4"
+				>
 					<Dialog.Title>{m.sidebar_project_path_title()}</Dialog.Title>
-					<Dialog.Description class="min-w-0 truncate">
+					<Dialog.Description class="block w-full min-w-0 max-w-full truncate">
 						{projectPathDialog?.chatTitle || m.sidebar_chats_unnamed()}
 					</Dialog.Description>
 				</Dialog.Header>

--- a/web/src/lib/components/sidebar/__tests__/sidebar-dialogs.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-dialogs.test.ts
@@ -57,6 +57,36 @@ function makeWorktree(path: string, branch: string, isCurrent = false): GitWorkt
 }
 
 describe('Sidebar dialogs', () => {
+	it('constrains long chat titles in the project path dialog header', async () => {
+		const longTitle = 'A'.repeat(500);
+		const rendered = render(SidebarProjectPathDialog, {
+			projectPathDialog: {
+				chatId: 'chat-1',
+				chatTitle: longTitle,
+				currentProjectPath: '/workspace/repo',
+			},
+			projectBasePath: '/workspace',
+			isMobile: false,
+			onClose: vi.fn(),
+			onConfirm: vi.fn(),
+		});
+
+		try {
+			const title = screen.getByText(longTitle);
+			const header = title.closest('[data-slot="dialog-header"]');
+			const content = title.closest('[data-slot="dialog-content"]');
+
+			expect(title.className).toContain('truncate');
+			expect(title.className).toContain('max-w-full');
+			expect(header?.className).toContain('min-w-0');
+			expect(header?.className).toContain('overflow-hidden');
+			expect(content?.className).toContain('overflow-hidden');
+			expect(screen.getByRole('textbox', { name: /new path/i })).toBeTruthy();
+		} finally {
+			await unmountDialog(rendered);
+		}
+	});
+
 	it('submits a validated project path and keeps server errors inline', async () => {
 		vi.useFakeTimers();
 		vi.mocked(chatsApi.validateStart).mockResolvedValue({ valid: true, isGitRepo: true });


### PR DESCRIPTION
Long unbroken chat titles could force the change-project-path dialog beyond its intended width and squeeze or truncate form controls. This constrains the dialog and header width, clips overflow, ellipsizes the chat title consistently with Chat Details, and adds regression coverage for oversized titles.