### PR TITLE
Align floating tab bars with pane boundary

### DIFF
--- a/web/src/lib/components/workspace/RightSidebarHost.svelte
+++ b/web/src/lib/components/workspace/RightSidebarHost.svelte
@@ -199,7 +199,7 @@
 	>
 		<div
 			data-floating-sidebar-toolbar
-			class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-center"
+			class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-start"
 		>
 			<WorkspaceTaskBar
 				host="sidebar"

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -239,7 +239,7 @@
 		{#if !isMobile}
 			<div
 				data-floating-workspace-toolbar
-				class={`pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 ${snapshot.main.order.length === 1 ? 'justify-end' : 'justify-center'}`}
+				class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-end"
 			>
 				<WorkspaceTaskBar
 					host="main"

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -412,6 +412,21 @@ describe('WorkspaceRoot', () => {
 		).toBe('false');
 	});
 
+	it('aligns desktop taskbars toward the right sidebar boundary', () => {
+		installContext(withAdditionalSurfaces());
+		const { container } = render(WorkspaceRoot, {
+			isMobile: false,
+			chatActions,
+		});
+		const mainToolbar = container.querySelector<HTMLElement>('[data-floating-workspace-toolbar]');
+		const sidebarToolbar = container.querySelector<HTMLElement>('[data-floating-sidebar-toolbar]');
+
+		expect(mainToolbar?.classList.contains('justify-end')).toBe(true);
+		expect(mainToolbar?.classList.contains('justify-center')).toBe(false);
+		expect(sidebarToolbar?.classList.contains('justify-start')).toBe(true);
+		expect(sidebarToolbar?.classList.contains('justify-center')).toBe(false);
+	});
+
 	it('binds focus, move, and close for every portable kind without replacing Chat', async () => {
 		const { workspace } = installContext();
 		const { container } = render(WorkspaceRoot, {


### PR DESCRIPTION
Aligns the main workspace floating tab bar to the trailing edge and the right-sidebar bar to the leading edge, creating clearer pane ownership around the shared boundary and eliminating the main toolbar's position shift when additional surfaces open. Adds regression coverage for both alignments.