### PR TITLE
Eliminate seams in virtualized Git diffs

### DIFF
--- a/web/src/lib/components/git/GitVirtualDiffRow.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffRow.svelte
@@ -157,7 +157,7 @@
 
 {#if row.kind === 'unified-row'}
 	<div
-		class="font-mono"
+		class="flow-root font-mono"
 		style:font-size={`${fontSize}px`}
 		style:line-height={`${rowLineHeight}px`}
 		data-git-diff-content-row
@@ -330,7 +330,7 @@
 	</div>
 {:else}
 	<div
-		class="font-mono"
+		class="flow-root font-mono"
 		style:font-size={`${fontSize}px`}
 		style:line-height={`${rowLineHeight}px`}
 		data-git-diff-content-row
@@ -358,10 +358,7 @@
 				{/if}
 			</div>
 		{:else}
-			<div
-				data-git-diff-review-row
-				class="grid grid-cols-[minmax(0,1fr)_1px_minmax(0,1fr)]"
-			>
+			<div data-git-diff-review-row class="grid grid-cols-[minmax(0,1fr)_1px_minmax(0,1fr)]">
 				{#each splitCellViews(row.view) as cellView, index}
 					<div
 						class="group/diff-cell grid min-w-0 grid-cols-[3rem_minmax(0,1fr)] {cellView?.bgClass ??

--- a/web/src/lib/components/git/GitVirtualDiffViewport.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffViewport.svelte
@@ -58,7 +58,6 @@
 
 	let virtualItems = $derived($virtualizer.getVirtualItems());
 	let totalHeight = $derived($virtualizer.getTotalSize());
-	// Keeps adjacent diff backgrounds in one flow layout; per-row transforms create fractional-DPR paint seams.
 	let windowStart = $derived(virtualItems[0]?.start ?? 0);
 	let visibleRows = $derived.by(() =>
 		virtualItems
@@ -221,6 +220,7 @@
 		</div>
 	{:else}
 		<div class="relative w-full" style:height={`${totalHeight}px`}>
+			<!-- Keeps adjacent diff backgrounds in one flow layout; per-row transforms create fractional-DPR paint seams. -->
 			<div class="absolute inset-x-0" style:top={`${windowStart}px`} data-git-virtual-row-window>
 				{#each virtualItems as virtualItem (virtualItem.key)}
 					{@const row = source.rowAt(virtualItem.index)}

--- a/web/src/lib/components/git/GitVirtualDiffViewport.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffViewport.svelte
@@ -57,6 +57,8 @@
 
 	let virtualItems = $derived($virtualizer.getVirtualItems());
 	let totalHeight = $derived($virtualizer.getTotalSize());
+	// Keeps adjacent diff backgrounds in one flow layout; per-row transforms create fractional-DPR paint seams.
+	let windowStart = $derived(virtualItems[0]?.start ?? 0);
 	let visibleRows = $derived.by(() =>
 		virtualItems
 			.map((virtualItem) => source.rowAt(virtualItem.index))
@@ -218,31 +220,31 @@
 		</div>
 	{:else}
 		<div class="relative w-full" style:height={`${totalHeight}px`}>
-			{#each virtualItems as virtualItem (virtualItem.key)}
-				{@const row = source.rowAt(virtualItem.index)}
-				{#if row}
-					<div
-						data-index={virtualItem.index}
-						data-git-virtual-row
-						use:measureRow={virtualItem.index}
-						class="absolute left-0 top-0 w-full"
-						style:transform={`translateY(${virtualItem.start}px)`}
-					>
-						<svelte:boundary>
-							{@render rowSnippet(row)}
-							{#snippet failed(error)}
-								<div
-									class="border border-status-error-border bg-status-error/10 px-3 py-2 text-xs text-status-error-foreground"
-								>
-									Failed to render diff row: {error instanceof Error
-										? error.message
-										: String(error)}
-								</div>
-							{/snippet}
-						</svelte:boundary>
-					</div>
-				{/if}
-			{/each}
+			<div class="absolute inset-x-0" style:top={`${windowStart}px`} data-git-virtual-row-window>
+				{#each virtualItems as virtualItem (virtualItem.key)}
+					{@const row = source.rowAt(virtualItem.index)}
+					{#if row}
+						<div
+							data-index={virtualItem.index}
+							data-git-virtual-row
+							use:measureRow={virtualItem.index}
+						>
+							<svelte:boundary>
+								{@render rowSnippet(row)}
+								{#snippet failed(error)}
+									<div
+										class="border border-status-error-border bg-status-error/10 px-3 py-2 text-xs text-status-error-foreground"
+									>
+										Failed to render diff row: {error instanceof Error
+											? error.message
+											: String(error)}
+									</div>
+								{/snippet}
+							</svelte:boundary>
+						</div>
+					{/if}
+				{/each}
+			</div>
 		</div>
 	{/if}
 </div>

--- a/web/src/lib/components/git/GitVirtualDiffViewport.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffViewport.svelte
@@ -7,6 +7,7 @@
 		markGitReviewFirstRow,
 		markGitReviewViewportReady,
 	} from '$lib/git/review/git-review-performance.js';
+	import { measureVirtualRow } from './git-virtual-row-measurement.js';
 
 	interface GitVirtualDiffViewportProps {
 		documentId?: string | null;
@@ -49,7 +50,7 @@
 		count: untrack(() => source.rowCount),
 		getScrollElement: () => viewportRef,
 		estimateSize: estimateRowHeight,
-		measureElement: (element) => element.getBoundingClientRect().height,
+		measureElement: measureVirtualRow,
 		initialRect: { width: 0, height: 720 },
 		overscan: 18,
 		getItemKey: (index) => source.rowKey(index),
@@ -94,7 +95,7 @@
 				estimateSize: (index) => {
 					return activeSource.estimateRowHeight(index, lineHeight);
 				},
-				measureElement: (element) => element.getBoundingClientRect().height,
+				measureElement: measureVirtualRow,
 				initialRect: { width: 0, height: 720 },
 				overscan: rowOverscan,
 				getItemKey: (index) => activeSource.rowKey(index),

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { PartialKeys, VirtualizerOptions } from '@tanstack/svelte-virtual';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
 	GitVirtualFileHeaderRow,
@@ -8,7 +9,16 @@ import type {
 	GitVirtualUnifiedRow,
 } from '$lib/git/review/git-virtual-review-document.svelte.js';
 import { arrayGitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+import { measureVirtualRow } from '../git-virtual-row-measurement.js';
 
+type TestInitialVirtualizerOptions = PartialKeys<
+	VirtualizerOptions<HTMLElement, HTMLDivElement>,
+	'observeElementRect' | 'observeElementOffset' | 'scrollToFn'
+>;
+type TestRefreshedVirtualizerOptions = Partial<VirtualizerOptions<HTMLElement, HTMLDivElement>>;
+
+let initialVirtualizerOptions: TestInitialVirtualizerOptions | null;
+let refreshedVirtualizerOptions: TestRefreshedVirtualizerOptions | null;
 let measureCalls: number;
 let scrollToIndexCalls: number[];
 
@@ -24,14 +34,21 @@ vi.mock('@tanstack/svelte-virtual', async () => {
 	const virtualizer = {
 		getVirtualItems: () => virtualItems,
 		getTotalSize: () => 126,
-		setOptions: () => undefined,
+		setOptions: (options: TestRefreshedVirtualizerOptions) => {
+			refreshedVirtualizerOptions = options;
+		},
 		measureElement: () => undefined,
 		scrollToIndex: (index: number) => scrollToIndexCalls.push(index),
 		measure: () => {
 			measureCalls += 1;
 		},
 	};
-	return { createVirtualizer: () => readable(virtualizer) };
+	return {
+		createVirtualizer: (options: TestInitialVirtualizerOptions) => {
+			initialVirtualizerOptions = options;
+			return readable(virtualizer);
+		},
+	};
 });
 
 import GitVirtualDiffSurface from '../GitVirtualDiffSurface.svelte';
@@ -137,11 +154,13 @@ function fileIndexes(rows: GitVirtualReviewRow[]): Map<string, number> {
 
 describe('Git virtual diff refresh', () => {
 	beforeEach(() => {
+		initialVirtualizerOptions = null;
+		refreshedVirtualizerOptions = null;
 		measureCalls = 0;
 		scrollToIndexCalls = [];
 	});
 
-	it('keeps the virtualizer snapshot keys while the refreshed rows reconcile', async () => {
+	it('keeps shared measurement options while refreshed rows reconcile', async () => {
 		const initialRows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
 		const replacementRows = [makeHeaderRow(2)];
 		const props = {
@@ -181,6 +200,10 @@ describe('Git virtual diff refresh', () => {
 		const { container, rerender } = render(GitVirtualDiffSurface, { props });
 		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
 		viewport.scrollTop = 300;
+		expect(initialVirtualizerOptions?.measureElement).toBe(measureVirtualRow);
+		await waitFor(() => {
+			expect(refreshedVirtualizerOptions?.measureElement).toBe(measureVirtualRow);
+		});
 		await waitFor(() => expect(measureCalls).toBe(1));
 
 		await rerender({
@@ -369,10 +392,7 @@ describe('Git virtual diff refresh', () => {
 		await waitFor(() => expect(scrollToIndexCalls).toEqual([4]));
 		await rerender({
 			...props,
-			source: arrayGitVirtualReviewRowSource([
-				...initialRows.slice(0, -1),
-				makeLimitRow(2),
-			]),
+			source: arrayGitVirtualReviewRowSource([...initialRows.slice(0, -1), makeLimitRow(2)]),
 		});
 
 		expect(scrollToIndexCalls).toEqual([4]);

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
@@ -214,6 +214,12 @@ describe('Git virtual diff refresh', () => {
 		expect(screen.getByText('file-2.ts')).toBeTruthy();
 		expect(viewport.scrollTop).toBe(300);
 		expect(measureCalls).toBe(1);
+		const rowWindow = container.querySelector<HTMLElement>('[data-git-virtual-row-window]');
+		expect(rowWindow).toBeTruthy();
+		if (!rowWindow) return;
+		const mountedRows = Array.from(rowWindow.children);
+		expect(mountedRows).toHaveLength(1);
+		expect(mountedRows[0]?.parentElement).toBe(rowWindow);
 	});
 
 	it('repositions a requested file when preceding rows move its index', async () => {

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
@@ -7,9 +7,7 @@ import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
 import { buildGitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
 import GitVirtualDiffRow from '../GitVirtualDiffRow.svelte';
 
-function buildVirtualRows(
-	options: Parameters<typeof buildGitVirtualReviewRowSource>[0],
-) {
+function buildVirtualRows(options: Parameters<typeof buildGitVirtualReviewRowSource>[0]) {
 	const source = buildGitVirtualReviewRowSource(options);
 	return source.rowsInRange(0, source.rowCount);
 }
@@ -226,6 +224,20 @@ describe('GitVirtualDiffRow', () => {
 		expect(affordance?.className).toContain('group-hover/diff-cell:opacity-100');
 		expect(container.querySelector('[data-git-diff-review-row]')).not.toBeNull();
 	});
+
+	it.each(['unified', 'split'] as const)(
+		'contains inline composer margins in the measured %s row',
+		(diffMode) => {
+			const row = buildRows(diffMode).find((candidate) => !candidate.view.isHunkHeader);
+			expect(row).toBeDefined();
+			if (!row) return;
+			const { container } = renderRow(row);
+
+			expect(
+				container.querySelector('[data-git-diff-content-row]')?.classList.contains('flow-root'),
+			).toBe(true);
+		},
+	);
 
 	it('does not render the inline composer when the workbench uses its mobile modal', () => {
 		const addedRow = findUnifiedRow('add');

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffSurface.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffSurface.test.ts
@@ -148,8 +148,7 @@ describe('GitVirtualDiffSurface', () => {
 			expect(element.style.top).toBe('');
 			expect(element.parentElement).toBe(rowWindow);
 		}
-		expect(rowWindow.classList.contains('absolute')).toBe(true);
-		expect(rowWindow.classList.contains('inset-x-0')).toBe(true);
+		expect(rowWindow.className).toBe('absolute inset-x-0');
 		expect(rowWindow.className).not.toMatch(/(?:^|\s)-?(?:translate|transform)(?:-|\s|$)/);
 		expect(rowWindow.style.transform).toBe('');
 	});

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffSurface.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffSurface.test.ts
@@ -110,7 +110,7 @@ describe('GitVirtualDiffSurface', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('uses one virtual diff root and mounts a bounded row window for large documents', async () => {
+	it('renders one bounded contiguous row window for large documents', async () => {
 		const rows = Array.from({ length: 10_000 }, (_, index) => makeHeaderRow(index));
 		const { container } = renderSurface(rows);
 
@@ -121,7 +121,37 @@ describe('GitVirtualDiffSurface', () => {
 		await waitFor(() => {
 			expect(container.querySelectorAll('[data-git-virtual-row]').length).toBeGreaterThan(0);
 		});
-		expect(container.querySelectorAll('[data-git-virtual-row]').length).toBeLessThan(300);
+
+		const rowWindows = container.querySelectorAll<HTMLElement>('[data-git-virtual-row-window]');
+		expect(rowWindows).toHaveLength(1);
+		const rowWindow = rowWindows.item(0);
+		expect(rowWindow).toBeTruthy();
+		if (!rowWindow) return;
+
+		const mountedRows = Array.from(rowWindow.children).filter((element): element is HTMLElement =>
+			element.hasAttribute('data-git-virtual-row'),
+		);
+		expect(mountedRows).toHaveLength(rowWindow.children.length);
+		expect(mountedRows.length).toBeLessThan(300);
+
+		const indexes = mountedRows.map((element) => Number(element.dataset.index));
+		const firstIndex = indexes[0];
+		expect(firstIndex).toBeDefined();
+		if (firstIndex === undefined) return;
+		expect(indexes).toEqual(
+			Array.from({ length: indexes.length }, (_, offset) => firstIndex + offset),
+		);
+
+		for (const element of mountedRows) {
+			expect(element.className).toBe('');
+			expect(element.style.transform).toBe('');
+			expect(element.style.top).toBe('');
+			expect(element.parentElement).toBe(rowWindow);
+		}
+		expect(rowWindow.classList.contains('absolute')).toBe(true);
+		expect(rowWindow.classList.contains('inset-x-0')).toBe(true);
+		expect(rowWindow.className).not.toMatch(/(?:^|\s)-?(?:translate|transform)(?:-|\s|$)/);
+		expect(rowWindow.style.transform).toBe('');
 	});
 
 	it('reconciles a refreshed document against the virtualizer item snapshot', async () => {

--- a/web/src/lib/components/git/__tests__/git-virtual-row-measurement.test.ts
+++ b/web/src/lib/components/git/__tests__/git-virtual-row-measurement.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	measureVirtualRow,
+	type VirtualRowMeasurementContext,
+} from '../git-virtual-row-measurement.js';
+
+function measurementContext(
+	itemSizeCache: ReadonlyMap<string | number | bigint, number> = new Map(),
+): VirtualRowMeasurementContext {
+	return {
+		indexFromElement: () => 7,
+		options: { getItemKey: () => 'row-7' },
+		itemSizeCache,
+	} satisfies VirtualRowMeasurementContext;
+}
+
+function rowRect(height: number): DOMRect {
+	return {
+		x: 0,
+		y: 0,
+		width: 800,
+		height,
+		top: 0,
+		right: 800,
+		bottom: height,
+		left: 0,
+		toJSON: () => ({}),
+	};
+}
+
+describe('measureVirtualRow', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('uses the observed block size without reading layout', () => {
+		const element = document.createElement('div');
+		const rect = vi.spyOn(element, 'getBoundingClientRect');
+		const entry = {
+			borderBoxSize: [{ blockSize: 63.5, inlineSize: 800 }],
+		} satisfies Pick<ResizeObserverEntry, 'borderBoxSize'>;
+
+		expect(measureVirtualRow(element, entry, measurementContext())).toBe(63.5);
+		expect(rect).not.toHaveBeenCalled();
+	});
+
+	it('reuses a cached size without reading layout', () => {
+		const element = document.createElement('div');
+		const rect = vi.spyOn(element, 'getBoundingClientRect');
+		const cache = new Map<string | number | bigint, number>([['row-7', 54]]);
+
+		expect(measureVirtualRow(element, undefined, measurementContext(cache))).toBe(54);
+		expect(rect).not.toHaveBeenCalled();
+	});
+
+	it('reads layout for the first measurement', () => {
+		const element = document.createElement('div');
+		vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rowRect(84));
+
+		expect(measureVirtualRow(element, undefined, measurementContext())).toBe(84);
+	});
+});

--- a/web/src/lib/components/git/__tests__/git-virtual-row-measurement.test.ts
+++ b/web/src/lib/components/git/__tests__/git-virtual-row-measurement.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	measureVirtualRow,
+	type VirtualRowKey,
 	type VirtualRowMeasurementContext,
 } from '../git-virtual-row-measurement.js';
 
 function measurementContext(
-	itemSizeCache: ReadonlyMap<string | number | bigint, number> = new Map(),
+	itemSizeCache: ReadonlyMap<VirtualRowKey, number> = new Map(),
 ): VirtualRowMeasurementContext {
 	return {
 		indexFromElement: () => 7,
@@ -47,10 +48,22 @@ describe('measureVirtualRow', () => {
 	it('reuses a cached size without reading layout', () => {
 		const element = document.createElement('div');
 		const rect = vi.spyOn(element, 'getBoundingClientRect');
-		const cache = new Map<string | number | bigint, number>([['row-7', 54]]);
+		const cache = new Map<VirtualRowKey, number>([['row-7', 54]]);
 
 		expect(measureVirtualRow(element, undefined, measurementContext(cache))).toBe(54);
 		expect(rect).not.toHaveBeenCalled();
+	});
+
+	it('reads layout when an observer entry omits its border box', () => {
+		const element = document.createElement('div');
+		const rect = vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rowRect(84));
+		const cache = new Map<VirtualRowKey, number>([['row-7', 54]]);
+		const entry = {
+			borderBoxSize: [],
+		} satisfies Pick<ResizeObserverEntry, 'borderBoxSize'>;
+
+		expect(measureVirtualRow(element, entry, measurementContext(cache))).toBe(84);
+		expect(rect).toHaveBeenCalledOnce();
 	});
 
 	it('reads layout for the first measurement', () => {

--- a/web/src/lib/components/git/git-virtual-row-measurement.ts
+++ b/web/src/lib/components/git/git-virtual-row-measurement.ts
@@ -1,4 +1,4 @@
-type VirtualRowKey = string | number | bigint;
+export type VirtualRowKey = string | number | bigint;
 
 export interface VirtualRowMeasurementContext {
 	indexFromElement(element: HTMLDivElement): number;
@@ -17,6 +17,7 @@ export function measureVirtualRow(
 ): number {
 	const box = entry?.borderBoxSize?.[0];
 	if (box) return box.blockSize;
+	if (entry) return element.getBoundingClientRect().height;
 	const index = instance.indexFromElement(element);
 	const key = instance.options.getItemKey(index);
 	return instance.itemSizeCache.get(key) ?? element.getBoundingClientRect().height;

--- a/web/src/lib/components/git/git-virtual-row-measurement.ts
+++ b/web/src/lib/components/git/git-virtual-row-measurement.ts
@@ -1,0 +1,23 @@
+type VirtualRowKey = string | number | bigint;
+
+export interface VirtualRowMeasurementContext {
+	indexFromElement(element: HTMLDivElement): number;
+	readonly options: {
+		getItemKey(index: number): VirtualRowKey;
+	};
+	readonly itemSizeCache: ReadonlyMap<VirtualRowKey, number>;
+}
+
+type VirtualRowResizeEntry = Pick<ResizeObserverEntry, 'borderBoxSize'>;
+
+export function measureVirtualRow(
+	element: HTMLDivElement,
+	entry: VirtualRowResizeEntry | undefined,
+	instance: VirtualRowMeasurementContext,
+): number {
+	const box = entry?.borderBoxSize?.[0];
+	if (box) return box.blockSize;
+	const index = instance.indexFromElement(element);
+	const key = instance.options.getItemKey(index);
+	return instance.itemSizeCache.get(key) ?? element.getBoundingClientRect().height;
+}

--- a/web/src/lib/git/pull-requests/__tests__/pull-request-virtual-row-source.test.ts
+++ b/web/src/lib/git/pull-requests/__tests__/pull-request-virtual-row-source.test.ts
@@ -3,7 +3,10 @@ import type { PullRequestThread } from '$lib/api/pull-requests.js';
 import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git.js';
 import { buildPullRequestVirtualRowSource } from '../pull-request-virtual-row-source.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
-import { buildGitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+import {
+	buildGitVirtualReviewRowSource,
+	type GitVirtualReviewRowSource,
+} from '$lib/git/review/git-virtual-review-row-source.js';
 
 const limits = {
 	maxSummaryFiles: 10_000,
@@ -107,6 +110,14 @@ function source(
 	});
 }
 
+function expectEveryRowPresent(rowSource: GitVirtualReviewRowSource): void {
+	for (let index = 0; index < rowSource.rowCount; index += 1) {
+		expect(rowSource.rowAt(index), `row ${index}`).not.toBeNull();
+	}
+	expect(rowSource.rowAt(-1)).toBeNull();
+	expect(rowSource.rowAt(rowSource.rowCount)).toBeNull();
+}
+
 describe('pull request virtual row source', () => {
 	it('inserts a thread after its matching diff line', () => {
 		const reviewFile = file('src/app.ts');
@@ -126,6 +137,7 @@ describe('pull request virtual row source', () => {
 			threadId: 'src/app.ts:2',
 			showUnanchoredLabel: false,
 		});
+		expectEveryRowPresent(rowSource);
 	});
 
 	it('places unmatched threads at file end and labels only the first one', () => {

--- a/web/src/lib/git/review/__tests__/git-virtual-review-row-source.test.ts
+++ b/web/src/lib/git/review/__tests__/git-virtual-review-row-source.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git.js';
+import type { BuildVirtualRowsOptions } from '$lib/git/review/git-virtual-review-document.svelte.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
-import { buildGitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+import {
+	buildGitVirtualReviewRowSource,
+	type GitVirtualReviewRowSource,
+} from '$lib/git/review/git-virtual-review-row-source.js';
 
 function summary(path: string, renderedRows: number): GitReviewFileSummary {
 	return {
@@ -38,7 +42,10 @@ function indexedBody(path: string, lineCount: number): GitReviewFileBody {
 	};
 }
 
-function options(files: GitReviewFileSummary[], bodies: Record<string, GitReviewFileBody>) {
+function options(
+	files: GitReviewFileSummary[],
+	bodies: Record<string, GitReviewFileBody>,
+): BuildVirtualRowsOptions {
 	return {
 		summary: {
 			documentId: 'document',
@@ -67,6 +74,14 @@ function options(files: GitReviewFileSummary[], bodies: Record<string, GitReview
 	};
 }
 
+function expectEveryRowPresent(source: GitVirtualReviewRowSource): void {
+	for (let index = 0; index < source.rowCount; index += 1) {
+		expect(source.rowAt(index), `row ${index}`).not.toBeNull();
+	}
+	expect(source.rowAt(-1)).toBeNull();
+	expect(source.rowAt(source.rowCount)).toBeNull();
+}
+
 describe('Git virtual review row source', () => {
 	it('resolves only requested rows from a 100,000-row document', () => {
 		const first = summary('first.txt', 49_999);
@@ -82,6 +97,43 @@ describe('Git virtual review row source', () => {
 		expect(source.rowsInRange(50_000, 50_020)).toHaveLength(20);
 		expect(source.fileStart('second.txt')).toBe(50_001);
 		expect(source.rowKey(50_001)).toBe(2_000_000);
+		expect(source.rowAt(0)).not.toBeNull();
+		expect(source.rowAt(50_001)).not.toBeNull();
+		expect(source.rowAt(source.rowCount - 1)).not.toBeNull();
+		expect(source.rowAt(source.rowCount)).toBeNull();
+	});
+
+	it('resolves every row in representative indexed sources', () => {
+		const pending = summary('pending.txt', 4);
+		const limited: GitReviewFileSummary = {
+			...summary('binary.dat', 0),
+			bodyState: 'binary',
+			isBinary: true,
+		};
+		const loaded = summary('loaded.txt', 2);
+		const loadedBody = indexedBody(loaded.path, 2);
+		const collectionOptions = options([pending], {});
+		collectionOptions.summary.collectionLimit = {
+			reason: 'collection-too-many-files',
+			message: 'Only a subset of files is shown.',
+			visibleFiles: 1,
+			totalFilesKnown: 2,
+		};
+
+		const splitOptions = options([loaded], { [loaded.path]: loadedBody });
+		splitOptions.diffMode = 'split';
+
+		const representativeSources = [
+			buildGitVirtualReviewRowSource(options([pending], {})),
+			buildGitVirtualReviewRowSource(options([limited], {})),
+			buildGitVirtualReviewRowSource(options([loaded], { [loaded.path]: loadedBody })),
+			buildGitVirtualReviewRowSource(splitOptions),
+			buildGitVirtualReviewRowSource(collectionOptions),
+		];
+
+		for (const source of representativeSources) {
+			expectEveryRowPresent(source);
+		}
 	});
 
 	it('aligns delete and add runs in split mode without legacy rows', () => {


### PR DESCRIPTION
Render each active virtual diff range as one normal-flow window so added and deleted rows remain visually continuous at fractional display scales without sacrificing bounded rendering for large reviews. The change preserves dynamic wrapping and inline comments, contains composer margins inside measured rows, and uses ResizeObserver sizes when available to avoid unnecessary synchronous layout reads.
