### PR TITLE
Detect stale revision comparisons

### DIFF
--- a/integration-tests/support/lightpanda-process.ts
+++ b/integration-tests/support/lightpanda-process.ts
@@ -8,6 +8,33 @@ const LOG_CAPACITY = 2_000;
 
 type LightpandaChild = Bun.Subprocess<'ignore', 'pipe', 'pipe'>;
 
+export interface LightpandaStopChild {
+  exited: Promise<number>;
+  kill(signal: 'SIGTERM' | 'SIGKILL'): void;
+}
+
+export async function stopLightpandaChild(
+  child: LightpandaStopChild,
+  describeLogs: () => string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  child.kill('SIGTERM');
+  try {
+    await withTimeout(
+      child.exited,
+      timeoutMs,
+      () => `Lightpanda did not stop after SIGTERM.\n${describeLogs()}`,
+    );
+  } catch {
+    child.kill('SIGKILL');
+    await withTimeout(
+      child.exited,
+      timeoutMs,
+      () => `Lightpanda did not exit after forced teardown.\n${describeLogs()}`,
+    );
+  }
+}
+
 async function pump(
   stream: ReadableStream<Uint8Array>,
   channel: 'stdout' | 'stderr',
@@ -158,23 +185,7 @@ export class LightpandaProcess {
   async stop(): Promise<void> {
     if (this.#exitCode !== null) return;
     this.#expectedExit = true;
-    this.#child.kill('SIGTERM');
-    try {
-      await withTimeout(
-        this.#child.exited,
-        10_000,
-        () => `Lightpanda did not stop after SIGTERM.\n${this.describeLogs()}`,
-      );
-    } catch (gracefulError) {
-      this.#child.kill('SIGKILL');
-      await withTimeout(
-        this.#child.exited,
-        10_000,
-        () => `Lightpanda did not exit after forced teardown.\n${this.describeLogs()}`,
-      );
-      await Promise.allSettled([this.#stdoutPump, this.#stderrPump]);
-      throw gracefulError;
-    }
+    await stopLightpandaChild(this.#child, () => this.describeLogs());
     await Promise.allSettled([this.#stdoutPump, this.#stderrPump]);
   }
 

--- a/integration-tests/tests/e2e/git-comparison.test.ts
+++ b/integration-tests/tests/e2e/git-comparison.test.ts
@@ -193,4 +193,88 @@ describe('Lightpanda Git comparison', () => {
       fixture.assertNoBrowserErrors();
     });
   });
+
+  test('freezes revision rows until a rewritten HEAD is explicitly refreshed', async () => {
+    await withE2eFixture('git-comparison-ref-freshness', async (fixture) => {
+      const project = fixture.integration.dirs.project;
+      await runGit(project, ['init', '-b', 'main']);
+      await runGit(project, ['config', 'user.email', 'test@example.com']);
+      await runGit(project, ['config', 'user.name', 'E2E Test']);
+      await writeFile(join(project, 'review.txt'), 'base marker\n', 'utf8');
+      await runGit(project, ['add', 'review.txt']);
+      await runGit(project, ['commit', '-m', 'base']);
+      await runGit(project, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+      await writeFile(join(project, 'review.txt'), 'before rewrite marker\n', 'utf8');
+      await runGit(project, ['commit', '-am', 'feature']);
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat('git-revision-freshness-seed');
+      await app.waitForText('echo:git-revision-freshness-seed');
+      await fixture.page.evaluate(() => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'p', ctrlKey: true, bubbles: true }),
+        );
+      });
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Command palette"]');
+      await fixture.page.evaluate(() => {
+        const option = [...document.querySelectorAll<HTMLButtonElement>('[role="option"]')]
+          .find((button) => button.textContent?.includes('Switch to Git'));
+        if (!option) throw new Error('Missing Switch to Git command.');
+        option.click();
+      });
+      await app.waitForButton('Compare revisions');
+      await app.clickButton('Compare revisions');
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      await app.fill('#git-comparison-from', 'origin/main');
+      await app.clickDialogButton('Revision');
+      await app.fill('#git-comparison-to', 'HEAD');
+      await app.clickDialogButton('Compare');
+      await fixture.page.waitForFunction(
+        () => !document.querySelector('[role="dialog"][aria-label="Compare revisions"]'),
+        { timeout: 20_000 },
+      );
+      await fixture.page.waitForSelector('[data-git-diff-document]');
+      await app.fill('[data-git-history-files-pane] input[type="search"]', 'review.txt');
+      await fixture.page.waitForSelector(
+        '[data-git-history-files-pane] [title="review.txt"]',
+      );
+      await fixture.page.evaluate(() => {
+        const label = document.querySelector<HTMLElement>(
+          '[data-git-history-files-pane] [title="review.txt"]',
+        );
+        const row = label?.closest<HTMLButtonElement>('[data-git-file-list-row]');
+        if (!row) throw new Error('Missing review.txt comparison row.');
+        row.click();
+      });
+      await fixture.page.waitForSelector('[data-git-history-diff-pane][aria-hidden="false"]');
+      await app.waitForText('before rewrite marker');
+
+      await writeFile(join(project, 'review.txt'), 'after rewrite marker\n', 'utf8');
+      await runGit(project, ['add', 'review.txt']);
+      await runGit(project, ['commit', '--amend', '--no-edit']);
+      await fixture.page.waitForFunction(
+        () => document.body.textContent?.includes('A selected revision moved.'),
+        { timeout: 25_000 },
+      );
+      expect(await fixture.page.$eval('body', (element) => element.textContent)).toContain(
+        'before rewrite marker',
+      );
+      expect(await fixture.page.$eval('body', (element) => element.textContent)).not.toContain(
+        'after rewrite marker',
+      );
+
+      await app.clickButton('Refresh comparison');
+      await fixture.page.waitForFunction(
+        () => !document.body.textContent?.includes('A selected revision moved.'),
+        { timeout: 20_000 },
+      );
+      await app.waitForText('after rewrite marker');
+      expect(await fixture.page.$eval('body', (element) => element.textContent)).not.toContain(
+        'before rewrite marker',
+      );
+      fixture.assertNoBrowserErrors();
+    });
+  });
 });

--- a/integration-tests/tests/e2e/queue-workflow.test.ts
+++ b/integration-tests/tests/e2e/queue-workflow.test.ts
@@ -21,6 +21,7 @@ describe('Lightpanda queue workflow', () => {
 			await app.sendComposer('ui-reorder-b');
 			await app.sendComposer('ui-reorder-c');
 			await app.sendComposer('ui-reorder-d');
+			await app.waitForQueuedPreview('ui-reorder-b');
 			await app.clickResponsiveAction('Edit queue');
 			await app.waitForQueuedDialogOrder(['ui-reorder-b', 'ui-reorder-c', 'ui-reorder-d']);
 

--- a/integration-tests/tests/server/git-comparison.test.ts
+++ b/integration-tests/tests/server/git-comparison.test.ts
@@ -161,4 +161,69 @@ describe('Git comparison HTTP API', () => {
       });
     });
   });
