### PR TITLE
Add close buttons to file surface headers

### DIFF
--- a/web/src/lib/components/files/FileSurface.svelte
+++ b/web/src/lib/components/files/FileSurface.svelte
@@ -6,6 +6,7 @@
 	import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
 	import FolderOpen from '@lucide/svelte/icons/folder-open';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+	import X from '@lucide/svelte/icons/x';
 	import { Button } from '$lib/components/ui/button';
 	import CodeEditor from './CodeEditor.svelte';
 	import MarkdownViewer from './MarkdownViewer.svelte';
@@ -25,13 +26,14 @@
 	import { startVisibilityPolling } from '$lib/components/shared/visibility-polling.js';
 	import { FILE_FRESHNESS_POLL_MS } from '$lib/files/sessions/file-freshness.js';
 
-	let {
-		session,
-		presentation,
-	}: {
+	interface Props {
 		session: FileSession;
 		presentation: PresentationHostId;
-	} = $props();
+		onClose?: () => void;
+		closeDisabled?: boolean;
+	}
+
+	let { session, presentation, onClose, closeDisabled = false }: Props = $props();
 	const files = getFileSessions();
 	const compact = $derived(presentation === 'sidebar' || presentation === 'mobile');
 	const toolbarActions = $derived.by<ResponsiveSurfaceAction[]>(() => {
@@ -138,6 +140,18 @@
 				{/if}
 			{/snippet}
 		</ResponsiveSurfaceActions>
+		{#if onClose}
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				onclick={onClose}
+				disabled={closeDisabled}
+				aria-label={m.file_session_close()}
+				title={m.file_session_close()}
+			>
+				<X class="h-4 w-4" />
+			</Button>
+		{/if}
 	</header>
 
 	{#if session.isExternallyStale || session.refreshError}

--- a/web/src/lib/components/files/__tests__/FileDialogHost.test.ts
+++ b/web/src/lib/components/files/__tests__/FileDialogHost.test.ts
@@ -21,6 +21,14 @@ describe('FileDialogHost', () => {
 		rendered.unmount();
 	});
 
+	it('keeps one dialog-owned Close control', async () => {
+		const rendered = render(FileDialogHostTestHost, { request: 'file' });
+		await screen.findByRole('dialog');
+
+		expect(await screen.findAllByRole('button', { name: m.file_session_close() })).toHaveLength(1);
+		rendered.unmount();
+	});
+
 	it('does not open the desktop file dialog on mobile', () => {
 		const rendered = render(FileDialogHostTestHost, { request: 'file', isMobile: true });
 

--- a/web/src/lib/components/files/__tests__/FileSurface.test.ts
+++ b/web/src/lib/components/files/__tests__/FileSurface.test.ts
@@ -1,11 +1,132 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	installResizeObserverHarness,
+	ResizeObserverHarness,
+} from '$lib/components/shared/__tests__/resize-observer-harness.js';
 import type { FileOpenRequest } from '$lib/files/sessions/file-session-registry.svelte.js';
+import * as m from '$lib/paraglide/messages.js';
 import FileSurfaceTestHost from './FileSurfaceTestHost.svelte';
 
 afterEach(cleanup);
 
 describe('FileSurface', () => {
+	const portablePresentations = ['main', 'sidebar', 'mobile'] as const;
+	const rendererModes = ['code', 'markdown', 'image'] as const;
+	const closeCases = portablePresentations.flatMap((presentation) =>
+		rendererModes.map((rendererMode) => ({ presentation, rendererMode })),
+	);
+
+	it.each(closeCases)(
+		'renders Close as the rightmost $presentation $rendererMode header control',
+		({ presentation, rendererMode }) => {
+			const { container } = render(FileSurfaceTestHost, {
+				presentation,
+				rendererMode,
+				onClose: vi.fn(),
+			});
+			const header = container.querySelector('header');
+			if (!header) throw new Error('Expected file header');
+			const close = within(header).getByRole('button', { name: m.file_session_close() });
+
+			expect(header.lastElementChild).toBe(close);
+		},
+	);
+
+	it('invokes and disables the supplied Close intent', async () => {
+		const onClose = vi.fn();
+		const rendered = render(FileSurfaceTestHost, {
+			presentation: 'main',
+			onClose,
+			closeDisabled: false,
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: m.file_session_close() }));
+		expect(onClose).toHaveBeenCalledOnce();
+
+		await rendered.rerender({
+			presentation: 'main',
+			onClose,
+			closeDisabled: true,
+		});
+		expect(
+			(screen.getByRole('button', { name: m.file_session_close() }) as HTMLButtonElement).disabled,
+		).toBe(true);
+	});
+
+	it('omits in-surface Close when the host does not supply the intent', () => {
+		render(FileSurfaceTestHost, { presentation: 'dialog' });
+
+		expect(screen.queryByRole('button', { name: m.file_session_close() })).toBeNull();
+	});
+
+	it('keeps Close visible and rightmost while lower-priority actions overflow', async () => {
+		const restoreResizeObserver = installResizeObserverHarness();
+		try {
+			const { container } = render(FileSurfaceTestHost, {
+				presentation: 'main',
+				rendererMode: 'code',
+				dirty: true,
+				onClose: vi.fn(),
+			});
+			await tick();
+			const measuredRoot = container.querySelector<HTMLElement>(
+				'[data-responsive-surface-actions]',
+			);
+			const header = container.querySelector('header');
+			if (!measuredRoot || !header) throw new Error('Expected responsive file header');
+			const root: HTMLElement = measuredRoot;
+			let availableWidth = 190;
+			Object.defineProperty(root, 'clientWidth', { get: () => availableWidth });
+			for (const element of container.querySelectorAll<HTMLElement>(
+				'[data-surface-action-measure]',
+			)) {
+				const widths: Record<string, number> = {
+					'open-files': 32,
+					save: 64,
+					'refresh-file': 32,
+				};
+				element.getBoundingClientRect = () =>
+					({
+						width: widths[element.dataset.surfaceActionMeasure ?? ''] ?? 0,
+					}) as DOMRect;
+			}
+			const fixedControl = root.firstElementChild as HTMLElement | null;
+			if (!fixedControl) throw new Error('Expected fixed editor settings control');
+			fixedControl.getBoundingClientRect = () => ({ width: 32 }) as DOMRect;
+			const menuMeasure = container.querySelector<HTMLElement>(
+				'[data-surface-action-overflow-measure]',
+			);
+			if (!menuMeasure) throw new Error('Expected overflow measurement control');
+			menuMeasure.getBoundingClientRect = () => ({ width: 32 }) as DOMRect;
+
+			async function setWidth(width: number): Promise<void> {
+				availableWidth = width;
+				ResizeObserverHarness.emit(root, availableWidth);
+				await tick();
+			}
+
+			await setWidth(190);
+			const close = screen.getByRole('button', { name: m.file_session_close() });
+			expect(screen.getByRole('button', { name: m.file_session_open_files() })).toBeTruthy();
+			expect(header.lastElementChild).toBe(close);
+
+			await setWidth(140);
+			expect(screen.getByRole('button', { name: m.file_session_close() })).toBe(close);
+			expect(screen.getByRole('button', { name: m.editor_actions_save() })).toBeTruthy();
+			expect(screen.queryByRole('button', { name: m.file_session_open_files() })).toBeNull();
+			expect(screen.queryByRole('button', { name: m.file_session_refresh() })).toBeNull();
+			expect(header.lastElementChild).toBe(close);
+
+			await fireEvent.click(screen.getByRole('button', { name: m.workspace_surface_actions() }));
+			expect(screen.getByRole('menuitem', { name: m.file_session_open_files() })).toBeTruthy();
+			expect(screen.getByRole('menuitem', { name: m.file_session_refresh() })).toBeTruthy();
+		} finally {
+			restoreResizeObserver();
+		}
+	});
+
 	it('hides File Sessions from mobile file chrome', () => {
 		const { container } = render(FileSurfaceTestHost, { presentation: 'mobile' });
 
@@ -26,7 +147,9 @@ describe('FileSurface', () => {
 				rendererMode,
 			});
 
-			expect(container.querySelector('[data-surface-action-measure="refresh-file"]')).not.toBeNull();
+			expect(
+				container.querySelector('[data-surface-action-measure="refresh-file"]'),
+			).not.toBeNull();
 		},
 	);
 
@@ -70,9 +193,7 @@ describe('FileSurface', () => {
 			dirty: true,
 		});
 
-		expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
-			true,
-		);
+		expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(true);
 	});
 
 	it('refreshes from the toolbar action', async () => {

--- a/web/src/lib/components/files/__tests__/FileSurfaceTestHost.svelte
+++ b/web/src/lib/components/files/__tests__/FileSurfaceTestHost.svelte
@@ -24,6 +24,8 @@
 		onRefresh = () => undefined,
 		onCheckFreshness = () => undefined,
 		onOpen = () => {},
+		onClose,
+		closeDisabled = false,
 	}: {
 		presentation: PresentationHostId;
 		rendererMode?: 'code' | 'markdown' | 'image';
@@ -36,6 +38,8 @@
 		onRefresh?: (sessionId: string) => void;
 		onCheckFreshness?: (sessionId: string) => void;
 		onOpen?: (request: FileOpenRequest) => void;
+		onClose?: () => void;
+		closeDisabled?: boolean;
 	} = $props();
 	const initial = untrack(() => ({
 		rendererMode,
@@ -134,4 +138,4 @@
 	onDestroy(() => localSettings.destroy());
 </script>
 
-<FileSurface {session} {presentation} />
+<FileSurface {session} {presentation} {onClose} {closeDisabled} />

--- a/web/src/lib/components/workspace/PortableSurfaceContent.svelte
+++ b/web/src/lib/components/workspace/PortableSurfaceContent.svelte
@@ -73,7 +73,12 @@
 		{@const session = files.get(surface.fileSessionId)}
 		{#if session}
 			{#await fileRenderer() then FileSurface}
-				<FileSurface {session} {presentation} />
+				<FileSurface
+					{session}
+					{presentation}
+					onClose={() => void workspace.closeSurface(surface.id)}
+					closeDisabled={workspace.isSurfaceCloseBlocked(surface.id)}
+				/>
 			{/await}
 		{:else if visible}
 			<div class="grid h-full place-items-center text-sm text-muted-foreground">

--- a/web/src/lib/components/workspace/PortableSurfaceFrame.svelte
+++ b/web/src/lib/components/workspace/PortableSurfaceFrame.svelte
@@ -70,28 +70,25 @@
 			onClose={() => void workspace.closeSurface(surface.id)}
 			closeDisabled={workspace.isSurfaceCloseBlocked(surface.id)}
 		/>
-	{:else if presentation === 'mobile' && (surface.type === 'file' || (surface.type === 'singleton' && surface.kind === 'commit'))}
+	{:else if presentation === 'mobile' && surface.type === 'singleton' && surface.kind === 'commit'}
 		<div class="flex h-full min-h-0 flex-col">
 			<div class="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background px-2">
-				{#if surface.type === 'singleton'}
-					<button
-						type="button"
-						class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-						onclick={() => void workspace.mobileBack()}
-						aria-label={m.workspace_back()}
-						title={m.workspace_back()}
-					>
-						<ArrowLeft class="h-4 w-4" />
-					</button>
-				{/if}
 				<button
 					type="button"
 					class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-					class:ml-auto={surface.type === 'file'}
+					onclick={() => void workspace.mobileBack()}
+					aria-label={m.workspace_back()}
+					title={m.workspace_back()}
+				>
+					<ArrowLeft class="h-4 w-4" />
+				</button>
+				<button
+					type="button"
+					class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
 					onclick={() => void workspace.closeSurface(surface.id)}
 					disabled={workspace.isSurfaceCloseBlocked(surface.id)}
-					aria-label={surface.type === 'file' ? m.file_session_close() : m.workspace_close_view()}
-					title={surface.type === 'file' ? m.file_session_close() : m.workspace_close_view()}
+					aria-label={m.workspace_close_view()}
+					title={m.workspace_close_view()}
 				>
 					<X class="h-4 w-4" />
 				</button>

--- a/web/src/lib/components/workspace/__tests__/SurfaceRendererTestStub.svelte
+++ b/web/src/lib/components/workspace/__tests__/SurfaceRendererTestStub.svelte
@@ -3,6 +3,14 @@
 	import { getSurfaceFrameBridge } from '$lib/workspace/surface-frame-context.js';
 	import { surfaceRendererTestProbe } from './surface-renderer-test-probe.js';
 
+	let {
+		onClose,
+		closeDisabled = false,
+	}: {
+		onClose?: () => void;
+		closeDisabled?: boolean;
+	} = $props();
+
 	const unregister = getSurfaceFrameBridge().provideRenderer({
 		attach: () => surfaceRendererTestProbe.attach(),
 		detach: () => surfaceRendererTestProbe.detach(),
@@ -13,3 +21,6 @@
 </script>
 
 <div data-testid="surface-renderer-stub">Surface renderer</div>
+{#if onClose}
+	<button type="button" onclick={onClose} disabled={closeDisabled}>Close file</button>
+{/if}

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -192,6 +192,13 @@ function mobileFileSnapshot(): WorkspaceLayoutSnapshot {
 	};
 }
 
+function mobileCommitSnapshot(): WorkspaceLayoutSnapshot {
+	return {
+		...canonicalWorkspaceSnapshot(),
+		mobileActiveSurfaceId: 'singleton:commit',
+	};
+}
+
 function createWorkspace(initial: WorkspaceLayoutSnapshot) {
 	const layout = new WorkspaceLayoutStore(initial);
 	const commit = (mutations: readonly WorkspaceLayoutMutation[]): void => {
@@ -377,7 +384,7 @@ describe('PortableSurfaceContent', () => {
 });
 
 describe('WorkspaceRoot', () => {
-	it('offers destructive Close without non-destructive Back for a mobile file', async () => {
+	it('offers one destructive Close without non-destructive Back for a mobile file', async () => {
 		const { workspace } = installContext(mobileFileSnapshot());
 		workspace.closeSurface.mockResolvedValueOnce(true);
 		render(WorkspaceRoot, {
@@ -386,10 +393,27 @@ describe('WorkspaceRoot', () => {
 		});
 
 		expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
-		await fireEvent.click(await screen.findByRole('button', { name: 'Close file' }));
+		const closeButtons = await screen.findAllByRole('button', { name: 'Close file' });
+		expect(closeButtons).toHaveLength(1);
+		await fireEvent.click(closeButtons[0]);
 
 		expect(workspace.closeSurface).toHaveBeenCalledWith('file:one');
 		expect(workspace.mobileBack).not.toHaveBeenCalled();
+	});
+
+	it('retains Back and Close view controls for mobile Commit', async () => {
+		const { workspace } = installContext(mobileCommitSnapshot());
+		workspace.closeSurface.mockResolvedValueOnce(true);
+		render(WorkspaceRoot, {
+			isMobile: true,
+			chatActions,
+		});
+
+		await fireEvent.click(await screen.findByRole('button', { name: 'Back' }));
+		expect(workspace.mobileBack).toHaveBeenCalledOnce();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Close view' }));
+		expect(workspace.closeSurface).toHaveBeenCalledWith('singleton:commit');
 	});
 
 	it('reserves chat content space only while the desktop taskbar is rendered', async () => {


### PR DESCRIPTION
File editors and Markdown and image viewers currently require desktop users to open a tab menu to close them, while mobile adds a redundant host-owned close row. This adds a persistent rightmost Close control to the shared responsive file header, delegates closing and blocked state to the existing workspace coordinator, and removes only the duplicate mobile file row while preserving dialog and Commit controls.