### PR TITLE
Verify Codex fork-of-fork source paths

### DIFF
--- a/integration-tests/support/fake-codex-app-server.ts
+++ b/integration-tests/support/fake-codex-app-server.ts
@@ -78,6 +78,8 @@ function respond(line: string): void {
   if (request.method === 'thread/fork') {
     const callLog = process.env.INTEGRATION_CODEX_CALL_LOG;
     if (callLog) appendFileSync(callLog, 'thread/fork\n');
+    const paramsLog = process.env.INTEGRATION_CODEX_FORK_PARAMS_LOG;
+    if (paramsLog) appendFileSync(paramsLog, `${JSON.stringify(request.params ?? {})}\n`);
     if (process.env.INTEGRATION_CODEX_FORK_JSONL === '1') {
       forkJsonlThread(request.id, request.params);
       return;

--- a/integration-tests/tests/server/codex-fork-at-message.test.ts
+++ b/integration-tests/tests/server/codex-fork-at-message.test.ts
@@ -13,6 +13,7 @@ describe('Codex fork at message', () => {
     const sourceChatId = String(Date.now() * 1_000 + 1);
     const sourceAgentSessionId = randomUUID();
     let sourceNativePath = '';
+    let forkParamsLogPath = '';
     const serverEnvironment = {
       GARCON_CODEX_CLI: fileURLToPath(new URL(
         '../../support/fake-codex-app-server.ts',
@@ -21,6 +22,7 @@ describe('Codex fork at message', () => {
       PATH: `${dirname(process.execPath)}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
       INTEGRATION_CODEX_DISCOVER_JSONL: '1',
       INTEGRATION_CODEX_FORK_JSONL: '1',
+      INTEGRATION_CODEX_FORK_PARAMS_LOG: '',
     };
 
     await withIntegrationFixture('codex-fork-at-message', async (fixture) => {
@@ -63,6 +65,16 @@ describe('Codex fork at message', () => {
       };
       const targetNative = registry.sessions[targetChatId]!.nativeSession.value;
       const targetNativePath = targetNative.path;
+      const forkParams = (await readFile(forkParamsLogPath, 'utf8'))
+        .trimEnd()
+        .split('\n')
+        .map((line) => JSON.parse(line)) as Array<{ threadId?: string; path?: string }>;
+      expect(forkParams).toHaveLength(1);
+      expect(forkParams[0]).toMatchObject({
+        threadId: targetNative.agentSessionId,
+        path: targetNativePath,
+      });
+      expect(forkParams[0]?.path).not.toBe(sourceNativePath);
       const targetLines = (await readFile(targetNativePath, 'utf8')).trimEnd().split('\n');
       expect(JSON.parse(targetLines[1]!)).toEqual({ type: 'garcon_fork_filtered' });
       expect(targetLines.some((line) => line.includes('"name":"exec"'))).toBe(true);
@@ -101,6 +113,8 @@ describe('Codex fork at message', () => {
     }, {
       serverEnvironment,
       async prepareWorkspace(directories) {
+        forkParamsLogPath = join(directories.root, 'codex-fork-params.log');
+        serverEnvironment.INTEGRATION_CODEX_FORK_PARAMS_LOG = forkParamsLogPath;
         sourceNativePath = join(
           directories.home,
           '.codex',


### PR DESCRIPTION
A fork-of-fork must use the selected fork's own rollout path rather than its ancestor because Codex treats an explicit path as authoritative over the thread ID. Record native fork parameters in the integration fixture and assert that the immediate second fork uses the selected fork's persisted path and thread ID while differing from the original source path.