+
+  test('reports a rewritten HEAD without replacing the frozen comparison snapshot', async () => {
+    await withIntegrationFixture('git-comparison-ref-freshness', async (fixture) => {
+      const project = fixture.dirs.project;
+      await runGit(project, ['init', '-b', 'main']);
+      await runGit(project, ['config', 'user.email', 'test@example.com']);
+      await runGit(project, ['config', 'user.name', 'Integration Test']);
+      await writeFile(join(project, 'review.txt'), 'base\n', 'utf8');
+      await runGit(project, ['add', 'review.txt']);
+      await runGit(project, ['commit', '-m', 'base']);
+      await runGit(project, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+      await writeFile(join(project, 'review.txt'), 'before rewrite\n', 'utf8');
+      await runGit(project, ['commit', '-am', 'feature']);
+
+      const snapshot = await postJson<{
+        status: 'ready';
+        documentId: string;
+        from: { requestedRevision: string; hash: string };
+        to: { kind: 'revision'; requestedRevision: string; hash: string };
+      }>(fixture.garcon.baseUrl, '/api/v1/git/comparisons/snapshot', {
+        project,
+        from: { kind: 'revision', revision: 'origin/main' },
+        to: { kind: 'revision', revision: 'HEAD' },
+        mode: 'direct',
+        context: 5,
+      });
+      const request = {
+        project,
+        from: {
+          kind: 'revision',
+          revision: snapshot.from.requestedRevision,
+          hash: snapshot.from.hash,
+        },
+        to: {
+          kind: 'revision',
+          revision: snapshot.to.requestedRevision,
+          hash: snapshot.to.hash,
+        },
+      };
+      const fresh = await postJson<{
+        status: 'ready';
+        changedEndpoints: Array<'from' | 'to'>;
+      }>(fixture.garcon.baseUrl, '/api/v1/git/comparisons/freshness', request);
+      expect(fresh.changedEndpoints).toEqual([]);
+
+      await writeFile(join(project, 'review.txt'), 'after rewrite\n', 'utf8');
+      await runGit(project, ['add', 'review.txt']);
+      await runGit(project, ['commit', '--amend', '--no-edit']);
+      const rewrittenHead = await runGit(project, ['rev-parse', 'HEAD']);
+      const stale = await postJson<{
+        status: 'ready';
+        changedEndpoints: Array<'from' | 'to'>;
+        fromHash: string;
+        to: { kind: 'revision'; hash: string };
+      }>(fixture.garcon.baseUrl, '/api/v1/git/comparisons/freshness', request);
+
+      expect(stale).toMatchObject({
+        status: 'ready',
+        changedEndpoints: ['to'],
+        fromHash: snapshot.from.hash,
+        to: { kind: 'revision', hash: rewrittenHead },
+      });
+      expect(snapshot.documentId).toBeTruthy();
+    });
+  });
 });

--- a/integration-tests/tests/server/support-contract.test.ts
+++ b/integration-tests/tests/server/support-contract.test.ts
@@ -7,6 +7,10 @@ import { FakeOpenAiResponsesServer } from '../../support/fake-openai-responses-s
 import { GarconTestClient } from '../../support/garcon-client.js';
 import { fakeAnthropicRequestHeaders } from '../../support/anthropic-test-contract.js';
 import { fakeOpenAiRequestHeaders } from '../../support/openai-test-contract.js';
