### PR TITLE
Stream direct provider generation requests

### DIFF
--- a/DIRECT_PROVIDER_SSE_DESIGN.md
+++ b/DIRECT_PROVIDER_SSE_DESIGN.md
@@ -1,0 +1,911 @@
+# Direct Provider SSE Unification
+
+Status: Implemented
+
+Baseline: `67d22ea7` (`Preserve single-query execution controls`)
+
+Date: 2026-07-20
+
+## Problem Statement
+
+Garcon has three direct provider runtimes:
+
+- OpenAI-compatible Chat Completions
+- OpenAI-compatible Responses
+- Anthropic-compatible Messages
+
+All interactive chat-session requests ask their upstream provider for Server-Sent Events (SSE), but only the Chat Completions runtime also uses SSE for one-shot generation. Anthropic Messages and OpenAI Responses still use buffered JSON for `runSingleQuery`. One-shot generation backs chat titles, commit messages, and generation-model tests, so those paths do not receive the latency and timeout behavior of the corresponding session path.
+
+The streaming implementations have also diverged. Anthropic validates its terminal event, Chat Completions validates `[DONE]`, and Responses accepts an arbitrary end-of-file as success. The Responses implementation can also return partial text after a provider failure because it only throws a stream error when no text was accumulated.
+
+The change should make every direct generation request ask for SSE and make one-shot and session requests share the same protocol-specific response reader.
+
+## Goals
+
+- Send `stream: true` for every direct generation request, including one-shot and session requests.
+- Share one response reader between the one-shot and session paths of each protocol.
+- Preserve visible text while safely ignoring reasoning events.
+- Require the protocol's successful terminal event before accepting streamed output.
+- Reject provider errors and incomplete streams even when partial text was received.
+- Preserve the caller abort signal, timeout, model, and thinking effort introduced by baseline commit `67d22ea7`.
+- Retain buffered JSON compatibility when a provider ignores `stream: true` and returns a successful JSON response.
+- Cover each protocol with unit tests and each shipped direct agent with black-box server integration tests.
+
+## Non-Goals
+
+- Streaming partial assistant text from the Garcon server to the web client.
+- Persisting partial assistant text before a provider response completes.
+- Adding or discovering endpoint reasoning capabilities.
+- Changing `thinkingMode` semantics or adding a reasoning on/off policy.
+- Retrying a thinking-only completion with different reasoning settings.
+- Treating hidden reasoning as visible assistant output.
+- Changing model discovery, provider authentication, endpoint storage, or provider templates.
+- Adding streaming tool-call execution to direct runtimes.
+
+## Scope Boundary
+
+This design concerns upstream provider transport. `DirectChatRuntimeBase` currently awaits a complete string from `streamSession`, persists it, and emits one final `AssistantMessage`. That behavior remains unchanged. A future client-token-streaming project would require new typed events, partial transcript state, reconnect behavior, and frontend rendering changes.
+
+## Current System
+
+### Routing
+
+`server-agents/common/src/direct/router.ts` creates one endpoint-scoped runtime family for each direct agent:
+
+- `createDirectOpenAiChatRuntime` uses `runOpenAiCompatibleSingleQuery` and `OpenAiCompatibleChatRuntime`.
+- `createDirectOpenAiResponsesRuntime` uses `runOpenAiResponsesSingleQuery` and `OpenAiCompatibleResponsesRuntime`.
+- `createDirectAnthropicRuntime` uses `runAnthropicCompatibleSingleQuery` and `AnthropicCompatibleChatRuntime`.
+
+The three integration packages under `server-agents/direct-*/src/index.ts` pass the normalized one-shot options to these common runtimes. The baseline commit makes `thinkingMode`, `timeoutMs`, and `signal` available there.
+
+### Transport Matrix
+
+| Protocol | One-shot request | Session request | Successful terminal validation |
+| --- | --- | --- | --- |
+| Chat Completions | SSE with JSON fallback | SSE | `[DONE]` |
+| Responses | Buffered JSON | SSE | Missing |
+| Anthropic Messages | Buffered JSON | SSE | `message_stop` |
+
+### Shared SSE Framing
+
+`server-agents/common/src/shared/sse.ts` owns `readSseDataEvents`. It correctly:
+
+- reads split UTF-8 chunks with `TextDecoder`;
+- normalizes CRLF line endings;
+- joins multiple `data:` lines in one event;
+- ignores non-data fields such as `event:` and comments;
+- emits the final unterminated buffered event;
+- cancels the body reader during cleanup.
+
+It should remain a transport-framing utility. Protocol event schemas should stay in their direct runtime modules.
+
+### Chat Completions
+
+`server-agents/common/src/direct/openai-compatible-chat-runtime.ts` already sends `stream: true` for both use cases. `readOpenAiCompatibleTextStream` accumulates `choices[0].delta.content`, surfaces streamed error objects, and requires `[DONE]`.
+
+`readOpenAiCompatibleSingleQueryResponse` also accepts a buffered JSON response based on `Content-Type`, but the session path calls `readOpenAiCompatibleTextStream` directly. The response-selection helper should be renamed and shared by both paths.
+
+### Anthropic Messages
+
+`server-agents/common/src/direct/anthropic-compatible-chat-runtime.ts` sends `stream: true` only from `streamSession`. `runAnthropicCompatibleSingleQuery` omits the field and reads `response.json()`.
+
+The session parser accumulates `content_block_delta` events whose delta type is `text_delta`, ignores thinking and signature deltas, surfaces `error` events, and requires `message_stop`. The one-shot path should use that same parser.
+
+### OpenAI Responses
+
+`server-agents/common/src/direct/openai-compatible-responses-runtime.ts` sends `stream: true` only from `streamSession`. `runOpenAiResponsesSingleQuery` reads buffered JSON with `extractResponsesOutputText`.
+
+`applyResponsesStreamEvent` recognizes visible `response.output_text.delta`, `error`, `response.failed`, and `response.incomplete`. The surrounding session reader has two correctness gaps:
+
+- it does not record or require `response.completed`;
+- it throws a stream error only when accumulated text is empty.
+
+The current test helper closes the stream after output deltas without a terminal event, so the unit tests encode the incomplete behavior.
+
+### Consumers
+
+One-shot generation is used by:
+
+- `server/chats/title-generator.ts` for automatic and manual chat titles;
+- `server/git/commit-message.ts` for commit message generation;
+- `server/settings/generation-model-test.ts` for explicit generation-model tests.
+
+No consumer needs incremental deltas. Each needs a final visible string or a precise failure.
+
+## External Research
+
+Alibaba Cloud Model Studio documents both relevant streaming interfaces for `qwen3.7-plus`:
+
+- [OpenAI-compatible Responses API](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-responses) uses `stream: true`, emits `response.output_text.delta`, and terminates with `response.completed`.
+- [Anthropic-compatible Messages API](https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages) uses `stream: true`, emits typed content-block deltas, and terminates with `message_stop`.
+- [Alibaba Cloud streaming overview](https://www.alibabacloud.com/help/en/model-studio/stream) identifies SSE as the streaming transport and notes that some Qwen models require streaming.
+
+The Responses documentation also states that only explicitly documented OpenAI fields are processed. This supports keeping protocol event parsing explicit rather than assuming every OpenAI-compatible field or event is universal.
+
+## Live Provider Verification
+
+The design was verified on 2026-07-20 against the configured Alibaba Cloud Global Frankfurt workspace using the locally stored API key and `qwen3.7-plus`. The key was read in process and was not printed or copied into the repository.
+
+### Raw OpenAI Responses SSE
+
+Request shape:
+
+```json
+{
+  "model": "qwen3.7-plus",
+  "input": [
+    { "role": "user", "content": "Reply with exactly ALIBABA_SSE_OK." }
+  ],
+  "stream": true,
+  "store": false
+}
+```
+
+Observed result:
+
+- HTTP status: 200
+- Content type: `text/event-stream; charset=utf-8`
+- First event: 2647 ms
+- Completed: 5557 ms
+- Reasoning summary deltas: 32
+- Visible output deltas: 4
+- Terminal event: `response.completed`
+- Visible output: `ALIBABA_SSE_OK`
+
+### Raw Anthropic Messages SSE
+
+Request shape:
+
+```json
+{
+  "model": "qwen3.7-plus",
+  "max_tokens": 128,
+  "messages": [
+    { "role": "user", "content": "Reply with exactly ALIBABA_SSE_OK." }
+  ],
+  "stream": true
+}
+```
+
+Observed result:
+
+- HTTP status: 200
+- Content type: `text/event-stream; charset=utf-8`
+- First event: 3522 ms
+- Completed: 7204 ms
+- Content blocks: thinking followed by text
+- Terminal event: `message_stop`
+- Visible output: `ALIBABA_SSE_OK`
+
+### Existing Session Runtime Verification
+
+The repository's current `AnthropicCompatibleChatRuntime` and `OpenAiCompatibleResponsesRuntime` were instantiated directly with the same endpoint and key. Each created an ephemeral session, consumed its upstream SSE stream, persisted one temporary JSONL transcript, and emitted `SESSION_SSE_OK`.
+
+| Runtime | Result | Completion time |
+| --- | --- | --- |
+| Anthropic Messages | `SESSION_SSE_OK` | 5093 ms |
+| OpenAI Responses | `SESSION_SSE_OK` | 5422 ms |
+
+This confirms that Alibaba's actual reasoning and visible-output event sequences are compatible with the current session parsers. The missing work is one-shot transport unification and stricter Responses terminal handling.
+
+## Proposed Design
+
+### Protocol-Specific Readers
+
+Each direct protocol module will own one successful-response reader used by both one-shot and session requests:
+
+```ts
+async function readAnthropicCompatibleResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string>;
+
+async function readOpenAiCompatibleResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string>;
+
+async function readOpenAiResponsesResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string>;
+```
+
+The callers remain responsible for checking `response.ok` and including the provider's HTTP error body in the thrown error. The readers handle successful response bodies only.
+
+### Response Media Type
+
+All generation requests will include `stream: true`. A successful provider can nevertheless return buffered JSON. The reader will select parsing by media type:
+
+```ts
+function isJsonResponse(response: Response): boolean {
+  const mediaType = response.headers
+    .get('content-type')
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+
+  return mediaType === 'application/json' || mediaType?.endsWith('+json') === true;
+}
+```
+
+This helper should live in `server-agents/common/src/direct/response-media-type.ts` because it is shared only by direct protocol adapters. It should not expand `shared/sse.ts` beyond SSE framing.
+
+JSON fallback is response compatibility, not request fallback. Garcon will not make a second billable request merely because a provider ignored `stream: true`.
+
+### Anthropic Reader
+
+The Anthropic reader will preserve the existing event semantics and add buffered JSON selection:
+
+```ts
+interface AnthropicStreamState {
+  text: string;
+  errorMessage: string | null;
+  sawMessageStop: boolean;
+}
+
+async function readAnthropicCompatibleResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string> {
+  if (isJsonResponse(response)) {
+    const data = await response.json() as {
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    return (data.content ?? [])
+      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .map((part) => part.text)
+      .join('');
+  }
+
+  if (!response.body) {
+    throw new Error(`${runtimeLabel} response did not include a stream body.`);
+  }
+
+  const state: AnthropicStreamState = {
+    text: '',
+    errorMessage: null,
+    sawMessageStop: false,
+  };
+  await readSseDataEvents(response.body, (data) => consumeAnthropicEvent(state, data));
+
+  if (state.errorMessage) {
+    throw new Error(`${runtimeLabel} stream error: ${state.errorMessage}`);
+  }
+  if (!state.sawMessageStop) {
+    throw new Error(`${runtimeLabel} stream ended before message_stop.`);
+  }
+  return state.text;
+}
+```
+
+`thinking_delta` and `signature_delta` remain ignored. A stream containing thinking followed by text succeeds. A thinking-only stream produces an empty visible result after a valid `message_stop`; existing callers retain responsibility for empty-output policy.
+
+Both request paths will use it:
+
+```ts
+body: JSON.stringify({
+  model,
+  max_tokens: config.maxTokens ?? DEFAULT_MAX_TOKENS,
+  messages: [{ role: 'user', content: prompt }],
+  stream: true,
+  ...(reasoningEffort ? { output_config: { effort: reasoningEffort } } : {}),
+}),
+
+return (await readAnthropicCompatibleResponse(response, config.runtimeLabel)).trim();
+```
+
+`streamSession` will replace its inline reader with the same function.
+
+### Chat Completions Reader
+
+Chat Completions already has the required transport. Rename the one-shot-specific selector and use it from both paths:
+
+```ts
+async function readOpenAiCompatibleResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string> {
+  if (!isJsonResponse(response)) {
+    return readOpenAiCompatibleTextStream(response, runtimeLabel);
+  }
+
+  const parsed = await response.json() as {
+    choices?: Array<{ message?: { content?: unknown } }>;
+    error?: { message?: string };
+  };
+  if (parsed.error?.message) {
+    throw new Error(`${runtimeLabel} response error: ${parsed.error.message}`);
+  }
+  return appendDeltaText('', parsed.choices?.[0]?.message?.content);
+}
+```
+
+The SSE parser continues to ignore provider-specific reasoning fields because it appends only `delta.content`. It must continue reading until `[DONE]`, so reasoning events before visible content do not end the request early.
+
+### Responses State Machine
+
+Responses needs an explicit terminal state rather than a string plus optional error:
+
+```ts
+interface ResponsesStreamState {
+  text: string;
+  errorMessage: string | null;
+  terminal: 'completed' | 'failed' | 'incomplete' | null;
+}
+
+interface ResponsesStreamEvent {
+  type?: string;
+  delta?: unknown;
+  error?: { message?: unknown };
+  response?: {
+    error?: { message?: unknown };
+    incomplete_details?: { reason?: unknown };
+    status_details?: { error?: { message?: unknown } };
+  };
+}
+
+function responsesFailureMessage(event: ResponsesStreamEvent): string {
+  const directMessage = event.response?.error?.message;
+  if (typeof directMessage === 'string') return directMessage;
+
+  const compatibleMessage = event.response?.status_details?.error?.message;
+  if (typeof compatibleMessage === 'string') return compatibleMessage;
+
+  const incompleteReason = event.response?.incomplete_details?.reason;
+  if (typeof incompleteReason === 'string') return incompleteReason;
+
+  return `Responses stream ended with ${event.type ?? 'an unknown failure'}.`;
+}
+
+function consumeResponsesStreamEvent(
+  state: ResponsesStreamState,
+  event: unknown,
+): void {
+  if (!event || typeof event !== 'object') return;
+  const parsed = event as ResponsesStreamEvent;
+
+  if (parsed.type === 'response.output_text.delta') {
+    if (typeof parsed.delta === 'string') state.text += parsed.delta;
+    return;
+  }
+  if (parsed.type === 'response.completed') {
+    state.terminal = 'completed';
+    return;
+  }
+  if (parsed.type === 'error') {
+    state.errorMessage = typeof parsed.error?.message === 'string'
+      ? parsed.error.message
+      : 'Responses stream returned an error.';
+    return;
+  }
+  if (parsed.type === 'response.failed' || parsed.type === 'response.incomplete') {
+    state.terminal = parsed.type === 'response.failed' ? 'failed' : 'incomplete';
+    state.errorMessage = responsesFailureMessage(parsed);
+  }
+}
+```
+
+The reader will reject any error regardless of accumulated text and require `response.completed`:
+
+```ts
+async function readOpenAiResponsesResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string> {
+  if (isJsonResponse(response)) {
+    const data = await response.json() as {
+      status?: unknown;
+      error?: { message?: unknown };
+      incomplete_details?: { reason?: unknown };
+    };
+    if (data.status === 'failed' || data.status === 'incomplete') {
+      const detail = typeof data.error?.message === 'string'
+        ? data.error.message
+        : typeof data.incomplete_details?.reason === 'string'
+          ? data.incomplete_details.reason
+          : `Responses API returned status ${data.status}.`;
+      throw new Error(`${runtimeLabel} response error: ${detail}`);
+    }
+    return extractResponsesOutputText(data);
+  }
+  if (!response.body) {
+    throw new Error(`${runtimeLabel} response did not include a stream body.`);
+  }
+
+  const state: ResponsesStreamState = {
+    text: '',
+    errorMessage: null,
+    terminal: null,
+  };
+  await readSseDataEvents(response.body, (data) => {
+    try {
+      consumeResponsesStreamEvent(state, JSON.parse(data));
+    } catch {
+      // Skips malformed chunks from partially-compatible providers.
+    }
+  });
+
+  if (state.errorMessage) {
+    throw new Error(`${runtimeLabel} stream error: ${state.errorMessage}`);
+  }
+  if (state.terminal !== 'completed') {
+    throw new Error(`${runtimeLabel} stream ended before response.completed.`);
+  }
+  return state.text;
+}
+```
+
+The one-shot request will add `stream: true` and both paths will call this reader.
+
+Reasoning summary and reasoning text events are intentionally ignored. Alibaba Cloud's verified event sequence contains many `response.reasoning_summary_text.delta` events before visible output, followed by `response.completed`; the state machine continues across them without storing their content.
+
+### Abort and Timeout Behavior
+
+No public contract changes are required. The baseline already forwards `signal` and `timeoutMs` into every server-agent one-shot request.
+
+Direct one-shots continue to combine:
+
+- the caller signal;
+- the direct runtime's bounded local timeout.
+
+Session requests continue to use their session abort controller and five-minute stream timeout. `readSseDataEvents` rejects when the aborted fetch body rejects and cancels its reader in `finally`.
+
+The refactor must not catch abort exceptions as malformed SSE data. Only JSON parsing inside an individual SSE callback should be caught.
+
+## Alternatives Considered
+
+### Keep Buffered JSON for One-Shots
+
+Rejected. It preserves the current latency inconsistency, cannot support models that require streaming, and keeps two response parsers per protocol.
+
+### Create One Universal Provider Event Parser
+
+Rejected. Anthropic Messages, Chat Completions, and Responses have different visible-content events, error events, and terminal conditions. A universal parser would hide protocol assumptions and make compatibility failures harder to diagnose. Only SSE framing and response media-type detection should be shared.
+
+### Reject Every JSON Response After Requesting SSE
+
+Rejected. Compatible providers sometimes ignore `stream: true` while returning a valid buffered response. Parsing that response is safe and does not add another request. Strict rejection would reduce compatibility without improving the upstream request path.
+
+### Retry Without Streaming
+
+Rejected. An ambiguous failure may occur after the provider has accepted and billed the first request. Automatic retry could duplicate cost and output. A clear HTTP rejection of `stream: true` should be surfaced rather than retried in this change.
+
+### Emit Partial Text to the Client
+
+Deferred. It changes the WebSocket contract, transcript lifecycle, reconnect semantics, and frontend state. This design intentionally returns one final string to existing callers.
+
+## Failure Modes and Edge Cases
+
+### HTTP Error Before SSE
+
+Existing callers read the response body and throw a protocol-labeled error with the HTTP status. This remains unchanged.
+
+### Provider Error After Partial Text
+
+All readers reject. Partial text is not persisted, returned to one-shot consumers, or emitted as an assistant message.
+
+### Truncated Stream
+
+- Anthropic rejects missing `message_stop`.
+- Chat Completions rejects missing `[DONE]`.
+- Responses rejects missing `response.completed`.
+
+### Empty Successful Stream
+
+The reader returns an empty string only after a valid success terminal event. Existing one-shot consumers and `DirectChatRuntimeBase` then apply their current empty-output behavior.
+
+### Thinking Before Visible Text
+
+The reader ignores reasoning content and continues until visible text or the terminal event. Tests must cover reasoning events before text for Anthropic and Responses.
+
+### Thinking-Only Completion
+
+The reader returns an empty visible string after the valid terminal event. Consuming hidden thinking is explicitly forbidden. A typed thinking-only diagnostic is deferred with the reasoning-policy work.
+
+### Malformed SSE Event
+
+A malformed JSON data event is skipped. A later valid visible event and valid terminal event can still complete the request. A stream made only of malformed data fails terminal validation.
+
+### JSON Response Despite `stream: true`
+
+The protocol's buffered JSON parser handles it. Tests cover this fallback for all three readers.
+
+### Missing or Incorrect Content Type
+
+A non-JSON response is treated as SSE. If it does not contain valid SSE data and the required terminal event, it fails as truncated. This avoids guessing from body prefixes.
+
+## Security and Privacy
+
+- API keys remain inside endpoint configuration and request headers.
+- Tests and logs must never include credential values.
+- Hidden reasoning text must not be logged, persisted, returned as a title, or emitted to the client.
+- Provider HTTP error bodies retain existing behavior; this change should not add request bodies or headers to error messages.
+- Live-provider verification remains a manual developer check and must not run in CI.
+
+## Performance
+
+- Every direct generation request begins consuming response bytes as soon as the provider emits them.
+- One-shot APIs still resolve only after the terminal event because consumers require a complete string.
+- Memory remains proportional to visible output length. Reasoning deltas are discarded rather than accumulated.
+- SSE framing adds negligible overhead relative to model generation.
+- No request retry is introduced.
+- Alibaba Cloud documents identical token billing for streaming and buffered output.
+
+## Compatibility and Migration
+
+There is no persisted-data, API, WebSocket, or settings migration.
+
+The server and server-agent packages ship together. Internal helper names can change without a compatibility layer. Buffered JSON responses remain supported, so the behavior is compatible with endpoints that ignore streaming.
+
+## Observability
+
+Existing protocol-labeled errors remain the primary signal. The implementation should produce distinct messages for:
+
+- HTTP rejection;
+- streamed provider error;
+- missing response body;
+- missing protocol terminal event;
+- valid terminal event with empty visible output at the caller boundary.
+
+No raw SSE data or reasoning content should be added to logs. Integration-test diagnostics should record request protocol, `stream: true`, model, message roles, and sanitized response-plan state only.
+
+## Execution Plan
+
+### 1. Add Direct Response Media-Type Detection
+
+Files:
+
+- Add `server-agents/common/src/direct/response-media-type.ts`.
+- Add `server-agents/common/src/direct/__tests__/response-media-type.test.js`.
+
+Implementation:
+
+```ts
+export function isJsonResponse(response: Response): boolean {
+  const mediaType = response.headers
+    .get('content-type')
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  return mediaType === 'application/json' || mediaType?.endsWith('+json') === true;
+}
+```
+
+Tests:
+
+```ts
+expect(isJsonResponse(Response.json({}))).toBe(true);
+expect(isJsonResponse(new Response('', {
+  headers: { 'content-type': 'application/problem+json; charset=utf-8' },
+}))).toBe(true);
+expect(isJsonResponse(new Response('', {
+  headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+}))).toBe(false);
+expect(isJsonResponse(new Response(''))).toBe(false);
+```
+
+Ordering: complete before refactoring the three readers.
+
+Rollback: inline the media-type check in each protocol module.
+
+### 2. Unify Anthropic One-Shot and Session Reading
+
+Files:
+
+- Modify `server-agents/common/src/direct/anthropic-compatible-chat-runtime.ts`.
+- Modify `server-agents/common/src/direct/__tests__/anthropic-compatible-chat-runtime.test.js`.
+
+Implementation:
+
+- Extract `readAnthropicCompatibleResponse` from the existing session parser.
+- Keep `consumeAnthropicEvent` protocol-specific.
+- Add `stream: true` to `runAnthropicCompatibleSingleQuery`.
+- Replace its direct `response.json()` call with the shared reader.
+- Replace the inline session parsing block with the shared reader.
+
+Required test cases:
+
+- One-shot request includes `stream: true` and preserves model, `max_tokens`, effort, timeout signal, and messages.
+- One-shot aggregates multiple text deltas.
+- Thinking and signature deltas before text are ignored.
+- A valid thinking-only stream returns empty visible text.
+- An `error` event rejects after partial text.
+- EOF before `message_stop` rejects.
+- Malformed data followed by text and `message_stop` succeeds.
+- Buffered JSON fallback still extracts only text blocks.
+- Session start and resume continue to use `stream: true` and the shared reader.
+
+Representative one-shot assertion:
+
+```ts
+expect(requestBody).toEqual({
+  model: 'acme-opus',
+  max_tokens: 4096,
+  messages: [{ role: 'user', content: 'Generate a commit message' }],
+  stream: true,
+  output_config: { effort: 'max' },
+});
+expect(result).toBe('commit message');
+```
+
+### 3. Share the Chat Completions Reader Across Use Cases
+
+Files:
+
+- Modify `server-agents/common/src/direct/openai-compatible-chat-runtime.ts`.
+- Modify `server-agents/common/src/direct/__tests__/openai-compatible-chat-runtime.test.js`.
+
+Implementation:
+
+- Rename `readOpenAiCompatibleSingleQueryResponse` to `readOpenAiCompatibleResponse`.
+- Use it from `runOpenAiCompatibleSingleQuery` and `streamSession`.
+- Use the shared `isJsonResponse` helper.
+- Keep the `[DONE]` requirement and partial-error rejection.
+
+Required test cases:
+
+- Existing one-shot and session requests still include `stream: true`.
+- Both paths aggregate text deltas and require `[DONE]`.
+- Both paths reject an error after partial output.
+- Both paths accept a buffered JSON response when the provider ignores streaming.
+- Reasoning-only deltas before visible content do not end the stream.
+
+This is primarily a consistency refactor; no request shape changes are expected.
+
+### 4. Implement a Strict Responses Stream State Machine
+
+Files:
+
+- Modify `server-agents/common/src/direct/openai-compatible-responses-runtime.ts`.
+- Modify `server-agents/common/src/direct/__tests__/openai-compatible-responses-runtime.test.js`.
+
+Implementation:
+
+- Replace `applyResponsesStreamEvent(accumulated, event)` with state mutation through `consumeResponsesStreamEvent`.
+- Track `response.completed`, `response.failed`, and `response.incomplete` explicitly.
+- Reject errors even after visible text was accumulated.
+- Require `response.completed` before returning SSE output.
+- Preserve `extractResponsesOutputText` for JSON fallback.
+- Add `stream: true` to `runOpenAiResponsesSingleQuery`.
+- Use `readOpenAiResponsesResponse` from both paths.
+
+Required test cases:
+
+- One-shot request contains `stream: true`, `store: false`, model, input, and reasoning effort.
+- One-shot and session aggregate `response.output_text.delta` events.
+- Reasoning summary and reasoning text events are ignored.
+- `response.completed` is required.
+- `response.failed` rejects before and after partial output.
+- `response.incomplete` rejects with the available reason.
+- Raw `error` rejects before and after partial output.
+- Malformed event followed by valid output and completion succeeds.
+- Buffered JSON fallback extracts `output_text` or output content items.
+- Abort during body reading rejects and does not emit or persist assistant text.
+
+The Responses test helper must emit realistic terminal events:
+
+```ts
+function streamResponse(events, { complete = true } = {}) {
+  const completeEvents = complete
+    ? [...events, { type: 'response.completed', response: { status: 'completed' } }]
+    : events;
+  return sseResponse(completeEvents);
+}
+```
+
+### 5. Add a Fake Responses Provider
+
+Files:
+
+- Add `integration-tests/support/fake-openai-responses-server.ts`.
+- Modify `integration-tests/support/garcon-client.ts`.
+- Modify `integration-tests/support/integration-fixture.ts`.
+- Update nearby support-contract tests.
+
+Rationale: `FakeOpenAiServer` currently validates only `/v1/chat/completions`. Responses has a distinct request and event contract, so a separate fake keeps protocol parsing focused and prevents a single support class from becoming multi-responsibility.
+
+Minimum fake request contract:
+
+```ts
+export interface FakeResponsesRequestBody {
+  model: string;
+  input: Array<{
+    role: 'user' | 'assistant';
+    content: string | Array<Record<string, unknown>>;
+  }>;
+  stream: true;
+  store: false;
+  reasoning?: { effort?: string };
+}
+```
+
+Successful fake response:
+
+```ts
+function responsesTextStream(text: string): Response {
+  return sseResponse([
+    { type: 'response.created', response: { status: 'in_progress' } },
+    ...deterministicChunks(text).map((delta) => ({
+      type: 'response.output_text.delta',
+      delta,
+    })),
+    { type: 'response.output_text.done', text },
+    { type: 'response.completed', response: { status: 'completed' } },
+  ]);
+}
+```
+
+The fake must support HTTP errors, stream errors, incomplete responses, empty completed responses, truncated streams, held responses, and abort observation using the same deterministic planning concepts as the existing fakes.
+
+`GarconTestClient` will add `createOpenAiResponsesProvider`, configured with:
+
+```ts
+capabilities: { chatCompletions: false, responses: true }
+```
+
+`DirectTestAgents` and `IntegrationFixture` will add an `openAiResponses` entry using `DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID`. Diagnostics will include its sanitized requests and protocol violations.
+
+### 6. Add Black-Box One-Shot and Session Coverage
+
+Files:
+
+- Modify `integration-tests/tests/server/chat-lifecycle.test.ts` or add `integration-tests/tests/server/openai-responses-chat-lifecycle.test.ts`.
+- Modify `integration-tests/tests/server/anthropic-chat-lifecycle.test.ts`.
+- Extend provider-failure integration coverage for Responses one-shots and sessions.
+
+Anthropic integration cases:
+
+- Existing start, resume, persistence, and rehydration requests remain streaming.
+- Title generation configured with the Anthropic direct agent produces a second request whose body has `stream: true`.
+- A title stream containing thinking events before text produces the visible title only.
+- A truncated title stream does not update the chat title.
+
+Responses integration cases:
+
+- Start, resume, persistence, and rehydration preserve context and use `stream: true` plus `store: false`.
+- Title generation uses the Responses direct agent and a distinct streaming request.
+- Provider `response.failed`, `response.incomplete`, empty completed, and truncated streams do not fabricate assistant turns or titles.
+- Abort reaches the fake provider and leaves no partial assistant transcript row.
+
+Representative title assertion:
+
+```ts
+const titleRequest = fixture.fakeProviders.openAiResponses.requests()
+  .find((request) => request.lastUserText.includes('### Task:'));
+expect(titleRequest?.body).toMatchObject({
+  stream: true,
+  store: false,
+  model: fixture.directAgents.openAiResponses.provider.model,
+});
+```
+
+### 7. Run Validation and Manual Provider Smoke Tests
+
+Repository validation:
+
+```sh
+bun run typecheck
+bun run check
+bun run test
+bun run test:integration:server
+timeout 30s bun run start --port 0
+```
+
+The startup smoke test must use a fresh workspace/config directory or otherwise avoid the active workspace lease. It must not stop the user's active server.
+
+Manual live-provider validation uses credentials supplied outside the repository. Run both protocols with `qwen3.7-plus`, a deterministic prompt, and `stream: true`. Record only:
+
+- status and content type;
+- first-event and completion timing;
+- event type counts;
+- visible text;
+- successful terminal presence.
+
+Never print or persist the API key, request headers, raw thinking deltas, or workspace-specific endpoint identifier.
+
+Expected assertions:
+
+```text
+Anthropic: HTTP 200, text/event-stream, visible text, message_stop
+Responses: HTTP 200, text/event-stream, visible text, response.completed
+```
+
+## Test Coverage Matrix
+
+| Behavior | Chat Completions | Responses | Anthropic |
+| --- | --- | --- | --- |
+| One-shot sends `stream: true` | Existing/update | Add | Add |
+| Session sends `stream: true` | Existing | Existing/update | Existing/update |
+| Multi-delta visible text | Existing | Add/update | Existing/add one-shot |
+| Reasoning before visible text | Add | Add | Add |
+| Buffered JSON fallback | Existing/expand session | Add | Add |
+| Provider error before text | Existing | Add | Existing/add one-shot |
+| Provider error after partial text | Existing | Add | Existing/add one-shot |
+| Required success terminal | Existing `[DONE]` | Add `response.completed` | Existing `message_stop` |
+| Truncated stream | Existing | Add | Existing/add one-shot |
+| Malformed then valid event | Existing integration | Add | Add |
+| Caller abort during one-shot | Shared/direct tests | Add | Add |
+| Session abort | Existing integration | Add integration | Existing integration |
+| Black-box title generation | Existing | Add | Add |
+| Black-box session lifecycle | Existing | Add | Existing |
+
+## Rollout
+
+The change ships atomically with the server-agent packages. No feature flag is required because:
+
+- all affected providers already support `stream: true` in their documented protocols;
+- Chat Completions already uses SSE for both paths;
+- Anthropic and Responses sessions already use SSE in production;
+- JSON fallback remains available for successful buffered responses.
+
+Monitor protocol-labeled provider failures after deployment, especially missing terminal events from partially compatible Responses endpoints. Such failures are preferable to accepting and persisting truncated output.
+
+## Rollback
+
+Rollback is a code revert only. There is no stored-data migration.
+
+If a provider regression requires an emergency rollback:
+
+- revert `stream: true` and the shared reader call in the affected one-shot function;
+- retain the stricter Responses session terminal validation unless evidence shows the provider sends a different documented success terminal;
+- retain test fixture additions because they improve protocol coverage without affecting production.
+
+Do not add silent non-stream retries as an emergency workaround. They can duplicate billable requests.
+
+## Acceptance Criteria
+
+- Every POST that generates model text in the three direct runtimes includes `stream: true`.
+- One-shot and session requests use the same response reader within each protocol.
+- Chat Completions accepts only `[DONE]`-terminated SSE success.
+- Anthropic accepts only `message_stop`-terminated SSE success.
+- Responses accepts only `response.completed`-terminated SSE success.
+- Provider errors reject even after partial text.
+- Reasoning events are ignored without terminating parsing or entering visible output.
+- Buffered JSON returned to a streaming request remains supported.
+- Caller abort and timeout behavior remains covered and functional.
+- Direct Chat Completions, Responses, and Anthropic each have black-box lifecycle and one-shot generation coverage.
+- The full validation commands pass.
+- A live `qwen3.7-plus` smoke test succeeds over Alibaba Cloud Global Anthropic Messages and OpenAI Responses SSE without exposing credentials.
+
+## Resolved Decisions
+
+- The scope is upstream provider SSE, not downstream UI token streaming.
+- Every generation request asks for SSE.
+- Successful buffered JSON is accepted without a retry.
+- Protocol readers remain separate; only SSE framing and media-type detection are shared.
+- Hidden reasoning is ignored and never promoted to visible output.
+- Reasoning capability configuration and thinking-only retry policy are deferred.
+- Responses terminal validation is corrected as part of the transport unification.
+- A separate fake Responses server is preferred over adding another protocol to the Chat Completions fake.
+
+## Deferred Risks
+
+- Some compatible endpoints may omit the documented terminal event despite producing complete text. The stricter behavior will reject those responses. The endpoint-specific compatibility policy, if needed, should be designed separately rather than inferred from partial output.
+- Direct sessions still deliver one final assistant message to the frontend rather than live token deltas.
+- Thinking-only completions still become empty visible output; this design deliberately does not choose a reasoning fallback policy.
+- Live provider tests are manual and depend on externally managed credentials, so CI confidence comes from strict fake-provider contract coverage.
+
+## Implementation Validation
+
+Implemented on 2026-07-20. The repository typecheck, check, unit suite, all 15 server integration files, and isolated random-port startup passed.
+
+Post-change live verification used the repository's actual one-shot runtime functions with `qwen3.7-plus`, explicit `high` effort, a 120-second timeout, and a caller abort signal:
+
+| Protocol | Request | Response | Visible result |
+| --- | --- | --- | --- |
+| Anthropic Messages | `stream: true`, effort and signal present | HTTP 200, `text/event-stream` | `ANTHROPIC_POST_CHANGE_OK` |
+| OpenAI Responses | `stream: true`, effort and signal present | HTTP 200, `text/event-stream` | `RESPONSES_POST_CHANGE_OK` |
+
+The live check read credentials only in process and did not print or persist keys, endpoints, headers, or hidden reasoning.
+
+Independent adversarial reviews were run against baseline commit `67d22ea7`, the complete implementation diff, this design, every changed and untracked file, and nearby callers/runtimes:
+
+- Claude Opus at `max`, session `23e8a952-cd7f-4c9b-8d12-9ca8b54514f7`.
+- Pi `moonshotai/kimi-k3` at `xhigh`, session `adversarial-pi-kimi-k3-20260720-1`.
+
+Neither reviewer found a substantive correctness defect. Their validated low-severity test and diagnostics findings were resolved by adding Anthropic one-shot abort and session JSON-fallback coverage, Responses pre-output failure and title-route failure coverage, and non-duplicative Responses error wording.
+
+The final full validation pass also caught baseline architecture-budget regressions in the Claude and OpenCode runtime files. Their one-shot process and request-control logic now live in focused sibling modules; the existing file-size ceilings were preserved rather than raised. Typecheck, static checks, 2,761 unit tests, 60 server integration tests across 15 files, and an isolated random-port startup all pass after these fixes.
+
+Both reviewers then resumed their original sessions against the complete post-fix worktree. Claude Opus at `max` and Pi `moonshotai/kimi-k3` at `xhigh` found no validated actionable findings and confirmed that the test additions and helper extractions preserve behavior.

--- a/integration-tests/support/fake-anthropic-server.ts
+++ b/integration-tests/support/fake-anthropic-server.ts
@@ -70,6 +70,7 @@ type PlannedResponse =
   | { kind: 'http-error'; status: number; message: string }
   | { kind: 'stream-error'; message: string }
   | { kind: 'malformed-then-text'; content: string }
+  | { kind: 'thinking-then-text'; content: string }
   | { kind: 'empty' }
   | { kind: 'truncated-stream' }
   | { kind: 'hold'; held: HeldAnthropicMessageController };
@@ -362,6 +363,75 @@ function textStreamEvents(
   ];
 }
 
