### PR TITLE
Render Codex Code Mode shell executions as commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "@openai/codex": "0.144.6",
         "acorn": "^8.17.0",
         "bun-pty": "^0.4.10",
+        "shell-quote": "^1.10.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,7 @@
         "@garcon/server-agent-common": "workspace:*",
         "@garcon/server-agent-interface": "workspace:*",
         "@openai/codex": "0.144.6",
+        "acorn": "^8.17.0",
         "bun-pty": "^0.4.10",
       },
       "devDependencies": {

--- a/integration-tests/tests/server/codex-fork-at-message.test.ts
+++ b/integration-tests/tests/server/codex-fork-at-message.test.ts
@@ -6,10 +6,11 @@ import { fileURLToPath } from 'node:url';
 import { CURRENT_WORKSPACE_VERSION } from '../../../server/migrations/index.js';
 import { CodexAppServerClient } from '../../../server-agents/codex/src/agents/codex/app-server/client.js';
 import { buildThreadResumeParams } from '../../../server-agents/codex/src/agents/codex/app-server/request-builders.js';
+import { projectCodexCodeModeCommands } from '../../../server-agents/codex/src/agents/codex/code-mode-command-projection.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
 
 describe('Codex fork at message', () => {
-  test('preserves a resumable legacy prefix while decoding Code Mode Exec after reload', async () => {
+  test('preserves resumable Code Mode prefixes across forks and reforks', async () => {
     const sourceChatId = String(Date.now() * 1_000 + 1);
     const sourceAgentSessionId = randomUUID();
     let sourceNativePath = '';
@@ -33,14 +34,17 @@ describe('Codex fork at message', () => {
         [3, 'bash-tool-use'],
         [4, 'tool-result'],
         [5, 'tool-result'],
-        [6, 'assistant-message'],
+        [6, 'bash-tool-use'],
+        [7, 'bash-tool-use'],
+        [8, 'tool-result'],
+        [9, 'assistant-message'],
       ]);
 
       const targetChatId = fixture.newChatId();
       const fork = await fixture.client.forkChat({
         sourceChatId,
         chatId: targetChatId,
-        upToSeq: 6,
+        upToSeq: 9,
       });
       expect(fork.chat.id).toBe(targetChatId);
 
@@ -111,6 +115,48 @@ describe('Codex fork at message', () => {
         .toEqual(source.messages.map((entry) => entry.message));
       expect(reloaded.messages.some((entry) => entry.message.type === 'exec-tool-use')).toBe(true);
       expect(reloaded.messages.some((entry) => entry.message.type === 'wait-tool-use')).toBe(false);
+
+      const partialChatId = fixture.newChatId();
+      await fixture.client.forkChat({
+        sourceChatId,
+        chatId: partialChatId,
+        upToSeq: 6,
+      });
+      const partial = await fixture.client.getMessages(partialChatId);
+      expect(partial.messages.map((entry) => entry.message))
+        .toEqual(source.messages.slice(0, 6).map((entry) => entry.message));
+
+      const partialRegistry = JSON.parse(
+        await readFile(join(fixture.dirs.workspace, 'chats.json'), 'utf8'),
+      ) as {
+        sessions: Record<string, {
+          nativeSession: { value: { path: string; agentSessionId: string } };
+        }>;
+      };
+      const partialNativePath = partialRegistry.sessions[partialChatId]!.nativeSession.value.path;
+      const partialLines = (await readFile(partialNativePath, 'utf8')).trimEnd().split('\n');
+      const projectedEntry = partialLines
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .find((entry) => (
+          entry.type === 'response_item'
+          && typeof entry.payload === 'object'
+          && entry.payload !== null
+          && (entry.payload as Record<string, unknown>).call_id === 'projected-exec'
+        ));
+      const projectedPayload = projectedEntry?.payload as Record<string, unknown> | undefined;
+      expect(projectCodexCodeModeCommands(String(projectedPayload?.input))).toEqual({
+        commands: ['printf "first;command\\n"'],
+      });
+
+      const reforkChatId = fixture.newChatId();
+      await fixture.client.forkChat({
+        sourceChatId: partialChatId,
+        chatId: reforkChatId,
+        upToSeq: 6,
+      });
+      const reforked = await fixture.client.getMessages(reforkChatId);
+      expect(reforked.messages.map((entry) => entry.message))
+        .toEqual(partial.messages.map((entry) => entry.message));
     }, {
       serverEnvironment,
       async prepareWorkspace(directories) {
@@ -198,6 +244,31 @@ describe('Codex fork at message', () => {
             timestamp,
             type: 'response_item',
             payload: {
+              type: 'custom_tool_call',
+              name: 'exec',
+              call_id: 'projected-exec',
+              input: [
+                'const results = await Promise.all([',
+                '  tools.exec_command({cmd: \'printf "first;command\\\\n"\'}),',
+                '  tools.exec_command({cmd: \'printf "second command\\\\n"\'}),',
+                ']);',
+                'results.forEach(result => text(result.output));',
+              ].join('\n'),
+            },
+          }),
+          JSON.stringify({
+            timestamp,
+            type: 'response_item',
+            payload: {
+              type: 'custom_tool_call_output',
+              call_id: 'projected-exec',
+              output: 'first command\nsecond command',
+            },
+          }),
+          JSON.stringify({
+            timestamp,
+            type: 'response_item',
+            payload: {
               type: 'function_call',
               name: 'wait',
               call_id: 'outer-wait',
@@ -259,5 +330,5 @@ describe('Codex fork at message', () => {
         }));
       },
     });
-  });
+  }, 15_000);
 });

--- a/server-agents/codex/package.json
+++ b/server-agents/codex/package.json
@@ -11,7 +11,8 @@
     "@garcon/server-agent-interface": "workspace:*",
     "@openai/codex": "0.144.6",
     "acorn": "^8.17.0",
-    "bun-pty": "^0.4.10"
+    "bun-pty": "^0.4.10",
+    "shell-quote": "^1.10.0"
   },
   "devDependencies": { "@types/bun": "^1.3.14", "typescript": "^6.0.3" },
   "garconBuild": {

--- a/server-agents/codex/package.json
+++ b/server-agents/codex/package.json
@@ -10,6 +10,7 @@
     "@garcon/server-agent-common": "workspace:*",
     "@garcon/server-agent-interface": "workspace:*",
     "@openai/codex": "0.144.6",
+    "acorn": "^8.17.0",
     "bun-pty": "^0.4.10"
   },
   "devDependencies": { "@types/bun": "^1.3.14", "typescript": "^6.0.3" },

--- a/server-agents/codex/src/agents/codex/__tests__/code-mode-command-projection.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/code-mode-command-projection.test.js
@@ -5,6 +5,7 @@ import {
   codexCodeModeResultToolId,
   createCodexCodeModeBashMessages,
   projectCodexCodeModeCommands,
+  rememberCodexCodeModeResult,
   rewriteCodexCodeModeCommandPrefix,
 } from '../code-mode-command-projection.js';
 
@@ -160,5 +161,16 @@ describe('Code Mode Bash message projection', () => {
     const source = rewriteCodexCodeModeCommandPrefix(commands);
 
     expect(projectCodexCodeModeCommands(source)).toEqual({ commands });
+  });
+
+  it('bounds pending result associations', () => {
+    const resultToolIds = new Map();
+    for (let index = 0; index <= 10_000; index += 1) {
+      rememberCodexCodeModeResult(resultToolIds, `outer-${index}`, `result-${index}`);
+    }
+
+    expect(resultToolIds.size).toBe(10_000);
+    expect(resultToolIds.has('outer-0')).toBe(false);
+    expect(resultToolIds.get('outer-10000')).toBe('result-10000');
   });
 });