+import {
+  stopLightpandaChild,
+  type LightpandaStopChild,
+} from '../../support/lightpanda-process.js';
 
 class ControlledWebSocket extends EventTarget {
   readyState = 0;
@@ -62,6 +66,22 @@ describe('integration support contracts', () => {
     log.push(2);
     log.push(3);
     expect(log.values()).toEqual([2, 3]);
+  });
+
+  test('forces a stuck Lightpanda process down without failing the scenario', async () => {
+    const exited = new Deferred<number>();
+    const signals: Array<'SIGTERM' | 'SIGKILL'> = [];
+    const child = {
+      exited: exited.promise,
+      kill(signal) {
+        signals.push(signal);
+        if (signal === 'SIGKILL') exited.resolve(137);
+      },
+    } satisfies LightpandaStopChild;
+
+    await stopLightpandaChild(child, () => '(test logs)', 1);
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
   });
 
   test('serves models and deterministic streaming echoes', async () => {

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1264,6 +1264,170 @@ describe("comparison operations", () => {
     }
   });
 
+  it("detects moved requested revisions without changing frozen comparison identities", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-comparison-revision-freshness-"),
+    );
+    const git = createGitService({
+      agents: mockAgents,
+      classifyGitError: mockClassifyGitError,
+    });
+
+    try {
+      await initRepoWithCommit(projectPath);
+      const { stdout: baseOutput } = await runGitCommand(projectPath, [
+        "rev-parse",
+        "HEAD",
+      ]);
+      const baseHash = baseOutput.trim();
+      await runGitCommand(projectPath, [
+        "update-ref",
+        "refs/remotes/origin/main",
+        baseHash,
+      ]);
+      await fs.writeFile(path.join(projectPath, "a.txt"), "feature\n", "utf-8");
+      await runGitCommand(projectPath, ["commit", "-am", "feature"]);
+
+      const snapshot = await git.getComparisonSnapshot({
+        projectPath,
+        from: { kind: "revision", revision: "origin/main" },
+        to: { kind: "revision", revision: "HEAD" },
+        mode: "direct",
+      });
+      expect(snapshot.status).toBe("ready");
+
+      const fresh = await git.getComparisonFreshness({
+        projectPath,
+        from: {
+          kind: "revision",
+          revision: snapshot.from.requestedRevision,
+          hash: snapshot.from.hash,
+        },
+        to: {
+          kind: "revision",
+          revision: snapshot.to.requestedRevision,
+          hash: snapshot.to.hash,
+        },
+      });
+      expect(fresh).toMatchObject({
+        status: "ready",
+        changedEndpoints: [],
+        fromHash: baseHash,
+        to: { kind: "revision", hash: snapshot.to.hash },
+      });
+
+      await fs.writeFile(path.join(projectPath, "a.txt"), "rewritten\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "a.txt"]);
+      await runGitCommand(projectPath, ["commit", "--amend", "--no-edit"]);
+      const { stdout: rewrittenOutput } = await runGitCommand(projectPath, [
+        "rev-parse",
+        "HEAD",
+      ]);
+      const rewrittenHash = rewrittenOutput.trim();
+
+      const stale = await git.getComparisonFreshness({
+        projectPath,
+        from: {
+          kind: "revision",
+          revision: snapshot.from.requestedRevision,
+          hash: snapshot.from.hash,
+        },
+        to: {
+          kind: "revision",
+          revision: snapshot.to.requestedRevision,
+          hash: snapshot.to.hash,
+        },
+      });
+      expect(stale).toMatchObject({
+        status: "ready",
+        changedEndpoints: ["to"],
+        fromHash: baseHash,
+        to: { kind: "revision", hash: rewrittenHash },
+      });
+
+      const literalHashes = await git.getComparisonFreshness({
+        projectPath,
+        from: { kind: "revision", revision: baseHash, hash: baseHash },
+        to: {
+          kind: "revision",
+          revision: rewrittenHash,
+          hash: rewrittenHash,
+        },
+      });
+      expect(literalHashes).toMatchObject({
+        status: "ready",
+        changedEndpoints: [],
+      });
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("detects a moved From revision in a Working Tree comparison", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-comparison-working-tree-base-freshness-"),
+    );
+    const git = createGitService({
+      agents: mockAgents,
+      classifyGitError: mockClassifyGitError,
+    });
+
+    try {
+      await initRepoWithCommit(projectPath);
+      const { stdout: baseOutput } = await runGitCommand(projectPath, [
+        "rev-parse",
+        "HEAD",
+      ]);
+      const baseHash = baseOutput.trim();
+      await runGitCommand(projectPath, [
+        "update-ref",
+        "refs/remotes/origin/main",
+        baseHash,
+      ]);
+      await fs.writeFile(path.join(projectPath, "a.txt"), "feature\n", "utf-8");
+      await runGitCommand(projectPath, ["commit", "-am", "feature"]);
+
+      const snapshot = await git.getComparisonSnapshot({
+        projectPath,
+        from: { kind: "revision", revision: "origin/main" },
+        to: { kind: "working-tree" },
+        mode: "direct",
+      });
+      expect(snapshot.status).toBe("ready");
+      expect(snapshot.to.kind).toBe("working-tree");
+
+      await runGitCommand(projectPath, [
+        "update-ref",
+        "refs/remotes/origin/main",
+        snapshot.to.headHash,
+      ]);
+      const freshness = await git.getComparisonFreshness({
+        projectPath,
+        from: {
+          kind: "revision",
+          revision: snapshot.from.requestedRevision,
+          hash: snapshot.from.hash,
+        },
+        to: {
+          kind: "working-tree",
+          fingerprint: snapshot.to.fingerprint,
+        },
+      });
+
+      expect(freshness).toMatchObject({
+        status: "ready",
+        changedEndpoints: ["from"],
+        fromHash: snapshot.to.headHash,
+        to: {
+          kind: "working-tree",
+          fingerprint: snapshot.to.fingerprint,
+        },
+      });
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
   it("uses the common ancestor only when requested", async () => {
     const projectPath = await fs.mkdtemp(
       path.join(os.tmpdir(), "garcon-git-comparison-merge-base-"),

--- a/server/git/comparison.ts
+++ b/server/git/comparison.ts
@@ -24,6 +24,8 @@ import {
   type GitCommandTrace,
   type GitCommitFileStatus,
   type GitCommitFileSummary,
+  type GitComparisonFreshnessOptions,
+  type GitComparisonFreshnessResponse,
   type GitComparisonFileBodiesOptions,
   type GitComparisonFileBodiesResponse,
   type GitComparisonFileRequest,
@@ -608,6 +610,70 @@ function assertResolvedHash(hash: string, field: string): void {
   }
 }
 
+async function getComparisonFreshness(
+  {
+    projectPath,
+    from: fromExpectation,
+    to: toExpectation,
+    trace,
+    signal,
+  }: GitComparisonFreshnessOptions,
+  assertProjectPathAllowed: (projectPath: string) => Promise<string>,
+): Promise<GitComparisonFreshnessResponse> {
+  await assertGitRepository(projectPath);
+  const repoRoot = await assertProjectPathAllowed(
+    await resolveRepositoryRoot(projectPath, trace, signal),
+  );
+  assertResolvedHash(fromExpectation.hash, 'from.hash');
+  if (toExpectation.kind === 'revision') {
+    assertResolvedHash(toExpectation.hash, 'to.hash');
+  }
+
+  const from = await resolveRevision(repoRoot, fromExpectation.revision, trace, signal);
+  if (!from) {
+    return {
+      status: 'not-found',
+      project: projectPath,
+      endpoint: 'from',
+      revision: fromExpectation.revision,
+      message: 'The From revision is no longer available in this repository.',
+    };
+  }
+
+  const changedEndpoints: Array<'from' | 'to'> = [];
+  if (from.hash !== fromExpectation.hash) changedEndpoints.push('from');
+  if (toExpectation.kind === 'revision') {
+    const to = await resolveRevision(repoRoot, toExpectation.revision, trace, signal);
+    if (!to) {
+      return {
+        status: 'not-found',
+        project: projectPath,
+        endpoint: 'to',
+        revision: toExpectation.revision,
+        message: 'The To revision is no longer available in this repository.',
+      };
+    }
+    if (to.hash !== toExpectation.hash) changedEndpoints.push('to');
+    return {
+      status: 'ready',
+      project: projectPath,
+      changedEndpoints,
+      fromHash: from.hash,
+      to: { kind: 'revision', hash: to.hash },
+    };
+  }
+
+  const fingerprint = await workingTreeFingerprint(repoRoot, trace, signal);
+  if (fingerprint !== toExpectation.fingerprint) changedEndpoints.push('to');
+  return {
+    status: 'ready',
+    project: projectPath,
+    changedEndpoints,
+    fromHash: from.hash,
+    to: { kind: 'working-tree', fingerprint },
+  };
+}
+
 async function loadComparisonBody({
   projectPath,
   effectiveFromHash,
@@ -797,6 +863,8 @@ export function createComparisonOperations(
   return {
     getComparisonSnapshot: (options: GitComparisonSnapshotOptions) =>
       getComparisonSnapshot(options, assertProjectPathAllowed),
+    getComparisonFreshness: (options: GitComparisonFreshnessOptions) =>
+      getComparisonFreshness(options, assertProjectPathAllowed),
     getComparisonFileBodies: (options: GitComparisonFileBodiesOptions) =>
       getComparisonFileBodies(options, assertProjectPathAllowed),
   };

--- a/server/git/types.ts
+++ b/server/git/types.ts
@@ -600,6 +600,44 @@ export interface GitComparisonWorkingTreeBodyTarget {
 export type GitComparisonBodyTarget =
   GitComparisonRevisionBodyTarget | GitComparisonWorkingTreeBodyTarget;
 
+export interface GitComparisonRevisionExpectation {
+  kind: 'revision';
+  revision: string;
+  hash: string;
+}
+
+export interface GitComparisonWorkingTreeExpectation {
+  kind: 'working-tree';
+  fingerprint: string;
+}
+
+export type GitComparisonFreshnessToExpectation =
+  GitComparisonRevisionExpectation | GitComparisonWorkingTreeExpectation;
+
+export interface GitComparisonFreshnessOptions extends ProjectOptions {
+  from: GitComparisonRevisionExpectation;
+  to: GitComparisonFreshnessToExpectation;
+}
+
+export interface GitComparisonFreshnessReady {
+  status: 'ready';
+  project: string;
+  changedEndpoints: Array<'from' | 'to'>;
+  fromHash: string;
+  to: { kind: 'revision'; hash: string } | { kind: 'working-tree'; fingerprint: string };
+}
+
+export interface GitComparisonFreshnessNotFound {
+  status: 'not-found';
+  project: string;
+  endpoint: 'from' | 'to';
+  revision: string;
+  message: string;
+}
+
+export type GitComparisonFreshnessResponse =
+  GitComparisonFreshnessReady | GitComparisonFreshnessNotFound;
+
 export interface GitComparisonFileBodiesOptions extends ProjectOptions {
   documentId: string;
   effectiveFromHash: string;
@@ -930,6 +968,9 @@ export interface GitService {
   getComparisonSnapshot(
     options: GitComparisonSnapshotOptions,
   ): Promise<GitComparisonSnapshotResponse>;
+  getComparisonFreshness(
+    options: GitComparisonFreshnessOptions,
+  ): Promise<GitComparisonFreshnessResponse>;
   getComparisonFileBodies(
     options: GitComparisonFileBodiesOptions,
   ): Promise<GitComparisonFileBodiesResponse>;

--- a/server/routes/__tests__/git-comparisons.test.js
+++ b/server/routes/__tests__/git-comparisons.test.js
@@ -12,6 +12,7 @@ const { createGitComparisonRoutes } = await import('../git-comparisons.js');
 
 const snapshotCalls = [];
 const bodyCalls = [];
+const freshnessCalls = [];
 const git = {
   getComparisonSnapshot: mock(async (options) => {
     snapshotCalls.push(options);
@@ -33,11 +34,24 @@ const git = {
       message: 'Working Tree changed.',
     };
   }),
+  getComparisonFreshness: mock(async (options) => {
+    freshnessCalls.push(options);
+    return {
+      status: 'ready',
+      project: options.projectPath,
+      changedEndpoints: ['to'],
+      fromHash: options.from.hash,
+      to: options.to.kind === 'revision'
+        ? { kind: 'revision', hash: 'c'.repeat(40) }
+        : { kind: 'working-tree', fingerprint: 'changed' },
+    };
+  }),
   toHttpError: (error) => Response.json({ error: String(error) }, { status: 500 }),
 };
 const routes = createGitComparisonRoutes(git);
 const snapshotHandler = routes['/api/v1/git/comparisons/snapshot'].POST;
 const filesHandler = routes['/api/v1/git/comparisons/files'].POST;
+const freshnessHandler = routes['/api/v1/git/comparisons/freshness'].POST;
 
 function request(path, body, signal) {
   return new Request(`http://localhost${path}`, {
@@ -52,8 +66,10 @@ describe('Git comparison route contracts', () => {
   beforeEach(() => {
     snapshotCalls.length = 0;
     bodyCalls.length = 0;
+    freshnessCalls.length = 0;
     git.getComparisonSnapshot.mockClear();
     git.getComparisonFileBodies.mockClear();
+    git.getComparisonFreshness.mockClear();
   });
 
 	it('forwards a typed snapshot request and its abort signal', async () => {
@@ -165,6 +181,56 @@ describe('Git comparison route contracts', () => {
       expect(git.getComparisonFileBodies).not.toHaveBeenCalled();
     },
   );
+
+  it('forwards frozen revision identities to the freshness operation', async () => {
+    const controller = new AbortController();
+    const inputRequest = request('/api/v1/git/comparisons/freshness', {
+      project: '/project',
+      from: { kind: 'revision', revision: 'origin/main', hash: 'a'.repeat(40) },
+      to: { kind: 'revision', revision: 'HEAD', hash: 'b'.repeat(40) },
+    }, controller.signal);
+    const response = await freshnessHandler(inputRequest);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: 'ready',
+      changedEndpoints: ['to'],
+    });
+    expect(freshnessCalls[0]).toMatchObject({
+      projectPath: '/project',
+      from: { kind: 'revision', revision: 'origin/main', hash: 'a'.repeat(40) },
+      to: { kind: 'revision', revision: 'HEAD', hash: 'b'.repeat(40) },
+    });
+    expect(freshnessCalls[0].signal).toBe(inputRequest.signal);
+  });
+
+  it.each([
+    [
+      { kind: 'revision', revision: 'main', hash: 'short' },
+      { kind: 'working-tree', fingerprint: 'fp' },
+    ],
+    [
+      { kind: 'revision', revision: '', hash: 'a'.repeat(40) },
+      { kind: 'working-tree', fingerprint: 'fp' },
+    ],
+    [
+      { kind: 'revision', revision: 'main', hash: 'a'.repeat(40) },
+      { kind: 'revision', revision: 'HEAD', hash: 'bad' },
+    ],
+    [
+      { kind: 'revision', revision: 'main', hash: 'a'.repeat(40) },
+      { kind: 'working-tree', fingerprint: '' },
+    ],
+  ])('rejects malformed comparison freshness identities', async (from, to) => {
+    const response = await freshnessHandler(request('/api/v1/git/comparisons/freshness', {
+      project: '/project',
+      from,
+      to,
+    }));
+
+    expect(response.status).toBe(400);
+    expect(git.getComparisonFreshness).not.toHaveBeenCalled();
+  });
 
 	it('serializes typed body statuses and forwards the abort signal', async () => {
 		const controller = new AbortController();

--- a/server/routes/__tests__/git-workbench.test.js
+++ b/server/routes/__tests__/git-workbench.test.js
@@ -822,6 +822,7 @@ describe('route registration', () => {
       '/api/v1/git/history/commit/files': 'POST',
       '/api/v1/git/comparisons/snapshot': 'POST',
       '/api/v1/git/comparisons/files': 'POST',
+      '/api/v1/git/comparisons/freshness': 'POST',
       '/api/v1/git/stage-selection': 'POST',
       '/api/v1/git/stage-hunk': 'POST',
       '/api/v1/git/revert-commit': 'POST',

--- a/server/routes/git-comparisons.ts
+++ b/server/routes/git-comparisons.ts
@@ -5,8 +5,10 @@ import {
   GIT_REVIEW_DOCUMENT_LIMITS,
   type GitCommandTrace,
   type GitComparisonBodyTarget,
+  type GitComparisonFreshnessToExpectation,
   type GitComparisonFromEndpoint,
   type GitComparisonMode,
+  type GitComparisonRevisionExpectation,
   type GitComparisonToEndpoint,
 } from '../git/types.js';
 import type { RouteMap } from '../lib/http-route-types.js';
@@ -59,6 +61,27 @@ function validComparisonBodyTarget(value: unknown): GitComparisonBodyTarget | nu
     return fingerprint ? { kind: 'working-tree', fingerprint } : null;
   }
   return null;
+}
+
+function validResolvedHash(value: unknown): string | null {
+  return typeof value === 'string' && /^[0-9a-f]{40,64}$/.test(value) ? value : null;
+}
+
+function validComparisonRevisionExpectation(
+  value: unknown,
+): GitComparisonRevisionExpectation | null {
+  if (!isRecord(value) || value.kind !== 'revision') return null;
+  const revision = nonEmptyString(value.revision);
+  const hash = validResolvedHash(value.hash);
+  return revision && hash ? { kind: 'revision', revision, hash } : null;
+}
+
+function validComparisonFreshnessTo(value: unknown): GitComparisonFreshnessToExpectation | null {
+  const revision = validComparisonRevisionExpectation(value);
+  if (revision) return revision;
+  if (!isRecord(value) || value.kind !== 'working-tree') return null;
+  const fingerprint = nonEmptyString(value.fingerprint);
+  return fingerprint ? { kind: 'working-tree', fingerprint } : null;
 }
 
 function routeError(error: string): Response {
@@ -147,8 +170,32 @@ export function createGitComparisonRoutes(git: GitService): RouteMap {
     });
   }
 
+  async function postFreshness(body: JsonBody, request: Request): Promise<Response> {
+    return gitJson(git, async () => {
+      const input = asJsonBody(body);
+      const project = nonEmptyString(input.project);
+      const from = validComparisonRevisionExpectation(input.from);
+      const to = validComparisonFreshnessTo(input.to);
+      if (!project || !from || !to) {
+        return routeError('Missing or invalid comparison freshness identities or project.');
+      }
+
+      const trace: GitCommandTrace[] = [];
+      const startedAt = performance.now();
+      const result = await git.getComparisonFreshness({
+        projectPath: project,
+        from,
+        to,
+        trace,
+        signal: request.signal,
+      });
+      return traceGitJsonResponse('comparison-freshness', startedAt, trace, result);
+    });
+  }
+
   return {
     '/api/v1/git/comparisons/snapshot': { POST: withJsonBody(postSnapshot) },
     '/api/v1/git/comparisons/files': { POST: withJsonBody(postFiles) },
+    '/api/v1/git/comparisons/freshness': { POST: withJsonBody(postFreshness) },
   };
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -593,6 +593,8 @@
 	"git_compare_load_rows_failed": "Failed to load comparison rows: {detail}",
 	"git_diff_document_changed": "The diff changed while loading.",
 	"git_compare_working_tree_changed": "The Working Tree changed. Refresh to review the latest content.",
+	"git_compare_revision_changed": "A selected revision moved. Refresh to review the latest commits.",
+	"git_compare_revision_unavailable": "A selected revision no longer resolves. Edit the comparison or refresh after restoring the ref.",
 	"git_diff_document_files": "Files",
 	"git_diff_document_diff": "Diff",
 	"git_diff_document_file_tree_item": "{status}, {name}",

--- a/web/src/lib/api/__tests__/git-contract.test.ts
+++ b/web/src/lib/api/__tests__/git-contract.test.ts
@@ -34,7 +34,11 @@ import {
 	gitRemoveWorktree,
 	gitRevertCommit,
 } from '../git';
-import { getGitComparisonFileBodies, getGitComparisonSnapshot } from '../git-comparison';
+import {
+	getGitComparisonFileBodies,
+	getGitComparisonFreshness,
+	getGitComparisonSnapshot,
+} from '../git-comparison';
 
 vi.stubGlobal('localStorage', {
 	getItem: () => 'test-token',
@@ -698,6 +702,35 @@ describe('git API contract', () => {
 			to: { kind: 'working-tree', fingerprint: 'v1:old' },
 			files: [{ path: 'new.ts', originalPath: 'old.ts' }],
 			context: 3,
+		});
+	});
+
+	it('getGitComparisonFreshness posts frozen labels and resolved identities', async () => {
+		fetchMock.mockResolvedValue(
+			jsonResponse({
+				status: 'ready',
+				project: '/project',
+				changedEndpoints: ['to'],
+				fromHash: 'a'.repeat(40),
+				to: { kind: 'revision', hash: 'c'.repeat(40) },
+			}),
+		);
+		const controller = new AbortController();
+
+		await getGitComparisonFreshness(
+			'/project',
+			{ kind: 'revision', revision: 'origin/main', hash: 'a'.repeat(40) },
+			{ kind: 'revision', revision: 'HEAD', hash: 'b'.repeat(40) },
+			{ signal: controller.signal },
+		);
+
+		const [url, opts] = fetchMock.mock.calls[0];
+		expect(url).toBe('/api/v1/git/comparisons/freshness');
+		expect(opts.signal).toBeInstanceOf(AbortSignal);
+		expect(JSON.parse(opts.body)).toEqual({
+			project: '/project',
+			from: { kind: 'revision', revision: 'origin/main', hash: 'a'.repeat(40) },
+			to: { kind: 'revision', revision: 'HEAD', hash: 'b'.repeat(40) },
 		});
 	});
 

--- a/web/src/lib/api/git-comparison.ts
+++ b/web/src/lib/api/git-comparison.ts
@@ -86,6 +86,39 @@ export type GitComparisonSnapshotResponse =
 	| GitComparisonSnapshotNoMergeBase
 	| GitComparisonSnapshotWorkingTreeChanging;
 
+export interface GitComparisonRevisionExpectation {
+	kind: 'revision';
+	revision: string;
+	hash: string;
+}
+
+export interface GitComparisonWorkingTreeExpectation {
+	kind: 'working-tree';
+	fingerprint: string;
+}
+
+export type GitComparisonFreshnessToExpectation =
+	GitComparisonRevisionExpectation | GitComparisonWorkingTreeExpectation;
+
+export interface GitComparisonFreshnessReady {
+	status: 'ready';
+	project: string;
+	changedEndpoints: Array<'from' | 'to'>;
+	fromHash: string;
+	to: { kind: 'revision'; hash: string } | { kind: 'working-tree'; fingerprint: string };
+}
+
+export interface GitComparisonFreshnessNotFound {
+	status: 'not-found';
+	project: string;
+	endpoint: 'from' | 'to';
+	revision: string;
+	message: string;
+}
+
+export type GitComparisonFreshnessResponse =
+	GitComparisonFreshnessReady | GitComparisonFreshnessNotFound;
+
 export type GitComparisonFileRequest = GitDiffFileRequest;
 
 export type GitComparisonBodyTarget =
@@ -118,6 +151,19 @@ export async function getGitComparisonSnapshot(
 		'/api/v1/git/comparisons/snapshot',
 		{ project, from, to, mode, context, bodyCandidateCount },
 		fetchOptions,
+	);
+}
+
+export async function getGitComparisonFreshness(
+	project: string,
+	from: GitComparisonRevisionExpectation,
+	to: GitComparisonFreshnessToExpectation,
+	options?: ApiFetchOptions,
+): Promise<GitComparisonFreshnessResponse> {
+	return apiPost<GitComparisonFreshnessResponse>(
+		'/api/v1/git/comparisons/freshness',
+		{ project, from, to },
+		options,
 	);
 }
 

--- a/web/src/lib/git/review/__tests__/git-comparison.test.ts
+++ b/web/src/lib/git/review/__tests__/git-comparison.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	getGitComparisonFreshness,
 	getGitComparisonFileBodies,
 	getGitComparisonSnapshot,
 	type GitComparisonSnapshotReady,
 } from '$lib/api/git-comparison.js';
-import { getGitWorkingTreeFingerprint } from '$lib/api/git.js';
 import {
 	GIT_EMPTY_TREE_REVISION,
 	GitComparisonController,
@@ -15,15 +15,11 @@ vi.mock('$lib/api/git-comparison.js', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api/git-comparison.js')>();
 	return {
 		...actual,
+		getGitComparisonFreshness: vi.fn(),
 		getGitComparisonSnapshot: vi.fn(),
 		getGitComparisonFileBodies: vi.fn(),
 	};
 });
-
-vi.mock('$lib/api/git.js', async (importOriginal) => ({
-	...(await importOriginal<typeof import('$lib/api/git.js')>()),
-	getGitWorkingTreeFingerprint: vi.fn(),
-}));
 
 const limits = {
 	maxSummaryFiles: 10_000,
@@ -151,12 +147,12 @@ describe('GitComparisonController', () => {
 			files: {},
 			errors: {},
 		});
-		vi.mocked(getGitWorkingTreeFingerprint).mockResolvedValue({
+		vi.mocked(getGitComparisonFreshness).mockResolvedValue({
 			status: 'ready',
 			project: '/project',
-			fingerprintVersion: 1,
-			fingerprint: 'v1:new',
-			changedPathCount: 1,
+			changedEndpoints: ['to'],
+			fromHash: snapshot.from.hash,
+			to: { kind: 'working-tree', fingerprint: 'v1:new' },
 		});
 		const comparison = new GitComparisonController();
 		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });
@@ -165,20 +161,105 @@ describe('GitComparisonController', () => {
 		expect(comparison.snapshot?.documentId).toBe('comparison-doc');
 		expect(comparison.dialogOpen).toBe(false);
 		await comparison.checkFreshness('/project');
-		expect(getGitWorkingTreeFingerprint).toHaveBeenCalledWith('/repo');
+		expect(getGitComparisonFreshness).toHaveBeenCalledWith(
+			'/repo',
+			{ kind: 'revision', revision: 'main', hash: 'a'.repeat(40) },
+			{ kind: 'working-tree', fingerprint: 'v1:old' },
+		);
 		expect(comparison.staleMessage).toContain('Working Tree changed');
 	});
 
-	it('does not report operational fingerprint failures as content staleness', async () => {
+	it('marks a frozen revision comparison stale when HEAD moves', async () => {
+		const original = revisionSnapshotWithFile();
+		const snapshot = {
+			...original,
+			from: {
+				...original.from,
+				requestedRevision: 'origin/main',
+				label: 'origin/main',
+			},
+			to: {
+				kind: 'revision' as const,
+				requestedRevision: 'HEAD',
+				label: 'HEAD',
+				hash: 'b'.repeat(40),
+				shortHash: 'bbbbbbb',
+			},
+		};
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
+		vi.mocked(getGitComparisonFreshness).mockResolvedValue({
+			status: 'ready',
+			project: '/project',
+			changedEndpoints: ['to'],
+			fromHash: snapshot.from.hash,
+			to: { kind: 'revision', hash: 'c'.repeat(40) },
+		});
+		const comparison = new GitComparisonController();
+		comparison.openDialog({
+			fromRevision: 'origin/main',
+			toKind: 'revision',
+			toRevision: 'HEAD',
+		});
+
+		expect(await comparison.compare('/project')).toBe(true);
+		await comparison.checkFreshness('/project');
+
+		expect(getGitComparisonFreshness).toHaveBeenCalledWith(
+			'/project',
+			{ kind: 'revision', revision: 'origin/main', hash: 'a'.repeat(40) },
+			{ kind: 'revision', revision: 'HEAD', hash: 'b'.repeat(40) },
+		);
+		expect(comparison.document.isStale).toBe(true);
+		expect(comparison.staleMessage).toContain('selected revision moved');
+	});
+
+	it('detects a moved From revision in a Working Tree comparison', async () => {
 		const snapshot = workingTreeSnapshot();
 		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
-		vi.mocked(getGitWorkingTreeFingerprint).mockResolvedValue({
-			status: 'unknown',
+		vi.mocked(getGitComparisonFreshness).mockResolvedValue({
+			status: 'ready',
 			project: '/project',
-			fingerprintVersion: 1,
-			fingerprint: null,
-			message: 'Fingerprint unavailable.',
+			changedEndpoints: ['from'],
+			fromHash: 'c'.repeat(40),
+			to: { kind: 'working-tree', fingerprint: 'v1:old' },
 		});
+		const comparison = new GitComparisonController();
+		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });
+
+		await comparison.compare('/project');
+		await comparison.checkFreshness('/project');
+
+		expect(comparison.document.isStale).toBe(true);
+		expect(comparison.staleMessage).toContain('selected revision moved');
+	});
+
+	it('does not poll a revision comparison whose requested values are resolved hashes', async () => {
+		const original = revisionSnapshotWithFile();
+		if (original.to.kind !== 'revision') throw new Error('Expected a revision snapshot.');
+		const snapshot = {
+			...original,
+			from: { ...original.from, requestedRevision: original.from.hash },
+			to: { ...original.to, requestedRevision: original.to.hash },
+		};
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
+		const comparison = new GitComparisonController();
+		comparison.openDialog({
+			fromRevision: snapshot.from.hash,
+			toKind: 'revision',
+			toRevision: snapshot.to.hash,
+		});
+
+		await comparison.compare('/project');
+		await comparison.checkFreshness('/project');
+
+		expect(getGitComparisonFreshness).not.toHaveBeenCalled();
+		expect(comparison.document.isStale).toBe(false);
+	});
+
+	it('does not report operational freshness failures as content staleness', async () => {
+		const snapshot = workingTreeSnapshot();
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
+		vi.mocked(getGitComparisonFreshness).mockRejectedValue(new Error('Freshness unavailable.'));
 		const comparison = new GitComparisonController();
 		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });
 
@@ -272,12 +353,12 @@ describe('GitComparisonController', () => {
 			project: '/project',
 			message: 'The Working Tree is still changing.',
 		});
-		vi.mocked(getGitWorkingTreeFingerprint).mockResolvedValue({
+		vi.mocked(getGitComparisonFreshness).mockResolvedValue({
 			status: 'ready',
 			project: '/project',
-			fingerprintVersion: 1,
-			fingerprint: 'v1:new',
-			changedPathCount: 1,
+			changedEndpoints: ['to'],
+			fromHash: snapshot.from.hash,
+			to: { kind: 'working-tree', fingerprint: 'v1:new' },
 		});
 		const comparison = new GitComparisonController();
 		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });
@@ -398,12 +479,12 @@ describe('GitComparisonController', () => {
 	it('preserves stale Working Tree content and an open comment across context changes', async () => {
 		const snapshot = workingTreeSnapshotWithFile();
 		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
-		vi.mocked(getGitWorkingTreeFingerprint).mockResolvedValue({
+		vi.mocked(getGitComparisonFreshness).mockResolvedValue({
 			status: 'ready',
 			project: '/project',
-			fingerprintVersion: 1,
-			fingerprint: 'v1:new',
-			changedPathCount: 1,
+			changedEndpoints: ['to'],
+			fromHash: snapshot.from.hash,
+			to: { kind: 'working-tree', fingerprint: 'v1:new' },
 		});
 		const comparison = new GitComparisonController();
 		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });
@@ -423,12 +504,12 @@ describe('GitComparisonController', () => {
 	it('upgrades a context refresh notice when the Working Tree later changes', async () => {
 		const snapshot = workingTreeSnapshotWithFile();
 		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
-		vi.mocked(getGitWorkingTreeFingerprint).mockResolvedValue({
+		vi.mocked(getGitComparisonFreshness).mockResolvedValue({
 			status: 'ready',
 			project: '/project',
-			fingerprintVersion: 1,
-			fingerprint: 'v1:new',
-			changedPathCount: 1,
+			changedEndpoints: ['to'],
+			fromHash: snapshot.from.hash,
+			to: { kind: 'working-tree', fingerprint: 'v1:new' },
 		});
 		const comparison = new GitComparisonController();
 		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });

--- a/web/src/lib/git/review/git-comparison.svelte.ts
+++ b/web/src/lib/git/review/git-comparison.svelte.ts
@@ -1,10 +1,10 @@
 import {
+	getGitComparisonFreshness,
 	getGitComparisonFileBodies,
 	getGitComparisonSnapshot,
 	type GitComparisonMode,
 	type GitComparisonSnapshotReady,
 } from '$lib/api/git-comparison.js';
-import { getGitWorkingTreeFingerprint } from '$lib/api/git.js';
 import { GitDiffDocumentController } from '$lib/git/review/git-diff-document.svelte.js';
 import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
@@ -291,21 +291,44 @@ export class GitComparisonController {
 
 	async checkFreshness(projectPath: string): Promise<void> {
 		const snapshot = this.snapshot;
+		if (!snapshot || this.activeProjectPath !== projectPath || this.document.isStale) return;
 		if (
-			!snapshot ||
-			this.activeProjectPath !== projectPath ||
-			snapshot.to.kind !== 'working-tree' ||
-			this.document.isStale
+			snapshot.to.kind === 'revision' &&
+			snapshot.from.requestedRevision === snapshot.from.hash &&
+			snapshot.to.requestedRevision === snapshot.to.hash
 		)
 			return;
 		try {
-			const result = await getGitWorkingTreeFingerprint(snapshot.repoRoot);
+			const result = await getGitComparisonFreshness(
+				snapshot.repoRoot,
+				{
+					kind: 'revision',
+					revision: snapshot.from.requestedRevision,
+					hash: snapshot.from.hash,
+				},
+				snapshot.to.kind === 'revision'
+					? {
+							kind: 'revision',
+							revision: snapshot.to.requestedRevision,
+							hash: snapshot.to.hash,
+						}
+					: { kind: 'working-tree', fingerprint: snapshot.to.fingerprint },
+			);
 			if (this.snapshot?.documentId !== snapshot.documentId) return;
-			if (result.status !== 'ready') return;
-			if (result.fingerprint !== snapshot.to.fingerprint) {
-				const message = m.git_compare_working_tree_changed();
-				this.document.markStale(message);
+			if (result.status === 'not-found') {
+				this.document.markStale(m.git_compare_revision_unavailable());
+				return;
 			}
+			if (result.changedEndpoints.length === 0) return;
+			const onlyWorkingTreeChanged =
+				snapshot.to.kind === 'working-tree' &&
+				result.changedEndpoints.length === 1 &&
+				result.changedEndpoints[0] === 'to';
+			this.document.markStale(
+				onlyWorkingTreeChanged
+					? m.git_compare_working_tree_changed()
+					: m.git_compare_revision_changed(),
+			);
 		} catch {
 			// Freshness polling remains quiet until the next scheduled check.
 		}


### PR DESCRIPTION
Revision comparisons could keep showing obsolete rows after a movable ref such as HEAD or origin/main was rewritten because the original Git object remained readable. This adds a typed freshness check that re-resolves movable endpoints, freezes the current virtualized diff when either endpoint moves, and prompts for an explicit refresh while leaving immutable hash-to-hash comparisons untouched; the client and server contract changes require no data migration.