### PR TITLE
Restore centered workspace tab bars

### DIFF
--- a/web/src/lib/components/workspace/RightSidebarHost.svelte
+++ b/web/src/lib/components/workspace/RightSidebarHost.svelte
@@ -199,7 +199,7 @@
 	>
 		<div
 			data-floating-sidebar-toolbar
-			class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-start"
+			class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-center"
 		>
 			<WorkspaceTaskBar
 				host="sidebar"

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -238,7 +238,7 @@
 		{#if !isMobile}
 			<div
 				data-floating-workspace-toolbar
-				class="pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 justify-end"
+				class={`pointer-events-none absolute inset-x-2 top-2 z-40 flex min-w-0 ${snapshot.main.order.length === 1 ? 'justify-end' : 'justify-center'}`}
 			>
 				<WorkspaceTaskBar
 					host="main"

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -436,7 +436,7 @@ describe('WorkspaceRoot', () => {
 		).toBe('false');
 	});
 
-	it('aligns desktop taskbars toward the right sidebar boundary', () => {
+	it('centers desktop taskbars when they contain multiple tabs', () => {
 		installContext(withAdditionalSurfaces());
 		const { container } = render(WorkspaceRoot, {
 			isMobile: false,
@@ -445,10 +445,10 @@ describe('WorkspaceRoot', () => {
 		const mainToolbar = container.querySelector<HTMLElement>('[data-floating-workspace-toolbar]');
 		const sidebarToolbar = container.querySelector<HTMLElement>('[data-floating-sidebar-toolbar]');
 
-		expect(mainToolbar?.classList.contains('justify-end')).toBe(true);
-		expect(mainToolbar?.classList.contains('justify-center')).toBe(false);
-		expect(sidebarToolbar?.classList.contains('justify-start')).toBe(true);
-		expect(sidebarToolbar?.classList.contains('justify-center')).toBe(false);
+		expect(mainToolbar?.classList.contains('justify-center')).toBe(true);
+		expect(mainToolbar?.classList.contains('justify-end')).toBe(false);
+		expect(sidebarToolbar?.classList.contains('justify-center')).toBe(true);
+		expect(sidebarToolbar?.classList.contains('justify-start')).toBe(false);
 	});
 
 	it('binds focus, move, and close for every portable kind without replacing Chat', async () => {


### PR DESCRIPTION
Partially reverts #376, which mistakenly included the floating-tab alignment change alongside the compact Git workbench update. This restores the prior centered positioning for multi-tab main and workspace-sidebar rails while preserving #376's Git workbench changes and the existing single-tab main alignment.