### PR TITLE
Use tabs for compact Git workbench layouts

### DIFF
--- a/web/src/lib/components/git/GitWorkbench.svelte
+++ b/web/src/lib/components/git/GitWorkbench.svelte
@@ -12,7 +12,6 @@
 	import HistoryIcon from '@lucide/svelte/icons/history';
 	import GitGraph from '@lucide/svelte/icons/git-graph';
 	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
-	import PanelLeft from '@lucide/svelte/icons/panel-left';
 	import GitFileTree from './GitFileTree.svelte';
 	import GitVirtualDiffSurface from './GitVirtualDiffSurface.svelte';
 	import GitPorcelainPanel from './GitPorcelainPanel.svelte';
@@ -35,7 +34,6 @@
 	import {
 		containerPresentationForWidth,
 		observeContainerWidth,
-		type ContainerPresentation,
 	} from '$lib/components/shared/container-presentation.js';
 	import { gitContainerBreakpoints } from './git-container-presentation.js';
 
@@ -94,12 +92,13 @@
 	type SinglePane = 'files' | 'diff';
 	let containerWidth = $state(0);
 	let singlePane = $state<SinglePane>('files');
-	let compactTreeOpen = $state(false);
 	const observeWorkbenchWidth = observeContainerWidth((width) => {
 		containerWidth = width;
 	});
