### PR TITLE
Restore Codex exec messages in history

### DIFF
--- a/integration-tests/tests/server/codex-fork-at-message.test.ts
+++ b/integration-tests/tests/server/codex-fork-at-message.test.ts
@@ -9,7 +9,7 @@ import { buildThreadResumeParams } from '../../../server-agents/codex/src/agents
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
 
 describe('Codex fork at message', () => {
-  test('preserves a resumable legacy prefix while hiding Code Mode envelopes after reload', async () => {
+  test('preserves a resumable legacy prefix while decoding Code Mode Exec after reload', async () => {
     const sourceChatId = String(Date.now() * 1_000 + 1);
     const sourceAgentSessionId = randomUUID();
     let sourceNativePath = '';
@@ -26,16 +26,18 @@ describe('Codex fork at message', () => {
       const source = await fixture.client.getMessages(sourceChatId);
       expect(source.messages.map((entry) => [entry.seq, entry.message.type])).toEqual([
         [1, 'user-message'],
-        [2, 'bash-tool-use'],
-        [3, 'tool-result'],
-        [4, 'assistant-message'],
+        [2, 'exec-tool-use'],
+        [3, 'bash-tool-use'],
+        [4, 'tool-result'],
+        [5, 'tool-result'],
+        [6, 'assistant-message'],
       ]);
 
       const targetChatId = fixture.newChatId();
       const fork = await fixture.client.forkChat({
         sourceChatId,
         chatId: targetChatId,
-        upToSeq: 4,
+        upToSeq: 6,
       });
       expect(fork.chat.id).toBe(targetChatId);
 
@@ -84,9 +86,8 @@ describe('Codex fork at message', () => {
       const reloaded = await fixture.client.getMessages(targetChatId);
       expect(reloaded.messages.map((entry) => entry.message))
         .toEqual(source.messages.map((entry) => entry.message));
-      expect(reloaded.messages.some((entry) => (
-        entry.message.type === 'exec-tool-use' || entry.message.type === 'wait-tool-use'
-      ))).toBe(false);
+      expect(reloaded.messages.some((entry) => entry.message.type === 'exec-tool-use')).toBe(true);
+      expect(reloaded.messages.some((entry) => entry.message.type === 'wait-tool-use')).toBe(false);
     }, {
       serverEnvironment,
       async prepareWorkspace(directories) {

--- a/server-agents/codex/src/agents/codex/__tests__/fork-transcript.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/fork-transcript.test.js
@@ -104,7 +104,7 @@ describe('rewriteCodexForkTranscriptEntry', () => {
     })).toEqual({ type: 'garcon_fork_filtered' });
   });
 
-  it('preserves hidden Code Mode envelopes and their paired outputs', () => {
+  it('counts Code Mode Exec envelopes and their paired outputs as rendered messages', () => {
     const rewrite = createCodexForkTranscriptRewriter();
     const exec = {
       type: 'response_item',
@@ -115,8 +115,14 @@ describe('rewriteCodexForkTranscriptEntry', () => {
       payload: { type: 'custom_tool_call_output', call_id: 'outer', output: 'done' },
     };
 
-    expect(rewrite(exec, { ...context, retainedMessageCount: 0 })).toBe(exec);
-    expect(rewrite(output, { ...context, retainedMessageCount: 0 })).toBe(output);
+    expect(rewrite(exec, { ...context, retainedMessageCount: 0 }))
+      .toEqual({ type: 'garcon_fork_filtered' });
+    expect(rewrite(output, { ...context, retainedMessageCount: 0 }))
+      .toEqual({ type: 'garcon_fork_filtered' });
+
+    const selectedRewrite = createCodexForkTranscriptRewriter();
+    expect(selectedRewrite(exec, { ...context, retainedMessageCount: 1 })).toBe(exec);
+    expect(selectedRewrite(output, { ...context, retainedMessageCount: 1 })).toBe(output);
   });
 
   it('preserves provider records that the shared legacy projection does not render', () => {

--- a/server-agents/codex/src/agents/codex/__tests__/history-loader.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/history-loader.test.js
@@ -28,7 +28,7 @@ describe('loadCodexChatMessages', () => {
     expect(messages).toMatchObject([{ type: 'user-message', content }]);
   });
 
-  it('hides Code Mode Exec envelopes and paired outputs from native history', async () => {
+  it('decodes Code Mode Exec envelopes and paired outputs from native history', async () => {
     const code = '// @exec: {"yield_time_ms": 1000}\ntext("ok")';
     const lines = [
       JSON.stringify({
@@ -54,7 +54,10 @@ describe('loadCodexChatMessages', () => {
 
     const messages = await withTempJsonl(lines, (filePath) => loadCodexChatMessages(filePath));
 
-    expect(messages).toEqual([]);
+    expect(messages).toMatchObject([
+      { type: 'exec-tool-use', toolId: 'call_exec', code, language: 'javascript' },
+      { type: 'tool-result', toolId: 'call_exec' },
+    ]);
   });
 
   it('hides Code Mode Wait envelopes and paired outputs from native history', async () => {
@@ -85,7 +88,7 @@ describe('loadCodexChatMessages', () => {
     expect(messages).toEqual([]);
   });
 
-  it('preserves nested commands while hiding their Code Mode envelope', async () => {
+  it('preserves Code Mode Exec envelopes and their nested commands', async () => {
     const lines = [
       JSON.stringify({
         type: 'response_item', timestamp: '2026-07-10T21:34:09.149Z',
@@ -113,8 +116,10 @@ describe('loadCodexChatMessages', () => {
       const page = await loadCodexChatMessagePage(filePath, 10, 0);
 
       expect(full.map((message) => [message.type, message.toolId])).toEqual([
+        ['exec-tool-use', 'outer'],
         ['bash-tool-use', 'inner'],
         ['tool-result', 'inner'],
+        ['tool-result', 'outer'],
       ]);
       expect(page.messages).toEqual(full);
       expect(page.revision).toBe(transcriptRevision(full));
@@ -124,11 +129,14 @@ describe('loadCodexChatMessages', () => {
   it('does not leak hidden call state between transcript loads', async () => {
     const hiddenCall = JSON.stringify({
       type: 'response_item', timestamp: '2026-07-10T21:34:09.149Z',
-      payload: { type: 'custom_tool_call', name: 'exec', call_id: 'shared', input: 'text("ok")' },
+      payload: {
+        type: 'function_call', name: 'wait', call_id: 'shared',
+        arguments: '{"cell_id":"46","yield_time_ms":30000}',
+      },
     });
     const visibleOutput = JSON.stringify({
       type: 'response_item', timestamp: '2026-07-10T21:34:09.150Z',
-      payload: { type: 'custom_tool_call_output', call_id: 'shared', output: 'unmatched output' },
+      payload: { type: 'function_call_output', call_id: 'shared', output: 'unmatched output' },
     });
 
     await withTempJsonl([hiddenCall], (filePath) => loadCodexChatMessages(filePath));

--- a/server-agents/codex/src/agents/codex/legacy-history-projection.ts
+++ b/server-agents/codex/src/agents/codex/legacy-history-projection.ts
@@ -4,45 +4,40 @@ import type {
 } from './history-normalizer.js';
 import { normalizeCodexJsonlEntry } from './history-normalizer.js';
 
-const MAX_PENDING_HIDDEN_CALLS = 10_000;
+const MAX_PENDING_HIDDEN_WAIT_CALLS = 10_000;
 
 export class LegacyCodexProjection {
-  readonly #hiddenCallIds = new Set<string>();
+  readonly #hiddenWaitCallIds = new Set<string>();
 
   project(
     entry: Record<string, unknown>,
     context: CodexJsonlNormalizationContext,
   ): CodexJsonlNormalizationResult | null {
     const payload = entry.type === 'response_item' ? record(entry.payload) : null;
-    if (isCodeModeEnvelopeCall(payload)) {
-      this.#remember(payload.call_id);
+    if (isHiddenCodeModeWaitCall(payload)) {
+      this.#rememberHiddenWait(payload.call_id);
       return emptyResult();
     }
     if (isToolOutput(payload)) {
       const callId = string(payload?.call_id);
-      if (callId && this.#hiddenCallIds.delete(callId)) return emptyResult();
+      if (callId && this.#hiddenWaitCallIds.delete(callId)) return emptyResult();
     }
     return normalizeCodexJsonlEntry(entry, context);
   }
 
-  #remember(callId: string): void {
-    this.#hiddenCallIds.add(callId);
-    if (this.#hiddenCallIds.size <= MAX_PENDING_HIDDEN_CALLS) return;
-    const oldest = this.#hiddenCallIds.values().next().value;
-    if (oldest) this.#hiddenCallIds.delete(oldest);
+  #rememberHiddenWait(callId: string): void {
+    this.#hiddenWaitCallIds.add(callId);
+    if (this.#hiddenWaitCallIds.size <= MAX_PENDING_HIDDEN_WAIT_CALLS) return;
+    const oldest = this.#hiddenWaitCallIds.values().next().value;
+    if (oldest) this.#hiddenWaitCallIds.delete(oldest);
   }
 }
 
-function isCodeModeEnvelopeCall(
+function isHiddenCodeModeWaitCall(
   payload: Record<string, unknown> | null,
 ): payload is Record<string, unknown> & { call_id: string } {
   const callId = string(payload?.call_id);
   if (!callId) return false;
-  if (
-    payload?.type === 'custom_tool_call'
-    && payload.name === 'exec'
-    && typeof payload.input === 'string'
-  ) return true;
   if (payload?.type !== 'function_call' || payload.name !== 'wait') return false;
   const argumentsValue = parseArguments(payload.arguments);
   return typeof argumentsValue.cell_id === 'string' && argumentsValue.cell_id.trim().length > 0;


### PR DESCRIPTION
Codex Code Mode exec calls were being treated as invisible envelopes during JSONL history projection, causing recorded execution activity to disappear after a chat reload. This change restores those calls and their results as execute messages while continuing to hide internal wait bookkeeping, keeping loaded and forked transcripts faithful to the original history.