--- a/server-agents/codex/src/agents/codex/__tests__/code-mode-command-projection.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/code-mode-command-projection.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'bun:test';
+import { BashToolUseMessage } from '@garcon/common/chat-types';
+import {
+  codexCodeModeBashToolId,
+  codexCodeModeResultToolId,
+  createCodexCodeModeBashMessages,
+  projectCodexCodeModeCommands,
+  rewriteCodexCodeModeCommandPrefix,
+} from '../code-mode-command-projection.js';
+
+const TS = '2026-07-21T12:00:00.000Z';
+
+describe('projectCodexCodeModeCommands', () => {
+  it('projects a direct command with JavaScript object syntax and local reporting', () => {
+    const source = `// @exec: {"yield_time_ms": 1000}
+const result = await tools.exec_command({
+  cmd: "printf 'one;two\\n'",
+  workdir: "/repo",
+  yield_time_ms: 1000,
+});
+text(result.output)
+if (result.exit_code !== undefined) text(String(result.exit_code));`;
+
+    expect(projectCodexCodeModeCommands(source)).toEqual({
+      commands: ["printf 'one;two\n'"],
+    });
+  });
+
+  it('projects a direct no-expression template command', () => {
+    expect(projectCodexCodeModeCommands(`
+      const result = await tools.exec_command({ cmd: \`git status\` });
+      text(JSON.stringify(result));
+    `)).toEqual({ commands: ['git status'] });
+  });
+
+  it('projects a literal Promise list in source order', () => {
+    const source = `
+      const results = await Promise.all([
+        tools.exec_command({cmd: "git status"}),
+        tools.exec_command({cmd: "git diff --stat", max_output_tokens: 4000}),
+        await tools.exec_command({cmd: "git log -1"}),
+      ]);
+      results.forEach((result, index) => text(\`CMD\${index + 1}\\n\${result.output}\`));
+    `;
+
+    expect(projectCodexCodeModeCommands(source)).toEqual({
+      commands: ['git status', 'git diff --stat', 'git log -1'],
+    });
+  });
+
+  it('projects a static string list mapped through an expression callback', () => {
+    const source = `
+      const commands = ["git status", "git diff --stat"];
+      const results = await Promise.all(
+        commands.map(async cmd => await tools.exec_command({cmd, workdir: "/repo"})),
+      );
+      text(results.join("\\n\\n"));
+    `;
+
+    expect(projectCodexCodeModeCommands(source)).toEqual({
+      commands: ['git status', 'git diff --stat'],
+    });
+  });
+
+  it('projects static tuples mapped through destructuring and local formatting', () => {
+    const source = `
+      const commands = [
+        ["git status", "/repo"],
+        ["git diff --stat", "/repo"],
+      ];
+      const results = await Promise.all(commands.map(async ([cmd, workdir]) => {
+        const result = await tools.exec_command({cmd, workdir, yield_time_ms: 1000});
+        return \`\${cmd}\\n\${result.output}\`;
+      }));
+      text(results.join("\\n\\n"));
+    `;
+
+    expect(projectCodexCodeModeCommands(source)).toEqual({
+      commands: ['git status', 'git diff --stat'],
+    });
+  });
+
+  it('projects a fixed tuple member from an identifier binding', () => {
+    const source = `
+      const entries = [["status", "git status"], ["diff", "git diff"]];
+      const results = await Promise.all(
+        entries.map(entry => tools.exec_command({cmd: entry[1]})),
+      );
+      for (const result of results) text(result.output);
+    `;
+
+    expect(projectCodexCodeModeCommands(source)).toEqual({
+      commands: ['git status', 'git diff'],
+    });
+  });
+
+  it('returns null for unsafe, dynamic, or unsupported programs', () => {
+    const rejected = [
+      'const result = await tools.exec_command({cmd: "git status"}',
+      'const result = await tools.exec_command({cmd: prefix + " status"}); text(result.output);',
+      'const result = await tools.exec_command({cmd: `git ${mode}`}); text(result.output);',
+      'if (enabled) { const result = await tools.exec_command({cmd: "git status"}); text(result.output); }',
+      'const result = await tools.exec_command({cmd: "git status", workdir: locateRepo()}); text(result.output);',
+      'const result = await tools.exec_command({cmd: "git status"}); notify(result.output);',
+      'const result = await tools.exec_command({cmd: "git status"}); store("result", result);',
+      'const result = await tools.exec_command({cmd: "git status"}); setTimeout(() => text(result.output), 0);',
+      'const result = await tools.exec_command({cmd: "git status"}); tools.write_stdin({chars: "x"});',
+      'const tools = {exec_command: fake}; const result = await tools.exec_command({cmd: "git status"}); text(result);',
+      'const text = value => value; const result = await tools.exec_command({cmd: "git status"}); text(result);',
+      'const result = await tools?.exec_command?.({cmd: "git status"}); text(result);',
+      'const a = await tools.exec_command({cmd: "a"}); const b = await tools.exec_command({cmd: "b"}); text(a.output);',
+      'const commands = getCommands(); const results = await Promise.all(commands.map(cmd => tools.exec_command({cmd}))); text(results);',
+      'const commands = ["a", "b"]; commands.push("c"); const results = await Promise.all(commands.map(cmd => tools.exec_command({cmd}))); text(results);',
+      'const commands = ["a", "b"]; const results = await Promise.all(commands.filter(Boolean).map(cmd => tools.exec_command({cmd}))); text(results);',
+      'const commands = ["a", "b"]; const results = await Promise.all(commands.map(cmd => enabled ? tools.exec_command({cmd}) : null)); text(results);',
+      'const commands = ["a", ...more]; const results = await Promise.all(commands.map(cmd => tools.exec_command({cmd}))); text(results);',
+      'const results = await Promise.all([tools.exec_command({cmd: "a"}), tools.web__run({})]); text(results);',
+      'const results = await Promise.all([]); text(results);',
+    ];
+
+    for (const source of rejected) {
+      expect(projectCodexCodeModeCommands(source), source).toBeNull();
+    }
+  });
+
+  it('bounds source size and command amplification', () => {
+    const oversizedSource = `const result = await tools.exec_command({cmd: "a"}); text(result.output);${' '.repeat(65 * 1024)}`;
+    const commands = Array.from({ length: 65 }, (_, index) => `"command-${index}"`).join(',');
+    const oversizedBatch = `
+      const commands = [${commands}];
+      const results = await Promise.all(commands.map(cmd => tools.exec_command({cmd})));
+      text(results);
+    `;
+
+    expect(projectCodexCodeModeCommands(oversizedSource)).toBeNull();
+    expect(projectCodexCodeModeCommands(oversizedBatch)).toBeNull();
+  });
+});
+
+describe('Code Mode Bash message projection', () => {
+  it('creates stable synthetic IDs and associates results with the final command', () => {
+    const projection = { commands: ['git status', 'git diff'] };
+    const messages = createCodexCodeModeBashMessages(TS, 'outer-call', projection);
+
+    expect(messages).toHaveLength(2);
+    expect(messages.every((message) => message instanceof BashToolUseMessage)).toBe(true);
+    expect(messages).toMatchObject([
+      { toolId: 'codex-code-mode:outer-call:0', command: 'git status' },
+      { toolId: 'codex-code-mode:outer-call:1', command: 'git diff' },
+    ]);
+    expect(codexCodeModeBashToolId('outer-call', 0)).toBe(messages[0].toolId);
+    expect(codexCodeModeResultToolId('outer-call', projection)).toBe(messages[1].toolId);
+  });
+
+  it('rewrites a command prefix into a round-trippable canonical program', () => {
+    const commands = [
+      'printf "one;two\\n"',
+      'printf "${literal} `ticks` \\n"',
+    ];
+    const source = rewriteCodexCodeModeCommandPrefix(commands);
+
+    expect(projectCodexCodeModeCommands(source)).toEqual({ commands });
+  });
+});

--- a/server-agents/codex/src/agents/codex/__tests__/fork-transcript.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/fork-transcript.test.js
@@ -3,6 +3,7 @@ import {
   createCodexForkTranscriptRewriter,
   rewriteCodexForkTranscriptEntry,
 } from '../fork-transcript.js';