+function thinkingThenTextStreamEvents(
+  content: string,
+  request: RecordedAnthropicRequest,
+): AnthropicSseEvent[] {
+  return [
+    {
+      event: 'message_start',
+      data: { type: 'message_start', message: baseMessage(request) },
+    },
+    {
+      event: 'content_block_start',
+      data: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'thinking', thinking: '' },
+      },
+    },
+    {
+      event: 'content_block_delta',
+      data: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'hidden fake reasoning' },
+      },
+    },
+    {
+      event: 'content_block_delta',
+      data: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'signature_delta', signature: 'fake-signature' },
+      },
+    },
+    {
+      event: 'content_block_stop',
+      data: { type: 'content_block_stop', index: 0 },
+    },
+    {
+      event: 'content_block_start',
+      data: {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'text', text: '' },
+      },
+    },
+    ...deterministicChunks(content).map((text) => ({
+      event: 'content_block_delta',
+      data: {
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'text_delta', text },
+      },
+    })),
+    {
+      event: 'content_block_stop',
+      data: { type: 'content_block_stop', index: 1 },
+    },
+    {
+      event: 'message_delta',
+      data: {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { output_tokens: 1 },
+      },
+    },
+    { event: 'message_stop', data: { type: 'message_stop' } },
+  ];
+}
+
 function anthropicSseResponse(
   events: AnthropicSseEvent[],
   request?: RecordedAnthropicRequest,
@@ -497,6 +567,10 @@ export class FakeAnthropicServer {
 
   respondMalformedThenTextNext(matcher: AnthropicRequestMatcher, content: string): void {
     this.#plans.push({ matcher, response: { kind: 'malformed-then-text', content } });
+  }
+
+  respondThinkingThenTextNext(matcher: AnthropicRequestMatcher, content: string): void {
+    this.#plans.push({ matcher, response: { kind: 'thinking-then-text', content } });
   }
 
   truncateNextStream(matcher: AnthropicRequestMatcher): void {
@@ -660,6 +734,9 @@ export class FakeAnthropicServer {
       return anthropicErrorResponse(plan.message, plan.status);
     }
     if (plan?.kind === 'stream-error') return anthropicStreamErrorResponse(plan.message, recorded);
+    if (plan?.kind === 'thinking-then-text') {
+      return anthropicSseResponse(thinkingThenTextStreamEvents(plan.content, recorded), recorded);
+    }
     if (plan?.kind === 'malformed-then-text') {
       if (!recorded.body.stream) return anthropicJsonMessageResponse(plan.content, recorded);
       const valid = await anthropicSseResponse(textStreamEvents(plan.content, recorded)).text();

--- a/integration-tests/support/fake-openai-responses-server.ts
+++ b/integration-tests/support/fake-openai-responses-server.ts
@@ -1,0 +1,610 @@
+import { isRecord } from '../../common/json.js';
+import { BoundedLog } from './bounded-log.js';
+import { Deferred, withTimeout } from './deferred.js';
+import { INTEGRATION_OPENAI_API_KEY } from './openai-test-contract.js';
+
+export interface FakeResponsesContentPart {
+  type: string;
+  text?: string;
+  image_url?: string;
+}
+
+export interface FakeResponsesInputMessage {
+  role: 'user' | 'assistant';
+  content: string | FakeResponsesContentPart[];
+}
+
+export interface FakeResponsesRequestBody {
+  model: string;
+  input: FakeResponsesInputMessage[];
+  stream: true;
+  store: false;
+  reasoning?: { effort: string };
+}
+
+export interface RecordedResponsesRequest {
+  id: number;
+  body: FakeResponsesRequestBody;
+  rawBody: Record<string, unknown>;
+  lastUserText: string;
+  receivedAt: number;
+  abortedAt: number | null;
+}
+
+export interface ResponsesRequestMatcher {
+  lastUserText?: string;
+  lastUserTextIncludes?: string;
+  model?: string;
+}
+
+export interface ResponsesRequestDiagnostic {
+  id: number;
+  model: string;
+  stream: true;
+  store: false;
+  lastUserText: string;
+  inputRoles: Array<'user' | 'assistant'>;
+  effort: string | null;
+  receivedAt: number;
+  abortedAt: number | null;
+}
+
+type PlannedResponse =
+  | { kind: 'http-error'; status: number; message: string }
+  | { kind: 'stream-error'; message: string }
+  | { kind: 'failed'; message: string }
+  | { kind: 'incomplete'; reason: string }
+  | { kind: 'malformed-then-text'; content: string }
+  | { kind: 'thinking-then-text'; content: string }
+  | { kind: 'empty' }
+  | { kind: 'truncated-stream' }
+  | { kind: 'hold'; held: HeldResponsesController };
+
+interface ResponsePlan {
+  matcher: ResponsesRequestMatcher;
+  response: PlannedResponse;
+}
+
+interface RequestWaiter {
+  matcher: ResponsesRequestMatcher;
+  afterId: number;
+  deferred: Deferred<RecordedResponsesRequest>;
+}
+
+export interface HeldResponsesRequest {
+  readonly received: Promise<RecordedResponsesRequest>;
+  expectAbort(): Promise<RecordedResponsesRequest>;
+  releaseEcho(): void;
+  releaseText(content: string): boolean;
+  releaseStreamError(message: string): boolean;
+  releaseTruncatedStream(): boolean;
+}
+
+class HeldResponsesController implements HeldResponsesRequest {
+  readonly #received = new Deferred<RecordedResponsesRequest>();
+  readonly #response = new Deferred<Response>();
+  readonly #aborted = new Deferred<RecordedResponsesRequest>();
+  #accepted = false;
+  #released = false;
+  #abortExpected = false;
+
+  constructor() {
+    void this.#received.promise.catch(() => undefined);
+  }
+
+  get received(): Promise<RecordedResponsesRequest> {
+    return withTimeout(
+      this.#received.promise,
+      10_000,
+      () => 'Timed out waiting for a held fake Responses request',
+    );
+  }
+
+  accept(request: RecordedResponsesRequest): Promise<Response> {
+    this.#accepted = true;
+    this.#received.resolve(request);
+    return this.#response.promise;
+  }
+
+  expectAbort(): Promise<RecordedResponsesRequest> {
+    this.#abortExpected = true;
+    return withTimeout(
+      this.#aborted.promise,
+      10_000,
+      () => 'Timed out waiting for the held fake Responses request to abort',
+    );
+  }
+
+  releaseEcho(): void {
+    void this.#received.promise.then(
+      (request) => this.#release(responsesTextResponse(
+        `echo:${request.lastUserText}`,
+        request,
+      )),
+      () => undefined,
+    );
+  }
+
+  releaseText(content: string): boolean {
+    if (!this.#received.settled) {
+      void this.#received.promise.then(
+        (request) => this.#release(responsesTextResponse(content, request)),
+        () => undefined,
+      );
+      return true;
+    }
+    void this.#received.promise.then(
+      (request) => this.#release(responsesTextResponse(content, request)),
+      () => undefined,
+    );
+    return !this.#response.settled;
+  }
+
+  releaseStreamError(message: string): boolean {
+    const released = this.#response.resolve(responsesStreamErrorResponse(message));
+    this.#released = released || this.#released;
+    return released;
+  }
+
+  releaseTruncatedStream(): boolean {
+    const released = this.#response.resolve(responsesTruncatedStreamResponse());
+    this.#released = released || this.#released;
+    return released;
+  }
+
+  observeAbort(request: RecordedResponsesRequest): void {
+    this.#aborted.resolve(request);
+    this.#response.resolve(Response.json(
+      { error: { message: 'Fake Responses request aborted' } },
+      { status: 499 },
+    ));
+  }
+
+  validationIssue(): string | null {
+    if (!this.#accepted || this.#released) return null;
+    if (this.#aborted.settled && this.#abortExpected) return null;
+    if (this.#aborted.settled) {
+      return 'Held fake Responses request aborted without an explicit expectation';
+    }
+    return 'Held fake Responses request remained unresolved';
+  }
+
+  cancel(reason: unknown): void {
+    this.#received.reject(reason);
+    this.#response.resolve(Response.json(
+      { error: { message: reason instanceof Error ? reason.message : String(reason) } },
+      { status: 503 },
+    ));
+  }
+
+  #release(response: Response): void {
+    const released = this.#response.resolve(response);
+    this.#released = released || this.#released;
+  }
+}
+
+function parseContent(value: unknown): FakeResponsesInputMessage['content'] | null {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return null;
+
+  const content: FakeResponsesContentPart[] = [];
+  for (const rawPart of value) {
+    if (!isRecord(rawPart) || typeof rawPart.type !== 'string') return null;
+    const part: FakeResponsesContentPart = { type: rawPart.type };
+    if (rawPart.text !== undefined) {
+      if (typeof rawPart.text !== 'string') return null;
+      part.text = rawPart.text;
+    }
+    if (rawPart.image_url !== undefined) {
+      if (typeof rawPart.image_url !== 'string') return null;
+      part.image_url = rawPart.image_url;
+    }
+    content.push(part);
+  }
+  return content;
+}
+
+function parseRequestBody(value: unknown): FakeResponsesRequestBody | null {
+  if (!isRecord(value) || typeof value.model !== 'string' || !value.model.trim()) return null;
+  if (value.stream !== true || value.store !== false || !Array.isArray(value.input) || !value.input.length) {
+    return null;
+  }
+
+  const input: FakeResponsesInputMessage[] = [];
+  for (const rawMessage of value.input) {
+    if (!isRecord(rawMessage) || (rawMessage.role !== 'user' && rawMessage.role !== 'assistant')) {
+      return null;
+    }
+    const content = parseContent(rawMessage.content);
+    if (content === null) return null;
+    input.push({ role: rawMessage.role, content });
+  }
+
+  let reasoning: { effort: string } | undefined;
+  if (value.reasoning !== undefined) {
+    if (!isRecord(value.reasoning) || typeof value.reasoning.effort !== 'string') return null;
+    reasoning = { effort: value.reasoning.effort };
+  }
+  return {
+    model: value.model,
+    input,
+    stream: true,
+    store: false,
+    ...(reasoning ? { reasoning } : {}),
+  };
+}
+
+function textFromContent(content: FakeResponsesInputMessage['content']): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((part) => part.type === 'input_text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join('\n');
+}
+
+function lastUserText(input: FakeResponsesInputMessage[]): string {
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    if (input[index].role === 'user') return textFromContent(input[index].content);
+  }
+  return '';
+}
+
+function matches(request: RecordedResponsesRequest, matcher: ResponsesRequestMatcher): boolean {
+  return (matcher.lastUserText === undefined || request.lastUserText === matcher.lastUserText)
+    && (matcher.lastUserTextIncludes === undefined
+      || request.lastUserText.includes(matcher.lastUserTextIncludes))
+    && (matcher.model === undefined || request.body.model === matcher.model);
+}
+
+function deterministicChunks(content: string): string[] {
+  if (content.length < 2) return [content];
+  const middle = Math.ceil(content.length / 2);
+  return [content.slice(0, middle), content.slice(middle)];
+}
+
+function responsesSseResponse(
+  events: Array<Record<string, unknown>>,
+  request?: RecordedResponsesRequest,
+): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+    cancel() {
+      if (request && request.abortedAt === null) request.abortedAt = Date.now();
+    },
+  }), {
+    status: 200,
+    headers: {
+      'cache-control': 'no-cache',
+      'content-type': 'text/event-stream; charset=utf-8',
+    },
+  });
+}
+
+function responseEnvelope(
+  request: RecordedResponsesRequest,
+  status: string,
+): Record<string, unknown> {
+  return {
+    id: `resp_fake_${request.id}`,
+    object: 'response',
+    model: request.body.model,
+    status,
+  };
+}
+
+function responsesTextEvents(
+  content: string,
+  request: RecordedResponsesRequest,
+  includeReasoning = true,
+): Array<Record<string, unknown>> {
+  return [
+    { type: 'response.created', response: responseEnvelope(request, 'in_progress') },
+    ...(includeReasoning ? [{
+      type: 'response.reasoning_summary_text.delta',
+      delta: 'hidden fake reasoning',
+    }] : []),
+    ...deterministicChunks(content).map((delta) => ({
+      type: 'response.output_text.delta',
+      delta,
+    })),
+    { type: 'response.output_text.done', text: content },
+    { type: 'response.completed', response: responseEnvelope(request, 'completed') },
+  ];
+}
+
+function responsesTextResponse(
+  content: string,
+  request: RecordedResponsesRequest,
+  includeReasoning = true,
+): Response {
+  return responsesSseResponse(responsesTextEvents(content, request, includeReasoning), request);
+}
+
+function responsesStreamErrorResponse(message: string): Response {
+  return responsesSseResponse([{ type: 'error', error: { message } }]);
+}
+
+function responsesFailedResponse(message: string, request: RecordedResponsesRequest): Response {
+  return responsesSseResponse([
+    { type: 'response.output_text.delta', delta: 'partial' },
+    {
+      type: 'response.failed',
+      response: { ...responseEnvelope(request, 'failed'), error: { message } },
+    },
+  ], request);
+}
+
+function responsesIncompleteResponse(reason: string, request: RecordedResponsesRequest): Response {
+  return responsesSseResponse([
+    { type: 'response.output_text.delta', delta: 'partial' },
+    {
+      type: 'response.incomplete',
+      response: {
+        ...responseEnvelope(request, 'incomplete'),
+        incomplete_details: { reason },
+      },
+    },
+  ], request);
+}
+
+function responsesEmptyResponse(request: RecordedResponsesRequest): Response {
+  return responsesSseResponse([
+    { type: 'response.created', response: responseEnvelope(request, 'in_progress') },
+    { type: 'response.completed', response: responseEnvelope(request, 'completed') },
+  ], request);
+}
+
+function responsesTruncatedStreamResponse(request?: RecordedResponsesRequest): Response {
+  return responsesSseResponse([
+    { type: 'response.output_text.delta', delta: 'partial' },
+  ], request);
+}
+
+export class FakeOpenAiResponsesServer {
+  readonly #server: Bun.Server<undefined>;
+  readonly #defaultDelayMs: number;
+  readonly #requests = new BoundedLog<RecordedResponsesRequest>(2_000);
+  readonly #violations = new BoundedLog<string>(100);
+  readonly #plans: ResponsePlan[] = [];
+  readonly #waiters: RequestWaiter[] = [];
+  readonly #activeHolds = new Set<HeldResponsesController>();
+  readonly #holds = new Set<HeldResponsesController>();
+  #requestId = 0;
+  #stopped = false;
+
+  private constructor(options: { defaultDelayMs?: number }) {
+    this.#defaultDelayMs = options.defaultDelayMs ?? 5;
+    this.#server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: (request) => this.#handleRequest(request),
+    });
+  }
+
+  static start(options: { defaultDelayMs?: number } = {}): FakeOpenAiResponsesServer {
+    return new FakeOpenAiResponsesServer(options);
+  }
+
+  get baseUrl(): string {
+    return `http://${this.#server.hostname}:${this.#server.port}`;
+  }
+
+  holdNext(matcher: ResponsesRequestMatcher): HeldResponsesRequest {
+    const held = new HeldResponsesController();
+    this.#holds.add(held);
+    this.#plans.push({ matcher, response: { kind: 'hold', held } });
+    return held;
+  }
+
+  failNextHttp(matcher: ResponsesRequestMatcher, status: number, message: string): void {
+    this.#plans.push({ matcher, response: { kind: 'http-error', status, message } });
+  }
+
+  failNextStream(matcher: ResponsesRequestMatcher, message: string): void {
+    this.#plans.push({ matcher, response: { kind: 'stream-error', message } });
+  }
+
+  failNextResponse(matcher: ResponsesRequestMatcher, message: string): void {
+    this.#plans.push({ matcher, response: { kind: 'failed', message } });
+  }
+
+  incompleteNextResponse(matcher: ResponsesRequestMatcher, reason: string): void {
+    this.#plans.push({ matcher, response: { kind: 'incomplete', reason } });
+  }
+
+  respondEmptyNext(matcher: ResponsesRequestMatcher): void {
+    this.#plans.push({ matcher, response: { kind: 'empty' } });
+  }
+
+  respondMalformedThenTextNext(matcher: ResponsesRequestMatcher, content: string): void {
+    this.#plans.push({ matcher, response: { kind: 'malformed-then-text', content } });
+  }
+
+  respondThinkingThenTextNext(matcher: ResponsesRequestMatcher, content: string): void {
+    this.#plans.push({ matcher, response: { kind: 'thinking-then-text', content } });
+  }
+
+  truncateNextStream(matcher: ResponsesRequestMatcher): void {
+    this.#plans.push({ matcher, response: { kind: 'truncated-stream' } });
+  }
+
+  requests(): readonly RecordedResponsesRequest[] {
+    return this.#requests.values();
+  }
+
+  diagnosticRequests(): readonly ResponsesRequestDiagnostic[] {
+    return this.requests().map((request) => ({
+      id: request.id,
+      model: request.body.model,
+      stream: true,
+      store: false,
+      lastUserText: request.lastUserText,
+      inputRoles: request.body.input.map((message) => message.role),
+      effort: request.body.reasoning?.effort ?? null,
+      receivedAt: request.receivedAt,
+      abortedAt: request.abortedAt,
+    }));
+  }
+
+  protocolViolations(): readonly string[] {
+    return this.#violations.values();
+  }
+
+  async waitForRequest(
+    matcher: ResponsesRequestMatcher,
+    options: { afterId?: number; timeoutMs?: number } = {},
+  ): Promise<RecordedResponsesRequest> {
+    const existing = this.requests().find((request) =>
+      request.id > (options.afterId ?? 0) && matches(request, matcher));
+    if (existing) return existing;
+
+    const deferred = new Deferred<RecordedResponsesRequest>();
+    const waiter = { matcher, afterId: options.afterId ?? 0, deferred };
+    this.#waiters.push(waiter);
+    try {
+      return await withTimeout(
+        deferred.promise,
+        options.timeoutMs ?? 10_000,
+        () => `Timed out waiting for fake Responses request ${JSON.stringify(matcher)}.\n${this.describeRequests()}`,
+      );
+    } finally {
+      const index = this.#waiters.indexOf(waiter);
+      if (index >= 0) this.#waiters.splice(index, 1);
+    }
+  }
+
+  assertNoProtocolViolations(): void {
+    const violations = this.protocolViolations();
+    const unusedPlans = this.#plans.map((plan) => JSON.stringify(plan.matcher));
+    const holdIssues = [...this.#holds].flatMap((held) => {
+      const issue = held.validationIssue();
+      return issue ? [issue] : [];
+    });
+    if (!violations.length && !unusedPlans.length && !holdIssues.length) return;
+    throw new Error([
+      ...(violations.length ? [`Fake Responses protocol violations:\n${violations.join('\n')}`] : []),
+      ...(unusedPlans.length ? [`Unused fake Responses response plans:\n${unusedPlans.join('\n')}`] : []),
+      ...(holdIssues.length ? [`Unsettled fake Responses holds:\n${holdIssues.join('\n')}`] : []),
+    ].join('\n'));
+  }
+
+  describeRequests(): string {
+    return JSON.stringify(this.diagnosticRequests(), null, 2);
+  }
+
+  stop(): void {
+    if (this.#stopped) return;
+    this.#stopped = true;
+    const error = new Error('Fake Responses server stopped');
+    for (const plan of this.#plans) {
+      if (plan.response.kind === 'hold') plan.response.held.cancel(error);
+    }
+    for (const held of this.#activeHolds) held.cancel(error);
+    for (const waiter of this.#waiters) waiter.deferred.reject(error);
+    this.#plans.length = 0;
+    this.#waiters.length = 0;
+    this.#server.stop(true);
+  }
+
+  async #handleRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.headers.get('authorization') !== `Bearer ${INTEGRATION_OPENAI_API_KEY}`) {
+      return this.#protocolViolation('Responses request is missing the configured bearer token');
+    }
+    if (request.method === 'GET' && url.pathname === '/v1/models') {
+      return Response.json({
+        object: 'list',
+        data: [{
+          id: 'integration-responses-echo',
+          object: 'model',
+          created: 0,
+          owned_by: 'garcon-integration',
+        }],
+      });
+    }
+    if (request.method !== 'POST' || url.pathname !== '/v1/responses') {
+      return this.#protocolViolation(`${request.method} ${url.pathname} is not supported`);
+    }
+    if (request.headers.get('content-type')?.split(';', 1)[0].trim().toLowerCase() !== 'application/json') {
+      return this.#protocolViolation('Responses content type must be application/json');
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return this.#protocolViolation('Responses body is not valid JSON');
+    }
+    const body = parseRequestBody(rawBody);
+    if (!body || !isRecord(rawBody)) {
+      return this.#protocolViolation(`Invalid Responses request: ${JSON.stringify(rawBody)}`);
+    }
+
+    const recorded: RecordedResponsesRequest = {
+      id: ++this.#requestId,
+      body,
+      rawBody,
+      lastUserText: lastUserText(body.input),
+      receivedAt: Date.now(),
+      abortedAt: null,
+    };
+    request.signal.addEventListener('abort', () => {
+      if (recorded.abortedAt === null) recorded.abortedAt = Date.now();
+    }, { once: true });
+    this.#requests.push(recorded);
+    this.#resolveRequestWaiters(recorded);
+
+    const planIndex = this.#plans.findIndex((plan) => matches(recorded, plan.matcher));
+    const plan = planIndex >= 0 ? this.#plans.splice(planIndex, 1)[0].response : null;
+    if (plan?.kind === 'hold') {
+      this.#activeHolds.add(plan.held);
+      request.signal.addEventListener('abort', () => plan.held.observeAbort(recorded), { once: true });
+      try {
+        return await plan.held.accept(recorded);
+      } finally {
+        this.#activeHolds.delete(plan.held);
+      }
+    }
+    if (plan?.kind === 'http-error') {
+      return Response.json({ error: { message: plan.message } }, { status: plan.status });
+    }
+    if (plan?.kind === 'stream-error') return responsesStreamErrorResponse(plan.message);
+    if (plan?.kind === 'failed') return responsesFailedResponse(plan.message, recorded);
+    if (plan?.kind === 'incomplete') return responsesIncompleteResponse(plan.reason, recorded);
+    if (plan?.kind === 'thinking-then-text') {
+      return responsesTextResponse(plan.content, recorded, true);
+    }
+    if (plan?.kind === 'malformed-then-text') {
+      const valid = await responsesTextResponse(plan.content, recorded).text();
+      return new Response(`data: {not-json}\n\n${valid}`, {
+        headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+      });
+    }
+    if (plan?.kind === 'empty') return responsesEmptyResponse(recorded);
+    if (plan?.kind === 'truncated-stream') return responsesTruncatedStreamResponse(recorded);
+
+    if (this.#defaultDelayMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, this.#defaultDelayMs));
+    }
+    return responsesTextResponse(`echo:${recorded.lastUserText}`, recorded);
+  }
+
+  #resolveRequestWaiters(request: RecordedResponsesRequest): void {
+    for (const waiter of [...this.#waiters]) {
+      if (request.id > waiter.afterId && matches(request, waiter.matcher)) {
+        waiter.deferred.resolve(request);
+      }
+    }
+  }
+
+  #protocolViolation(message: string): Response {
+    this.#violations.push(message);
+    return Response.json({ error: { message } }, { status: 400 });
+  }
+}

