### PR TITLE
Fix immediate Codex fork-of-fork failures

### DIFF
--- a/integration-tests/support/fake-codex-app-server.ts
+++ b/integration-tests/support/fake-codex-app-server.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
-import { appendFileSync, readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { appendFileSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 export {};
 
@@ -21,7 +22,11 @@ if (buffered.trim()) respond(buffered);
 
 function respond(line: string): void {
   if (!line.trim()) return;
-  const request = JSON.parse(line) as { id?: number; method?: string };
+  const request = JSON.parse(line) as {
+    id?: number;
+    method?: string;
+    params?: Record<string, unknown>;
+  };
   if (typeof request.id !== 'number') return;
   if (request.method === 'initialize') {
     write(request.id, {
@@ -73,6 +78,10 @@ function respond(line: string): void {
   if (request.method === 'thread/fork') {
     const callLog = process.env.INTEGRATION_CODEX_CALL_LOG;
     if (callLog) appendFileSync(callLog, 'thread/fork\n');
+    if (process.env.INTEGRATION_CODEX_FORK_JSONL === '1') {
+      forkJsonlThread(request.id, request.params);
+      return;
+    }
     process.stdout.write(`${JSON.stringify({
       id: request.id,
       error: { code: -32601, message: 'paginated_threads is not supported yet' },
@@ -83,6 +92,51 @@ function respond(line: string): void {
     id: request.id,
     error: { code: -32601, message: `Unsupported integration fixture method ${request.method}` },
   })}\n`);
+}
+
+function forkJsonlThread(id: number, params: Record<string, unknown> | undefined): void {
+  const sourcePath = typeof params?.path === 'string' ? params.path : null;
+  if (!sourcePath) {
+    process.stdout.write(`${JSON.stringify({
+      id,
+      error: { code: -32602, message: 'thread not found without rollout path' },
+    })}\n`);
+    return;
+  }
+
+  try {
+    const targetThreadId = randomUUID();
+    const targetPath = join(dirname(sourcePath), `${targetThreadId}.jsonl`);
+    const lines = readFileSync(sourcePath, 'utf8').split('\n');
+    const metadataIndex = lines.findIndex((entry) => entry.trim());
+    const metadata = JSON.parse(lines[metadataIndex]!) as {
+      type?: unknown;
+      payload?: Record<string, unknown>;
+    };
+    if (metadata.type !== 'session_meta' || !metadata.payload) {
+      throw new Error('source transcript has no session metadata');
+    }
+    lines[metadataIndex] = JSON.stringify({
+      ...metadata,
+      payload: { ...metadata.payload, id: targetThreadId },
+    });
+    writeFileSync(targetPath, lines.join('\n'));
+    write(id, {
+      thread: { id: targetThreadId, path: targetPath },
+      model: typeof params?.model === 'string' ? params.model : 'gpt',
+      modelProvider: 'openai',
+      serviceTier: null,
+      cwd: typeof params?.cwd === 'string' ? params.cwd : '/',
+    });
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify({
+      id,
+      error: {
+        code: -32602,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    })}\n`);
+  }
 }
 
 function write(id: number, result: unknown): void {

--- a/integration-tests/tests/server/codex-fork-at-message.test.ts
+++ b/integration-tests/tests/server/codex-fork-at-message.test.ts
@@ -20,6 +20,7 @@ describe('Codex fork at message', () => {
       )),
       PATH: `${dirname(process.execPath)}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
       INTEGRATION_CODEX_DISCOVER_JSONL: '1',
+      INTEGRATION_CODEX_FORK_JSONL: '1',
     };
 
     await withIntegrationFixture('codex-fork-at-message', async (fixture) => {
@@ -41,6 +42,16 @@ describe('Codex fork at message', () => {
 
       const forked = await fixture.client.getMessages(targetChatId);
       expect(forked.messages.map((entry) => entry.message))
+        .toEqual(source.messages.map((entry) => entry.message));
+
+      const secondTargetChatId = fixture.newChatId();
+      const secondFork = await fixture.client.forkChat({
+        sourceChatId: targetChatId,
+        chatId: secondTargetChatId,
+      });
+      expect(secondFork.chat.id).toBe(secondTargetChatId);
+      const secondForked = await fixture.client.getMessages(secondTargetChatId);
+      expect(secondForked.messages.map((entry) => entry.message))
         .toEqual(source.messages.map((entry) => entry.message));
 
       const registry = JSON.parse(

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -508,7 +508,7 @@ describe('Codex app-server request builders', () => {
     expect(params).not.toHaveProperty('persistExtendedHistory');
   });
 
-  it('builds thread/fork params from durable thread identity', () => {
+  it('builds thread/fork params from durable thread identity and path', () => {
     const params = buildThreadForkParams({
       agentSessionId: 'thread-1',
       nativePath: '/tmp/jsonl.jsonl',
@@ -522,6 +522,7 @@ describe('Codex app-server request builders', () => {
       model: 'gpt-5.4-codex',
       ephemeral: false,
       excludeTurns: true,
+      path: '/tmp/jsonl.jsonl',
     });
   });
 

--- a/server-agents/codex/src/agents/codex/app-server/request-builders.ts
+++ b/server-agents/codex/src/agents/codex/app-server/request-builders.ts
@@ -129,6 +129,7 @@ export function buildThreadForkParams(sourceSession: {
     ephemeral: false,
     excludeTurns: true,
   };
+  if (sourceSession.nativePath) params.path = sourceSession.nativePath;
   if (sourceSession.codexConfig?.config) params.config = sourceSession.codexConfig.config;
   return params;
 }


### PR DESCRIPTION
A Codex point fork can be re-forked before its new thread ID is discoverable by a fresh app-server, causing the native fork request to fail. Include the known rollout path in thread fork requests so Codex can resolve the source deterministically, with regression coverage for the immediate fork-of-fork flow.