+import { projectCodexCodeModeCommands } from '../code-mode-command-projection.js';
 
 const context = {
   sourceAgentSessionId: '11111111-1111-1111-1111-111111111111',
@@ -123,6 +124,63 @@ describe('rewriteCodexForkTranscriptEntry', () => {
     const selectedRewrite = createCodexForkTranscriptRewriter();
     expect(selectedRewrite(exec, { ...context, retainedMessageCount: 1 })).toBe(exec);
     expect(selectedRewrite(output, { ...context, retainedMessageCount: 1 })).toBe(output);
+  });
+
+  it('rewrites a partially selected Code Mode command group to a stable prefix', () => {
+    const rewrite = createCodexForkTranscriptRewriter();
+    const exec = {
+      type: 'response_item',
+      payload: {
+        type: 'custom_tool_call',
+        name: 'exec',
+        call_id: 'outer',
+        input: `
+          const results = await Promise.all([
+            tools.exec_command({cmd: "printf 'one;two\\n'"}),
+            tools.exec_command({cmd: "printf '\${literal} \\n'"}),
+          ]);
+          results.forEach(result => text(result.output));
+        `,
+      },
+    };
+    const output = {
+      type: 'response_item',
+      payload: { type: 'custom_tool_call_output', call_id: 'outer', output: 'aggregate' },
+    };
+
+    const rewritten = rewrite(exec, { ...context, retainedMessageCount: 1 });
+    expect(rewritten).not.toBe(exec);
+    expect(projectCodexCodeModeCommands(rewritten.payload.input)).toEqual({
+      commands: ["printf 'one;two\n'"],
+    });
+    expect(rewrite(output, { ...context, retainedMessageCount: 0 }))
+      .toEqual({ type: 'garcon_fork_filtered' });
+
+    const reforkRewrite = createCodexForkTranscriptRewriter();
+    expect(reforkRewrite(rewritten, { ...context, retainedMessageCount: 1 })).toBe(rewritten);
+  });
+
+  it('preserves a fully selected Code Mode command group', () => {
+    const exec = {
+      type: 'response_item',
+      payload: {
+        type: 'custom_tool_call',
+        name: 'exec',
+        call_id: 'outer',
+        input: `
+          const results = await Promise.all([
+            tools.exec_command({cmd: "one"}),
+            tools.exec_command({cmd: "two"}),
+          ]);
+          results.forEach(result => text(result.output));
+        `,
+      },
+    };
+
+    expect(createCodexForkTranscriptRewriter()(
+      exec,
+      { ...context, retainedMessageCount: 2 },
+    )).toBe(exec);
   });
 
   it('preserves provider records that the shared legacy projection does not render', () => {

--- a/server-agents/codex/src/agents/codex/__tests__/history-loader.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/history-loader.test.js
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { loadCodexChatMessages, loadCodexChatMessagePage } from '../history-loader.js';
-import { getNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
+import { getNativeMessageRevisionSource, getNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { transcriptRevision } from '@garcon/server-agent-common/lib/transcript-revision';
 
 async function withTempJsonl(lines, fn) {
@@ -58,6 +58,59 @@ describe('loadCodexChatMessages', () => {
       { type: 'exec-tool-use', toolId: 'call_exec', code, language: 'javascript' },
       { type: 'tool-result', toolId: 'call_exec' },
     ]);
+  });
+
+  it('projects shell-only Code Mode entries across full and paginated history', async () => {
+    const lines = [
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-07-10T21:34:09.149Z',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'outer',
+          input: `
+            const results = await Promise.all([
+              tools.exec_command({cmd: "git status"}),
+              tools.exec_command({cmd: "git diff --stat"}),
+            ]);
+            results.forEach(result => text(result.output));
+          `,
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-07-10T21:34:09.150Z',
+        payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'outer',
+          output: 'aggregate output',
+        },
+      }),
+    ];
+
+    await withTempJsonl(lines, async (filePath) => {
+      const full = await loadCodexChatMessages(filePath);
+      const page = await loadCodexChatMessagePage(filePath, 2, 0);
+
+      expect(full.map((message) => [message.type, message.toolId])).toEqual([
+        ['bash-tool-use', 'codex-code-mode:outer:0'],
+        ['bash-tool-use', 'codex-code-mode:outer:1'],
+        ['tool-result', 'codex-code-mode:outer:1'],
+      ]);
+      expect(getNativeMessageRevisionSource(full[0])).toMatchObject({
+        lineNumber: 1,
+        withinSourceOrdinal: 0,
+      });
+      expect(getNativeMessageRevisionSource(full[1])).toMatchObject({
+        lineNumber: 1,
+        withinSourceOrdinal: 1,
+      });
+      expect(page.messages).toEqual(full.slice(1));
+      expect(page.total).toBe(3);
+      expect(page.hasMore).toBe(true);
+      expect(page.revision).toBe(transcriptRevision(full));
+    });
   });
 
   it('hides Code Mode Wait envelopes and paired outputs from native history', async () => {

--- a/server-agents/codex/src/agents/codex/__tests__/legacy-history-projection.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/legacy-history-projection.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  BashToolUseMessage,
+  ExecToolUseMessage,
+  ToolResultMessage,
+} from '@garcon/common/chat-types';
+import { LegacyCodexProjection } from '../legacy-history-projection.js';
+
+const TS = '2026-07-21T12:00:00.000Z';
+
+function codeModeCall(callId, input) {
+  return {
+    type: 'response_item',
+    timestamp: TS,
+    payload: { type: 'custom_tool_call', name: 'exec', call_id: callId, input },
+  };
+}
+
+function codeModeOutput(callId, output = 'aggregate output') {
+  return {
+    type: 'response_item',
+    timestamp: TS,
+    payload: { type: 'custom_tool_call_output', call_id: callId, output },
+  };
+}
+
+describe('LegacyCodexProjection Code Mode commands', () => {
+  it('projects Bash commands and remaps the aggregate result to the final command', () => {
+    const projection = new LegacyCodexProjection();
+    const input = projection.project(codeModeCall('outer', `
+      const results = await Promise.all([
+        tools.exec_command({cmd: "git status"}),
+        tools.exec_command({cmd: "git diff --stat"}),
+      ]);
+      results.forEach(result => text(result.output));
+    `), {});
+    const output = projection.project(codeModeOutput('outer'), {});
+
+    expect(input.canonical).toHaveLength(2);
+    expect(input.canonical.every((message) => message instanceof BashToolUseMessage)).toBe(true);
+    expect(input.canonical).toMatchObject([
+      { toolId: 'codex-code-mode:outer:0', command: 'git status' },
+      { toolId: 'codex-code-mode:outer:1', command: 'git diff --stat' },
+    ]);
+    expect(output.canonical[0]).toBeInstanceOf(ToolResultMessage);
+    expect(output.canonical[0]).toMatchObject({
+      toolId: 'codex-code-mode:outer:1',
+      content: { raw: 'aggregate output' },
+      isError: false,
+    });
+  });
+
+  it('keeps unsupported programs and their results on the outer Exec ID', () => {
+    const projection = new LegacyCodexProjection();
+    const code = 'const value = await tools.web__run({}); text(value);';
+    const input = projection.project(codeModeCall('outer', code), {});
+    const output = projection.project(codeModeOutput('outer'), {});
+
+    expect(input.canonical[0]).toBeInstanceOf(ExecToolUseMessage);
+    expect(input.canonical[0]).toMatchObject({
+      toolId: 'outer',
+      code,
+      language: 'javascript',
+    });
+    expect(output.canonical[0]).toMatchObject({ toolId: 'outer' });
+  });
+
+  it('does not fabricate results for an unfinished projected call', () => {
+    const projection = new LegacyCodexProjection();
+    const input = projection.project(codeModeCall(
+      'outer',
+      'const result = await tools.exec_command({cmd: "pwd"}); text(result.output);',
+    ), {});
+
+    expect(input.canonical).toMatchObject([{
+      type: 'bash-tool-use',
+      toolId: 'codex-code-mode:outer:0',
+      command: 'pwd',
+    }]);
+  });
+
+  it('leaves unrelated outputs unchanged', () => {
+    const output = new LegacyCodexProjection().project(codeModeOutput('untracked'), {});
+
+    expect(output.canonical[0]).toMatchObject({
+      type: 'tool-result',
+      toolId: 'untracked',
+    });
+  });
+});

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage, WaitToolUseMessage, codexSubagentSourceFingerprint } from '@garcon/common/chat-types';
+import { BashToolUseMessage, CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage, WaitToolUseMessage, codexSubagentSourceFingerprint } from '@garcon/common/chat-types';
 import { buildApprovalResponse, createPendingApproval } from '../approvals.ts';
 import { CodexAppServerClient, CodexAppServerRpcError } from '../client.ts';
 import { convertCodexAppServerItem, convertCodexAppServerLiveItem, convertCodexRawCodeModeItem } from '../converter.ts';
@@ -616,7 +616,7 @@ describe('Codex app-server durability', () => {
 
 describe('Codex app-server converter', () => {
   it('normalizes only tracked raw Exec calls and outputs', () => {
-    const activeCodeModeCallIds = new Set();
+    const activeCodeModeResultToolIds = new Map();
     const code = '// @exec: {"yield_time_ms": 1000}\ntext("ok")';
 
     expect(convertCodexRawCodeModeItem({
@@ -624,19 +624,19 @@ describe('Codex app-server converter', () => {
       name: 'other',
       call_id: 'call-other',
       input: code,
-    }, '2026-07-10T21:34:09.149Z', activeCodeModeCallIds)).toEqual([]);
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds)).toEqual([]);
     expect(convertCodexRawCodeModeItem({
       type: 'custom_tool_call_output',
       call_id: 'call-other',
       output: 'ignored',
-    }, '2026-07-10T21:34:09.149Z', activeCodeModeCallIds)).toEqual([]);
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds)).toEqual([]);
 
     const input = convertCodexRawCodeModeItem({
       type: 'custom_tool_call',
       name: 'exec',
       call_id: 'call-exec',
       input: code,
-    }, '2026-07-10T21:34:09.149Z', activeCodeModeCallIds);
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds);
     expect(input).toHaveLength(1);
     expect(input[0]).toBeInstanceOf(ExecToolUseMessage);
     expect(input[0]).toMatchObject({
@@ -644,20 +644,20 @@ describe('Codex app-server converter', () => {
       code,
       language: 'javascript',
     });
-    expect(activeCodeModeCallIds.has('call-exec')).toBe(true);
+    expect(activeCodeModeResultToolIds.get('call-exec')).toBe('call-exec');
 
     expect(convertCodexRawCodeModeItem({
       type: 'custom_tool_call',
       name: 'exec',
       call_id: 'call-exec',
       input: code,
-    }, '2026-07-10T21:34:09.149Z', activeCodeModeCallIds)).toEqual([]);
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds)).toEqual([]);
 
     const output = convertCodexRawCodeModeItem({
       type: 'custom_tool_call_output',
       call_id: 'call-exec',
       output: [{ type: 'input_text', text: 'ok' }],
-    }, '2026-07-10T21:34:09.150Z', activeCodeModeCallIds);
+    }, '2026-07-10T21:34:09.150Z', activeCodeModeResultToolIds);
     expect(output).toHaveLength(1);
     expect(output[0]).toBeInstanceOf(ToolResultMessage);
     expect(output[0]).toMatchObject({
@@ -665,46 +665,92 @@ describe('Codex app-server converter', () => {
       content: { items: [{ type: 'input_text', text: 'ok' }] },
       isError: false,
     });
-    expect(activeCodeModeCallIds.has('call-exec')).toBe(false);
+    expect(activeCodeModeResultToolIds.has('call-exec')).toBe(false);
     expect(convertCodexRawCodeModeItem({
       type: 'custom_tool_call_output',
       call_id: 'call-exec',
       output: 'duplicate',
-    }, '2026-07-10T21:34:09.151Z', activeCodeModeCallIds)).toEqual([]);
+    }, '2026-07-10T21:34:09.151Z', activeCodeModeResultToolIds)).toEqual([]);
 
     convertCodexRawCodeModeItem({
       type: 'custom_tool_call',
       name: 'exec',
       call_id: 'call-exec-string',
       input: 'text("done")',
-    }, '2026-07-10T21:34:09.152Z', activeCodeModeCallIds);
+    }, '2026-07-10T21:34:09.152Z', activeCodeModeResultToolIds);
     expect(convertCodexRawCodeModeItem({
       type: 'custom_tool_call_output',
       call_id: 'call-exec-string',
       output: 'Script completed',
-    }, '2026-07-10T21:34:09.153Z', activeCodeModeCallIds)[0]).toMatchObject({
+    }, '2026-07-10T21:34:09.153Z', activeCodeModeResultToolIds)[0]).toMatchObject({
       content: { raw: 'Script completed' },
     });
   });
 
+  it('projects shell-only raw Exec calls and associates output with the final command', () => {
+    const activeCodeModeResultToolIds = new Map();
+    const code = `
+      const results = await Promise.all([
+        tools.exec_command({cmd: "git status"}),
+        tools.exec_command({cmd: "git diff --stat"}),
+      ]);
+      results.forEach(result => text(result.output));
+    `;
+
+    const input = convertCodexRawCodeModeItem({
+      type: 'custom_tool_call',
+      name: 'exec',
+      call_id: 'call-bash',
+      input: code,
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds);
+
+    expect(input).toHaveLength(2);
+    expect(input.every((message) => message instanceof BashToolUseMessage)).toBe(true);
+    expect(input).toMatchObject([
+      { toolId: 'codex-code-mode:call-bash:0', command: 'git status' },
+      { toolId: 'codex-code-mode:call-bash:1', command: 'git diff --stat' },
+    ]);
+    expect(activeCodeModeResultToolIds.get('call-bash')).toBe('codex-code-mode:call-bash:1');
+
+    expect(convertCodexRawCodeModeItem({
+      type: 'custom_tool_call',
+      name: 'exec',
+      call_id: 'call-bash',
+      input: code,
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds)).toEqual([]);
+
+    const output = convertCodexRawCodeModeItem({
+      type: 'custom_tool_call_output',
+      call_id: 'call-bash',
+      output: 'aggregate output',
+    }, '2026-07-10T21:34:09.150Z', activeCodeModeResultToolIds);
+
+    expect(output).toMatchObject([{
+      type: 'tool-result',
+      toolId: 'codex-code-mode:call-bash:1',
+      content: { raw: 'aggregate output' },
+    }]);
+    expect(activeCodeModeResultToolIds.size).toBe(0);
+  });
+
   it('ignores malformed raw Exec calls', () => {
-    const activeCodeModeCallIds = new Set();
+    const activeCodeModeResultToolIds = new Map();
     expect(convertCodexRawCodeModeItem({
       type: 'custom_tool_call',
       name: 'exec',
       call_id: 'call-exec',
-    }, '2026-07-10T21:34:09.149Z', activeCodeModeCallIds)).toEqual([]);
-    expect(activeCodeModeCallIds.size).toBe(0);
+    }, '2026-07-10T21:34:09.149Z', activeCodeModeResultToolIds)).toEqual([]);
+    expect(activeCodeModeResultToolIds.size).toBe(0);
   });
 
   it('normalizes only tracked raw Wait calls and outputs', () => {
-    const activeCodeModeCallIds = new Set();
+    const activeCodeModeResultToolIds = new Map();
     const input = convertCodexRawCodeModeItem({
       type: 'function_call',
       name: 'wait',
       call_id: 'call-wait',
       arguments: '{"cell_id":"46","yield_time_ms":30000,"max_tokens":12000}',
-    }, '2026-07-11T00:27:03.417Z', activeCodeModeCallIds);
+    }, '2026-07-11T00:27:03.417Z', activeCodeModeResultToolIds);
 
     expect(input).toHaveLength(1);
     expect(input[0]).toBeInstanceOf(WaitToolUseMessage);
