### PR TITLE
Simplify chat list resize feedback

### DIFF
--- a/web/src/lib/components/layout/ResizeHandle.svelte
+++ b/web/src/lib/components/layout/ResizeHandle.svelte
@@ -58,10 +58,7 @@
 	)}
 >
 	<div
-		class={cn(
-			'absolute inset-y-0 -left-2 w-4 cursor-col-resize group select-none touch-none pointer-events-auto',
-			isDragging && 'bg-primary/10',
-		)}
+		class="absolute inset-y-0 -left-2 w-4 cursor-col-resize group select-none touch-none pointer-events-auto"
 		onpointerdown={handlePointerDown}
 		role="separator"
 		aria-orientation="vertical"

--- a/web/src/lib/components/layout/__tests__/ResizeHandle.test.ts
+++ b/web/src/lib/components/layout/__tests__/ResizeHandle.test.ts
@@ -34,4 +34,15 @@ describe('ResizeHandle', () => {
 
 		expect(onResize).toHaveBeenCalledWith(expectedWidth);
 	});
+
+	it('uses a line-only active indicator while resizing', async () => {
+		render(ResizeHandle, { width: 400, onResize: vi.fn() });
+		const separator = screen.getByRole('separator') as HTMLElement;
+		separator.setPointerCapture = vi.fn();
+
+		await fireEvent.pointerDown(separator, { pointerId: 6, clientX: 500 });
+
+		expect(separator.classList).not.toContain('bg-primary/10');
+		expect(separator.firstElementChild?.classList).toContain('bg-primary/30');
+	});
 });


### PR DESCRIPTION
Makes pane resizing feel visually consistent by removing the broad translucent highlight from the chat-list drag target and retaining only the thin active divider line used by the workspace-sidebar resize handle.