### PR TITLE
Retain recently viewed chat generations

### DIFF
--- a/server/__tests__/chat-stream-resume.test.js
+++ b/server/__tests__/chat-stream-resume.test.js
@@ -47,6 +47,35 @@ describe('chat stream resume integration', () => {
     expect(replay.lastSeq).toBe(3);
   });
 
+  it('retains the most recently subscribed idle chat for same-generation replay', async () => {
+    let now = 0;
+    const views = new ChatViewStore(() => false, {
+      recentViewRetentionCount: 1,
+      staleNonActiveMs: 10,
+      now: () => now,
+    });
+    const watched = await views.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => [],
+      [assistant('first')],
+    );
+    await views.appendAfterEnsuringGeneration(
+      'chat-2',
+      async () => [],
+      [assistant('other')],
+    );
+    views.readReplay('chat-1', watched.generationId, watched.lastSeq);
+
+    now = 11;
+    views.prune();
+    expect(views.getCursor('chat-2')).toBeNull();
+    await views.appendAfterEnsuringGeneration('chat-1', async () => [], [assistant('missed')]);
+
+    const replay = views.readReplay('chat-1', watched.generationId, watched.lastSeq);
+    expect(replay.mode).toBe('delta');
+    expect(contents(replay)).toEqual(['missed']);
+  });
+
   it('process failure reload resets generation and prevents stale late output', async () => {
     const views = new ChatViewStore(() => false);
     const nativeReloader = new ChatNativeReloader(

--- a/server/chats/__tests__/chat-execution-activity.test.js
+++ b/server/chats/__tests__/chat-execution-activity.test.js
@@ -133,6 +133,7 @@ describe('ChatExecutionActivity', () => {
       const views = new ChatViewStore(activity.isActive, {
         now: () => now,
         staleNonActiveMs: 1,
+        recentViewRetentionCount: 0,
       });
       const queue = new ChatExecutionCoordinator(
         workspaceDir,

--- a/server/chats/__tests__/chat-native-reload.test.js
+++ b/server/chats/__tests__/chat-native-reload.test.js
@@ -34,6 +34,33 @@ describe('ChatNativeReloader', () => {
     expect(nativeSource.loadNativeMessages).toHaveBeenCalledWith('chat-1');
   });
 
+  it('logs the reload mode as the generation replacement reason', async () => {
+    const originalInfo = console.info;
+    const info = mock(() => undefined);
+    console.info = info;
+    try {
+      const views = new ChatViewStore(() => false);
+      const reloader = new ChatNativeReloader(
+        views,
+        { loadNativeMessages: async () => [assistant('native')] },
+        () => false,
+      );
+      const before = await views.appendToCurrentOrEmpty('chat-1', [assistant('live')]);
+
+      const replacement = await reloader.reloadFromNative('chat-1', 'manual-reload');
+
+      const messages = info.mock.calls.map((call) => call[1]);
+      expect(messages.some((message) => (
+        message.includes('generation replaced')
+        && message.includes(`generationId=${replacement.generationId}`)
+        && message.includes('reason=manual-reload')
+        && message.includes(`previousGenerationId=${before.generationId}`)
+      ))).toBe(true);
+    } finally {
+      console.info = originalInfo;
+    }
+  });
+
   it('process-error reload appends a normal in-memory error row', async () => {
     const views = new ChatViewStore(() => false);
     const nativeSource = {

--- a/server/chats/__tests__/chat-view-store.test.js
+++ b/server/chats/__tests__/chat-view-store.test.js
@@ -568,6 +568,43 @@ describe('ChatViewStore', () => {
     expect(older.generationId).not.toBe(recent.generationId);
   });
 
+  it('logs explicit reasons for preserved and replaced native generations', async () => {
+    const originalInfo = console.info;
+    const info = mock(() => undefined);
+    console.info = info;
+    try {
+      const initialHistory = [assistant('1'), assistant('2'), assistant('3')];
+      const historyRef = { current: initialHistory };
+      const store = new ChatViewStore(() => false);
+      const initial = await store.getOrCreatePage('chat-1', pagedLoader(historyRef), 1);
+
+      await store.getOrCreateMessages('chat-1', async () => initialHistory);
+      const preserved = store.getCursor('chat-1').generationId;
+      await store.reconcileNativeSnapshot('chat-1', [
+        assistant('replacement'),
+        ...initialHistory.slice(1),
+      ]);
+      const replaced = store.getCursor('chat-1').generationId;
+
+      expect(preserved).toBe(initial.generationId);
+      expect(replaced).not.toBe(preserved);
+      const messages = info.mock.calls.map((call) => call[1]);
+      expect(messages.some((message) => (
+        message.includes('generation preserved')
+        && message.includes(`generationId=${preserved}`)
+        && message.includes('reason=native-history-reconciled')
+      ))).toBe(true);
+      expect(messages.some((message) => (
+        message.includes('generation replaced')
+        && message.includes(`generationId=${replaced}`)
+        && message.includes('reason=native-history-mismatch')
+        && message.includes(`previousGenerationId=${preserved}`)
+      ))).toBe(true);
+    } finally {
+      console.info = originalInfo;
+    }
+  });
+
   it('changes generation when unretained compaction metadata changes', async () => {
     const historyRef = {
       current: [

--- a/server/chats/__tests__/chat-view-store.test.js
+++ b/server/chats/__tests__/chat-view-store.test.js
@@ -378,7 +378,11 @@ describe('ChatViewStore', () => {
         return { messages: history.slice(start, end), total: 4, hasMore: start > 0, offset, limit };
       },
     };
-    const store = new ChatViewStore(() => false, { staleNonActiveMs: 10, now: () => now });
+    const store = new ChatViewStore(() => false, {
+      staleNonActiveMs: 10,
+      recentViewRetentionCount: 0,
+      now: () => now,
+    });
     const recent = await store.getOrCreatePage('chat-1', loader, 1);
 
     now = 11;
@@ -397,7 +401,7 @@ describe('ChatViewStore', () => {
     let queueDraining = true;
     const store = new ChatViewStore(
       (chatId) => chatId === 'chat-1' && queueDraining,
-      { staleNonActiveMs: 10, now: () => now },
+      { staleNonActiveMs: 10, recentViewRetentionCount: 0, now: () => now },
     );
     const created = await store.appendAfterEnsuringGeneration(
       'chat-1',
@@ -457,6 +461,29 @@ describe('ChatViewStore', () => {
     expect(secondRetained.generationId).toBe(second.generationId);
     expect(firstRetained.messages.length + secondRetained.messages.length).toBe(3);
     expect(store.readReplay('chat-1', first.generationId, 0)?.mode).toBe('snapshot-required');
+  });
+
+  it('trims recently retained views instead of evicting their generations', async () => {
+    const store = new ChatViewStore(() => false, {
+      messageLimit: 3,
+      recentViewRetentionCount: 2,
+    });
+    const first = await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => [],
+      [assistant('1'), assistant('2')],
+    );
+    const second = await store.appendAfterEnsuringGeneration(
+      'chat-2',
+      async () => [],
+      [assistant('3'), assistant('4')],
+    );
+
+    const firstRetained = store.readPage('chat-1', 10);
+    const secondRetained = store.readPage('chat-2', 10);
+    expect(firstRetained.generationId).toBe(first.generationId);
+    expect(secondRetained.generationId).toBe(second.generationId);
+    expect(firstRetained.messages.length + secondRetained.messages.length).toBe(3);
   });
 
   it('returns a wider in-flight page without growing the retained suffix past its cap', async () => {
@@ -819,6 +846,7 @@ describe('ChatViewStore', () => {
       cacheLimit: 100,
       messageLimit: 2,
       staleNonActiveMs: 10,
+      recentViewRetentionCount: 0,
       now: () => now,
     });
     const loads = new Map();
@@ -836,5 +864,60 @@ describe('ChatViewStore', () => {
     await store.getOrCreatePage('chat-3', loaderFor('chat-3'), 1);
     await store.getOrCreatePage('chat-2', loaderFor('chat-2'), 1);
     expect(loads.get('chat-2')).toBe(2);
+  });
+
+  it('retains the ten most recently accessed views after they become stale', async () => {
+    let now = 0;
+    const store = new ChatViewStore(() => false, {
+      staleNonActiveMs: 10,
+      now: () => now,
+    });
+
+    for (let index = 1; index <= 11; index += 1) {
+      await store.getOrCreatePage(
+        `chat-${index}`,
+        fullLoader(async () => [assistant(String(index))]),
+        1,
+      );
+    }
+    const firstGenerationId = store.getCursor('chat-1').generationId;
+
+    now = 11;
+    store.prune();
+
+    expect(store.getCursor('chat-2')).toBeNull();
+    expect(store.getCursor('chat-1')?.generationId).toBe(firstGenerationId);
+    for (let index = 3; index <= 11; index += 1) {
+      expect(store.getCursor(`chat-${index}`)).not.toBeNull();
+    }
+  });
+
+  it('logs stale prune evictions with the generation and reason', async () => {
+    const originalInfo = console.info;
+    const info = mock(() => undefined);
+    console.info = info;
+    try {
+      let now = 0;
+      const store = new ChatViewStore(() => false, {
+        staleNonActiveMs: 10,
+        recentViewRetentionCount: 0,
+        now: () => now,
+      });
+      const page = await store.getOrCreatePage(
+        'chat-1',
+        fullLoader(async () => [assistant('one')]),
+        1,
+      );
+
+      now = 11;
+      store.prune();
+
+      expect(info).toHaveBeenCalledWith(
+        '[chat-view]',
+        `view evicted chat=chat-1 generationId=${page.generationId} reason=stale ageMs=11 messages=1`,
+      );
+    } finally {
+      console.info = originalInfo;
+    }
   });
 });

--- a/server/chats/chat-native-reload.ts
+++ b/server/chats/chat-native-reload.ts
@@ -78,7 +78,7 @@ export class ChatNativeReloader {
     const page = await this.#views.replaceFromNative(
       chatId,
       () => this.#source.loadNativeMessages(chatId),
-      { processErrorNotice, assertReplacementAllowed },
+      { processErrorNotice, assertReplacementAllowed, replacementReason: mode },
     );
     logger.info(`reload complete mode=${mode} chat=${chatId} messages=${page.lastSeq}`);
     return { ...page, mode };

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -18,6 +18,7 @@ export interface ChatViewStoreOptions {
   cacheLimit?: number;
   messageLimit?: number;
   staleNonActiveMs?: number;
+  recentViewRetentionCount?: number;
   now?: () => number;
 }
 
@@ -63,12 +64,16 @@ interface ChatView {
   evictedLiveDigest: OrderedTranscriptDigest;
   streamFence: number;
   lastAccessAt: number;
+  lastAccessOrder: number;
 }
 
 const REPLAY_LIMIT = 2048;
 const CACHE_LIMIT = 100;
 const MESSAGE_LIMIT = 20_000;
 const STALE_NON_ACTIVE_MS = 10 * 60 * 1000;
+const RECENT_VIEW_RETENTION_COUNT = 10;
+
+type PruneEvictionReason = 'stale' | 'view-capacity' | 'message-capacity';
 
 export class ChatViewStore {
   #views = new Map<string, ChatView>();
@@ -79,6 +84,8 @@ export class ChatViewStore {
   #cacheLimit: number;
   #messageLimit: number;
   #staleNonActiveMs: number;
+  #recentViewRetentionCount: number;
+  #lastAccessOrder = 0;
   #now: () => number;
   #isChatActive: (chatId: string) => boolean;
 
@@ -91,6 +98,10 @@ export class ChatViewStore {
     this.#cacheLimit = options.cacheLimit ?? CACHE_LIMIT;
     this.#messageLimit = Math.max(1, Math.floor(options.messageLimit ?? MESSAGE_LIMIT));
     this.#staleNonActiveMs = options.staleNonActiveMs ?? STALE_NON_ACTIVE_MS;
+    this.#recentViewRetentionCount = Math.max(
+      0,
+      Math.floor(options.recentViewRetentionCount ?? RECENT_VIEW_RETENTION_COUNT),
+    );
     this.#now = options.now ?? (() => Date.now());
   }
 
@@ -109,21 +120,21 @@ export class ChatViewStore {
   getCursor(chatId: string): { generationId: string; lastSeq: number } | null {
     const view = this.#views.get(chatId);
     if (!view) return null;
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
     return { generationId: view.generationId, lastSeq: view.lastSeq };
   }
 
   getLoadedMessages(chatId: string): ChatMessage[] | null {
     const view = this.#views.get(chatId);
     if (!view?.complete) return null;
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
     return view.messages.map((entry) => entry.message);
   }
 
   getRetainedHistoryMessages(chatId: string): ChatMessage[] | null {
     const view = this.#views.get(chatId);
     if (!view) return null;
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
     return view.messages
       .filter((entry) => entry.seq <= view.historyLastSeq)
       .map((entry) => entry.message);
@@ -188,7 +199,7 @@ export class ChatViewStore {
 
       const missingHistory = this.#missingHistoryRequest(view, limit, beforeSeq);
       if (missingHistory) {
-        view.lastAccessAt = this.#now();
+        this.#touch(view);
         if (missingHistory.kind === 'full') {
           const fullMessages = await loader.loadAll();
           const reconciled = this.#reconcileFullView(chatId, fullMessages);
@@ -229,7 +240,7 @@ export class ChatViewStore {
         }
       }
 
-      view.lastAccessAt = this.#now();
+      this.#touch(view);
       return this.#readPageFromView(view, limit, beforeSeq);
     });
   }
@@ -313,7 +324,7 @@ export class ChatViewStore {
   readReplay(chatId: string, generationId: string, afterSeq: number): ChatReplayResult | null {
     const view = this.#views.get(chatId);
     if (!view) return null;
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
     if (
       view.generationId !== generationId ||
       afterSeq > view.lastSeq ||
@@ -351,11 +362,23 @@ export class ChatViewStore {
 
   prune(): void {
     const now = this.#now();
-    const views = [...this.#views.values()].sort((a, b) => a.lastAccessAt - b.lastAccessAt);
+    const views = [...this.#views.values()].sort(
+      (left, right) => left.lastAccessOrder - right.lastAccessOrder,
+    );
+    const retainedRecentViews = this.#recentViewRetentionCount === 0
+      ? []
+      : views.slice(-this.#recentViewRetentionCount);
+    const retainedRecentChatIds = new Set(
+      retainedRecentViews.map((view) => view.chatId),
+    );
     for (const view of views) {
-      if (this.#isChatActive(view.chatId) || this.#inFlightChats.has(view.chatId)) continue;
+      if (
+        retainedRecentChatIds.has(view.chatId)
+        || this.#isChatActive(view.chatId)
+        || this.#inFlightChats.has(view.chatId)
+      ) continue;
       const isStale = now - view.lastAccessAt > this.#staleNonActiveMs;
-      if (isStale) this.#views.delete(view.chatId);
+      if (isStale) this.#evictForPrune(view, 'stale', now);
     }
 
     let cachedMessages = this.#cachedMessageCount();
@@ -368,11 +391,16 @@ export class ChatViewStore {
       }
       if (
         !this.#views.has(view.chatId)
+        || retainedRecentChatIds.has(view.chatId)
         || this.#isChatActive(view.chatId)
         || this.#inFlightChats.has(view.chatId)
       ) continue;
-      this.#views.delete(view.chatId);
-      cachedMessages -= view.messages.length;
+      const reason = this.#views.size > this.#cacheLimit
+        ? 'view-capacity'
+        : 'message-capacity';
+      if (this.#evictForPrune(view, reason, now)) {
+        cachedMessages -= view.messages.length;
+      }
     }
 
     // Active views keep their generation but not an exemption from the global
@@ -387,6 +415,9 @@ export class ChatViewStore {
       );
       this.#trimOldestMessages(view, trimCount);
       cachedMessages -= trimCount;
+      if (trimCount > 0) {
+        logger.debug(`view trimmed chat=${view.chatId} generationId=${view.generationId} reason=message-capacity removed=${trimCount} retained=${view.messages.length}`);
+      }
     }
   }
 
@@ -394,7 +425,7 @@ export class ChatViewStore {
     return this.#locks.runExclusive(`chat:${chatId}`, async () => {
       this.#inFlightChats.add(chatId);
       const view = this.#views.get(chatId);
-      if (view) view.lastAccessAt = this.#now();
+      if (view) this.#touch(view);
       try {
         return await fn();
       } finally {
@@ -410,7 +441,7 @@ export class ChatViewStore {
   ): Promise<ChatView> {
     const view = this.#views.get(chatId);
     if (view?.loadedFromFullHistory) {
-      view.lastAccessAt = this.#now();
+      this.#touch(view);
       return view;
     }
     return (await this.#loadFullView(chatId, loadNativeMessages)).view;
@@ -422,7 +453,7 @@ export class ChatViewStore {
   ): Promise<{ view: ChatView; messages: ChatMessage[] }> {
     let view = this.#views.get(chatId);
     if (view?.complete) {
-      view.lastAccessAt = this.#now();
+      this.#touch(view);
       return { view, messages: view.messages.map((entry) => entry.message) };
     }
     const nativeMessages = await loadNativeMessages();
@@ -532,6 +563,7 @@ export class ChatViewStore {
       evictedLiveDigest: new OrderedTranscriptDigest(),
       streamFence: this.captureFence(chatId),
       lastAccessAt: now,
+      lastAccessOrder: ++this.#lastAccessOrder,
     };
     this.#appendToView(view, messages);
     logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${messages.length} lastSeq=${view.lastSeq}`);
@@ -556,6 +588,7 @@ export class ChatViewStore {
       evictedLiveDigest: new OrderedTranscriptDigest(),
       streamFence: this.captureFence(chatId),
       lastAccessAt: now,
+      lastAccessOrder: ++this.#lastAccessOrder,
     };
     this.#mergeHistoryPage(view, page);
     logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${page.messages.length} lastSeq=${view.lastSeq}`);
@@ -573,7 +606,7 @@ export class ChatViewStore {
     });
     view.messages.push(...appended);
     this.#enforceViewMessageLimit(view);
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
     return appended;
   }
 
@@ -634,7 +667,7 @@ export class ChatViewStore {
     view.historyLastSeq = page.total;
     view.lastSeq = Math.max(view.lastSeq, page.total);
     this.#enforceViewMessageLimit(view);
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
   }
 
   #messagesFromHistoryPage(page: ChatHistoryPage): ChatViewMessage[] {
@@ -769,7 +802,7 @@ export class ChatViewStore {
   }
 
   #readPageFromView(view: ChatView, limit: number, beforeSeq?: number): ChatViewPage {
-    view.lastAccessAt = this.#now();
+    this.#touch(view);
     return this.#readPageFromMessages(view, view.messages, limit, beforeSeq);
   }
 
@@ -798,6 +831,18 @@ export class ChatViewStore {
     let count = 0;
     for (const view of this.#views.values()) count += view.messages.length;
     return count;
+  }
+
+  #touch(view: ChatView): void {
+    view.lastAccessAt = this.#now();
+    view.lastAccessOrder = ++this.#lastAccessOrder;
+  }
+
+  #evictForPrune(view: ChatView, reason: PruneEvictionReason, now: number): boolean {
+    if (!this.#views.delete(view.chatId)) return false;
+    const ageMs = Math.max(0, now - view.lastAccessAt);
+    logger.info(`view evicted chat=${view.chatId} generationId=${view.generationId} reason=${reason} ageMs=${ageMs} messages=${view.messages.length}`);
+    return true;
   }
 }
 

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -74,6 +74,28 @@ const STALE_NON_ACTIVE_MS = 10 * 60 * 1000;
 const RECENT_VIEW_RETENTION_COUNT = 10;
 
 type PruneEvictionReason = 'stale' | 'view-capacity' | 'message-capacity';
+type GenerationReason =
+  | 'native-history-load'
+  | 'native-history-page'
+  | 'native-history-reconciled'
+  | 'native-history-mismatch'
+  | 'native-replacement'
+  | 'manual-reload'
+  | 'process-error'
+  | 'initial-live-append'
+  | 'initial-provisional-append';
+
+export type ChatViewReplacementReason = Extract<
+  GenerationReason,
+  'native-replacement' | 'manual-reload' | 'process-error'
+>;
+
+interface GenerationTransition {
+  reason: GenerationReason;
+  previousGenerationId?: string;
+  generationId?: string;
+  nativeRevision?: string;
+}
 
 export class ChatViewStore {
   #views = new Map<string, ChatView>();
@@ -251,13 +273,17 @@ export class ChatViewStore {
     options: {
       processErrorNotice?: string;
       assertReplacementAllowed?: () => void;
+      replacementReason?: ChatViewReplacementReason;
     } = {},
   ): Promise<ChatViewPage> {
     return this.#withChat(chatId, async () => {
       const nativeMessages = await loadNativeMessages();
       options.assertReplacementAllowed?.();
       this.invalidateFence(chatId);
-      const view = this.#createGeneration(chatId, nativeMessages);
+      const view = this.#createGeneration(chatId, nativeMessages, {
+        reason: options.replacementReason ?? 'native-replacement',
+        previousGenerationId: this.#views.get(chatId)?.generationId,
+      });
       if (options.processErrorNotice) {
         this.#appendToView(view, [new ErrorMessage(new Date().toISOString(), options.processErrorNotice)]);
       }
@@ -289,7 +315,7 @@ export class ChatViewStore {
     return this.#withChat(chatId, async () => {
       let view = this.#views.get(chatId);
       if (!view) {
-        view = this.#createGeneration(chatId, []);
+        view = this.#createGeneration(chatId, [], { reason: 'initial-live-append' });
         this.#views.set(chatId, view);
       }
       const appended = this.#appendLiveToView(view, messages);
@@ -304,7 +330,7 @@ export class ChatViewStore {
     return this.#withChat(chatId, async () => {
       let view = this.#views.get(chatId);
       if (!view) {
-        view = this.#createGeneration(chatId, []);
+        view = this.#createGeneration(chatId, [], { reason: 'initial-provisional-append' });
         view.complete = false;
         view.loadedFromFullHistory = false;
         view.nativeRevision = undefined;
@@ -520,12 +546,16 @@ export class ChatViewStore {
       && retainedNativeOverlapMatches,
     );
 
-    const view = this.#createGeneration(
-      chatId,
-      reconciledNativeMessages,
-      preservesGeneration ? previous?.generationId : undefined,
-      revisions.full,
-    );
+    const view = this.#createGeneration(chatId, reconciledNativeMessages, {
+      reason: !previous
+        ? 'native-history-load'
+        : preservesGeneration
+          ? 'native-history-reconciled'
+          : 'native-history-mismatch',
+      previousGenerationId: previous?.generationId,
+      generationId: preservesGeneration ? previous?.generationId : undefined,
+      nativeRevision: revisions.full,
+    });
     const unpersistedLiveMessages = previous
       ? retainedLiveEntries
         .filter((entry) => entry.seq > reconciledNativeMessages.length)
@@ -543,14 +573,13 @@ export class ChatViewStore {
   #createGeneration(
     chatId: string,
     messages: ChatMessage[],
-    generationId: string = crypto.randomUUID(),
-    nativeRevision = transcriptRevision(messages),
+    transition: GenerationTransition,
   ): ChatView {
     const now = this.#now();
     const isoNow = new Date(now).toISOString();
     const view: ChatView = {
       chatId,
-      generationId,
+      generationId: transition.generationId ?? crypto.randomUUID(),
       createdAt: isoNow,
       historyReadAt: isoNow,
       messages: [],
@@ -559,14 +588,14 @@ export class ChatViewStore {
       complete: true,
       loadedFromFullHistory: true,
       retainedStartSeq: 1,
-      nativeRevision,
+      nativeRevision: transition.nativeRevision ?? transcriptRevision(messages),
       evictedLiveDigest: new OrderedTranscriptDigest(),
       streamFence: this.captureFence(chatId),
       lastAccessAt: now,
       lastAccessOrder: ++this.#lastAccessOrder,
     };
     this.#appendToView(view, messages);
-    logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${messages.length} lastSeq=${view.lastSeq}`);
+    this.#logGenerationTransition(view, transition);
     return view;
   }
 
@@ -591,7 +620,7 @@ export class ChatViewStore {
       lastAccessOrder: ++this.#lastAccessOrder,
     };
     this.#mergeHistoryPage(view, page);
-    logger.info(`generation created chat=${chatId} generationId=${view.generationId} messages=${page.messages.length} lastSeq=${view.lastSeq}`);
+    this.#logGenerationTransition(view, { reason: 'native-history-page' });
     return view;
   }
 
@@ -843,6 +872,18 @@ export class ChatViewStore {
     const ageMs = Math.max(0, now - view.lastAccessAt);
     logger.info(`view evicted chat=${view.chatId} generationId=${view.generationId} reason=${reason} ageMs=${ageMs} messages=${view.messages.length}`);
     return true;
+  }
+
+  #logGenerationTransition(view: ChatView, transition: GenerationTransition): void {
+    const action = transition.previousGenerationId === undefined
+      ? 'created'
+      : transition.previousGenerationId === view.generationId
+        ? 'preserved'
+        : 'replaced';
+    const previousGeneration = transition.previousGenerationId === undefined
+      ? ''
+      : ` previousGenerationId=${transition.previousGenerationId}`;
+    logger.info(`generation ${action} chat=${view.chatId} generationId=${view.generationId} reason=${transition.reason}${previousGeneration} messages=${view.messages.length} lastSeq=${view.lastSeq}`);
   }
 }
 


### PR DESCRIPTION
Retains the 10 most recently accessed transcript views across idle pruning so reconnects can replay same-generation events instead of falling back to native history, while continuing to pin active work and enforce the global message bound through trimming. Adds explicit reasoned logs for eviction, trimming, and generation transitions so unavoidable resets can be diagnosed.