@@ -714,13 +760,13 @@ describe('Codex app-server converter', () => {
       yieldTimeMs: 30000,
       maxTokens: 12000,
     });
-    expect(activeCodeModeCallIds.has('call-wait')).toBe(true);
+    expect(activeCodeModeResultToolIds.get('call-wait')).toBe('call-wait');
 
     const output = convertCodexRawCodeModeItem({
       type: 'function_call_output',
       call_id: 'call-wait',
       output: 'Script completed',
-    }, '2026-07-11T00:27:33.417Z', activeCodeModeCallIds);
+    }, '2026-07-11T00:27:33.417Z', activeCodeModeResultToolIds);
 
     expect(output[0]).toBeInstanceOf(ToolResultMessage);
     expect(output[0]).toMatchObject({
@@ -728,18 +774,18 @@ describe('Codex app-server converter', () => {
       content: { raw: 'Script completed' },
       isError: false,
     });
-    expect(activeCodeModeCallIds.has('call-wait')).toBe(false);
+    expect(activeCodeModeResultToolIds.has('call-wait')).toBe(false);
   });
 
   it('ignores malformed raw Wait calls', () => {
-    const activeCodeModeCallIds = new Set();
+    const activeCodeModeResultToolIds = new Map();
     expect(convertCodexRawCodeModeItem({
       type: 'function_call',
       name: 'wait',
       call_id: 'call-wait',
       arguments: '{"yield_time_ms":30000}',
-    }, '2026-07-11T00:27:03.417Z', activeCodeModeCallIds)).toEqual([]);
-    expect(activeCodeModeCallIds.size).toBe(0);
+    }, '2026-07-11T00:27:03.417Z', activeCodeModeResultToolIds)).toEqual([]);
+    expect(activeCodeModeResultToolIds.size).toBe(0);
   });
 
   it('converts app-server live item families to shared chat messages', () => {
@@ -995,7 +1041,7 @@ describe('Codex app-server converter', () => {
         type: 'input_text',
         text: envelope,
       }],
-    }, '2026-02-21T10:01:00.000Z', new Set());
+    }, '2026-02-21T10:01:00.000Z', new Map());
 
     expect(activity[0]).toMatchObject({
       action: 'agent_status',
@@ -1028,7 +1074,7 @@ describe('Codex app-server converter', () => {
         type: 'input_text',
         text: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n${message}`,
       }],
-    }, '2026-02-21T10:01:00.000Z', new Set());
+    }, '2026-02-21T10:01:00.000Z', new Map());
 
     expect(completion[0]).toMatchObject({
       action: 'agent_status',
@@ -1049,7 +1095,7 @@ describe('Codex app-server converter', () => {
         type: 'input_text',
         text: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/reviewer\nPayload:\n${message}`,
       }],
-    }, '2026-02-21T10:01:00.000Z', new Set());
+    }, '2026-02-21T10:01:00.000Z', new Map());
 
     expect(completion[0]).toMatchObject({
       action: 'agent_status',
@@ -1071,19 +1117,19 @@ describe('Codex app-server converter', () => {
       author: '/root/other',
       recipient: '/root',
       content,
-    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    }, '2026-02-21T10:01:00.000Z', new Map())).toEqual([]);
     expect(convertCodexRawCodeModeItem({
       type: 'agent_message',
       author: '/root/reviewer',
       recipient: 'root',
       content,
-    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    }, '2026-02-21T10:01:00.000Z', new Map())).toEqual([]);
     expect(convertCodexRawCodeModeItem({
       type: 'agent_message',
       author: '/root/reviewer',
       recipient: '/root/other',
       content,
-    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    }, '2026-02-21T10:01:00.000Z', new Map())).toEqual([]);
 
     const nestedContent = [{
       type: 'input_text',
@@ -1094,7 +1140,7 @@ describe('Codex app-server converter', () => {
       author: '/root/parent/child',
       recipient: '/root',
       content: nestedContent,
-    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    }, '2026-02-21T10:01:00.000Z', new Map())).toEqual([]);
   });
 
   it('maps nested v2 terminal response items to their immediate parent', () => {
@@ -1106,7 +1152,7 @@ describe('Codex app-server converter', () => {
         type: 'input_text',
         text: 'Message Type: FINAL_ANSWER\nTask name: /root/parent\nSender: /root/parent/child\nPayload:\nDone',
       }],
-    }, '2026-02-21T10:01:00.000Z', new Set());
+    }, '2026-02-21T10:01:00.000Z', new Map());
 
     expect(completion[0]).toMatchObject({
       action: 'agent_status',
@@ -1134,7 +1180,7 @@ describe('Codex app-server converter', () => {
       type: 'message',
       role: 'assistant',
       content: [{ type: 'output_text', text }],
-    }, '2026-02-21T10:01:00.000Z', new Set())).toEqual([]);
+    }, '2026-02-21T10:01:00.000Z', new Map())).toEqual([]);
   });
 
   it('does not interpret structured user messages as legacy lifecycle notifications', () => {
@@ -1160,7 +1206,7 @@ describe('Codex app-server converter', () => {
         type: 'input_text',
         text: envelope,
       }],
-    }, '2026-02-21T10:01:00.000Z', new Set());
+    }, '2026-02-21T10:01:00.000Z', new Map());
 
     expect(messages[0]).toMatchObject({
       action: 'agent_status',
@@ -2399,7 +2445,7 @@ describe('CodexAppServerRuntime', () => {
           type: 'custom_tool_call',
           name: 'exec',
           call_id: 'call-exec-1',
-          input: 'const value = 1; text(value);',
+          input: 'const result = await tools.exec_command({cmd: "pwd"}); text(result.output);',
         },
       },
     });
@@ -2455,18 +2501,17 @@ describe('CodexAppServerRuntime', () => {
     });
 
     expect(emitted.map((message) => message.type)).toEqual([
-      'exec-tool-use',
+      'bash-tool-use',
       'tool-result',
       'wait-tool-use',
       'tool-result',
     ]);
     expect(emitted[0]).toMatchObject({
-      toolId: 'call-exec-1',
-      code: 'const value = 1; text(value);',
-      language: 'javascript',
+      toolId: 'codex-code-mode:call-exec-1:0',
+      command: 'pwd',
     });
     expect(emitted[1]).toMatchObject({
-      toolId: 'call-exec-1',
+      toolId: 'codex-code-mode:call-exec-1:0',
       content: { items: [{ type: 'input_text', text: '1' }] },
       isError: false,
     });

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -814,6 +814,31 @@ describe('Codex app-server converter', () => {
     expect(messages.find((message) => message.type === 'web-search-tool-use')?.query).toBe('codex app server');
   });
 