--- a/integration-tests/support/garcon-client.ts
+++ b/integration-tests/support/garcon-client.ts
@@ -33,6 +33,10 @@ import type {
   MarkChatsReadResponse,
 } from '../../common/chat-list.js';
 import type { ChatSearchRequest, ChatSearchResponse } from '../../common/chat-search.js';
+import type {
+  GenerateChatTitleRequest,
+  GenerateChatTitleResponse,
+} from '../../common/chat-title-contracts.js';
 import {
   normalizeScheduledPromptsSnapshot,
   type CreateScheduledPromptRequest,
@@ -95,6 +99,7 @@ export interface ConfiguredDirectTestAgent {
 
 export interface DirectTestAgents {
   openAi: ConfiguredDirectTestAgent;
+  openAiResponses: ConfiguredDirectTestAgent;
   anthropic: ConfiguredDirectTestAgent;
 }
 
@@ -339,6 +344,32 @@ export class GarconTestClient {
     };
   }
 
+  async createOpenAiResponsesProvider(providerBaseUrl: string): Promise<ConfiguredTestProvider> {
+    const model = 'integration-responses-echo';
+    const created = await this.post<ApiProviderCatalogEntry>('/api/v1/api-providers', {
+      templateId: 'custom',
+      label: 'Integration Fake OpenAI Responses',
+      endpoint: {
+        protocol: 'openai-compatible',
+        baseUrl: `${providerBaseUrl.replace(/\/$/, '')}/v1`,
+        apiKey: INTEGRATION_OPENAI_API_KEY,
+        capabilities: { chatCompletions: false, responses: true },
+        defaultModel: model,
+        models: [{ value: model, label: 'Integration Responses Echo' }],
+        supportsImages: false,
+        modelDiscovery: 'openai-models',
+      },
+    });
+    const endpoint = created.endpoints[0];
+    if (!endpoint) throw new Error('Created Responses provider did not contain an endpoint');
+    return {
+      providerId: created.id,
+      endpointId: endpoint.id,
+      model,
+      protocol: 'openai-compatible',
+    };
+  }
+
   async createAnthropicProvider(providerBaseUrl: string): Promise<ConfiguredTestProvider> {
     const model = 'integration-anthropic-echo';
     const created = await this.post<ApiProviderCatalogEntry>('/api/v1/api-providers', {
@@ -370,6 +401,10 @@ export class GarconTestClient {
 
   listChats(): Promise<ChatListResponse> {
     return this.get<ChatListResponse>('/api/v1/chats');
+  }
+
+  generateChatTitle(request: GenerateChatTitleRequest): Promise<GenerateChatTitleResponse> {
+    return this.post<GenerateChatTitleResponse>('/api/v1/chats/title/generate', request);
   }
 
   async getScheduledPrompts(): Promise<ScheduledPromptsSnapshot> {

--- a/integration-tests/support/integration-fixture.ts
+++ b/integration-tests/support/integration-fixture.ts
@@ -5,10 +5,12 @@ import { fileURLToPath } from 'node:url';
 import {
   DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID,
   DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
+  DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
   type AgentId,
 } from '../../common/agents.js';
 import { FakeAnthropicServer } from './fake-anthropic-server.js';
 import { FakeOpenAiServer } from './fake-openai-server.js';
+import { FakeOpenAiResponsesServer } from './fake-openai-responses-server.js';
 import {
   GarconTestClient,
   type ConfiguredDirectTestAgent,
@@ -42,6 +44,7 @@ export interface IntegrationDirectories {
 
 export interface IntegrationFixtureOptions {
   chatTitleEnabled?: boolean;
+  chatTitleAgent?: keyof DirectTestAgents;
   prepareWorkspace?: (directories: IntegrationDirectories) => Promise<void>;
   serverEnvironment?: Record<string, string>;
 }
@@ -63,6 +66,10 @@ export interface IntegrationDiagnostics {
       requests: ReturnType<FakeOpenAiServer['requests']>;
       protocolViolations: ReturnType<FakeOpenAiServer['protocolViolations']>;
     };
+    openAiResponses: {
+      requests: ReturnType<FakeOpenAiResponsesServer['diagnosticRequests']>;
+      protocolViolations: ReturnType<FakeOpenAiResponsesServer['protocolViolations']>;
+    };
     anthropic: {
       requests: ReturnType<FakeAnthropicServer['diagnosticRequests']>;
       protocolViolations: ReturnType<FakeAnthropicServer['protocolViolations']>;
@@ -74,6 +81,7 @@ export class IntegrationFixture {
   readonly dirs: IntegrationDirectories;
   readonly fakeProviders: {
     openAi: FakeOpenAiServer;
+    openAiResponses: FakeOpenAiResponsesServer;
     anthropic: FakeAnthropicServer;
   };
   readonly directAgents: DirectTestAgents;
@@ -114,6 +122,7 @@ export class IntegrationFixture {
 
     const fakeProviders = {
       openAi: FakeOpenAiServer.start(),
+      openAiResponses: FakeOpenAiResponsesServer.start(),
       anthropic: FakeAnthropicServer.start(),
     };
     let garcon: GarconProcess | null = null;
@@ -131,26 +140,35 @@ export class IntegrationFixture {
       client = await GarconTestClient.connect(garcon.baseUrl);
       await client.ping();
       const openAiProvider = await client.createOpenAiProvider(fakeProviders.openAi.baseUrl);
+      const openAiResponsesProvider = await client.createOpenAiResponsesProvider(
+        fakeProviders.openAiResponses.baseUrl,
+      );
       const anthropicProvider = await client.createAnthropicProvider(fakeProviders.anthropic.baseUrl);
       const directAgents = {
         openAi: directAgent(
           DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
           openAiProvider,
         ),
+        openAiResponses: directAgent(
+          DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
+          openAiResponsesProvider,
+        ),
         anthropic: directAgent(
           DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID,
           anthropicProvider,
         ),
       } satisfies DirectTestAgents;
+      const titleAgent = directAgents[options.chatTitleAgent ?? 'openAi'];
+      const hasExplicitTitleAgent = options.chatTitleAgent !== undefined;
       await client.updateSettings({
         ui: {
-          chatTitle: options.chatTitleEnabled ? {
-            enabled: true,
-            agentId: DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
-            model: openAiProvider.model,
-            apiProviderId: openAiProvider.providerId,
-            modelEndpointId: openAiProvider.endpointId,
-            modelProtocol: openAiProvider.protocol,
+          chatTitle: options.chatTitleEnabled || hasExplicitTitleAgent ? {
+            enabled: options.chatTitleEnabled === true,
+            agentId: titleAgent.agentId,
+            model: titleAgent.provider.model,
+            apiProviderId: titleAgent.provider.providerId,
+            modelEndpointId: titleAgent.provider.endpointId,
+            modelProtocol: titleAgent.provider.protocol,
             thinkingMode: 'none',
           } : { enabled: false },
         },
@@ -167,6 +185,7 @@ export class IntegrationFixture {
       await client?.close().catch(() => undefined);
       await garcon?.stop().catch(() => undefined);
       fakeProviders.openAi.stop();
+      fakeProviders.openAiResponses.stop();
       fakeProviders.anthropic.stop();
       await rm(root, { recursive: true, force: true });
       throw error;
@@ -305,6 +324,10 @@ export class IntegrationFixture {
           requests: this.fakeProviders.openAi.requests(),
           protocolViolations: this.fakeProviders.openAi.protocolViolations(),
         },
+        openAiResponses: {
+          requests: this.fakeProviders.openAiResponses.diagnosticRequests(),
+          protocolViolations: this.fakeProviders.openAiResponses.protocolViolations(),
+        },
         anthropic: {
           requests: this.fakeProviders.anthropic.diagnosticRequests(),
           protocolViolations: this.fakeProviders.anthropic.protocolViolations(),
@@ -332,6 +355,7 @@ export class IntegrationFixture {
       `Directories: ${JSON.stringify(this.dirs, null, 2)}`,
       `Process runs:\n${JSON.stringify(this.diagnostics().processRuns, null, 2)}`,
       `OpenAI requests:\n${this.fakeProviders.openAi.describeRequests()}`,
+      `Responses requests:\n${this.fakeProviders.openAiResponses.describeRequests()}`,
       `Anthropic requests:\n${this.fakeProviders.anthropic.describeRequests()}`,
     ].join('\n\n');
   }
@@ -352,12 +376,14 @@ export class IntegrationFixture {
     }
     try {
       this.fakeProviders.openAi.assertNoProtocolViolations();
+      this.fakeProviders.openAiResponses.assertNoProtocolViolations();
       this.fakeProviders.anthropic.assertNoProtocolViolations();
       this.garcon.assertNoUnexpectedExit();
     } catch (error) {
       errors.push(error);
     }
     this.fakeProviders.openAi.stop();
+    this.fakeProviders.openAiResponses.stop();
     this.fakeProviders.anthropic.stop();
 
     if (errors.length === 0 && process.env.KEEP_INTEGRATION_ARTIFACTS !== '1') {

--- a/integration-tests/tests/server/anthropic-chat-lifecycle.test.ts
+++ b/integration-tests/tests/server/anthropic-chat-lifecycle.test.ts
@@ -68,4 +68,53 @@ describe('Anthropic chat lifecycle', () => {
       expect(fixture.fakeProviders.openAi.requests()).toEqual([]);
     });
   });
+
+  test('generates titles from reasoning-first Anthropic SSE and rejects truncation', async () => {
+    await withIntegrationFixture('anthropic-title-generation', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const started = await fixture.client.startDirectChat({
+        chatId,
+        content: 'create-anthropic-title-source-chat',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAi,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, started.turnId);
+
+      fixture.fakeProviders.anthropic.respondThinkingThenTextNext(
+        { model: 'integration-anthropic-echo', stream: true },
+        'Anthropic Stream Title',
+      );
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'anthropic-title-source',
+      })).resolves.toEqual({
+        success: true,
+        chatId,
+        title: 'Anthropic Stream Title',
+      });
+
+      const titleRequest = fixture.fakeProviders.anthropic.requests()[0];
+      expect(titleRequest.body).toMatchObject({
+        model: 'integration-anthropic-echo',
+        max_tokens: 4096,
+        stream: true,
+      });
+      expect(titleRequest.lastUserText).toContain('### Task:');
+      expect(titleRequest.lastUserText).toContain('anthropic-title-source');
+
+      fixture.fakeProviders.anthropic.truncateNextStream({
+        model: 'integration-anthropic-echo',
+        stream: true,
+      });
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'anthropic-truncated-title',
+      })).rejects.toMatchObject({ status: 502 });
+
+      const chats = await fixture.client.listChats();
+      expect(chats.sessions.find((chat) => chat.id === chatId)?.title).toBe(
+        'Anthropic Stream Title',
+      );
+    }, { chatTitleAgent: 'anthropic' });
+  });
 });

--- a/integration-tests/tests/server/openai-responses-chat-lifecycle.test.ts
+++ b/integration-tests/tests/server/openai-responses-chat-lifecycle.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentRunFailedMessage } from '../../../common/ws-events.js';
+import { assistantContents, userContents } from '../../support/chat-assertions.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+describe('OpenAI Responses chat lifecycle', () => {
+  test('starts, resumes, persists, and rehydrates direct Responses history', async () => {
+    await withIntegrationFixture('openai-responses-chat-lifecycle', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const first = await fixture.client.startDirectChat({
+        chatId,
+        content: 'responses-turn-one',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAiResponses,
+      });
+      expect((await fixture.client.waitForTurnTerminal(chatId, first.turnId)).type).toBe(
+        'agent-run-finished',
+      );
+
+      const firstRequest = fixture.fakeProviders.openAiResponses.requests()[0];
+      expect(firstRequest.body).toEqual({
+        model: 'integration-responses-echo',
+        input: [{ role: 'user', content: 'responses-turn-one' }],
+        stream: true,
+        store: false,
+      });
+
+      const second = await fixture.client.runDirectChat({
+        chatId,
+        content: 'responses-turn-two',
+        agent: fixture.directAgents.openAiResponses,
+      });
+      expect((await fixture.client.waitForTurnTerminal(chatId, second.turnId)).type).toBe(
+        'agent-run-finished',
+      );
+      expect(fixture.fakeProviders.openAiResponses.requests()[1].body.input).toEqual([
+        { role: 'user', content: 'responses-turn-one' },
+        { role: 'assistant', content: 'echo:responses-turn-one' },
+        { role: 'user', content: 'responses-turn-two' },
+      ]);
+
+      const beforeRestart = await fixture.client.getMessages(chatId);
+      expect(userContents(beforeRestart.messages)).toEqual([
+        'responses-turn-one',
+        'responses-turn-two',
+      ]);
+      expect(assistantContents(beforeRestart.messages)).toEqual([
+        'echo:responses-turn-one',
+        'echo:responses-turn-two',
+      ]);
+
+      await fixture.restartGarcon();
+      const third = await fixture.client.runDirectChat({
+        chatId,
+        content: 'responses-turn-three',
+        agent: fixture.directAgents.openAiResponses,
+      });
+      expect((await fixture.client.waitForTurnTerminal(chatId, third.turnId)).type).toBe(
+        'agent-run-finished',
+      );
+      expect(fixture.fakeProviders.openAiResponses.requests()[2].body.input).toEqual([
+        { role: 'user', content: 'responses-turn-one' },
+        { role: 'assistant', content: 'echo:responses-turn-one' },
+        { role: 'user', content: 'responses-turn-two' },
+        { role: 'assistant', content: 'echo:responses-turn-two' },
+        { role: 'user', content: 'responses-turn-three' },
+      ]);
+      expect(fixture.fakeProviders.openAi.requests()).toEqual([]);
+      expect(fixture.fakeProviders.anthropic.requests()).toEqual([]);
+    });
+  });
+
+  test('generates titles from reasoning-first Responses SSE and rejects truncation', async () => {
+    await withIntegrationFixture('openai-responses-title-generation', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const started = await fixture.client.startDirectChat({
+        chatId,
+        content: 'create-title-source-chat',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAi,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, started.turnId);
+
+      fixture.fakeProviders.openAiResponses.respondThinkingThenTextNext(
+        { lastUserTextIncludes: 'responses-title-source' },
+        'Responses Stream Title',
+      );
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'responses-title-source',
+      })).resolves.toEqual({
+        success: true,
+        chatId,
+        title: 'Responses Stream Title',
+      });
+
+      const titleRequest = fixture.fakeProviders.openAiResponses.requests()[0];
+      expect(titleRequest.body).toMatchObject({
+        model: 'integration-responses-echo',
+        stream: true,
+        store: false,
+      });
+      expect(titleRequest.lastUserText).toContain('### Task:');
+      expect(titleRequest.lastUserText).toContain('responses-title-source');
+
+      fixture.fakeProviders.openAiResponses.failNextResponse(
+        { lastUserTextIncludes: 'responses-failed-title' },
+        'title generation failed',
+      );
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'responses-failed-title',
+      })).rejects.toMatchObject({
+        status: 502,
+        body: { errorCode: 'TITLE_GENERATION_FAILED' },
+      });
+
+      fixture.fakeProviders.openAiResponses.incompleteNextResponse(
+        { lastUserTextIncludes: 'responses-incomplete-title' },
+        'max_output_tokens',
+      );
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'responses-incomplete-title',
+      })).rejects.toMatchObject({
+        status: 502,
+        body: { errorCode: 'TITLE_GENERATION_FAILED' },
+      });
+
+      fixture.fakeProviders.openAiResponses.respondEmptyNext({
+        lastUserTextIncludes: 'responses-empty-title',
+      });
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'responses-empty-title',
+      })).rejects.toMatchObject({
+        status: 422,
+        body: { errorCode: 'TITLE_GENERATION_EMPTY' },
+      });
+
+      fixture.fakeProviders.openAiResponses.truncateNextStream({
+        lastUserTextIncludes: 'responses-truncated-title',
+      });
+      await expect(fixture.client.generateChatTitle({
+        chatId,
+        message: 'responses-truncated-title',
+      })).rejects.toMatchObject({ status: 502 });
+
+      const chats = await fixture.client.listChats();
+      expect(chats.sessions.find((chat) => chat.id === chatId)?.title).toBe(
+        'Responses Stream Title',
+      );
+      expect(fixture.fakeProviders.openAiResponses.requests()).toHaveLength(5);
+      expect(fixture.fakeProviders.openAiResponses.requests().every((request) => (
+        request.body.stream === true && request.body.store === false
+      ))).toBe(true);
+    }, { chatTitleAgent: 'openAiResponses' });
+  });
+
+  test('rejects Responses failures without persisting partial assistant output', async () => {
+    await withIntegrationFixture('openai-responses-provider-failures', async (fixture) => {
+      const failures = [
+        {
+          content: 'responses-http-error',
+          configure: () => fixture.fakeProviders.openAiResponses.failNextHttp(
+            { lastUserText: 'responses-http-error' },
+            429,
+            'rate limited',
+          ),
+        },
+        {
+          content: 'responses-stream-error',
+          configure: () => fixture.fakeProviders.openAiResponses.failNextStream(
+            { lastUserText: 'responses-stream-error' },
+            'stream failed',
+          ),
+        },
+        {
+          content: 'responses-failed',
+          configure: () => fixture.fakeProviders.openAiResponses.failNextResponse(
+            { lastUserText: 'responses-failed' },
+            'generation failed',
+          ),
+        },
+        {
+          content: 'responses-incomplete',
+          configure: () => fixture.fakeProviders.openAiResponses.incompleteNextResponse(
+            { lastUserText: 'responses-incomplete' },
+            'max_output_tokens',
+          ),
+        },
+        {
+          content: 'responses-empty',
+          configure: () => fixture.fakeProviders.openAiResponses.respondEmptyNext({
+            lastUserText: 'responses-empty',
+          }),
+        },
+        {
+          content: 'responses-truncated',
+          configure: () => fixture.fakeProviders.openAiResponses.truncateNextStream({
+            lastUserText: 'responses-truncated',
+          }),
+        },
+      ];
+
+      for (const failure of failures) {
+        const chatId = fixture.newChatId();
+        failure.configure();
+        const accepted = await fixture.client.startDirectChat({
+          chatId,
+          content: failure.content,
+          projectPath: fixture.dirs.project,
+          agent: fixture.directAgents.openAiResponses,
+        });
+        const terminal = await fixture.client.waitForTurnTerminal(chatId, accepted.turnId);
+        expect(terminal).toMatchObject({
+          type: 'agent-run-failed',
+          chatId,
+          turnId: accepted.turnId,
+        });
+        expect((terminal as AgentRunFailedMessage).error).toBeString();
+
+        const transcript = await fixture.client.getMessages(chatId);
+        expect(userContents(transcript.messages)).toEqual([failure.content]);
+        expect(assistantContents(transcript.messages)).toEqual([]);
+      }
+      expect(fixture.fakeProviders.openAiResponses.requests()).toHaveLength(failures.length);
+    });
+  });
+
+  test('skips malformed Responses events before a valid completion', async () => {
+    await withIntegrationFixture('openai-responses-malformed-sse', async (fixture) => {
+      const chatId = fixture.newChatId();
+      fixture.fakeProviders.openAiResponses.respondMalformedThenTextNext(
+        { lastUserText: 'responses-malformed-then-valid' },
+        'valid-after-malformed',
+      );
+      const accepted = await fixture.client.startDirectChat({
+        chatId,
+        content: 'responses-malformed-then-valid',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAiResponses,
+      });
+      expect((await fixture.client.waitForTurnTerminal(chatId, accepted.turnId)).type).toBe(
+        'agent-run-finished',
+      );
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(assistantContents(transcript.messages)).toEqual(['valid-after-malformed']);
+    });
+  });
+
+  test('propagates session abort and leaves no partial assistant turn', async () => {
+    await withIntegrationFixture('openai-responses-session-abort', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const held = fixture.fakeProviders.openAiResponses.holdNext({
+        lastUserText: 'responses-abort',
+      });
+      const accepted = await fixture.client.startDirectChat({
+        chatId,
+        content: 'responses-abort',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAiResponses,
+      });
+      await held.received;
+      const aborted = held.expectAbort();
+      const cursor = fixture.client.markEvents();
+
+      const stopped = await fixture.client.stopChat({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        agentId: fixture.directAgents.openAiResponses.agentId,
+      });
+      expect(stopped.stopped).toBe(true);
+      expect((await aborted).abortedAt).toBeNumber();
+      expect((await fixture.client.waitForTurnTerminal(chatId, accepted.turnId, {
+        afterIndex: cursor,
+      })).type).toBe('agent-run-finished');
+
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(userContents(transcript.messages)).toEqual(['responses-abort']);
+      expect(assistantContents(transcript.messages)).toEqual([]);
+    });
+  });
+});