-	let containerPresentation = $derived<ContainerPresentation>(
-		isMobile ? 'narrow' : containerPresentationForWidth(containerWidth, gitContainerBreakpoints),
+	let containerPresentation = $derived<'narrow' | 'wide'>(
+		isMobile || containerPresentationForWidth(containerWidth, gitContainerBreakpoints) !== 'wide'
+			? 'narrow'
+			: 'wide',
 	);
 
 	function handleVisibleRowsChange(rows: GitVirtualReviewRow[]): void {
@@ -111,7 +110,6 @@
 		if (!activeProjectPath) return;
 		void wb.selectFile(activeProjectPath, path);
 		if (containerPresentation === 'narrow') singlePane = 'diff';
-		if (containerPresentation === 'compact') compactTreeOpen = false;
 	}
 
 	function handleSelectDirectory(path: string): void {
@@ -120,7 +118,6 @@
 		if (!firstFile) return;
 		void wb.selectFile(activeProjectPath, firstFile);
 		if (containerPresentation === 'narrow') singlePane = 'diff';
-		if (containerPresentation === 'compact') compactTreeOpen = false;
 	}
 
 	function handleAddCommentForFile(filePath: string, side: 'before' | 'after', line: number): void {
@@ -570,54 +567,21 @@
 				style={containerPresentation === 'wide'
 					? `grid-template-columns: ${files.treePaneWidthPx}px 6px minmax(0,1fr); grid-template-rows: minmax(0,1fr);`
 					: undefined}
-				data-git-compact-layout={containerPresentation === 'compact' ? '' : undefined}
 				data-git-wide-layout={containerPresentation === 'wide' ? '' : undefined}
 			>
-				{#if containerPresentation === 'compact' && compactTreeOpen}
-					<button
-						type="button"
-						class="absolute inset-0 z-10 cursor-default rounded-none bg-background/60"
-						aria-label="Close changed files"
-						onclick={() => (compactTreeOpen = false)}
-					></button>
-				{/if}
 				<div
 					class={cn(
 						'flex min-h-0 flex-col overflow-hidden bg-background',
 						containerPresentation === 'wide' && 'border-r border-border',
-						containerPresentation === 'compact' &&
-							(compactTreeOpen
-								? 'absolute inset-y-0 left-0 z-20 max-w-[85%] border-r border-border shadow-lg'
-								: 'hidden'),
 						containerPresentation === 'narrow' && 'absolute inset-0',
 						containerPresentation === 'narrow' &&
 							singlePane !== 'files' &&
 							'invisible pointer-events-none',
 					)}
-					style={containerPresentation === 'compact' && compactTreeOpen
-						? 'width: min(20rem, 85%);'
-						: undefined}
-					aria-label={containerPresentation === 'compact' ? 'Changed files' : undefined}
-					role={containerPresentation === 'compact' ? 'complementary' : undefined}
 					aria-hidden={containerPresentation === 'narrow' && singlePane !== 'files'}
 					inert={containerPresentation === 'narrow' && singlePane !== 'files'}
 					data-git-files-pane
 				>
-					{#if containerPresentation === 'compact'}
-						<div
-							class="flex shrink-0 items-center justify-between border-b border-border px-3 py-1.5"
-						>
-							<span class="text-xs font-medium text-foreground">Changed files</span>
-							<button
-								type="button"
-								class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-								aria-label="Close changed files"
-								onclick={() => (compactTreeOpen = false)}
-							>
-								<X class="h-3.5 w-3.5" />
-							</button>
-						</div>
-					{/if}
 					<div class="min-h-0 flex-1 overflow-hidden">
 						{@render fileTree(containerPresentation !== 'wide')}
 					</div>
@@ -654,22 +618,8 @@
 					inert={containerPresentation === 'narrow' && singlePane !== 'diff'}
 					data-git-diff-pane
 				>
-					{#if containerPresentation === 'compact'}
-						<div class="shrink-0 border-b border-border px-2 py-1">
-							<button
-								type="button"
-								class="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-								onclick={() => (compactTreeOpen = !compactTreeOpen)}
-								aria-expanded={compactTreeOpen}
-								aria-label={compactTreeOpen ? 'Hide changed files' : 'Show changed files'}
-							>
-								<PanelLeft class="h-3.5 w-3.5" />
-								Files
-							</button>
-						</div>
-					{/if}
 					{@render diffPane(
-						containerPresentation === 'wide' ? 5 : containerPresentation === 'compact' ? 4 : 3,
+						containerPresentation === 'wide' ? 5 : 3,
 						containerPresentation === 'narrow',
 					)}
 				</div>

--- a/web/src/lib/components/git/__tests__/GitWorkbench.test.ts
+++ b/web/src/lib/components/git/__tests__/GitWorkbench.test.ts
@@ -167,7 +167,7 @@ describe('GitWorkbench', () => {
 		expect(screen.queryByText('No changed files')).toBeNull();
 	});
 
-	it('switches wide, compact, and narrow layouts from host width without a viewport change', async () => {
+	it('uses tabs whenever the host is too narrow for the side-by-side layout', async () => {
 		const target = makeTarget();
 		const { container } = render(GitWorkbenchTestHost, {
 			props: {
@@ -188,19 +188,17 @@ describe('GitWorkbench', () => {
 		expect(diffSurface).toBeTruthy();
 
 		ResizeObserverHarness.emit(workbench, 700);
-		await waitFor(() => expect(workbench.getAttribute('data-git-layout')).toBe('compact'));
+		await waitFor(() => expect(workbench.getAttribute('data-git-layout')).toBe('narrow'));
 		expect(container.querySelector('[data-git-tree-resizer]')).toBeNull();
 		expect(container.querySelector('[data-git-virtual-diff-root]')).toBe(diffSurface);
-		expect(screen.getByRole('button', { name: 'Show changed files' })).toBeTruthy();
-		await fireEvent.click(screen.getByRole('button', { name: 'Show changed files' }));
-		expect(screen.getByRole('complementary', { name: 'Changed files' })).toBeTruthy();
+		expect(container.querySelector('[data-git-segmented-navigation]')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Files' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Diff' })).toBeTruthy();
 
 		ResizeObserverHarness.emit(workbench, 480);
 		await waitFor(() => expect(workbench.getAttribute('data-git-layout')).toBe('narrow'));
 		expect(container.querySelector('[data-git-segmented-navigation]')).toBeTruthy();
 		expect(container.querySelector('[data-git-virtual-diff-root]')).toBe(diffSurface);
-		expect(screen.getByRole('button', { name: 'Files' })).toBeTruthy();
-		expect(screen.getByRole('button', { name: 'Diff' })).toBeTruthy();
 
 		const filesPane = container.querySelector('[data-git-files-pane]');
 		const diffPane = container.querySelector('[data-git-diff-pane]');

--- a/web/src/lib/components/workspace/RightSidebarHost.svelte
+++ b/web/src/lib/components/workspace/RightSidebarHost.svelte
@@ -199,7 +199,7 @@
 	>
 		<div
 			data-floating-sidebar-toolbar
-			class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-center"
+			class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-start"
 		>
 			<WorkspaceTaskBar
 				host="sidebar"

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -239,7 +239,7 @@
 		{#if !isMobile}
 			<div
 				data-floating-workspace-toolbar
-				class={`pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 ${snapshot.main.order.length === 1 ? 'justify-end' : 'justify-center'}`}
+				class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-end"
 			>
 				<WorkspaceTaskBar
 					host="main"

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -412,6 +412,21 @@ describe('WorkspaceRoot', () => {
 		).toBe('false');
 	});
 
+	it('aligns desktop taskbars toward the right sidebar boundary', () => {
+		installContext(withAdditionalSurfaces());
+		const { container } = render(WorkspaceRoot, {
+			isMobile: false,
+			chatActions,
+		});
+		const mainToolbar = container.querySelector<HTMLElement>('[data-floating-workspace-toolbar]');
+		const sidebarToolbar = container.querySelector<HTMLElement>('[data-floating-sidebar-toolbar]');
+
+		expect(mainToolbar?.classList.contains('justify-end')).toBe(true);
+		expect(mainToolbar?.classList.contains('justify-center')).toBe(false);
+		expect(sidebarToolbar?.classList.contains('justify-start')).toBe(true);
+		expect(sidebarToolbar?.classList.contains('justify-center')).toBe(false);
+	});
+
 	it('binds focus, move, and close for every portable kind without replacing Chat', async () => {
 		const { workspace } = installContext();
 		const { container } = render(WorkspaceRoot, {


### PR DESCRIPTION
The Git workbench now falls back directly from the side-by-side file tree and diff layout to separate Files and Diff tabs whenever the container is too narrow. This removes the overlay file-tree sidebar, keeps navigation consistent across constrained layouts, and preserves adequate space for reviewing diffs.