+  it('normalizes Codex shell wrappers for loaded and live command executions', () => {
+    const item = {
+      type: 'commandExecution',
+      id: 'command-1',
+      command: "/bin/zsh -lc 'git status --short'",
+      cwd: '/repo',
+      processId: null,
+      source: 'agent',
+      status: 'inProgress',
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+
+    expect(convertCodexAppServerItem(item, '2026-02-21T10:00:00.000Z')[0]).toMatchObject({
+      type: 'bash-tool-use',
+      command: 'git status --short',
+    });
+    expect(convertCodexAppServerLiveItem(item, '2026-02-21T10:00:00.000Z')[0]).toMatchObject({
+      type: 'bash-tool-use',
+      command: 'git status --short',
+    });
+  });
+
   it('suppresses echoed user messages on the live notification path', () => {
     expect(convertCodexAppServerLiveItem({
       type: 'userMessage',

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/command-display.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/command-display.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+import { quote } from 'shell-quote';
+import { normalizeCodexCommandDisplay } from '../command-display.ts';
+
+describe('normalizeCodexCommandDisplay', () => {
+  it('unwraps Codex Unix shell wrappers', () => {
+    const cases = [
+      ['/bin/zsh', '-lc'],
+      ['/usr/bin/bash', '-c'],
+      ['/bin/sh', '-lc'],
+      ['C:\\Program Files\\Git\\bin\\bash.exe', '-c'],
+    ];
+
+    for (const [shell, flag] of cases) {
+      expect(normalizeCodexCommandDisplay(quote([shell, flag, 'git status --short']))).toBe('git status --short');
+    }
+  });
+
+  it('unwraps the shlex quoting emitted for embedded quotes and variables', () => {
+    const command = String.raw`/bin/zsh -lc 'printf '"'"'%s\n'"'"' "$HOME"'`;
+    expect(normalizeCodexCommandDisplay(command)).toBe(String.raw`printf '%s\n' "$HOME"`);
+  });
+
+  it('preserves multiline scripts and shell syntax inside the wrapped token', () => {
+    const script = `cat <<'EOF'
+a; b | c
+EOF`;
+    expect(normalizeCodexCommandDisplay(quote(['/bin/zsh', '-lc', script]))).toBe(script);
+  });
+
+  it('unwraps Codex PowerShell wrappers', () => {
+    expect(normalizeCodexCommandDisplay(
+      quote(['C:\\Program Files\\PowerShell\\7\\pwsh.exe', '-Command', 'Get-ChildItem -Force']),
+    )).toBe('Get-ChildItem -Force');
+    expect(normalizeCodexCommandDisplay(
+      quote(['powershell.exe', '-NOPROFILE', '-COMMAND', 'Write-Host hi']),
+    )).toBe('Write-Host hi');
+  });
+
+  it('unwraps Codex cmd wrappers', () => {
+    expect(normalizeCodexCommandDisplay(
+      quote(['C:\\Windows\\System32\\cmd.exe', '/C', 'dir /b']),
+    )).toBe('dir /b');
+  });
+
+  it('removes only the outer transport wrapper', () => {
+    expect(normalizeCodexCommandDisplay(
+      quote(['/bin/zsh', '-lc', 'bash -lc pwd']),
+    )).toBe('bash -lc pwd');
+  });
+
+  it('preserves commands that do not match Codex wrapper shapes', () => {
+    const commands = [
+      '',
+      'pwd',
+      "/bin/fish -lc 'echo hi'",
+      "/bin/zsh -ilc 'echo hi'",
+      "/bin/zsh -lc 'echo hi' extra",
+      '/bin/zsh -lc foo && bar',
+      '/bin/zsh -lc *.ts',
+    ];
+
+    for (const command of commands) {
+      expect(normalizeCodexCommandDisplay(command)).toBe(command);
+    }
+  });
+
+  it('preserves malformed or expandable outer command strings', () => {
+    const commands = [
+      "/bin/zsh -lc 'unterminated",
+      '/bin/zsh -lc trailing\\',
+      '/bin/zsh -lc "$HOME"',
+    ];
+
+    for (const command of commands) {
+      expect(normalizeCodexCommandDisplay(command)).toBe(command);
+    }
+  });
+});

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/paginated-history-source.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/paginated-history-source.test.js
@@ -43,7 +43,7 @@ describe('PaginatedCodexHistorySource', () => {
       }],
       ['page-2', {
         data: [turn('turn-2', [{
-          type: 'commandExecution', id: 'command-1', command: 'pwd', cwd: '/repo',
+          type: 'commandExecution', id: 'command-1', command: "/bin/zsh -lc 'pwd'", cwd: '/repo',
           processId: null, source: 'agent', status: 'completed', commandActions: [],
           aggregatedOutput: '/repo', exitCode: 0, durationMs: 4,
         }], 1_753_056_001)],
@@ -80,6 +80,7 @@ describe('PaginatedCodexHistorySource', () => {
     expect(getNativeMessageSource(messages[0])).toEqual({ entryId: 'turn:turn-1:item:user-1' });
     expect(getNativeMessageSource(messages[1])).toEqual({ entryId: 'turn:turn-2:item:command-1' });
     expect(getNativeMessageSource(messages[2])).toEqual({ entryId: 'turn:turn-2:item:command-1' });
+    expect(messages[1]).toMatchObject({ type: 'bash-tool-use', command: 'pwd' });
     expect(messages[3].timestamp).toBe(profile.createdAt);
     expect(shutdown).toHaveBeenCalledTimes(1);
 

--- a/server-agents/codex/src/agents/codex/app-server/command-display.ts
+++ b/server-agents/codex/src/agents/codex/app-server/command-display.ts
@@ -1,0 +1,90 @@
+import { parse } from 'shell-quote';
+
+const UNIX_SHELLS = new Set(['bash', 'sh', 'zsh']);
+const POWERSHELL_SHELLS = new Set(['powershell', 'pwsh']);
+const VARIABLE_REFERENCE = Object.freeze({});
+
+export function normalizeCodexCommandDisplay(command: string): string {
+  if (!hasBalancedPosixQuoting(command)) return command;
+
+  try {
+    const parsed = parse(command, () => VARIABLE_REFERENCE);
+    if (!parsed.every((token): token is string => typeof token === 'string')) return command;
+    return unwrapCodexShellCommand(parsed) ?? command;
+  } catch {
+    return command;
+  }
+}
+
+function unwrapCodexShellCommand(argv: string[]): string | undefined {
+  // Mirrors Codex's generated shell argv shapes: https://github.com/openai/codex/blob/rust-v0.144.6/codex-rs/core/src/shell.rs#L22-L48
+  const shell = executableName(argv[0]);
+
+  if (
+    argv.length === 3
+    && UNIX_SHELLS.has(shell)
+    && (argv[1] === '-lc' || argv[1] === '-c')
+  ) {
+    return argv[2];
+  }
+
+  if (
+    argv.length === 3
+    && POWERSHELL_SHELLS.has(shell)
+    && argv[1]?.toLowerCase() === '-command'
+  ) {
+    return argv[2];
+  }
+
+  if (
+    argv.length === 4
+    && POWERSHELL_SHELLS.has(shell)
+    && argv[1]?.toLowerCase() === '-noprofile'
+    && argv[2]?.toLowerCase() === '-command'
+  ) {
+    return argv[3];
+  }
+
+  if (
+    argv.length === 3
+    && shell === 'cmd'
+    && argv[1]?.toLowerCase() === '/c'
+  ) {
+    return argv[2];
+  }
+
+  return undefined;
+}
+
+function executableName(executable: string | undefined): string {
+  const basename = executable?.split(/[\\/]/u).at(-1)?.toLowerCase() ?? '';
+  return basename.endsWith('.exe') ? basename.slice(0, -4) : basename;
+}
+
+function hasBalancedPosixQuoting(command: string): boolean {
+  let quote: "'" | '"' | undefined;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+
+    if (quote === "'") {
+      if (character === "'") quote = undefined;
+      continue;
+    }
+
+    if (character === '\\') {
+      if (index + 1 >= command.length) return false;
+      index += 1;
+      continue;
+    }
+
+    if (quote === '"') {
+      if (character === '"') quote = undefined;
+      continue;
+    }
+
+    if (character === "'" || character === '"') quote = character;
+  }
+
+  return quote === undefined;
+}

--- a/server-agents/codex/src/agents/codex/app-server/converter.ts
+++ b/server-agents/codex/src/agents/codex/app-server/converter.ts
@@ -32,6 +32,12 @@ import { normalizeTodoItems, normalizeToolInput, normalizeToolResultContent } fr
 import { convertCodexSubagentToolUse } from '../subagent-tool-use.js';
 import { convertCodexWaitFunctionCall } from '../jsonl-tool-use-converter.js';
 import {
+  codexCodeModeResultToolId,
+  createCodexCodeModeBashMessages,
+  projectCodexCodeModeCommands,
+  rememberCodexCodeModeResult,
+} from '../code-mode-command-projection.js';
+import {
   convertCodexSubagentActivity,
   convertCodexInterAgentLifecycle,
   convertCodexSubagentLifecycleText,
@@ -120,7 +126,7 @@ export function convertCodexAppServerItem(
 export function convertCodexRawCodeModeItem(
   item: CodexRawResponseItem,
   timestamp: string,
-  activeCodeModeCallIds: Set<string>,
+  activeCodeModeResultToolIds: Map<string, string>,
 ): ChatMessage[] {
   if (item.type === 'agent_message') {
     const text = rawResponseItemText(item.content);
@@ -150,9 +156,18 @@ export function convertCodexRawCodeModeItem(
     && typeof item.call_id === 'string'
     && typeof item.input === 'string'
   ) {
-    if (activeCodeModeCallIds.has(item.call_id)) return [];
-    activeCodeModeCallIds.add(item.call_id);
-    return [new ExecToolUseMessage(timestamp, item.call_id, item.input, 'javascript')];
+    if (activeCodeModeResultToolIds.has(item.call_id)) return [];
+    const projection = projectCodexCodeModeCommands(item.input);
+    if (!projection) {
+      rememberCodexCodeModeResult(activeCodeModeResultToolIds, item.call_id, item.call_id);
+      return [new ExecToolUseMessage(timestamp, item.call_id, item.input, 'javascript')];
+    }
+    rememberCodexCodeModeResult(
+      activeCodeModeResultToolIds,
+      item.call_id,
+      codexCodeModeResultToolId(item.call_id, projection),
+    );
+    return createCodexCodeModeBashMessages(timestamp, item.call_id, projection);
   }
 
   if (
@@ -160,22 +175,24 @@ export function convertCodexRawCodeModeItem(
     && item.name === 'wait'
     && typeof item.call_id === 'string'
   ) {
-    if (activeCodeModeCallIds.has(item.call_id)) return [];
+    if (activeCodeModeResultToolIds.has(item.call_id)) return [];
     const message = convertCodexWaitFunctionCall(timestamp, item.call_id, item.arguments);
     if (!message) return [];
-    activeCodeModeCallIds.add(item.call_id);
+    rememberCodexCodeModeResult(activeCodeModeResultToolIds, item.call_id, item.call_id);
     return [message];
   }
 
   if (
     (item.type === 'custom_tool_call_output' || item.type === 'function_call_output')
     && typeof item.call_id === 'string'
-    && activeCodeModeCallIds.delete(item.call_id)
   ) {
+    const resultToolId = activeCodeModeResultToolIds.get(item.call_id);
+    if (!resultToolId) return [];
+    activeCodeModeResultToolIds.delete(item.call_id);
     return [
       new ToolResultMessage(
         timestamp,
-        item.call_id,
+        resultToolId,
         normalizeToolResultContent(item.output),
         false,
       ),

--- a/server-agents/codex/src/agents/codex/app-server/converter.ts
+++ b/server-agents/codex/src/agents/codex/app-server/converter.ts
@@ -42,6 +42,7 @@ import {
   convertCodexInterAgentLifecycle,
   convertCodexSubagentLifecycleText,
 } from '../subagent-lifecycle.js';
+import { normalizeCodexCommandDisplay } from './command-display.js';
 import type {
   CodexCollabAgentState,
   CodexCollabAgentTool,
@@ -213,7 +214,7 @@ function rawResponseItemText(content: unknown): string {
 
 function convertCommandExecution(item: Extract<CodexThreadItem, { type: 'commandExecution' }>, timestamp: string): ChatMessage[] {
   const messages: ChatMessage[] = [
-    new BashToolUseMessage(timestamp, item.id, item.command || ''),
+    new BashToolUseMessage(timestamp, item.id, normalizeCodexCommandDisplay(item.command || '')),
   ];
   if (item.status !== 'inProgress') {
     const content = item.aggregatedOutput || (item.status === 'completed' ? '' : item.status);

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -104,7 +104,7 @@ interface RunningCodexSession {
   activeInputChain: Promise<void>;
   activeDeliveryReservations: number;
   pendingFinish: FinishSessionOptions | null;
-  liveCodeModeCallIds: Set<string>;
+  liveCodeModeResultToolIds: Map<string, string>;
   capacityRetryCount: number;
   turnAttemptGeneration: number;
   pendingCapacityFailure: { turnId: string; message: string } | null;
@@ -1007,7 +1007,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       activeInputChain: Promise.resolve(),
       activeDeliveryReservations: 0,
       pendingFinish: null,
-      liveCodeModeCallIds: new Set(),
+      liveCodeModeResultToolIds: new Map(),
       capacityRetryCount: 0,
       turnAttemptGeneration: 0,
       pendingCapacityFailure: null,
@@ -1248,7 +1248,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     const messages = convertCodexRawCodeModeItem(
       params.item,
       new Date().toISOString(),
-      session.liveCodeModeCallIds,
+      session.liveCodeModeResultToolIds,
     );
     if (messages.length) this.emitMessages(session.chatId, messages);
   }
@@ -1268,7 +1268,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
 
   async #completeTurn(session: RunningCodexSession, params: TurnCompletedNotification): Promise<void> {
     session.turnAttemptGeneration += 1;
-    session.liveCodeModeCallIds.clear();
+    session.liveCodeModeResultToolIds.clear();
     if (params.turn.status === 'failed') {
       const pendingCapacityFailure = session.pendingCapacityFailure?.turnId === params.turn.id
         ? session.pendingCapacityFailure

--- a/server-agents/codex/src/agents/codex/code-mode-command-expressions.ts
+++ b/server-agents/codex/src/agents/codex/code-mode-command-expressions.ts
@@ -1,0 +1,191 @@
+import type { Expression } from 'acorn';
+
+export type StaticValue = string | number | boolean | null | StaticValue[];
+export type StaticBindings = ReadonlyMap<string, StaticValue>;
+
+export function isPureReporterExpression(expression: Expression): boolean {
+  switch (expression.type) {
+    case 'Identifier':
+    case 'Literal':
+      return true;
+    case 'TemplateLiteral':
+      return expression.expressions.every(isPureReporterExpression);
+    case 'MemberExpression':
+      return expression.object.type !== 'Super'
+        && isPureReporterExpression(expression.object)
+        && (!expression.computed || (
+          expression.property.type !== 'PrivateIdentifier'
+          && isPureReporterExpression(expression.property)
+        ));
+    case 'UnaryExpression':
+      return expression.operator !== 'delete' && isPureReporterExpression(expression.argument);
+    case 'BinaryExpression':
+      return expression.left.type !== 'PrivateIdentifier'
+        && isPureReporterExpression(expression.left)
+        && isPureReporterExpression(expression.right);
+    case 'LogicalExpression':
+      return isPureReporterExpression(expression.left) && isPureReporterExpression(expression.right);
+    case 'ConditionalExpression':
+      return isPureReporterExpression(expression.test)
+        && isPureReporterExpression(expression.consequent)
+        && isPureReporterExpression(expression.alternate);
+    case 'ArrayExpression':
+      return expression.elements.every((element) => (
+        element === null
+        || (element.type !== 'SpreadElement' && isPureReporterExpression(element))
+      ));
+    case 'ObjectExpression':
+      return expression.properties.every((property) => (
+        property.type === 'Property'
+        && property.kind === 'init'
+        && !property.method
+        && !property.computed
+        && isPureReporterExpression(property.value)
+      ));
+    case 'SequenceExpression':
+      return expression.expressions.every(isPureReporterExpression);
+    case 'ChainExpression':
+    case 'ParenthesizedExpression':
+      return isPureReporterExpression(expression.expression);
+    case 'CallExpression':
+      return isKnownPureReporterCall(expression);
+    default:
+      return false;
+  }
+}
+
+export function isDataExpression(expression: Expression): boolean {
+  switch (expression.type) {
+    case 'Identifier':
+    case 'Literal':
+      return true;
+    case 'TemplateLiteral':
+      return expression.expressions.every(isDataExpression);
+    case 'MemberExpression':
+      return expression.object.type !== 'Super'
+        && isDataExpression(expression.object)
+        && (!expression.computed || (
+          expression.property.type !== 'PrivateIdentifier'
+          && isDataExpression(expression.property)
+        ));
+    case 'UnaryExpression':
+      return expression.operator !== 'delete' && isDataExpression(expression.argument);
+    case 'BinaryExpression':
+      return expression.left.type !== 'PrivateIdentifier'
+        && isDataExpression(expression.left)
+        && isDataExpression(expression.right);
+    case 'LogicalExpression':
+      return isDataExpression(expression.left) && isDataExpression(expression.right);
+    case 'ConditionalExpression':
+      return isDataExpression(expression.test)
+        && isDataExpression(expression.consequent)
+        && isDataExpression(expression.alternate);
+    case 'ArrayExpression':
+      return expression.elements.every((element) => (
+        element !== null
+        && element.type !== 'SpreadElement'
+        && isDataExpression(element)
+      ));
+    case 'ObjectExpression':
+      return expression.properties.every((property) => (
+        property.type === 'Property'
+        && property.kind === 'init'
+        && !property.method
+        && !property.computed
+        && isDataExpression(property.value)
+      ));
+    case 'ChainExpression':
+    case 'ParenthesizedExpression':
+      return isDataExpression(expression.expression);
+    default:
+      return false;
+  }
+}
+
+export function resolveStaticString(
+  expression: Expression,
+  bindings: StaticBindings,
+): string | null {
+  if (expression.type === 'Literal' && typeof expression.value === 'string') {
+    return expression.value;
+  }
+  if (expression.type === 'TemplateLiteral' && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? expression.quasis[0]?.value.raw ?? null;
+  }
+  if (expression.type === 'Identifier') {
+    const value = bindings.get(expression.name);
+    return typeof value === 'string' ? value : null;
+  }
+  if (
+    expression.type === 'MemberExpression'
+    && expression.computed
+    && expression.object.type === 'Identifier'
+    && expression.property.type === 'Literal'
+    && typeof expression.property.value === 'number'
+    && Number.isInteger(expression.property.value)
+  ) {
+    const value = bindings.get(expression.object.name);
+    const item = Array.isArray(value) ? value[expression.property.value] : null;
+    return typeof item === 'string' ? item : null;
+  }
+  return null;
+}
+
+export function staticValue(expression: Expression): StaticValue | undefined {
+  if (expression.type === 'Literal') {
+    return typeof expression.value === 'string'
+      || typeof expression.value === 'number'
+      || typeof expression.value === 'boolean'
+      || expression.value === null
+      ? expression.value
+      : undefined;
+  }
+  if (expression.type === 'TemplateLiteral' && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? expression.quasis[0]?.value.raw;
+  }
+  if (expression.type === 'ArrayExpression') {
+    const values = expression.elements.map((element) => (
+      element && element.type !== 'SpreadElement' ? staticValue(element) : undefined
+    ));
+    return values.some((value) => value === undefined) ? undefined : values as StaticValue[];
+  }
+  return undefined;
+}
+
+export function propertyName(expression: Expression): string | null {
+  if (expression.type === 'Identifier') return expression.name;
+  return expression.type === 'Literal' && typeof expression.value === 'string'
+    ? expression.value
+    : null;
+}
+
+function isKnownPureReporterCall(call: Extract<Expression, { type: 'CallExpression' }>): boolean {
+  if (!call.arguments.every((argument) => (
+    argument.type !== 'SpreadElement' && isPureReporterExpression(argument)
+  ))) return false;
+  if (call.callee.type === 'Identifier') {
+    return call.callee.name === 'String'
+      || call.callee.name === 'Number'
+      || call.callee.name === 'Boolean';
+  }
+  if (isMemberCall(call, 'stringify')) {
+    return call.callee.object.type === 'Identifier' && call.callee.object.name === 'JSON';
+  }
+  return isMemberCall(call, 'join')
+    && call.callee.object.type !== 'Super'
+    && isPureReporterExpression(call.callee.object);
+}
+
+function isMemberCall(
+  call: Extract<Expression, { type: 'CallExpression' }>,
+  propertyNameValue: string,
+): call is Extract<Expression, { type: 'CallExpression' }> & {
+  callee: Extract<Expression, { type: 'MemberExpression' }>;
+} {
+  return call.callee.type === 'MemberExpression'
+    && !call.optional
+    && !call.callee.optional
+    && !call.callee.computed
+    && call.callee.property.type === 'Identifier'
+    && call.callee.property.name === propertyNameValue;
+}

--- a/server-agents/codex/src/agents/codex/code-mode-command-parser.ts
+++ b/server-agents/codex/src/agents/codex/code-mode-command-parser.ts
@@ -1,0 +1,426 @@
+import {
+  parse,
+  type AnyNode,
+  type ArrowFunctionExpression,
+  type CallExpression,
+  type Expression,
+  type FunctionExpression,
+  type Pattern,
+  type Program,
+  type Statement,
+  type VariableDeclaration,
+} from 'acorn';
+import {
+  isDataExpression,
+  isPureReporterExpression,
+  propertyName,
+  resolveStaticString,
+  staticValue,
+  type StaticBindings,
+  type StaticValue,
+} from './code-mode-command-expressions.js';
+
+const MAX_SOURCE_BYTES = 64 * 1024;
+const MAX_COMMANDS = 64;
+
+type CallbackExpression = ArrowFunctionExpression | FunctionExpression;
+
+interface RecognizedProgram {
+  readonly commands: string[];
+  readonly consumedStatements: ReadonlySet<Statement>;
+  readonly resultBinding: string;
+}
+
+export interface CodexCodeModeCommandProjection {
+  readonly commands: readonly string[];
+}
+
+/** Parses a bounded Code Mode program without evaluating it. */
+export function projectCodexCodeModeCommands(
+  source: string,
+): CodexCodeModeCommandProjection | null {
+  if (Buffer.byteLength(source, 'utf8') > MAX_SOURCE_BYTES) return null;
+
+  let program: Program;
+  try {
+    program = parse(source, { ecmaVersion: 'latest', sourceType: 'module' });
+  } catch {
+    return null;
+  }
+  if (hasReservedTopLevelBinding(program)) return null;
+
+  const recognizers = [recognizeDirectCommand, recognizeLiteralBatch, recognizeMappedBatch];
+  for (const recognize of recognizers) {
+    const recognized = recognize(program);
+    if (!recognized) continue;
+    if (
+      recognized.commands.length === 0
+      || recognized.commands.length > MAX_COMMANDS
+      || recognized.commands.some((command) => command.length === 0)
+    ) return null;
+    if (!validateRemainingProgram(program, recognized)) return null;
+    return { commands: recognized.commands };
+  }
+
+  return null;
+}
+
+function recognizeDirectCommand(program: Program): RecognizedProgram | null {
+  const matches: RecognizedProgram[] = [];
+  for (const statement of program.body) {
+    const declaration = singleConstDeclaration(statement);
+    if (!declaration || declaration.declarations[0].id.type !== 'Identifier') continue;
+    const call = awaitedCall(declaration.declarations[0].init);
+    if (!call || !isToolsExecCommandCall(call)) continue;
+    const command = extractExecCommand(call, new Map());
+    if (command === null) return null;
+    matches.push({
+      commands: [command],
+      consumedStatements: new Set([declaration]),
+      resultBinding: declaration.declarations[0].id.name,
+    });
+  }
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function recognizeLiteralBatch(program: Program): RecognizedProgram | null {
+  const matches: RecognizedProgram[] = [];
+  for (const statement of program.body) {
+    const declaration = singleConstDeclaration(statement);
+    if (!declaration || declaration.declarations[0].id.type !== 'Identifier') continue;
+    const promiseInput = awaitedPromiseAllInput(declaration.declarations[0].init);
+    if (!promiseInput || promiseInput.type !== 'ArrayExpression') continue;
+
+    const commands: string[] = [];
+    for (const element of promiseInput.elements) {
+      if (!element || element.type === 'SpreadElement') return null;
+      const call = unwrapCall(element);
+      if (!call || !isToolsExecCommandCall(call)) return null;
+      const command = extractExecCommand(call, new Map());
+      if (command === null) return null;
+      commands.push(command);
+    }
+    matches.push({
+      commands,
+      consumedStatements: new Set([declaration]),
+      resultBinding: declaration.declarations[0].id.name,
+    });
+  }
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function recognizeMappedBatch(program: Program): RecognizedProgram | null {
+  const declarations = topLevelConstArrays(program);
+  const matches: RecognizedProgram[] = [];
+
+  for (const statement of program.body) {
+    const resultDeclaration = singleConstDeclaration(statement);
+    if (!resultDeclaration || resultDeclaration.declarations[0].id.type !== 'Identifier') continue;
+    const promiseInput = awaitedPromiseAllInput(resultDeclaration.declarations[0].init);
+    const map = promiseInput && mappedCallback(promiseInput);
+    if (!map) continue;
+
+    const commandDeclaration = declarations.get(map.sourceName);
+    if (!commandDeclaration) return null;
+    const callbackExec = unconditionalCallbackExec(map.callback);
+    if (!callbackExec) return null;
+
+    const commands: string[] = [];
+    for (const item of commandDeclaration.values) {
+      const bindings = bindStaticPattern(map.callback.params[0], item);
+      if (!bindings) return null;
+      const command = extractExecCommand(callbackExec, bindings);
+      if (command === null) return null;
+      commands.push(command);
+    }
+
+    matches.push({
+      commands,
+      consumedStatements: new Set([commandDeclaration.statement, resultDeclaration]),
+      resultBinding: resultDeclaration.declarations[0].id.name,
+    });
+  }
+
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function validateRemainingProgram(program: Program, recognized: RecognizedProgram): boolean {
+  return program.body.every((statement) => (
+    statement.type !== 'ImportDeclaration'
+    && statement.type !== 'ExportNamedDeclaration'
+    && statement.type !== 'ExportDefaultDeclaration'
+    && statement.type !== 'ExportAllDeclaration'
+    && (
+      recognized.consumedStatements.has(statement)
+      || isReporterStatement(statement, new Set([recognized.resultBinding]))
+    )
+  ));
+}
+
+function isReporterStatement(statement: Statement, resultBindings: ReadonlySet<string>): boolean {
+  switch (statement.type) {
+    case 'EmptyStatement':
+      return true;
+    case 'BlockStatement':
+      return statement.body.every((child) => isReporterStatement(child, resultBindings));
+    case 'ExpressionStatement':
+      return isTextCall(statement.expression)
+        || isResultForEachCall(statement.expression, resultBindings);
+    case 'VariableDeclaration':
+      return statement.kind === 'const'
+        && statement.declarations.every((declaration) => (
+          declaration.id.type === 'Identifier'
+          && !isReservedBinding(declaration.id.name)
+          && Boolean(declaration.init)
+          && isPureReporterExpression(declaration.init!)
+        ));
+    case 'IfStatement':
+      return isPureReporterExpression(statement.test)
+        && isReporterStatement(statement.consequent, resultBindings)
+        && (!statement.alternate || isReporterStatement(statement.alternate, resultBindings));
+    case 'ForOfStatement':
+      return !statement.await
+        && isSingleIdentifierConst(statement.left)
+        && isResultBindingExpression(statement.right, resultBindings)
+        && isReporterStatement(statement.body, resultBindings);
+    default:
+      return false;
+  }
+}
+
+function isResultForEachCall(
+  expression: Expression,
+  resultBindings: ReadonlySet<string>,
+): boolean {
+  if (expression.type !== 'CallExpression' || expression.arguments.length !== 1) return false;
+  if (!isMemberCall(expression, 'forEach')) return false;
+  if (expression.callee.object.type === 'Super') return false;
+  if (!isResultBindingExpression(expression.callee.object, resultBindings)) return false;
+  const callback = expression.arguments[0];
+  if (!isCallback(callback)) return false;
+  if (callback.body.type === 'BlockStatement') {
+    return callback.body.body.every((statement) => isReporterStatement(statement, resultBindings));
+  }
+  return isTextCall(callback.body);
+}
+
+function isTextCall(expression: Expression): boolean {
+  return expression.type === 'CallExpression'
+    && expression.callee.type === 'Identifier'
+    && expression.callee.name === 'text'
+    && expression.arguments.every((argument) => (
+      argument.type !== 'SpreadElement' && isPureReporterExpression(argument)
+    ));
+}
+
+function extractExecCommand(call: CallExpression, bindings: StaticBindings): string | null {
+  if (call.arguments.length !== 1) return null;
+  const argument = call.arguments[0];
+  if (argument.type !== 'ObjectExpression') return null;
+
+  let command: string | null = null;
+  let commandProperties = 0;
+  for (const property of argument.properties) {
+    if (
+      property.type !== 'Property'
+      || property.kind !== 'init'
+      || property.method
+      || property.computed
+      || !isDataExpression(property.value)
+    ) return null;
+    if (propertyName(property.key) !== 'cmd') continue;
+    commandProperties += 1;
+    command = resolveStaticString(property.value, bindings);
+  }
+
+  return commandProperties === 1 ? command : null;
+}
+
+function unconditionalCallbackExec(callback: CallbackExpression): CallExpression | null {
+  if (callback.params.length !== 1) return null;
+  if (patternBindsReserved(callback.params[0])) return null;
+  if (callback.body.type !== 'BlockStatement') {
+    const call = unwrapCall(callback.body);
+    return call && isToolsExecCommandCall(call) ? call : null;
+  }
+
+  let execCall: CallExpression | null = null;
+  for (const statement of callback.body.body) {
+    const candidate = callbackExecStatement(statement);
+    if (candidate) {
+      if (execCall) return null;
+      execCall = candidate;
+      continue;
+    }
+    if (!isCallbackLocalStatement(statement)) return null;
+  }
+  return execCall;
+}
+
+function callbackExecStatement(statement: Statement): CallExpression | null {
+  if (statement.type === 'ReturnStatement' && statement.argument) {
+    const call = unwrapCall(statement.argument);
+    return call && isToolsExecCommandCall(call) ? call : null;
+  }
+  const declaration = singleConstDeclaration(statement);
+  if (!declaration || declaration.declarations[0].id.type !== 'Identifier') return null;
+  const call = unwrapCall(declaration.declarations[0].init);
+  return call && isToolsExecCommandCall(call) ? call : null;
+}
+
+function isCallbackLocalStatement(statement: Statement): boolean {
+  if (statement.type === 'EmptyStatement') return true;
+  if (statement.type === 'ReturnStatement') {
+    return !statement.argument || isPureReporterExpression(statement.argument);
+  }
+  if (statement.type === 'VariableDeclaration') {
+    return statement.kind === 'const'
+      && statement.declarations.every((declaration) => (
+        declaration.id.type === 'Identifier'
+        && !isReservedBinding(declaration.id.name)
+        && Boolean(declaration.init)
+        && isPureReporterExpression(declaration.init!)
+      ));
+  }
+  return false;
+}
+
+function topLevelConstArrays(program: Program): Map<string, {
+  readonly statement: Statement;
+  readonly values: readonly StaticValue[];
+}> {
+  const arrays = new Map<string, { statement: Statement; values: readonly StaticValue[] }>();
+  for (const statement of program.body) {
+    const declaration = singleConstDeclaration(statement);
+    if (!declaration) continue;
+    const declarator = declaration.declarations[0];
+    if (declarator.id.type !== 'Identifier' || declarator.init?.type !== 'ArrayExpression') continue;
+    const values = declarator.init.elements.map((element) => (
+      element && element.type !== 'SpreadElement' ? staticValue(element) : undefined
+    ));
+    if (values.some((value) => value === undefined)) continue;
+    arrays.set(declarator.id.name, { statement: declaration, values: values as StaticValue[] });
+  }
+  return arrays;
+}
+
+function bindStaticPattern(pattern: Pattern, value: StaticValue): StaticBindings | null {
+  const bindings = new Map<string, StaticValue>();
+  if (pattern.type === 'Identifier') {
+    bindings.set(pattern.name, value);
+    return bindings;
+  }
+  if (pattern.type !== 'ArrayPattern' || !Array.isArray(value)) return null;
+  for (let index = 0; index < pattern.elements.length; index += 1) {
+    const element = pattern.elements[index];
+    if (element === null) continue;
+    if (element.type !== 'Identifier' || index >= value.length) return null;
+    bindings.set(element.name, value[index]);
+  }
+  return bindings;
+}
+
+function mappedCallback(expression: Expression): {
+  readonly sourceName: string;
+  readonly callback: CallbackExpression;
+} | null {
+  if (expression.type !== 'CallExpression' || expression.arguments.length !== 1) return null;
+  if (!isMemberCall(expression, 'map') || expression.callee.object.type !== 'Identifier') return null;
+  const callback = expression.arguments[0];
+  return isCallback(callback)
+    ? { sourceName: expression.callee.object.name, callback }
+    : null;
+}
+
+function awaitedPromiseAllInput(expression: Expression | null | undefined): Expression | null {
+  const call = awaitedCall(expression);
+  if (!call || call.arguments.length !== 1 || !isMemberCall(call, 'all')) return null;
+  if (call.callee.object.type !== 'Identifier' || call.callee.object.name !== 'Promise') return null;
+  const argument = call.arguments[0];
+  return argument.type === 'SpreadElement' ? null : argument;
+}
+
+function awaitedCall(expression: Expression | null | undefined): CallExpression | null {
+  return expression?.type === 'AwaitExpression' && expression.argument.type === 'CallExpression'
+    ? expression.argument
+    : null;
+}
+
+function unwrapCall(expression: Expression | null | undefined): CallExpression | null {
+  if (expression?.type === 'CallExpression') return expression;
+  return awaitedCall(expression);
+}
+
+function isToolsExecCommandCall(call: CallExpression): boolean {
+  return isMemberCall(call, 'exec_command')
+    && call.callee.object.type === 'Identifier'
+    && call.callee.object.name === 'tools';
+}
+
+function isMemberCall(
+  call: CallExpression,
+  propertyNameValue: string,
+): call is CallExpression & { callee: Extract<Expression, { type: 'MemberExpression' }> } {
+  return call.callee.type === 'MemberExpression'
+    && !call.optional
+    && !call.callee.optional
+    && !call.callee.computed
+    && call.callee.property.type === 'Identifier'
+    && call.callee.property.name === propertyNameValue;
+}
+
+function singleConstDeclaration(node: AnyNode): VariableDeclaration | null {
+  return node.type === 'VariableDeclaration'
+    && node.kind === 'const'
+    && node.declarations.length === 1
+    && Boolean(node.declarations[0].init)
+    ? node
+    : null;
+}
+
+function isSingleIdentifierConst(node: Pattern | VariableDeclaration): boolean {
+  return node.type === 'VariableDeclaration'
+    && node.kind === 'const'
+    && node.declarations.length === 1
+    && node.declarations[0].id.type === 'Identifier'
+    && !node.declarations[0].init;
+}
+
+function isResultBindingExpression(
+  expression: Expression,
+  resultBindings: ReadonlySet<string>,
+): boolean {
+  return expression.type === 'Identifier' && resultBindings.has(expression.name);
+}
+
+function isCallback(node: AnyNode): node is CallbackExpression {
+  return node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression';
+}
+
+function hasReservedTopLevelBinding(program: Program): boolean {
+  return program.body.some((statement) => (
+    statement.type === 'VariableDeclaration'
+    && statement.declarations.some((declaration) => patternBindsReserved(declaration.id))
+  ));
+}
+
+function patternBindsReserved(pattern: Pattern): boolean {
+  if (pattern.type === 'Identifier') return isReservedBinding(pattern.name);
+  if (pattern.type === 'ArrayPattern') {
+    return pattern.elements.some((element) => element && patternBindsReserved(element));
+  }
+  if (pattern.type === 'ObjectPattern') {
+    return pattern.properties.some((property) => (
+      property.type === 'RestElement'
+        ? patternBindsReserved(property.argument)
+        : patternBindsReserved(property.value)
+    ));
+  }
+  if (pattern.type === 'AssignmentPattern') return patternBindsReserved(pattern.left);
+  if (pattern.type === 'RestElement') return patternBindsReserved(pattern.argument);
+  return false;
+}
+
+function isReservedBinding(name: string): boolean {
+  return name === 'tools' || name === 'Promise' || name === 'text';
+}

--- a/server-agents/codex/src/agents/codex/code-mode-command-projection.ts
+++ b/server-agents/codex/src/agents/codex/code-mode-command-projection.ts
@@ -1,0 +1,43 @@
+import { BashToolUseMessage } from '@garcon/common/chat-types';
+import {
+  projectCodexCodeModeCommands,
+  type CodexCodeModeCommandProjection,
+} from './code-mode-command-parser.js';
+
+export { projectCodexCodeModeCommands, type CodexCodeModeCommandProjection };
+
+export function codexCodeModeBashToolId(
+  outerCallId: string,
+  commandIndex: number,
+): string {
+  return `codex-code-mode:${outerCallId}:${commandIndex}`;
+}
+
+export function codexCodeModeResultToolId(
+  outerCallId: string,
+  projection: CodexCodeModeCommandProjection,
+): string {
+  return codexCodeModeBashToolId(outerCallId, projection.commands.length - 1);
+}
+
+export function createCodexCodeModeBashMessages(
+  timestamp: string,
+  outerCallId: string,
+  projection: CodexCodeModeCommandProjection,
+): BashToolUseMessage[] {
+  return projection.commands.map((command, index) => (
+    new BashToolUseMessage(timestamp, codexCodeModeBashToolId(outerCallId, index), command)
+  ));
+}
+
+export function rewriteCodexCodeModeCommandPrefix(commands: readonly string[]): string {
+  const calls = commands
+    .map((command) => `  tools.exec_command({ cmd: ${JSON.stringify(command)} })`)
+    .join(',\n');
+  return [
+    'const results = await Promise.all([',
+    calls,
+    ']);',
+    'for (const result of results) text(result.output);',
+  ].join('\n');
+}

--- a/server-agents/codex/src/agents/codex/code-mode-command-projection.ts
+++ b/server-agents/codex/src/agents/codex/code-mode-command-projection.ts
@@ -6,6 +6,8 @@ import {
 
 export { projectCodexCodeModeCommands, type CodexCodeModeCommandProjection };
 
+const MAX_PENDING_CODE_MODE_CALLS = 10_000;
+
 export function codexCodeModeBashToolId(
   outerCallId: string,
   commandIndex: number,
@@ -28,6 +30,17 @@ export function createCodexCodeModeBashMessages(
   return projection.commands.map((command, index) => (
     new BashToolUseMessage(timestamp, codexCodeModeBashToolId(outerCallId, index), command)
   ));
+}
+
+export function rememberCodexCodeModeResult(
+  resultToolIds: Map<string, string>,
+  outerCallId: string,
+  resultToolId: string,
+): void {
+  resultToolIds.set(outerCallId, resultToolId);
+  if (resultToolIds.size <= MAX_PENDING_CODE_MODE_CALLS) return;
+  const oldest = resultToolIds.keys().next().value;
+  if (oldest) resultToolIds.delete(oldest);
 }
 
 export function rewriteCodexCodeModeCommandPrefix(commands: readonly string[]): string {

--- a/server-agents/codex/src/agents/codex/fork-transcript.ts
+++ b/server-agents/codex/src/agents/codex/fork-transcript.ts
@@ -1,6 +1,10 @@
 import type { ForkTranscriptEntryContext } from '@garcon/server-agent-common/forking/fork-jsonl';
 import { isRecord } from '@garcon/common/json';
 import { LegacyCodexProjection } from './legacy-history-projection.js';
+import {
+  projectCodexCodeModeCommands,
+  rewriteCodexCodeModeCommandPrefix,
+} from './code-mode-command-projection.js';
 
 export function rewriteCodexForkTranscriptEntry(
   entry: unknown,
@@ -37,6 +41,8 @@ function rewriteCodexForkEntry(
       : 0;
     if (emittedCount > retainedMessageCount) {
       if (retainedMessageCount === 0) return { type: 'garcon_fork_filtered' };
+      const codeModePrefix = rewriteCodeModePrefix(entry, retainedMessageCount);
+      if (codeModePrefix) return codeModePrefix;
       if (
         retainedMessageCount === 1
         && entry.type === 'response_item'
@@ -67,5 +73,29 @@ function rewriteCodexForkEntry(
   return {
     ...entry,
     payload,
+  };
+}
+
+function rewriteCodeModePrefix(
+  entry: Record<string, unknown>,
+  retainedMessageCount: number,
+): Record<string, unknown> | null {
+  if (entry.type !== 'response_item' || !isRecord(entry.payload)) return null;
+  const payload = entry.payload;
+  if (
+    payload.type !== 'custom_tool_call'
+    || payload.name !== 'exec'
+    || typeof payload.input !== 'string'
+  ) return null;
+  const projection = projectCodexCodeModeCommands(payload.input);
+  if (!projection || retainedMessageCount >= projection.commands.length) return null;
+  return {
+    ...entry,
+    payload: {
+      ...payload,
+      input: rewriteCodexCodeModeCommandPrefix(
+        projection.commands.slice(0, retainedMessageCount),
+      ),
+    },
   };
 }

--- a/server-agents/codex/src/agents/codex/legacy-history-projection.ts
+++ b/server-agents/codex/src/agents/codex/legacy-history-projection.ts
@@ -3,11 +3,19 @@ import type {
   CodexJsonlNormalizationResult,
 } from './history-normalizer.js';
 import { normalizeCodexJsonlEntry } from './history-normalizer.js';
+import { ExecToolUseMessage } from '@garcon/common/chat-types';
+import {
+  codexCodeModeResultToolId,
+  createCodexCodeModeBashMessages,
+  projectCodexCodeModeCommands,
+  rememberCodexCodeModeResult,
+} from './code-mode-command-projection.js';
 
 const MAX_PENDING_HIDDEN_WAIT_CALLS = 10_000;
 
 export class LegacyCodexProjection {
   readonly #hiddenWaitCallIds = new Set<string>();
+  readonly #codeModeResultToolIds = new Map<string, string>();
 
   project(
     entry: Record<string, unknown>,
@@ -21,6 +29,36 @@ export class LegacyCodexProjection {
     if (isToolOutput(payload)) {
       const callId = string(payload?.call_id);
       if (callId && this.#hiddenWaitCallIds.delete(callId)) return emptyResult();
+      const resultToolId = callId ? this.#codeModeResultToolIds.get(callId) : undefined;
+      if (callId && resultToolId) {
+        this.#codeModeResultToolIds.delete(callId);
+        return normalizeCodexJsonlEntry({
+          ...entry,
+          payload: { ...payload, call_id: resultToolId },
+        }, context);
+      }
+    }
+    if (isCodeModeExecCall(payload)) {
+      const normalized = normalizeCodexJsonlEntry(entry, context);
+      const projection = projectCodexCodeModeCommands(payload.input);
+      if (!normalized || !projection) return normalized;
+      const outerMessage = normalized.canonical[0];
+      if (normalized.canonical.length !== 1 || !(outerMessage instanceof ExecToolUseMessage)) {
+        return normalized;
+      }
+      rememberCodexCodeModeResult(
+        this.#codeModeResultToolIds,
+        payload.call_id,
+        codexCodeModeResultToolId(payload.call_id, projection),
+      );
+      return {
+        ...normalized,
+        canonical: createCodexCodeModeBashMessages(
+          outerMessage.timestamp,
+          payload.call_id,
+          projection,
+        ),
+      };
     }
     return normalizeCodexJsonlEntry(entry, context);
   }
@@ -31,6 +69,15 @@ export class LegacyCodexProjection {
     const oldest = this.#hiddenWaitCallIds.values().next().value;
     if (oldest) this.#hiddenWaitCallIds.delete(oldest);
   }
+}
+
+function isCodeModeExecCall(
+  payload: Record<string, unknown> | null,
+): payload is Record<string, unknown> & { call_id: string; input: string } {
+  return payload?.type === 'custom_tool_call'
+    && payload.name === 'exec'
+    && Boolean(string(payload.call_id))
+    && typeof payload.input === 'string';
 }
 
 function isHiddenCodeModeWaitCall(


### PR DESCRIPTION
Codex Code Mode stores exec_command calls inside Exec code, causing shell activity to disappear or render as opaque execute messages in loaded transcripts. This change statically projects supported shell-only Exec programs into canonical bash tool-use rows across live history, legacy history, and forks, and removes Codex's generated shell launcher wrapper from app-server command display while preserving ambiguous inputs unchanged.