--- a/integration-tests/tests/server/support-contract.test.ts
+++ b/integration-tests/tests/server/support-contract.test.ts
@@ -3,6 +3,7 @@ import { BoundedLog } from '../../support/bounded-log.js';
 import { Deferred } from '../../support/deferred.js';
 import { FakeAnthropicServer } from '../../support/fake-anthropic-server.js';
 import { FakeOpenAiServer } from '../../support/fake-openai-server.js';
+import { FakeOpenAiResponsesServer } from '../../support/fake-openai-responses-server.js';
 import { GarconTestClient } from '../../support/garcon-client.js';
 import { fakeAnthropicRequestHeaders } from '../../support/anthropic-test-contract.js';
 import { fakeOpenAiRequestHeaders } from '../../support/openai-test-contract.js';
@@ -86,6 +87,42 @@ describe('integration support contracts', () => {
       expect(text).toContain('hello');
       expect(text).toContain('data: [DONE]');
       expect(fake.requests()).toHaveLength(1);
+      expect(fake.requests()[0].lastUserText).toBe('hello');
+      fake.assertNoProtocolViolations();
+    } finally {
+      fake.stop();
+    }
+  });
+
+  test('serves strict OpenAI Responses streaming echoes', async () => {
+    const fake = FakeOpenAiResponsesServer.start({ defaultDelayMs: 0 });
+    try {
+      const models = await fetch(`${fake.baseUrl}/v1/models`, {
+        headers: fakeOpenAiRequestHeaders(),
+      }).then((response) => response.json());
+      expect(models).toMatchObject({ data: [{ id: 'integration-responses-echo' }] });
+
+      const response = await fetch(`${fake.baseUrl}/v1/responses`, {
+        method: 'POST',
+        headers: fakeOpenAiRequestHeaders(),
+        body: JSON.stringify({
+          model: 'integration-responses-echo',
+          input: [{ role: 'user', content: 'hello' }],
+          stream: true,
+          store: false,
+          reasoning: { effort: 'high' },
+        }),
+      });
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      expect(text).toContain('response.reasoning_summary_text.delta');
+      expect(text).toContain('response.output_text.delta');
+      expect(text).toContain('response.completed');
+      expect(fake.requests()[0].body).toMatchObject({
+        stream: true,
+        store: false,
+        reasoning: { effort: 'high' },
+      });
       expect(fake.requests()[0].lastUserText).toBe('hello');
       fake.assertNoProtocolViolations();
     } finally {

--- a/server-agents/amp/src/agents/amp/amp-cli.ts
+++ b/server-agents/amp/src/agents/amp/amp-cli.ts
@@ -22,6 +22,7 @@ import {
   type AmpStartedSession,
 } from './runtime-types.js';
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 import { normalizeThinkingMode } from '@garcon/common/chat-modes';
 import {
   AGENT_UNSUPPORTED_SINGLE_QUERY_THINKING_MODE,
@@ -134,7 +135,7 @@ async function readAmpStdout(proc: ReturnType<typeof Bun.spawn>): Promise<string
 
 async function runAmpCommand(
   args: string[],
-  { cwd, input }: { cwd?: string; input?: string } = {},
+  { cwd, input, signal }: { cwd?: string; input?: string; signal?: AbortSignal } = {},
   config: AmpConfig = DEFAULT_CONFIG,
 ): Promise<string> {
   const ampBinary = config.binary();
@@ -143,6 +144,7 @@ async function runAmpCommand(
     stdin: input == null ? 'ignore' : 'pipe',
     stdout: 'pipe',
     stderr: 'pipe',
+    signal,
   });
 
   if (input != null) {
@@ -157,6 +159,7 @@ async function runAmpCommand(
     proc.stderr ? new Response(proc.stderr).text() : Promise.resolve(''),
     proc.exited,
   ]);
+  signal?.throwIfAborted();
 
   if (exitCode !== 0) {
     const details = (stderr || stdout || '').trim();
@@ -298,36 +301,38 @@ async function runSingleQuery(
     '--stream-json-thinking',
     '-x',
   ];
-  let raw = '';
+  return withSingleQueryControl(options, async (signal) => {
+    let raw = '';
 
-  try {
-    raw = await runAmpCommand(args, { cwd, input: prompt }, config);
-  } catch (err) {
-    logger.error('Amp one-shot stdout read failed.', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    throw err;
-  }
-
-  const textParts: string[] = [];
-
-  for (const line of raw.split('\n')) {
-    if (!line.trim()) continue;
     try {
-      const msg = JSON.parse(line) as AmpCliMessage;
-      if (msg.type === 'assistant') {
-        for (const part of getAssistantContent(msg)) {
-          if (part.type === 'text' && part.text?.trim()) {
-            textParts.push(part.text);
+      raw = await runAmpCommand(args, { cwd, input: prompt, signal }, config);
+    } catch (err) {
+      logger.error('Amp one-shot stdout read failed.', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+
+    const textParts: string[] = [];
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line) as AmpCliMessage;
+        if (msg.type === 'assistant') {
+          for (const part of getAssistantContent(msg)) {
+            if (part.type === 'text' && part.text?.trim()) {
+              textParts.push(part.text);
+            }
           }
         }
+      } catch {
+        // skip non-JSON lines
       }
-    } catch {
-      // skip non-JSON lines
     }
-  }
 
-  return textParts.join('\n');
+    return textParts.join('\n');
+  });
 }
 
 function createSession(

--- a/server-agents/amp/src/index.ts
+++ b/server-agents/amp/src/index.ts
@@ -15,6 +15,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createAmpConfig } from './config.js';
 import { getAmpAuthStatus } from './agents/amp/amp-auth.js';
 import { AmpCliRuntime, runSingleQuery } from './agents/amp/amp-cli.js';
@@ -109,7 +110,7 @@ export default class AmpAgentIntegration implements AgentIntegration {
           return await runSingleQuery(request.prompt, {
             cwd: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           }, config, logger);
         } catch (error) {
           if (error instanceof AgentIntegrationError) throw error;

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -31,6 +31,7 @@ import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import { isRecord } from '@garcon/common/json';
 import { isManualBypassMode, providerStartupPermissionMode } from '@garcon/server-agent-common/execution/permission-modes';
 import { IdleSessionPurger } from '@garcon/server-agent-common/shared/idle-session-purger';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -183,6 +184,8 @@ interface ClaudeSingleQueryOptions {
   thinkingMode?: ThinkingMode;
   claudeThinkingMode?: ClaudeThinkingMode;
   envOverrides?: Record<string, string>;
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 export interface ClaudeCliDependencies {
@@ -325,40 +328,53 @@ function convertCLIMessageToChatMessages(msg: CLIMessage): ChatMessage[] {
 // Runs a one-shot CLI query and returns the plain text output.
 async function runSingleQuery(
   prompt: string,
-  { model, cwd, permissionMode, thinkingMode, claudeThinkingMode, envOverrides }: ClaudeSingleQueryOptions = {},
+  {
+    model,
+    cwd,
+    permissionMode,
+    thinkingMode,
+    claudeThinkingMode,
+    envOverrides,
+    timeoutMs,
+    signal,
+  }: ClaudeSingleQueryOptions = {},
   dependencies: ClaudeCliDependencies = defaultClaudeCliDependencies(),
 ): Promise<string> {
-  const claudeBinary = dependencies.binary();
-  const supportsLegacyThinkingFlag = await dependencies.versionProbe.supportsLegacyThinkingFlag(claudeBinary);
-  const args = buildClaudeCLIArgs({ model, permissionMode, thinkingMode, claudeThinkingMode, prompt, supportsLegacyThinkingFlag });
+  return withSingleQueryControl({ signal, timeoutMs }, async (querySignal) => {
+    const claudeBinary = dependencies.binary();
+    const supportsLegacyThinkingFlag = await dependencies.versionProbe.supportsLegacyThinkingFlag(claudeBinary);
+    const args = buildClaudeCLIArgs({ model, permissionMode, thinkingMode, claudeThinkingMode, prompt, supportsLegacyThinkingFlag });
 
-  const proc = Bun.spawn([claudeBinary, ...args], {
-    cwd: cwd || process.cwd(),
-    stdin: 'ignore',
-    stdout: 'pipe',
-    stderr: 'pipe',
-    env: (() => { const { CLAUDECODE, ...env } = process.env; return { ...env, ...envOverrides }; })(),
-  });
-
-  const chunks: Uint8Array[] = [];
-  const reader = proc.stdout.getReader();
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      chunks.push(value);
-    }
-  } catch (err: unknown) {
-    dependencies.logger.error('Claude one-shot stdout read failed', {
-      error: errorMessage(err),
+    const proc = Bun.spawn([claudeBinary, ...args], {
+      cwd: cwd || process.cwd(),
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      signal: querySignal,
+      env: (() => { const { CLAUDECODE, ...env } = process.env; return { ...env, ...envOverrides }; })(),
     });
-  }
 
-  await proc.exited;
+    const chunks: Uint8Array[] = [];
+    const reader = proc.stdout.getReader();
 
-  const decoder = new TextDecoder();
-  return chunks.map((c) => decoder.decode(c, { stream: true })).join('') + decoder.decode();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+    } catch (err: unknown) {
+      dependencies.logger.error('Claude one-shot stdout read failed', {
+        error: errorMessage(err),
+      });
+    }
+
+    await proc.exited;
+    querySignal.throwIfAborted();
+
+    const decoder = new TextDecoder();
+    return chunks.map((c) => decoder.decode(c, { stream: true })).join('') + decoder.decode();
+  });
 }
 
 // Forwards non-default effort exactly and leaves unsupported values to the CLI.

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -32,6 +32,7 @@ import { isRecord } from '@garcon/common/json';
 import { isManualBypassMode, providerStartupPermissionMode } from '@garcon/server-agent-common/execution/permission-modes';
 import { IdleSessionPurger } from '@garcon/server-agent-common/shared/idle-session-purger';
 import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
+import { runClaudeSingleQueryProcess } from './single-query-process.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -345,35 +346,14 @@ async function runSingleQuery(
     const supportsLegacyThinkingFlag = await dependencies.versionProbe.supportsLegacyThinkingFlag(claudeBinary);
     const args = buildClaudeCLIArgs({ model, permissionMode, thinkingMode, claudeThinkingMode, prompt, supportsLegacyThinkingFlag });
 
-    const proc = Bun.spawn([claudeBinary, ...args], {
+    return runClaudeSingleQueryProcess({
+      binary: claudeBinary,
+      args,
       cwd: cwd || process.cwd(),
-      stdin: 'ignore',
-      stdout: 'pipe',
-      stderr: 'pipe',
       signal: querySignal,
-      env: (() => { const { CLAUDECODE, ...env } = process.env; return { ...env, ...envOverrides }; })(),
+      envOverrides,
+      logger: dependencies.logger,
     });
-
-    const chunks: Uint8Array[] = [];
-    const reader = proc.stdout.getReader();
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        chunks.push(value);
-      }
-    } catch (err: unknown) {
-      dependencies.logger.error('Claude one-shot stdout read failed', {
-        error: errorMessage(err),
-      });
-    }
-
-    await proc.exited;
-    querySignal.throwIfAborted();
-
-    const decoder = new TextDecoder();
-    return chunks.map((c) => decoder.decode(c, { stream: true })).join('') + decoder.decode();
   });
 }
 

--- a/server-agents/claude/src/agents/claude/single-query-process.ts
+++ b/server-agents/claude/src/agents/claude/single-query-process.ts
@@ -1,0 +1,50 @@
+import { errorMessage } from '@garcon/server-agent-common/lib/errors';
+import type { AgentLogger } from '@garcon/server-agent-interface';
+
+interface ClaudeSingleQueryProcessOptions {
+  readonly binary: string;
+  readonly args: string[];
+  readonly cwd: string;
+  readonly envOverrides?: Record<string, string>;
+  readonly signal: AbortSignal;
+  readonly logger: AgentLogger;
+}
+
+export async function runClaudeSingleQueryProcess({
+  binary,
+  args,
+  cwd,
+  envOverrides,
+  signal,
+  logger,
+}: ClaudeSingleQueryProcessOptions): Promise<string> {
+  const { CLAUDECODE, ...env } = process.env;
+  const proc = Bun.spawn([binary, ...args], {
+    cwd,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    signal,
+    env: { ...env, ...envOverrides },
+  });
+
+  const chunks: Uint8Array[] = [];
+  const reader = proc.stdout.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+  } catch (err: unknown) {
+    logger.error('Claude one-shot stdout read failed', {
+      error: errorMessage(err),
+    });
+  }
+
+  await proc.exited;
+  signal.throwIfAborted();
+
+  const decoder = new TextDecoder();
+  return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join('') + decoder.decode();
+}

--- a/server-agents/claude/src/index.ts
+++ b/server-agents/claude/src/index.ts
@@ -17,6 +17,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createClaudeConfig } from './config.js';
 import { getClaudeAuthStatus } from './agents/claude/claude-auth.js';
 import {
@@ -210,7 +211,7 @@ export default class ClaudeAgentIntegration implements AgentIntegration {
           return await runSingleQuery(request.prompt, {
             cwd: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
             envOverrides: {
               ...buildClaudeHostEnvironment(config),
               ...endpointRuntime?.envOverrides,

--- a/server-agents/codex/src/agents/codex/app-server/run-single-query.ts
+++ b/server-agents/codex/src/agents/codex/app-server/run-single-query.ts
@@ -5,6 +5,7 @@ import type { CodexConfigObject, CodexConfigValue, CodexProviderConfig } from '.
 import type { PermissionMode, ThinkingMode } from '@garcon/common/chat-modes';
 import { resolveCodexCliCommand } from './cli.js';
 import { buildCodexEnv, codexSandboxSettings } from './request-builders.js';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 
 export { resolveCodexCliCommand } from './cli.js';
 
@@ -16,6 +17,8 @@ interface CodexSingleQueryOptions {
   thinkingMode?: ThinkingMode;
   envOverrides?: Record<string, string>;
   codexConfig?: CodexProviderConfig;
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 function mapSingleQueryThinkingModeToCodexEffort(
@@ -29,6 +32,7 @@ async function runCodexExec(
   input: string,
   envOverrides?: Record<string, string>,
   codexConfig?: CodexProviderConfig,
+  signal?: AbortSignal,
 ): Promise<{ stdout: string; stderr: string }> {
   const env = buildCodexExecEnv(envOverrides, codexConfig);
   const codexCommand = await resolveCodexCliCommand();
@@ -37,12 +41,14 @@ async function runCodexExec(
     stdout: 'pipe',
     stderr: 'pipe',
     ...(env ? { env } : {}),
+    signal,
   });
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
+  signal?.throwIfAborted();
 
   if (exitCode !== 0) {
     const details = (stderr || stdout || '').trim();
@@ -61,42 +67,46 @@ export async function runSingleQuery(prompt: string, options: CodexSingleQueryOp
     thinkingMode,
     envOverrides,
     codexConfig,
+    timeoutMs,
+    signal,
   } = options;
 
-  const workingDirectory = cwd || projectPath || process.cwd();
-  const { sandbox, approvalPolicy } = codexSandboxSettings(permissionMode);
-  const reasoningEffort = mapSingleQueryThinkingModeToCodexEffort(thinkingMode);
+  return withSingleQueryControl({ signal, timeoutMs }, async (querySignal) => {
+    const workingDirectory = cwd || projectPath || process.cwd();
+    const { sandbox, approvalPolicy } = codexSandboxSettings(permissionMode);
+    const reasoningEffort = mapSingleQueryThinkingModeToCodexEffort(thinkingMode);
 
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-single-query-'));
-  const outputPath = path.join(tmpDir, 'last-message.txt');
-  const args = [
-    'exec',
-    '--ephemeral',
-    '--skip-git-repo-check',
-    '--sandbox',
-    sandbox,
-    '--cd',
-    workingDirectory,
-    '--output-last-message',
-    outputPath,
-  ];
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-single-query-'));
+    const outputPath = path.join(tmpDir, 'last-message.txt');
+    const args = [
+      'exec',
+      '--ephemeral',
+      '--skip-git-repo-check',
+      '--sandbox',
+      sandbox,
+      '--cd',
+      workingDirectory,
+      '--output-last-message',
+      outputPath,
+    ];
 
-  if (model) args.push('--model', model);
-  appendCodexConfigArgs(args, codexConfig?.config);
-  if (reasoningEffort) args.push('--config', `model_reasoning_effort="${reasoningEffort}"`);
-  if (approvalPolicy) args.push('--config', `approval_policy="${approvalPolicy}"`);
-  args.push('-');
+    if (model) args.push('--model', model);
+    appendCodexConfigArgs(args, codexConfig?.config);
+    if (reasoningEffort) args.push('--config', `model_reasoning_effort="${reasoningEffort}"`);
+    if (approvalPolicy) args.push('--config', `approval_policy="${approvalPolicy}"`);
+    args.push('-');
 
-  try {
-    const { stdout } = await runCodexExec(args, prompt, envOverrides, codexConfig);
     try {
-      return (await fs.readFile(outputPath, 'utf8')).trim();
-    } catch {
-      return stdout.trim();
+      const { stdout } = await runCodexExec(args, prompt, envOverrides, codexConfig, querySignal);
+      try {
+        return (await fs.readFile(outputPath, 'utf8')).trim();
+      } catch {
+        return stdout.trim();
+      }
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
     }
-  } finally {
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  }
+  });
 }
 
 function buildCodexExecEnv(

--- a/server-agents/codex/src/index.ts
+++ b/server-agents/codex/src/index.ts
@@ -19,6 +19,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createCodexConfig, type CodexConfig } from './config.js';
 import { getCodexAuthStatus } from './agents/codex/codex-auth.js';
 import { CodexExecution } from './agents/codex/execution.js';
@@ -224,8 +225,8 @@ export default class CodexAgentIntegration implements AgentIntegration {
           return await runSingleQuery(request.prompt, {
             projectPath: request.projectPath,
             model: request.model,
+            ...singleQueryRuntimeOptions(request),
             permissionMode: 'default',
-            thinkingMode: 'none',
             envOverrides: buildCodexHostEnvironment(config),
             codexConfig: endpointRuntime?.codexConfig,
           });

--- a/server-agents/common/src/direct/__tests__/anthropic-compatible-chat-runtime.test.js
+++ b/server-agents/common/src/direct/__tests__/anthropic-compatible-chat-runtime.test.js
@@ -176,6 +176,35 @@ describe('AnthropicCompatibleChatRuntime', () => {
     expect(messages[0].content).toBe('hello world');
   });
 
+  it('accepts buffered JSON for an interactive Anthropic session', async () => {
+    const dir = await tempDir();
+    let requestBody;
+    globalThis.fetch = mock(async (_url, init) => {
+      requestBody = JSON.parse(init.body);
+      return Response.json({
+        content: [
+          { type: 'thinking', thinking: 'hidden' },
+          { type: 'text', text: 'session response' },
+        ],
+      });
+    });
+    const runtime = makeRuntime(dir);
+    const messages = waitForMessages(runtime);
+
+    await runtime.startSession({
+      chatId: 'chat-json',
+      command: 'hello',
+      projectPath: '/tmp/project',
+      model: 'acme-sonnet',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      claudeThinkingMode: 'auto',
+    });
+
+    expect(requestBody.stream).toBe(true);
+    await expect(messages).resolves.toMatchObject([{ content: 'session response' }]);
+  });
+
   it('forwards the current interactive effort and removes it for Default', async () => {
     const dir = await tempDir();
     const requestBodies = [];
@@ -269,16 +298,14 @@ describe('AnthropicCompatibleChatRuntime', () => {
     expect(requestBody).not.toHaveProperty('thinking');
   });
 
-  it('runs one-shot prompts through non-streaming Anthropic Messages', async () => {
+  it('streams one-shot prompts through Anthropic Messages', async () => {
     let requestBody;
     globalThis.fetch = mock(async (_url, init) => {
       requestBody = JSON.parse(init.body);
-      return new Response(JSON.stringify({
-        content: [
-          { type: 'text', text: 'commit' },
-          { type: 'text', text: ' message' },
-        ],
-      }));
+      return streamResponse([
+        { type: 'content_block_delta', delta: { type: 'text_delta', text: 'commit' } },
+        { type: 'content_block_delta', delta: { type: 'text_delta', text: ' message' } },
+      ]);
     });
 
     const result = await runAnthropicCompatibleSingleQuery(
@@ -292,6 +319,7 @@ describe('AnthropicCompatibleChatRuntime', () => {
       model: 'acme-opus',
       max_tokens: 4096,
       messages: [{ role: 'user', content: 'Generate a commit message' }],
+      stream: true,
     });
     expect(requestBody).not.toHaveProperty('output_config');
     expect(requestBody).not.toHaveProperty('thinking');
@@ -313,6 +341,7 @@ describe('AnthropicCompatibleChatRuntime', () => {
 
     expect(result).toBe('OK');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestBody.stream).toBe(true);
     expect(requestBody.output_config).toEqual({ effort: 'max' });
     expect(requestBody).not.toHaveProperty('thinking');
   });
@@ -328,6 +357,122 @@ describe('AnthropicCompatibleChatRuntime', () => {
     )).rejects.toThrow('Direct (Anthropic) API error 400: unsupported effort');
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores one-shot thinking and signature deltas before visible text', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hidden' } },
+      { type: 'content_block_delta', delta: { type: 'signature_delta', signature: 'secret' } },
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: 'visible' } },
+    ]));
+
+    await expect(runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+    )).resolves.toBe('visible');
+  });
+
+  it('returns no visible one-shot text for a completed thinking-only stream', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hidden' } },
+    ]));
+
+    await expect(runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+    )).resolves.toBe('');
+  });
+
+  it('accepts buffered JSON when Anthropic ignores the streaming request', async () => {
+    globalThis.fetch = mock(async () => Response.json({
+      content: [
+        { type: 'thinking', thinking: 'hidden' },
+        { type: 'text', text: 'visible' },
+      ],
+    }));
+
+    await expect(runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+    )).resolves.toBe('visible');
+  });
+
+  it('rejects partial one-shot text followed by an Anthropic error event', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: 'partial' } },
+      { type: 'error', error: { message: 'generation failed' } },
+    ]));
+
+    await expect(runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+    )).rejects.toThrow('Direct (Anthropic) stream error: generation failed');
+  });
+
+  it('rejects a one-shot stream that closes before message_stop', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: 'partial' } },
+    ], { complete: false }));
+
+    await expect(runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+    )).rejects.toThrow('Direct (Anthropic) stream ended before message_stop.');
+  });
+
+  it('skips malformed one-shot events before valid text and message_stop', async () => {
+    const encoder = new TextEncoder();
+    globalThis.fetch = mock(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {malformed}\n\n'));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'valid' },
+        })}\n\n`));
+        controller.enqueue(encoder.encode('data: {"type":"message_stop"}\n\n'));
+        controller.close();
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+    }));
+
+    await expect(runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+    )).resolves.toBe('valid');
+  });
+
+  it('preserves caller abort while reading a one-shot stream', async () => {
+    const externalController = new AbortController();
+    const encoder = new TextEncoder();
+    let markBodyStarted;
+    const bodyStarted = new Promise((resolve) => {
+      markBodyStarted = resolve;
+    });
+    globalThis.fetch = mock(async (_url, init) => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'partial' },
+        })}\n\n`));
+        init.signal.addEventListener('abort', () => {
+          controller.error(init.signal.reason);
+        }, { once: true });
+        markBodyStarted();
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+    }));
+
+    const result = runAnthropicCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'test',
+      { signal: externalController.signal },
+    );
+    await bodyStarted;
+    externalController.abort(new DOMException('Stopped', 'AbortError'));
+
+    await expect(result).rejects.toThrow('Stopped');
   });
 
   it('rejects partial streamed text followed by an Anthropic error event', async () => {

--- a/server-agents/common/src/direct/__tests__/openai-compatible-chat-runtime.test.js
+++ b/server-agents/common/src/direct/__tests__/openai-compatible-chat-runtime.test.js
@@ -229,6 +229,50 @@ describe('OpenAiCompatibleChatRuntime', () => {
     expect(result).toBe('generated message');
   });
 
+  it('accepts a buffered JSON response for an interactive session', async () => {
+    const dir = await tempDir();
+    globalThis.fetch = mock(async () => Response.json({
+      choices: [{ message: { content: 'session response' } }],
+    }));
+    const runtime = new OpenAiCompatibleChatRuntime(runtimeConfig(dir));
+    const messages = waitForMessages(runtime);
+
+    await runtime.startSession({
+      chatId: 'chat-json',
+      command: 'hello',
+      projectPath: '/tmp/project',
+      model: 'selected-model',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      claudeThinkingMode: 'auto',
+    });
+
+    await expect(messages).resolves.toMatchObject([{ content: 'session response' }]);
+  });
+
+  it('ignores reasoning-only deltas before visible one-shot content', async () => {
+    const encoder = new TextEncoder();
+    globalThis.fetch = mock(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          choices: [{ delta: { reasoning_content: 'hidden' } }],
+        })}\n\n`));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          choices: [{ delta: { content: 'visible' } }],
+        })}\n\n`));
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+    }));
+
+    await expect(runOpenAiCompatibleSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'Describe the change.',
+    )).resolves.toBe('visible');
+  });
+
   it('surfaces a provider error from an empty one-shot stream', async () => {
     const encoder = new TextEncoder();
     globalThis.fetch = mock(async () => new Response(new ReadableStream({

--- a/server-agents/common/src/direct/__tests__/openai-compatible-responses-runtime.test.js
+++ b/server-agents/common/src/direct/__tests__/openai-compatible-responses-runtime.test.js
@@ -4,8 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   OpenAiCompatibleResponsesRuntime,
-  applyResponsesStreamEvent,
   buildOpenAiResponsesUserContent,
+  consumeResponsesStreamEvent,
   extractOpenAiResponsesTextContent,
   extractResponsesOutputText,
   runOpenAiResponsesSingleQuery,
@@ -14,11 +14,14 @@ import {
 const createdDirs = [];
 const originalFetch = globalThis.fetch;
 
-function streamResponse(chunks) {
+function streamResponse(chunks, options = {}) {
   const encoder = new TextEncoder();
+  const events = options.complete === false
+    ? chunks
+    : [...chunks, { type: 'response.completed', response: { status: 'completed' } }];
   return new Response(new ReadableStream({
     start(controller) {
-      for (const chunk of chunks) {
+      for (const chunk of events) {
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
       }
       controller.close();
@@ -90,24 +93,36 @@ describe('OpenAiCompatibleResponsesRuntime', () => {
     })).toBe('hello');
   });
 
-  it('applies streaming deltas and stream errors', () => {
-    expect(applyResponsesStreamEvent('hel', {
+  it('tracks streaming deltas, errors, and terminal state', () => {
+    const state = { text: 'hel', errorMessage: null, terminal: null };
+    consumeResponsesStreamEvent(state, {
       type: 'response.output_text.delta',
       delta: 'lo',
-    })).toEqual({ text: 'hello' });
-    expect(applyResponsesStreamEvent('', {
+    });
+    expect(state).toEqual({ text: 'hello', errorMessage: null, terminal: null });
+
+    consumeResponsesStreamEvent(state, {
       type: 'response.failed',
       response: { status_details: { error: { message: 'bad request' } } },
-    })).toEqual({ text: '', error: 'bad request' });
+    });
+    expect(state).toEqual({
+      text: 'hello',
+      errorMessage: 'bad request',
+      terminal: 'failed',
+    });
   });
 
-  it('posts single queries to /responses and extracts output text', async () => {
+  it('posts streaming single queries to /responses and extracts output text', async () => {
     let requestUrl = '';
     let requestBody;
     globalThis.fetch = mock(async (url, init) => {
       requestUrl = String(url);
       requestBody = JSON.parse(init.body);
-      return Response.json({ output_text: 'single response' });
+      return streamResponse([
+        { type: 'response.reasoning_summary_text.delta', delta: 'hidden' },
+        { type: 'response.output_text.delta', delta: 'single' },
+        { type: 'response.output_text.delta', delta: ' response' },
+      ]);
     });
 
     const dir = await tempDir();
@@ -122,6 +137,7 @@ describe('OpenAiCompatibleResponsesRuntime', () => {
     expect(requestBody).toEqual({
       model: 'selected-model',
       input: [{ role: 'user', content: 'hi' }],
+      stream: true,
       store: false,
       reasoning: { effort: 'ultra' },
     });
@@ -139,6 +155,179 @@ describe('OpenAiCompatibleResponsesRuntime', () => {
     });
 
     expect(requestBody).not.toHaveProperty('reasoning');
+    expect(requestBody.stream).toBe(true);
+  });
+
+  it('accepts buffered JSON when a Responses provider ignores streaming', async () => {
+    globalThis.fetch = mock(async () => Response.json({
+      output: [{
+        type: 'message',
+        content: [{ type: 'output_text', text: 'buffered response' }],
+      }],
+    }));
+
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).resolves.toBe('buffered response');
+  });
+
+  it('rejects failed and incomplete buffered Responses payloads', async () => {
+    globalThis.fetch = mock(async () => Response.json({
+      status: 'failed',
+      output_text: 'partial',
+      error: { message: 'generation failed' },
+    }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) response error: generation failed');
+
+    globalThis.fetch = mock(async () => Response.json({
+      status: 'incomplete',
+      output_text: 'partial',
+      incomplete_details: { reason: 'max_output_tokens' },
+    }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) response error: max_output_tokens');
+
+    globalThis.fetch = mock(async () => Response.json({
+      error: { message: 'buffered provider error' },
+    }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) response error: buffered provider error');
+  });
+
+  it('rejects a stream error after partial one-shot output', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'response.output_text.delta', delta: 'partial' },
+      { type: 'error', error: { message: 'generation failed' } },
+    ]));
+
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) stream error: generation failed');
+  });
+
+  it('rejects failed and incomplete one-shot streams after partial output', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'response.output_text.delta', delta: 'partial' },
+      {
+        type: 'response.failed',
+        response: { error: { message: 'provider failed' } },
+      },
+    ], { complete: false }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) stream error: provider failed');
+
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'response.output_text.delta', delta: 'partial' },
+      {
+        type: 'response.incomplete',
+        response: { incomplete_details: { reason: 'max_output_tokens' } },
+      },
+    ], { complete: false }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) stream error: max_output_tokens');
+  });
+
+  it('rejects failed and incomplete one-shot streams before visible output', async () => {
+    globalThis.fetch = mock(async () => streamResponse([{
+      type: 'response.failed',
+      response: { error: { message: 'provider failed before output' } },
+    }], { complete: false }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) stream error: provider failed before output');
+
+    globalThis.fetch = mock(async () => streamResponse([{
+      type: 'response.incomplete',
+      response: { incomplete_details: { reason: 'content_filter' } },
+    }], { complete: false }));
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow('Direct (Responses) stream error: content_filter');
+  });
+
+  it('requires response.completed for one-shot streams', async () => {
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'response.output_text.delta', delta: 'partial' },
+    ], { complete: false }));
+
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).rejects.toThrow(
+      'Direct (Responses) stream ended before response.completed.',
+    );
+  });
+
+  it('skips malformed and reasoning events before valid one-shot output', async () => {
+    const encoder = new TextEncoder();
+    globalThis.fetch = mock(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {malformed}\n\n'));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          type: 'response.reasoning_text.delta',
+          delta: 'hidden',
+        })}\n\n`));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          type: 'response.output_text.delta',
+          delta: 'visible',
+        })}\n\n`));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          type: 'response.completed',
+          response: { status: 'completed' },
+        })}\n\n`));
+        controller.close();
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+    }));
+
+    await expect(runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+    )).resolves.toBe('visible');
+  });
+
+  it('preserves caller abort while reading a one-shot stream', async () => {
+    const externalController = new AbortController();
+    const encoder = new TextEncoder();
+    globalThis.fetch = mock(async (_url, init) => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+          type: 'response.output_text.delta',
+          delta: 'partial',
+        })}\n\n`));
+        init.signal.addEventListener('abort', () => {
+          controller.error(init.signal.reason);
+        }, { once: true });
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+    }));
+
+    const result = runOpenAiResponsesSingleQuery(
+      runtimeConfig('/tmp/unused'),
+      'hi',
+      { signal: externalController.signal },
+    );
+    await Promise.resolve();
+    externalController.abort(new DOMException('Stopped', 'AbortError'));
+
+    await expect(result).rejects.toThrow('Stopped');
   });
 
   it('streams Direct Responses turns and persists assistant text', async () => {
@@ -182,6 +371,53 @@ describe('OpenAiCompatibleResponsesRuntime', () => {
     const persisted = await fs.readFile(path.join(dir, `${started.agentSessionId}.jsonl`), 'utf8');
     expect(persisted).toContain('"content":"hi"');
     expect(persisted).toContain('"content":"hello world"');
+  });
+
+  it('accepts a buffered JSON response for an interactive Responses session', async () => {
+    const dir = await tempDir();
+    globalThis.fetch = mock(async () => Response.json({ output_text: 'session response' }));
+    const runtime = new OpenAiCompatibleResponsesRuntime(runtimeConfig(dir));
+    const messages = waitForMessages(runtime);
+
+    await runtime.startSession({
+      chatId: 'chat-json',
+      command: 'hi',
+      projectPath: '/tmp/project',
+      model: 'selected-model',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      claudeThinkingMode: 'auto',
+    });
+
+    await expect(messages).resolves.toMatchObject([{ content: 'session response' }]);
+  });
+
+  it('does not emit or persist partial session output after a stream failure', async () => {
+    const dir = await tempDir();
+    globalThis.fetch = mock(async () => streamResponse([
+      { type: 'response.output_text.delta', delta: 'partial' },
+      { type: 'response.failed', response: { error: { message: 'failed' } } },
+    ], { complete: false }));
+    const runtime = new OpenAiCompatibleResponsesRuntime(runtimeConfig(dir));
+    const emitted = mock(() => {});
+    runtime.onMessages(emitted);
+    const failure = new Promise((resolve) => runtime.onFailed((_chatId, message) => resolve(message)));
+
+    const started = await runtime.startSession({
+      chatId: 'chat-failed',
+      command: 'hi',
+      projectPath: '/tmp/project',
+      model: 'selected-model',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      claudeThinkingMode: 'auto',
+    });
+
+    await expect(failure).resolves.toBe('Direct (Responses) stream error: failed');
+    expect(emitted).not.toHaveBeenCalled();
+    const persisted = await fs.readFile(started.nativePath, 'utf8');
+    expect(persisted).toContain('"content":"hi"');
+    expect(persisted).not.toContain('partial');
   });
 
   it('forwards the current interactive effort and removes it for Default', async () => {

--- a/server-agents/common/src/direct/__tests__/response-media-type.test.js
+++ b/server-agents/common/src/direct/__tests__/response-media-type.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+import { isJsonResponse } from '../response-media-type.ts';
+
+describe('isJsonResponse', () => {
+  it('recognizes JSON and structured JSON media types', () => {
+    expect(isJsonResponse(Response.json({}))).toBe(true);
+    expect(isJsonResponse(new Response('', {
+      headers: { 'content-type': 'application/problem+json; charset=utf-8' },
+    }))).toBe(true);
+  });
+
+  it('treats SSE and missing content types as streaming responses', () => {
+    expect(isJsonResponse(new Response('', {
+      headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+    }))).toBe(false);
+    expect(isJsonResponse(new Response(null))).toBe(false);
+  });
+});

--- a/server-agents/common/src/direct/anthropic-compatible-chat-runtime.ts
+++ b/server-agents/common/src/direct/anthropic-compatible-chat-runtime.ts
@@ -15,6 +15,7 @@ import {
   directSingleQueryTimeoutMs,
 } from './single-query-options.js';
 import { resolveDirectExplicitEffort } from './reasoning-effort.js';
+import { isJsonResponse } from './response-media-type.js';
 
 const STREAM_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_MAX_TOKENS = 4096;
@@ -153,6 +154,42 @@ function consumeAnthropicEvent(state: AnthropicStreamState, data: string): void 
   }
 }
 
+async function readAnthropicCompatibleResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string> {
+  if (isJsonResponse(response)) {
+    const data = await response.json() as {
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    return (data.content ?? [])
+      .filter((part) => part.type === 'text' && typeof part.text === 'string')
+      .map((part) => part.text)
+      .join('');
+  }
+
+  if (!response.body) {
+    throw new Error(`${runtimeLabel} response did not include a stream body.`);
+  }
+
+  const state: AnthropicStreamState = {
+    text: '',
+    errorMessage: null,
+    sawMessageStop: false,
+  };
+  await readSseDataEvents(response.body, (data) => {
+    consumeAnthropicEvent(state, data);
+  });
+
+  if (state.errorMessage) {
+    throw new Error(`${runtimeLabel} stream error: ${state.errorMessage}`);
+  }
+  if (!state.sawMessageStop) {
+    throw new Error(`${runtimeLabel} stream ended before message_stop.`);
+  }
+  return state.text;
+}
+
 export async function runAnthropicCompatibleSingleQuery(
   config: AnthropicCompatibleChatRuntimeConfig,
   prompt: string,
@@ -174,6 +211,7 @@ export async function runAnthropicCompatibleSingleQuery(
         model,
         max_tokens: config.maxTokens ?? DEFAULT_MAX_TOKENS,
         messages: [{ role: 'user', content: prompt }],
+        stream: true,
         ...(reasoningEffort ? { output_config: { effort: reasoningEffort } } : {}),
       }),
       signal: directSingleQuerySignal(options, controller.signal),
@@ -184,14 +222,7 @@ export async function runAnthropicCompatibleSingleQuery(
       throw new Error(`${config.runtimeLabel} API error ${response.status}: ${errorText}`);
     }
 
-    const data = await response.json() as {
-      content?: Array<{ type?: string; text?: string }>;
-    };
-    return (data.content ?? [])
-      .filter((part) => part.type === 'text' && typeof part.text === 'string')
-      .map((part) => part.text)
-      .join('')
-      .trim();
+    return (await readAnthropicCompatibleResponse(response, config.runtimeLabel)).trim();
   } finally {
     clearTimeout(timer);
   }
@@ -248,28 +279,7 @@ export class AnthropicCompatibleChatRuntime extends DirectChatRuntimeBase<
         const errorText = await response.text();
         throw new Error(`${this.config.runtimeLabel} API error ${response.status}: ${errorText}`);
       }
-      if (!response.body) {
-        throw new Error(`${this.config.runtimeLabel} response did not include a stream body.`);
-      }
-
-      const state: AnthropicStreamState = {
-        text: '',
-        errorMessage: null,
-        sawMessageStop: false,
-      };
-
-      await readSseDataEvents(response.body, (data) => {
-        consumeAnthropicEvent(state, data);
-      });
-
-      if (state.errorMessage) {
-        throw new Error(`${this.config.runtimeLabel} stream error: ${state.errorMessage}`);
-      }
-      if (!state.sawMessageStop) {
-        throw new Error(`${this.config.runtimeLabel} stream ended before message_stop.`);
-      }
-
-      return state.text;
+      return await readAnthropicCompatibleResponse(response, this.config.runtimeLabel);
     } finally {
       clearTimeout(streamTimer);
       session.abortController = null;

--- a/server-agents/common/src/direct/openai-compatible-chat-runtime.ts
+++ b/server-agents/common/src/direct/openai-compatible-chat-runtime.ts
@@ -17,6 +17,7 @@ import {
   directSingleQueryTimeoutMs,
 } from './single-query-options.js';
 import { resolveDirectExplicitEffort } from './reasoning-effort.js';
+import { isJsonResponse } from './response-media-type.js';
 
 const SILENT_LOGGER: AgentLogger = Object.freeze({
   debug() {},
@@ -158,12 +159,11 @@ async function readOpenAiCompatibleTextStream(
   return accumulated;
 }
 
-async function readOpenAiCompatibleSingleQueryResponse(
+async function readOpenAiCompatibleResponse(
   response: Response,
   runtimeLabel: string,
 ): Promise<string> {
-  const mediaType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
-  if (mediaType !== 'application/json' && !mediaType?.endsWith('+json')) {
+  if (!isJsonResponse(response)) {
     return readOpenAiCompatibleTextStream(response, runtimeLabel);
   }
 
@@ -209,7 +209,7 @@ export async function runOpenAiCompatibleSingleQuery(
       throw new Error(`${config.runtimeLabel} API error ${response.status}: ${errorText}`);
     }
 
-    return (await readOpenAiCompatibleSingleQueryResponse(response, config.runtimeLabel)).trim();
+    return (await readOpenAiCompatibleResponse(response, config.runtimeLabel)).trim();
   } finally {
     clearTimeout(timer);
   }
@@ -271,7 +271,7 @@ export class OpenAiCompatibleChatRuntime extends DirectChatRuntimeBase<
         const errorText = await response.text();
         throw new Error(`${this.config.runtimeLabel} API error ${response.status}: ${errorText}`);
       }
-      return await readOpenAiCompatibleTextStream(response, this.config.runtimeLabel);
+      return await readOpenAiCompatibleResponse(response, this.config.runtimeLabel);
     } finally {
       clearTimeout(streamTimer);
       session.abortController = null;

--- a/server-agents/common/src/direct/openai-compatible-responses-runtime.ts
+++ b/server-agents/common/src/direct/openai-compatible-responses-runtime.ts
@@ -16,6 +16,7 @@ import {
   directSingleQueryTimeoutMs,
 } from './single-query-options.js';
 import { resolveDirectExplicitEffort } from './reasoning-effort.js';
+import { isJsonResponse } from './response-media-type.js';
 
 const STREAM_TIMEOUT_MS = 5 * 60_000;
 
@@ -127,43 +128,117 @@ export function extractResponsesOutputText(data: unknown): string {
     .trim();
 }
 
-export function applyResponsesStreamEvent(accumulated: string, event: unknown): {
+export interface ResponsesStreamState {
   text: string;
-  error?: string;
-} {
-  if (!event || typeof event !== 'object') return { text: accumulated };
-  const parsed = event as {
-    type?: string;
-    delta?: unknown;
+  errorMessage: string | null;
+  terminal: 'completed' | 'failed' | 'incomplete' | null;
+}
+
+interface ResponsesStreamEvent {
+  type?: string;
+  delta?: unknown;
+  error?: { message?: unknown };
+  response?: {
     error?: { message?: unknown };
-    response?: { status_details?: { error?: { message?: unknown } } };
+    incomplete_details?: { reason?: unknown };
+    status_details?: { error?: { message?: unknown } };
   };
+}
+
+function responsesFailureMessage(event: ResponsesStreamEvent): string {
+  const directMessage = event.response?.error?.message;
+  if (typeof directMessage === 'string') return directMessage;
+
+  const compatibleMessage = event.response?.status_details?.error?.message;
+  if (typeof compatibleMessage === 'string') return compatibleMessage;
+
+  const incompleteReason = event.response?.incomplete_details?.reason;
+  if (typeof incompleteReason === 'string') return incompleteReason;
+
+  return `Responses stream ended with ${event.type ?? 'an unknown failure'}.`;
+}
+
+export function consumeResponsesStreamEvent(
+  state: ResponsesStreamState,
+  event: unknown,
+): void {
+  if (!event || typeof event !== 'object') return;
+  const parsed = event as ResponsesStreamEvent;
 
   if (parsed.type === 'response.output_text.delta') {
-    return {
-      text: accumulated + (typeof parsed.delta === 'string' ? parsed.delta : ''),
-    };
+    if (typeof parsed.delta === 'string') state.text += parsed.delta;
+    return;
+  }
+
+  if (parsed.type === 'response.completed') {
+    state.terminal = 'completed';
+    return;
   }
 
   if (parsed.type === 'error') {
-    return {
-      text: accumulated,
-      error: typeof parsed.error?.message === 'string'
-        ? parsed.error.message
-        : 'Responses stream returned an error.',
-    };
+    state.errorMessage = typeof parsed.error?.message === 'string'
+      ? parsed.error.message
+      : 'Responses stream returned an error.';
+    return;
   }
 
   if (parsed.type === 'response.failed' || parsed.type === 'response.incomplete') {
-    return {
-      text: accumulated,
-      error: typeof parsed.response?.status_details?.error?.message === 'string'
-        ? parsed.response.status_details.error.message
-        : `Responses stream ended with ${parsed.type}.`,
+    state.terminal = parsed.type === 'response.failed' ? 'failed' : 'incomplete';
+    state.errorMessage = responsesFailureMessage(parsed);
+  }
+}
+
+async function readOpenAiResponsesResponse(
+  response: Response,
+  runtimeLabel: string,
+): Promise<string> {
+  if (isJsonResponse(response)) {
+    const data = await response.json() as {
+      status?: unknown;
+      error?: { message?: unknown };
+      incomplete_details?: { reason?: unknown };
+      status_details?: { error?: { message?: unknown } };
     };
+    const responseError = typeof data.error?.message === 'string'
+      ? data.error.message
+      : typeof data.status_details?.error?.message === 'string'
+        ? data.status_details.error.message
+        : null;
+    if (data.status === 'failed' || data.status === 'incomplete' || responseError) {
+      const detail = responseError
+        ?? (typeof data.incomplete_details?.reason === 'string'
+          ? data.incomplete_details.reason
+          : `Responses API returned status ${data.status}.`);
+      throw new Error(`${runtimeLabel} response error: ${detail}`);
+    }
+    return extractResponsesOutputText(data);
   }
 
-  return { text: accumulated };
+  if (!response.body) {
+    throw new Error(`${runtimeLabel} response did not include a stream body.`);
+  }
+
+  const state: ResponsesStreamState = {
+    text: '',
+    errorMessage: null,
+    terminal: null,
+  };
+  await readSseDataEvents(response.body, (data) => {
+    try {
+      consumeResponsesStreamEvent(state, JSON.parse(data));
+    } catch {
+      // Skips malformed chunks from partially-compatible providers.
+    }
+  });
+
+  if (state.errorMessage) {
+    throw new Error(`${runtimeLabel} stream error: ${state.errorMessage}`);
+  }
+  if (state.terminal !== 'completed') {
+    throw new Error(`${runtimeLabel} stream ended before response.completed.`);
+  }
+
+  return state.text;
 }
 
 export async function runOpenAiResponsesSingleQuery(
@@ -187,6 +262,7 @@ export async function runOpenAiResponsesSingleQuery(
       body: JSON.stringify({
         model,
         input: [{ role: 'user', content: prompt }],
+        stream: true,
         store: false,
         ...(reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {}),
       }),
@@ -195,10 +271,10 @@ export async function runOpenAiResponsesSingleQuery(
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`${config.runtimeLabel} Responses API error ${response.status}: ${errorText}`);
+      throw new Error(`${config.runtimeLabel} API error ${response.status}: ${errorText}`);
     }
 
-    return extractResponsesOutputText(await response.json());
+    return (await readOpenAiResponsesResponse(response, config.runtimeLabel)).trim();
   } finally {
     clearTimeout(timer);
   }
@@ -254,28 +330,9 @@ export class OpenAiCompatibleResponsesRuntime extends DirectChatRuntimeBase<
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`${this.config.runtimeLabel} Responses API error ${response.status}: ${errorText}`);
+        throw new Error(`${this.config.runtimeLabel} API error ${response.status}: ${errorText}`);
       }
-      if (!response.body) {
-        throw new Error(`${this.config.runtimeLabel} response did not include a stream body.`);
-      }
-
-      let accumulated = '';
-      let streamError = '';
-      await readSseDataEvents(response.body, (data) => {
-        try {
-          const result = applyResponsesStreamEvent(accumulated, JSON.parse(data));
-          accumulated = result.text;
-          if (result.error) streamError = result.error;
-        } catch {
-          // Skips malformed chunks from partially-compatible providers.
-        }
-      });
-
-      if (!accumulated.trim() && streamError) {
-        throw new Error(`${this.config.runtimeLabel} Responses stream error: ${streamError}`);
-      }
-      return accumulated;
+      return await readOpenAiResponsesResponse(response, this.config.runtimeLabel);
     } finally {
       clearTimeout(timer);
       session.abortController = null;

--- a/server-agents/common/src/direct/response-media-type.ts
+++ b/server-agents/common/src/direct/response-media-type.ts
@@ -1,0 +1,9 @@
+export function isJsonResponse(response: Response): boolean {
+  const mediaType = response.headers
+    .get('content-type')
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+
+  return mediaType === 'application/json' || mediaType?.endsWith('+json') === true;
+}

--- a/server-agents/common/src/shared/__tests__/single-query-control.test.ts
+++ b/server-agents/common/src/shared/__tests__/single-query-control.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test';
+import type { AgentSingleQueryRequest } from '@garcon/server-agent-interface';
+import {
+  singleQueryRuntimeOptions,
+  withSingleQueryControl,
+} from '../single-query-control.js';
+
+function request(overrides: Partial<AgentSingleQueryRequest> = {}): AgentSingleQueryRequest {
+  return {
+    prompt: 'prompt',
+    projectPath: '/repo',
+    model: 'model-a',
+    thinkingMode: 'high',
+    timeoutMs: 42_000,
+    settings: {
+      ownerId: 'test',
+      schemaVersion: 1,
+      values: { providerOption: true, thinkingMode: 'low', timeoutMs: 1 },
+    },
+    endpoint: null,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+describe('single-query controls', () => {
+  it('places canonical controls after provider settings', () => {
+    const input = request();
+
+    expect(singleQueryRuntimeOptions(input)).toEqual({
+      providerOption: true,
+      thinkingMode: 'high',
+      timeoutMs: 42_000,
+      signal: input.signal,
+    });
+  });
+
+  it('propagates caller cancellation to the running operation', async () => {
+    const caller = new AbortController();
+    const reason = new Error('cancelled');
+    const running = withSingleQueryControl({ signal: caller.signal }, async (signal) => {
+      await new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }));
+      signal.throwIfAborted();
+      return 'unreachable';
+    });
+
+    caller.abort(reason);
+
+    await expect(running).rejects.toBe(reason);
+  });
+
+  it('terminates the operation at the requested timeout', async () => {
+    const running = withSingleQueryControl({ timeoutMs: 1 }, async () => (
+      await new Promise<string>(() => {})
+    ));
+
+    await expect(running).rejects.toMatchObject({ code: 'TIMEOUT' });
+  });
+});

--- a/server-agents/common/src/shared/single-query-control.ts
+++ b/server-agents/common/src/shared/single-query-control.ts
@@ -1,0 +1,62 @@
+import {
+  AgentIntegrationError,
+  type AgentSingleQueryRequest,
+} from '@garcon/server-agent-interface';
+
+export interface SingleQueryControlOptions {
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}
+
+export function singleQueryRuntimeOptions(
+  request: AgentSingleQueryRequest,
+): Record<string, unknown> & SingleQueryControlOptions {
+  return {
+    ...request.settings.values,
+    thinkingMode: request.thinkingMode,
+    ...(request.timeoutMs === undefined ? {} : { timeoutMs: request.timeoutMs }),
+    signal: request.signal,
+  };
+}
+
+export async function withSingleQueryControl<T>(
+  options: { readonly signal?: unknown; readonly timeoutMs?: unknown },
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const callerSignal = options.signal instanceof AbortSignal ? options.signal : null;
+  const abortFromCaller = () => controller.abort(callerSignal?.reason);
+  callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+  if (callerSignal?.aborted) abortFromCaller();
+
+  const timeoutMs = normalizedTimeoutMs(options.timeoutMs);
+  const timeout = timeoutMs === null
+    ? null
+    : setTimeout(() => controller.abort(new AgentIntegrationError(
+      'TIMEOUT',
+      `Single query timed out after ${timeoutMs}ms.`,
+      true,
+    )), timeoutMs);
+  timeout?.unref?.();
+
+  let removeAbortRejection = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    const rejectAborted = () => reject(controller.signal.reason);
+    controller.signal.addEventListener('abort', rejectAborted, { once: true });
+    removeAbortRejection = () => controller.signal.removeEventListener('abort', rejectAborted);
+  });
+
+  try {
+    controller.signal.throwIfAborted();
+    return await Promise.race([operation(controller.signal), aborted]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
+    removeAbortRejection();
+  }
+}
+
+function normalizedTimeoutMs(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  return Math.max(1, Math.round(value));
+}

--- a/server-agents/cursor/src/agents/cursor/run-single-query.ts
+++ b/server-agents/cursor/src/agents/cursor/run-single-query.ts
@@ -8,6 +8,7 @@ import {
   AGENT_UNSUPPORTED_SINGLE_QUERY_THINKING_MODE,
   AgentIntegrationError,
 } from '@garcon/server-agent-interface';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 
 interface CursorSingleQueryOptions {
   cwd?: string;
@@ -77,78 +78,88 @@ export async function runSingleQuery(
       AGENT_UNSUPPORTED_SINGLE_QUERY_THINKING_MODE,
     );
   }
-  const options = normalizeOptions(rawOptions);
-  const cwd = options.cwd || options.projectPath || process.cwd();
-  const transport = options.createTransport?.() ?? new AcpTransport();
-  const client = new AcpClient(transport, {
-    initialize: {
-      protocolVersion: 1,
-      clientInfo: { name: 'garcon', version: '1.0.0' },
-      clientCapabilities: { _meta: { parameterizedModelPicker: true } },
-      mcpServers: [],
-    },
-    authenticateMethodId: 'cursor_login',
+  return withSingleQueryControl(rawOptions, async (signal) => {
+    const options = normalizeOptions(rawOptions);
+    const cwd = options.cwd || options.projectPath || process.cwd();
+    const timeoutMs = typeof rawOptions.timeoutMs === 'number' && Number.isFinite(rawOptions.timeoutMs)
+      ? Math.max(1, Math.round(rawOptions.timeoutMs))
+      : undefined;
+    const transport = options.createTransport?.() ?? new AcpTransport(
+      timeoutMs === undefined ? {} : { requestTimeoutMs: timeoutMs },
+    );
+    const client = new AcpClient(transport, {
+      initialize: {
+        protocolVersion: 1,
+        clientInfo: { name: 'garcon', version: '1.0.0' },
+        clientCapabilities: { _meta: { parameterizedModelPicker: true } },
+        mcpServers: [],
+      },
+      authenticateMethodId: 'cursor_login',
+    });
+    const assistantChunks: string[] = [];
+    const abort = () => client.close();
+    signal.addEventListener('abort', abort, { once: true });
+
+    client.onRpcMessage((message) => {
+      if (message.method === 'session/request_permission' && isJsonRpcId(message.id)) {
+        client.respond(message.id, { outcome: { outcome: 'selected', optionId: 'reject-once' } });
+        return;
+      }
+
+      if (message.method === 'cursor/ask_question' && isJsonRpcId(message.id)) {
+        client.respond(message.id, { outcome: { outcome: 'skipped', reason: 'Noninteractive query' } });
+        return;
+      }
+
+      if (message.method === 'cursor/create_plan' && isJsonRpcId(message.id)) {
+        client.respond(message.id, { outcome: { outcome: 'rejected', reason: 'Noninteractive query' } });
+        return;
+      }
+
+      if (typeof message.method === 'string' && isJsonRpcId(message.id)) {
+        client.respondError(message.id, -32601, `Unsupported ACP request method: ${message.method}`);
+        return;
+      }
+
+      if (message.method !== 'session/update') return;
+      const params = asObject(message.params);
+      const update = asObject(params.update);
+      const updateType = asString(update.sessionUpdate);
+      if (updateType === 'agent_message_chunk' || updateType === 'agent_message') {
+        assistantChunks.push(textFromContent(update.content));
+      }
+    });
+
+    try {
+      await client.connect({
+        command: config.binary(),
+        args: ['acp'],
+        cwd,
+        env: optionsEnv(options, config),
+      });
+
+      const created = await client.newSession({
+        cwd,
+        mcpServers: [],
+      });
+
+      await configureCursorAcpSessionOptions({
+        client,
+        sessionId: created.sessionId,
+        model: options.model ?? 'default',
+        mode: 'ask',
+        configOptions: created.configOptions,
+      });
+
+      await client.promptSession({
+        sessionId: created.sessionId,
+        prompt: [{ type: 'text', text: prompt.trim() }],
+      });
+
+      return assistantChunks.join('').trim();
+    } finally {
+      signal.removeEventListener('abort', abort);
+      client.close();
+    }
   });
-  const assistantChunks: string[] = [];
-
-  client.onRpcMessage((message) => {
-    if (message.method === 'session/request_permission' && isJsonRpcId(message.id)) {
-      client.respond(message.id, { outcome: { outcome: 'selected', optionId: 'reject-once' } });
-      return;
-    }
-
-    if (message.method === 'cursor/ask_question' && isJsonRpcId(message.id)) {
-      client.respond(message.id, { outcome: { outcome: 'skipped', reason: 'Noninteractive query' } });
-      return;
-    }
-
-    if (message.method === 'cursor/create_plan' && isJsonRpcId(message.id)) {
-      client.respond(message.id, { outcome: { outcome: 'rejected', reason: 'Noninteractive query' } });
-      return;
-    }
-
-    if (typeof message.method === 'string' && isJsonRpcId(message.id)) {
-      client.respondError(message.id, -32601, `Unsupported ACP request method: ${message.method}`);
-      return;
-    }
-
-    if (message.method !== 'session/update') return;
-    const params = asObject(message.params);
-    const update = asObject(params.update);
-    const updateType = asString(update.sessionUpdate);
-    if (updateType === 'agent_message_chunk' || updateType === 'agent_message') {
-      assistantChunks.push(textFromContent(update.content));
-    }
-  });
-
-  try {
-    await client.connect({
-      command: config.binary(),
-      args: ['acp'],
-      cwd,
-      env: optionsEnv(options, config),
-    });
-
-    const created = await client.newSession({
-      cwd,
-      mcpServers: [],
-    });
-
-    await configureCursorAcpSessionOptions({
-      client,
-      sessionId: created.sessionId,
-      model: options.model ?? 'default',
-      mode: 'ask',
-      configOptions: created.configOptions,
-    });
-
-    await client.promptSession({
-      sessionId: created.sessionId,
-      prompt: [{ type: 'text', text: prompt.trim() }],
-    });
-
-    return assistantChunks.join('').trim();
-  } finally {
-    client.close();
-  }
 }

--- a/server-agents/cursor/src/index.ts
+++ b/server-agents/cursor/src/index.ts
@@ -14,6 +14,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createCursorConfig } from './config.js';
 import { AcpAgentRuntime } from './agents/shared/acp-agent-runtime.js';
 import { createCursorAcpPolicy } from './agents/cursor/cursor-acp-policy.js';
@@ -150,7 +151,7 @@ export default class CursorAgentIntegration implements AgentIntegration {
           return await runSingleQuery(request.prompt, {
             projectPath: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           }, config);
         } catch (error) {
           if (error instanceof AgentIntegrationError) throw error;

--- a/server-agents/direct-anthropic-compatible/src/index.ts
+++ b/server-agents/direct-anthropic-compatible/src/index.ts
@@ -25,6 +25,7 @@ import { createIntegrationLifecycle } from '@garcon/server-agent-common/lifecycl
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 
 const SESSIONS_LABEL = 'anthropic-compatible-sessions';
 
@@ -144,7 +145,7 @@ export default class DirectAnthropicCompatibleIntegration implements AgentIntegr
           return await runtime.runSingleQuery(request.prompt, endpoint, {
             projectPath: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           });
         } catch (error) {
           throw classifyDirectIntegrationError(error);

--- a/server-agents/direct-openai-compatible/src/index.ts
+++ b/server-agents/direct-openai-compatible/src/index.ts
@@ -25,6 +25,7 @@ import { createIntegrationLifecycle } from '@garcon/server-agent-common/lifecycl
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 
 const SESSIONS_LABEL = 'openai-compatible-sessions';
 
@@ -144,7 +145,7 @@ export default class DirectOpenAiCompatibleIntegration implements AgentIntegrati
           return await runtime.runSingleQuery(request.prompt, endpoint, {
             projectPath: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           });
         } catch (error) {
           throw classifyDirectIntegrationError(error);

--- a/server-agents/direct-openai-responses-compatible/src/index.ts
+++ b/server-agents/direct-openai-responses-compatible/src/index.ts
@@ -25,6 +25,7 @@ import { createIntegrationLifecycle } from '@garcon/server-agent-common/lifecycl
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 
 const SESSIONS_LABEL = 'openai-compatible-responses-sessions';
 
@@ -144,7 +145,7 @@ export default class DirectOpenAiResponsesCompatibleIntegration implements Agent
           return await runtime.runSingleQuery(request.prompt, endpoint, {
             projectPath: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           });
         } catch (error) {
           throw classifyDirectIntegrationError(error);

--- a/server-agents/factory/src/agents/factory/factory-cli.ts
+++ b/server-agents/factory/src/agents/factory/factory-cli.ts
@@ -25,6 +25,7 @@ import { inferFactoryModelSupportsImages, isFactoryCustomModel } from './factory
 import { buildFactoryCliEnv } from './factory-env.js';
 import type { AgentLogger } from '@garcon/server-agent-interface';
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 import { findFactorySessionFileBySessionId } from './history-loader.js';
 import { convertFactoryAssistantText, visibleFactoryAssistantText } from './factory-text.js';
 import { normalizeThinkingMode } from '@garcon/common/chat-modes';
@@ -286,7 +287,7 @@ function buildFactoryEnvironment(config: FactoryConfig, airgap: boolean) {
 async function runFactoryExec(
   args: string[],
   prompt: string,
-  options: { airgap: boolean; config?: FactoryConfig },
+  options: { airgap: boolean; config?: FactoryConfig; signal?: AbortSignal },
 ): Promise<{ stderr: string; stdout: string }> {
   const factoryBinary = (options.config ?? DEFAULT_CONFIG).binary();
   const proc = Bun.spawn([factoryBinary, ...args], {
@@ -294,6 +295,7 @@ async function runFactoryExec(
     stdin: new Blob([prompt]),
     stdout: 'pipe',
     stderr: 'pipe',
+    signal: options.signal,
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([
@@ -301,6 +303,7 @@ async function runFactoryExec(
     new Response(proc.stderr as ReadableStream).text(),
     proc.exited,
   ]);
+  options.signal?.throwIfAborted();
 
   if (exitCode !== 0) {
     const details = (stderr || stdout || '').trim();
@@ -334,24 +337,27 @@ export async function runSingleQuery(
         : process.cwd(),
     thinkingMode: normalizeThinkingMode(options.thinkingMode),
   };
-  const metadata = request.model ? await models.getModelMetadata(request.model) : null;
-  const reasoningEffort = request.thinkingMode === 'none' ? undefined : request.thinkingMode;
-  const supportsImages = metadata?.supportsImages ?? inferFactoryModelSupportsImages(request.model);
-  const args = buildFactoryArgs(request, reasoningEffort).map((entry) => entry);
-  args[1] = '--output-format';
-  args[2] = 'json';
+  return withSingleQueryControl(options, async (signal) => {
+    const metadata = request.model ? await models.getModelMetadata(request.model) : null;
+    const reasoningEffort = request.thinkingMode === 'none' ? undefined : request.thinkingMode;
+    const supportsImages = metadata?.supportsImages ?? inferFactoryModelSupportsImages(request.model);
+    const args = buildFactoryArgs(request, reasoningEffort).map((entry) => entry);
+    args[1] = '--output-format';
+    args[2] = 'json';
 
-  const { cleanup, prompt: nextPrompt } = await buildFactoryPrompt(prompt, undefined, supportsImages, request.permissionMode);
-  try {
-    const { stdout } = await runFactoryExec(args, nextPrompt, {
-      airgap: shouldAirgapFactoryInvocation(request.model, { resume: false }),
-      config,
-    });
-    const parsed = JSON.parse(stdout) as { result?: string };
-    return typeof parsed.result === 'string' ? visibleFactoryAssistantText(parsed.result) : '';
-  } finally {
-    if (cleanup) await cleanup();
-  }
+    const { cleanup, prompt: nextPrompt } = await buildFactoryPrompt(prompt, undefined, supportsImages, request.permissionMode);
+    try {
+      const { stdout } = await runFactoryExec(args, nextPrompt, {
+        airgap: shouldAirgapFactoryInvocation(request.model, { resume: false }),
+        config,
+        signal,
+      });
+      const parsed = JSON.parse(stdout) as { result?: string };
+      return typeof parsed.result === 'string' ? visibleFactoryAssistantText(parsed.result) : '';
+    } finally {
+      if (cleanup) await cleanup();
+    }
+  });
 }
 
 function convertFactoryMessageEvent(event: FactoryMessageEvent): ChatMessage[] {

--- a/server-agents/factory/src/index.ts
+++ b/server-agents/factory/src/index.ts
@@ -15,6 +15,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createFactoryConfig } from './config.js';
 import { getFactoryAuthStatus } from './agents/factory/factory-auth.js';
 import { FactoryCliRuntime, runSingleQuery } from './agents/factory/factory-cli.js';
@@ -108,7 +109,7 @@ export default class FactoryAgentIntegration implements AgentIntegration {
           return await runSingleQuery(request.prompt, {
             cwd: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           }, config, models);
         } catch (error) {
           if (error instanceof AgentIntegrationError) throw error;

--- a/server-agents/interface/src/contracts/services.ts
+++ b/server-agents/interface/src/contracts/services.ts
@@ -12,6 +12,7 @@ import type {
   AgentSettingsEnvelope,
 } from '@garcon/common/agent-integration';
 import type { AgentModelOption } from '@garcon/common/agents';
+import type { ThinkingMode } from '@garcon/common/chat-modes';
 import type { JsonObject } from '@garcon/common/json';
 import type { SlashCommand } from '@garcon/common/slash-commands';
 import type {
@@ -103,6 +104,8 @@ export interface AgentSingleQueryRequest {
   readonly prompt: string;
   readonly projectPath: string;
   readonly model: string;
+  readonly thinkingMode: ThinkingMode;
+  readonly timeoutMs?: number;
   readonly settings: AgentSettingsEnvelope;
   readonly endpoint: AgentEndpointSelection | null;
   readonly signal: AbortSignal;

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -36,6 +36,7 @@ import {
 } from '@garcon/server-agent-interface';
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import { OpenCodeEndpointCoordinator } from './endpoint-coordinator.js';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 
 const SILENT_LOGGER: AgentLogger = Object.freeze({
   debug() {},
@@ -327,10 +328,15 @@ async function withAbortableTimeout<T>(
   operation: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   label: string,
+  callerSignal?: AbortSignal,
 ): Promise<T> {
   const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(callerSignal?.reason);
+  callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+  if (callerSignal?.aborted) abortFromCaller();
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   try {
+    controller.signal.throwIfAborted();
     return await Promise.race([
       operation(controller.signal),
       new Promise<never>((_, reject) => {
@@ -343,6 +349,7 @@ async function withAbortableTimeout<T>(
     ]);
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
   }
 }
 
@@ -1134,10 +1141,19 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     return modelsFromProviders(connectedProvidersFromListResult(result));
   }
 
-  async #runRequest<T>(label: string, operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  async #runRequest<T>(
+    label: string,
+    operation: (signal: AbortSignal) => Promise<T>,
+    control: { signal?: AbortSignal; timeoutMs?: number } = {},
+  ): Promise<T> {
     this.#endpointCoordinator.requestStarted();
     try {
-      return await withAbortableTimeout(operation, this.#options.requestTimeoutMs, label);
+      return await withAbortableTimeout(
+        operation,
+        control.timeoutMs ?? this.#options.requestTimeoutMs,
+        label,
+        control.signal,
+      );
     } catch (err) {
       if (err instanceof OpenCodeTimeoutError) {
         const reason = errorMessage(err);
@@ -1155,15 +1171,16 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     label: string,
     scope: OpenCodeRequestScope,
     operation: (signal: AbortSignal, scope: OpenCodeRequestScope) => Promise<T>,
+    control: { signal?: AbortSignal; timeoutMs?: number } = {},
   ): Promise<T> {
-    const result = await this.#runRequest<T>(label, (signal) => operation(signal, scope));
+    const result = await this.#runRequest<T>(label, (signal) => operation(signal, scope), control);
     if (!scope.directory || !isOpenCodeNotFoundResult(result)) return result;
 
     this.#logger.warn('OpenCode request missed the scoped directory; retrying without it', {
       label,
       directory: scope.directory,
     });
-    return await this.#runRequest<T>(`${label} legacy`, (signal) => operation(signal, {}));
+    return await this.#runRequest<T>(`${label} legacy`, (signal) => operation(signal, {}), control);
   }
 
   async startSession(request: OpenCodeStartRequest): Promise<string> {
@@ -1492,12 +1509,16 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     }
     const { cwd, projectPath, model, permissionMode = 'default' } = options;
     const scope = createOpenCodeRequestScope(projectPath || cwd);
-    return this.withClientLease(async (client) => {
+    const requestTimeoutMs = typeof options.timeoutMs === 'number' && Number.isFinite(options.timeoutMs)
+      ? Math.max(1, Math.round(options.timeoutMs))
+      : undefined;
+    return withSingleQueryControl(options, async (signal) => this.withClientLease(async (client) => {
       const createResult: any = await this.#runRequest<any>(
         'OpenCode session create',
-        (signal) => client.session.create(withOpenCodeRequestScope({
+        (requestSignal) => client.session.create(withOpenCodeRequestScope({
           permission: mapPermissionMode(permissionMode),
-        }, scope), { signal }),
+        }, scope), { signal: requestSignal }),
+        { signal, timeoutMs: requestTimeoutMs },
       );
 
       throwOpenCodeResultError(createResult, 'Failed to create OpenCode session');
@@ -1518,10 +1539,11 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
         const promptResult: any = await this.#runScopedSessionRequest<any>(
           'OpenCode prompt',
           scope,
-          (signal, requestScope) => client.session.prompt(withOpenCodeRequestScope({
+          (requestSignal, requestScope) => client.session.prompt(withOpenCodeRequestScope({
             sessionID: sessionId,
             ...body,
-          }, requestScope), { signal }),
+          }, requestScope), { signal: requestSignal }),
+          { signal, timeoutMs: requestTimeoutMs },
         );
 
         throwOpenCodeResultError(promptResult, 'OpenCode one-shot prompt failed');
@@ -1530,15 +1552,15 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
         await this.#runScopedSessionRequest(
           'OpenCode session delete',
           scope,
-          (signal, requestScope) => client.session.delete(
+          (requestSignal, requestScope) => client.session.delete(
             withOpenCodeRequestScope({ sessionID: sessionId }, requestScope),
-            { signal },
+            { signal: requestSignal },
           ),
         ).then((result) => {
           throwOpenCodeResultError(result, 'OpenCode session delete failed');
         }).catch(() => {});
       }
-    });
+    }));
   }
 
   startPurgeTimer(): void {

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -37,6 +37,10 @@ import {
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import { OpenCodeEndpointCoordinator } from './endpoint-coordinator.js';
 import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
+import {
+  OpenCodeTimeoutError,
+  withAbortableTimeout,
+} from './request-control.js';
 
 const SILENT_LOGGER: AgentLogger = Object.freeze({
   debug() {},
@@ -264,13 +268,6 @@ interface OpenCodeModelCache {
   fetchedAt: number;
 }
 
-class OpenCodeTimeoutError extends Error {
-  constructor(label: string, timeoutMs: number) {
-    super(`${label} timed out after ${timeoutMs}ms`);
-    this.name = 'OpenCodeTimeoutError';
-  }
-}
-
 function normalizeOptions(options: OpenCodeRuntimeOptions): NormalizedOpenCodeRuntimeOptions {
   return {
     startupTimeoutMs: options.startupTimeoutMs ?? DEFAULT_OPENCODE_STARTUP_TIMEOUT_MS,
@@ -322,35 +319,6 @@ function modelsFromProviders(providers: any[]): OpenCodeModelOption[] {
     }
   }
   return models;
-}
-
-async function withAbortableTimeout<T>(
-  operation: (signal: AbortSignal) => Promise<T>,
-  timeoutMs: number,
-  label: string,
-  callerSignal?: AbortSignal,
-): Promise<T> {
-  const controller = new AbortController();
-  const abortFromCaller = () => controller.abort(callerSignal?.reason);
-  callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
-  if (callerSignal?.aborted) abortFromCaller();
-  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  try {
-    controller.signal.throwIfAborted();
-    return await Promise.race([
-      operation(controller.signal),
-      new Promise<never>((_, reject) => {
-        timeoutHandle = setTimeout(() => {
-          const error = new OpenCodeTimeoutError(label, timeoutMs);
-          controller.abort(error);
-          reject(error);
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-    callerSignal?.removeEventListener('abort', abortFromCaller);
-  }
 }
 
 function stopOpenCodeProcess(proc: ChildProcess): void {

--- a/server-agents/opencode/src/agents/opencode/request-control.ts
+++ b/server-agents/opencode/src/agents/opencode/request-control.ts
@@ -1,0 +1,35 @@
+export class OpenCodeTimeoutError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`${label} timed out after ${timeoutMs}ms`);
+    this.name = 'OpenCodeTimeoutError';
+  }
+}
+
+export async function withAbortableTimeout<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  label: string,
+  callerSignal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(callerSignal?.reason);
+  callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+  if (callerSignal?.aborted) abortFromCaller();
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    controller.signal.throwIfAborted();
+    return await Promise.race([
+      operation(controller.signal),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          const error = new OpenCodeTimeoutError(label, timeoutMs);
+          controller.abort(error);
+          reject(error);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
+  }
+}

--- a/server-agents/opencode/src/index.ts
+++ b/server-agents/opencode/src/index.ts
@@ -17,6 +17,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createOpenCodeConfig } from './config.js';
 import { OpenCodeExecution } from './agents/opencode/execution.js';
 import {
@@ -138,7 +139,7 @@ export default class OpenCodeAgentIntegration implements AgentIntegration {
           return await runtime.runSingleQuery(request.prompt, {
             projectPath: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           });
         } catch (error) {
           if (error instanceof AgentIntegrationError) throw error;

--- a/server-agents/pi/src/agents/pi/pi-cli.ts
+++ b/server-agents/pi/src/agents/pi/pi-cli.ts
@@ -31,6 +31,7 @@ import type { AgentAttachment } from '@garcon/common/agent-execution';
 import type { PermissionMode, ThinkingMode } from '@garcon/common/chat-modes';
 import type { AgentLogger } from '@garcon/server-agent-interface';
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
+import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 
 export interface PiModelReader {
   getModels(): Promise<Array<{ value: string; label: string; supportsImages?: boolean }>>;
@@ -239,7 +240,7 @@ async function buildPiRun(
 async function runPiCommand(
   args: string[],
   config: PiConfig,
-  { cwd, input }: { cwd?: string; input?: string } = {},
+  { cwd, input, signal }: { cwd?: string; input?: string; signal?: AbortSignal } = {},
 ): Promise<string> {
   const proc = Bun.spawn([config.binary(), ...args], {
     cwd: cwd || process.cwd(),
@@ -247,6 +248,7 @@ async function runPiCommand(
     stdin: input == null ? 'ignore' : 'pipe',
     stdout: 'pipe',
     stderr: 'pipe',
+    signal,
   });
 
   if (input != null) {
@@ -261,6 +263,7 @@ async function runPiCommand(
     new Response(proc.stderr as ReadableStream).text(),
     proc.exited,
   ]);
+  signal?.throwIfAborted();
 
   if (exitCode !== 0) {
     const details = (stderr || stdout || '').trim();
@@ -284,7 +287,9 @@ export async function runSingleQuery(
   args.push('--model', model);
   const thinkingMode = normalizeThinkingMode(options.thinkingMode);
   if (thinkingMode !== 'none') args.push('--thinking', thinkingMode);
-  return (await runPiCommand(args, config, { cwd, input: prompt })).trim();
+  return withSingleQueryControl(options, async (signal) => (
+    await runPiCommand(args, config, { cwd, input: prompt, signal })
+  ).trim());
 }
 
 function createSession(

--- a/server-agents/pi/src/index.ts
+++ b/server-agents/pi/src/index.ts
@@ -19,6 +19,7 @@ import { createScopedAgentLogger } from '@garcon/server-agent-common/logging/sco
 import { createVersion1RecordMigration } from '@garcon/server-agent-common/migration/version-1-record-migration';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { createVersionedSettings } from '@garcon/server-agent-common/settings/versioned-settings';
+import { singleQueryRuntimeOptions } from '@garcon/server-agent-common/shared/single-query-control';
 import { createPiConfig } from './config.js';
 import { PiExecution } from './agents/pi/execution.js';
 import { LazyPiRuntime } from './agents/pi/lazy-runtime.js';
@@ -144,7 +145,7 @@ export default class PiAgentIntegration implements AgentIntegration {
           return await runSingleQuery(request.prompt, {
             projectPath: request.projectPath,
             model: request.model,
-            ...request.settings.values,
+            ...singleQueryRuntimeOptions(request),
           }, config);
         } catch (error) {
           if (error instanceof AgentIntegrationError) throw error;

--- a/server/agents/__tests__/agents-run-single-query.test.js
+++ b/server/agents/__tests__/agents-run-single-query.test.js
@@ -108,6 +108,27 @@ describe('AgentRuntimeRouter.runSingleQuery', () => {
     }));
   });
 
+  it('preserves one-shot thinking, timeout, cancellation, and cwd fallback', async () => {
+    const { router, run } = makeRouter();
+    const controller = new AbortController();
+
+    await router.runSingleQuery('prompt', {
+      agentId: 'test',
+      model: 'model-a',
+      cwd: '/repo-from-cwd',
+      thinkingMode: 'xhigh',
+      timeoutMs: 110_000,
+      signal: controller.signal,
+    });
+
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      projectPath: '/repo-from-cwd',
+      thinkingMode: 'xhigh',
+      timeoutMs: 110_000,
+      signal: controller.signal,
+    }));
+  });
+
   it('rejects integrations without the optional one-shot facet', async () => {
     const { router } = makeRouter({ singleQuery: null });
 

--- a/server/agents/__tests__/architecture-boundaries.test.js
+++ b/server/agents/__tests__/architecture-boundaries.test.js
@@ -75,6 +75,17 @@ describe('agent architecture boundaries', () => {
     }
   });
 
+  test('forwards canonical controls through every single-query integration', () => {
+    for (const providerId of providerIds) {
+      const source = readFileSync(`server-agents/${providerId}/src/index.ts`, 'utf8');
+      if (!source.includes('this.singleQuery =')) continue;
+      expect(source, providerId).toContain('singleQueryRuntimeOptions(request)');
+      expect(source, providerId).not.toMatch(
+        /this\.singleQuery = \{[\s\S]*?\.\.\.request\.settings\.values/,
+      );
+    }
+  });
+
   test('keeps generic server modules out of provider implementation paths', () => {
     for (const root of ['server/chats', 'server/routes', 'server/ws']) {
       for (const file of walk(root)) {

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -27,7 +27,7 @@ import type {
 import { AgentCatalogService, type AgentModelQuery } from './catalog-service.js';
 import { AgentDirectory } from './directory.js';
 import { AgentEventBus, type TurnEventMetadata } from './event-bus.js';
-import { AgentRuntimeRouter } from './runtime-router.js';
+import { AgentRuntimeRouter, type RunSingleQueryOptions } from './runtime-router.js';
 import { AgentSessionSettingsService } from './session-settings-service.js';
 import { toAgentChatReference } from './integration-chat-reference.js';
 import { createLogger } from '../lib/log.js';
@@ -71,7 +71,7 @@ export interface AgentRegistryServiceContract {
     apiProviderId?: string | null;
     modelEndpointId?: string | null;
   }): Promise<boolean>;
-  runSingleQuery(prompt: string, options: { agentId: string; [key: string]: unknown }): Promise<string>;
+  runSingleQuery(prompt: string, options: RunSingleQueryOptions): Promise<string>;
   getSlashCommands(agentId: string, projectPath: string): Promise<SlashCommand[]>;
   resolvePermission(chatId: string, permissionRequestId: string, decision: PermissionDecisionPayload): void;
   prepareProjectPathUpdate(agentId: string, request: PrepareProjectPathUpdateRequest): Promise<void>;
@@ -201,7 +201,7 @@ export class AgentRegistry implements AgentRegistryServiceContract {
   updateSessionSettings(chatId: string, patch: AgentSessionSettingsPatch) {
     return this.#settings.updateSessionSettings(chatId, patch);
   }
-  runSingleQuery(prompt: string, options: { agentId: string; [key: string]: unknown }) {
+  runSingleQuery(prompt: string, options: RunSingleQueryOptions) {
     return this.#runtime.runSingleQuery(prompt, options);
   }
   getSlashCommands(agentId: string, projectPath: string): Promise<SlashCommand[]> {

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -7,7 +7,11 @@ import {
 import type { AgentSettingsEnvelope } from '@garcon/common/agent-integration';
 import type { ChatMessage } from '@garcon/common/chat-types';
 import type { PermissionDecisionPayload } from '../../common/chat-command-contracts.js';
-import { normalizePermissionMode, normalizeThinkingMode } from '../../common/chat-modes.js';
+import {
+  normalizePermissionMode,
+  normalizeThinkingMode,
+  type ThinkingMode,
+} from '../../common/chat-modes.js';
 import type { IChatRegistry } from '../chats/store.js';
 import type { ApiProviderEndpointResolver } from '../api-providers/endpoint-resolver.js';
 import { assertSameApiProviderBoundary } from '../api-providers/endpoint-resolver.js';
@@ -38,6 +42,20 @@ export interface AgentRuntimeRouterOptions {
   events: AgentEventBus;
   getCarryOverRevision(chatId: string): string;
   loadCarryOver(chatId: string, entry: AgentChatEntry): readonly ChatMessage[];
+}
+
+export interface RunSingleQueryOptions {
+  readonly agentId: string;
+  readonly model?: string;
+  readonly projectPath?: string;
+  readonly cwd?: string;
+  readonly thinkingMode?: ThinkingMode;
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  readonly apiProviderId?: string | null;
+  readonly modelEndpointId?: string | null;
+  readonly agentSettings?: AgentSettingsEnvelope;
+  readonly [key: string]: unknown;
 }
 
 export class AgentRuntimeRouter {
@@ -380,7 +398,7 @@ export class AgentRuntimeRouter {
 
   async runSingleQuery(
     prompt: string,
-    options: { agentId: string; [key: string]: unknown },
+    options: RunSingleQueryOptions,
   ): Promise<string> {
     const { agentId } = options;
     const integration = this.#directory.require(agentId);
@@ -393,17 +411,30 @@ export class AgentRuntimeRouter {
       modelEndpointId: typeof options.modelEndpointId === 'string' ? options.modelEndpointId : null,
     }) : null;
     if (selection) await this.#validateEndpoint(integration, selection);
+    const timeoutMs = typeof options.timeoutMs === 'number'
+      && Number.isFinite(options.timeoutMs)
+      && options.timeoutMs > 0
+      ? options.timeoutMs
+      : undefined;
     return integration.singleQuery.run({
       prompt,
-      projectPath: typeof options.projectPath === 'string' ? options.projectPath : process.cwd(),
+      projectPath: typeof options.projectPath === 'string'
+        ? options.projectPath
+        : typeof options.cwd === 'string'
+          ? options.cwd
+          : process.cwd(),
       model: selection?.model ?? model,
+      thinkingMode: normalizeThinkingMode(options.thinkingMode),
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
       settings: integration.settings.parse(
         isAgentSettingsEnvelope(options.agentSettings)
           ? options.agentSettings
           : integration.settings.defaults(),
       ),
       endpoint: selection ? toAgentEndpointSelection(this.#endpointResolver, selection) : null,
-      signal: new AbortController().signal,
+      signal: options.signal instanceof AbortSignal
+        ? options.signal
+        : new AbortController().signal,
     });
   }
 


### PR DESCRIPTION
Direct Anthropic and OpenAI Responses one-shot generation relied on buffered JSON even though session requests already used faster SSE transport, which could fail with streaming-required models and handled incomplete Responses output too permissively. This change routes every direct one-shot and chat session through shared protocol-specific SSE readers, validates each protocol's completion sentinel, ignores hidden reasoning while preserving visible text, retains buffered JSON compatibility and caller thinking/timeout/abort controls, and adds black-box lifecycle coverage for Anthropic and OpenAI Responses providers.