### PR TITLE
Prevent Codex reconciliation from blocking startup

### DIFF
--- a/integration-tests/support/fake-codex-app-server.ts
+++ b/integration-tests/support/fake-codex-app-server.ts
@@ -54,6 +54,8 @@ function respond(line: string): void {
     return;
   }
   if (request.method === 'thread/list') {
+    const callLog = process.env.INTEGRATION_CODEX_CALL_LOG;
+    if (callLog) appendFileSync(callLog, 'thread/list\n');
     const discoveryMode = codexDiscoveryMode();
     if (discoveryMode === 'error') {
       writeError(

--- a/integration-tests/tests/server/codex-native-path-preservation.test.ts
+++ b/integration-tests/tests/server/codex-native-path-preservation.test.ts
@@ -200,6 +200,60 @@ describe('Codex native transcript path preservation', () => {
     );
   }, 15_000);
 
+  test('starts with one discovery snapshot for many preserved pathless chats', async () => {
+    const chatIds = Array.from(
+      { length: 100 },
+      (_, index) => String(Date.now() * 1_000 + 10_000 + index),
+    );
+    const serverEnvironment = codexServerEnvironment();
+    let callLogPath = '';
+
+    await withIntegrationFixture(
+      'codex-native-path-startup-snapshot',
+      async (fixture) => {
+        expect(
+          fixture.garcon.logs.filter((line) =>
+            line.includes('preserving chat') && line.includes('unresolved native session')
+          ),
+        ).toEqual([]);
+        expect(await readFile(callLogPath, 'utf8')).toBe('thread/list\n');
+
+        const firstFailure = await captureApiError(fixture.client.getMessages(chatIds[0]!));
+        expect(firstFailure).toMatchObject({
+          status: 503,
+          body: {
+            errorCode: 'TRANSCRIPT_UNAVAILABLE',
+            retryable: true,
+          },
+        });
+        expect(await readFile(callLogPath, 'utf8')).toBe('thread/list\n');
+
+        const retryFailure = await captureApiError(fixture.client.getMessages(chatIds[0]!));
+        expect(retryFailure).toMatchObject({
+          status: 503,
+          body: {
+            errorCode: 'TRANSCRIPT_UNAVAILABLE',
+            retryable: true,
+          },
+        });
+        expect(await readFile(callLogPath, 'utf8')).toBe('thread/list\nthread/list\n');
+      },
+      {
+        serverEnvironment,
+        async prepareWorkspace(directories) {
+          callLogPath = join(directories.root, 'codex-calls.log');
+          serverEnvironment.INTEGRATION_CODEX_CALL_LOG = callLogPath;
+          await writeFile(callLogPath, '');
+          await seedPathlessWorkspace({
+            workspace: directories.workspace,
+            chatIds,
+            projectPath: directories.project,
+          });
+        },
+      },
+    );
+  }, 15_000);
+
   test('distinguishes discovery errors and retries a later discovery miss', async () => {
     const chatId = String(Date.now() * 1_000 + 3);
     const threadId = randomUUID();
@@ -421,6 +475,70 @@ async function seedWorkspace(input: {
           ],
         },
       },
+    }),
+  );
+}
+
+async function seedPathlessWorkspace(input: {
+  workspace: string;
+  chatIds: readonly string[];
+  projectPath: string;
+}): Promise<void> {
+  const firstChatId = input.chatIds[0];
+  if (!firstChatId) throw new Error('Pathless startup fixture requires at least one chat');
+  await seedWorkspace({
+    workspace: input.workspace,
+    chatId: firstChatId,
+    threadId: randomUUID(),
+    nativePath: null,
+    projectPath: input.projectPath,
+    carryUser: 'startup-carry',
+    carryAssistant: 'startup-carry-answer',
+  });
+
+  const registryPath = join(input.workspace, 'chats.json');
+  const registry = JSON.parse(await readFile(registryPath, 'utf8')) as {
+    sessions: Record<string, {
+      agentOwnershipEpoch: string;
+      agentSessionId: string;
+      nativeSession: {
+        ownerId: string;
+        schemaVersion: number;
+        value: { agentSessionId: string };
+      };
+    }>;
+  };
+  const template = registry.sessions[firstChatId];
+  if (!template) throw new Error('Pathless startup fixture template is missing');
+
+  for (const chatId of input.chatIds.slice(1)) {
+    const agentSessionId = randomUUID();
+    registry.sessions[chatId] = {
+      ...template,
+      agentOwnershipEpoch: randomUUID(),
+      agentSessionId,
+      nativeSession: {
+        ...template.nativeSession,
+        value: { agentSessionId },
+      },
+    };
+  }
+  await writeFile(registryPath, JSON.stringify(registry));
+  await writeFile(
+    join(input.workspace, 'chat-metadata.json'),
+    JSON.stringify({
+      version: 1,
+      chats: Object.fromEntries(input.chatIds.map((chatId) => [
+        chatId,
+        {
+          chatId,
+          createdAt: timestamp,
+          lastActivity: timestamp,
+          lastMessage: 'startup-carry-answer',
+          firstMessage: 'startup-carry',
+          source: 'startup',
+        },
+      ])),
     }),
   );
 }

--- a/server-agents/codex/src/agents/codex/__tests__/transcript.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/transcript.test.js
@@ -42,6 +42,7 @@ async function writeTranscript(directory, fileName, threadId = 'thread-1') {
 function createRuntime({ discoveredPath = null } = {}) {
   const calls = {
     discover: 0,
+    requestDiscoveryRefresh: [],
     load: [],
     page: [],
     preview: [],
@@ -52,6 +53,9 @@ function createRuntime({ discoveredPath = null } = {}) {
       async resolveNativePath() {
         calls.discover += 1;
         return discoveredPath;
+      },
+      requestNativePathDiscoveryRefresh(agentSessionId) {
+        calls.requestDiscoveryRefresh.push(agentSessionId);
       },
       async loadMessages(reference) {
         calls.load.push(reference);
@@ -119,6 +123,53 @@ describe('createCodexTranscript', () => {
         }),
       ).resolves.toBe(nativeSession);
       expect(fixture.calls.discover).toBe(0);
+    });
+  });
+
+  it('preserves a pathless stored reference when discovery misses', async () => {
+    await withDirectory(async (directory) => {
+      const codec = createPathNativeSessionCodec('codex');
+      const nativeSession = codec.encode({
+        path: null,
+        agentSessionId: 'thread-1',
+        modelEndpointId: 'endpoint-1',
+      });
+      const fixture = createFixture(directory, nativeSession);
+
+      await expect(
+        fixture.transcript.resolveNativeSession({
+          chat: fixture.chat,
+          signal,
+        }),
+      ).resolves.toBe(nativeSession);
+      expect(fixture.calls.discover).toBe(1);
+      expect(fixture.calls.requestDiscoveryRefresh).toEqual([]);
+    });
+  });
+
+  it('acquires a discoverable path for a pathless stored reference', async () => {
+    await withDirectory(async (directory) => {
+      const discoveredPath = await writeTranscript(directory, 'discovered.jsonl');
+      const codec = createPathNativeSessionCodec('codex');
+      const nativeSession = codec.encode({
+        path: null,
+        agentSessionId: 'thread-1',
+        modelEndpointId: 'endpoint-1',
+      });
+      const fixture = createFixture(directory, nativeSession, { discoveredPath });
+
+      await expect(
+        fixture.transcript.resolveNativeSession({
+          chat: fixture.chat,
+          signal,
+        }),
+      ).resolves.toEqual(codec.encode({
+        path: discoveredPath,
+        agentSessionId: 'thread-1',
+        modelEndpointId: 'endpoint-1',
+      }));
+      expect(fixture.calls.discover).toBe(1);
+      expect(fixture.calls.requestDiscoveryRefresh).toEqual([]);
     });
   });
 
@@ -196,7 +247,7 @@ describe('createCodexTranscript', () => {
     });
   });
 
-  it('fails every read closed and retries discovery when a known session has no path', async () => {
+  it('fails every read closed and requests refresh only for full and paged loads', async () => {
     await withDirectory(async (directory) => {
       const codec = createPathNativeSessionCodec('codex');
       const fixture = createFixture(
@@ -227,12 +278,14 @@ describe('createCodexTranscript', () => {
         });
       }
       expect(fixture.calls.discover).toBe(requests.length);
+      expect(fixture.calls.requestDiscoveryRefresh).toEqual(['thread-1', 'thread-1']);
       await expect(
         fixture.transcript.resolveNativeSession({
           chat: fixture.chat,
           signal,
         }),
-      ).resolves.toBeNull();
+      ).resolves.toBe(fixture.chat.nativeSession);
+      expect(fixture.calls.discover).toBe(requests.length + 1);
     });
   });
 

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -4948,7 +4948,7 @@ describe('CodexAppServerRuntime', () => {
     expect(resolvedPath).toBe(nativePath);
   });
 
-  it('refreshes a cached discovery miss on a later native path resolution', async () => {
+  it('shares cached discovery misses until an explicit transcript load requests a refresh', async () => {
     const nativePath = path.join(tmpDir, 'later-resolved-thread.jsonl');
     await fs.writeFile(nativePath, '{}\n');
     let discoverable = false;
@@ -4969,9 +4969,98 @@ describe('CodexAppServerRuntime', () => {
 
     await expect(provider.resolveNativePath(session)).resolves.toBeNull();
     discoverable = true;
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    expect(fake.listThreads).toHaveBeenCalledTimes(1);
+
+    provider.requestNativePathDiscoveryRefresh('thread-1');
     await expect(provider.resolveNativePath(session)).resolves.toBe(nativePath);
 
     expect(fake.listThreads).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses one discovery snapshot for sequential missing-session resolutions', async () => {
+    const fake = new FakeClient();
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    for (let index = 0; index < 100; index += 1) {
+      await expect(provider.resolveNativePath({
+        provider: 'codex',
+        agentSessionId: `missing-thread-${index}`,
+        nativePath: null,
+        projectPath: '/repo',
+      })).resolves.toBeNull();
+    }
+
+    expect(fake.listThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds repeated native path discovery refresh requests', async () => {
+    let now = 0;
+    const fake = new FakeClient();
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      nativePathDiscoveryRefresh: {
+        sessionIntervalMs: 30_000,
+        globalIntervalMs: 1_000,
+        now: () => now,
+      },
+    });
+    const session = {
+      provider: 'codex',
+      agentSessionId: 'missing-thread',
+      nativePath: null,
+      projectPath: '/repo',
+    };
+
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    provider.requestNativePathDiscoveryRefresh('missing-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    provider.requestNativePathDiscoveryRefresh('missing-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    expect(fake.listThreads).toHaveBeenCalledTimes(2);
+
+    now = 30_000;
+    provider.requestNativePathDiscoveryRefresh('missing-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    expect(fake.listThreads).toHaveBeenCalledTimes(3);
+
+    now = 0;
+    provider.requestNativePathDiscoveryRefresh('missing-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    expect(fake.listThreads).toHaveBeenCalledTimes(4);
+  });
+
+  it('lets another session request a refresh after the global minimum interval', async () => {
+    let now = 0;
+    const fake = new FakeClient();
+    const provider = new CodexAppServerRuntime({
+      createClient: () => fake,
+      nativePathDiscoveryRefresh: {
+        sessionIntervalMs: 30_000,
+        globalIntervalMs: 1_000,
+        now: () => now,
+      },
+    });
+    const session = {
+      provider: 'codex',
+      agentSessionId: 'missing-thread',
+      nativePath: null,
+      projectPath: '/repo',
+    };
+
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    provider.requestNativePathDiscoveryRefresh('background-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+
+    now = 100;
+    provider.requestNativePathDiscoveryRefresh('user-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    expect(fake.listThreads).toHaveBeenCalledTimes(2);
+
+    now = 1_000;
+    provider.requestNativePathDiscoveryRefresh('user-thread');
+    await expect(provider.resolveNativePath(session)).resolves.toBeNull();
+    expect(fake.listThreads).toHaveBeenCalledTimes(3);
   });
 
   it('surfaces thread/list failures during native path reconciliation', async () => {

--- a/server-agents/codex/src/agents/codex/app-server/native-path-discovery-refresh.ts
+++ b/server-agents/codex/src/agents/codex/app-server/native-path-discovery-refresh.ts
@@ -1,0 +1,40 @@
+const SESSION_REFRESH_INTERVAL_MS = 30_000;
+const GLOBAL_REFRESH_INTERVAL_MS = 1_000;
+
+export interface NativePathDiscoveryRefreshLimiterOptions {
+  readonly sessionIntervalMs?: number;
+  readonly globalIntervalMs?: number;
+  readonly now?: () => number;
+}
+
+export class NativePathDiscoveryRefreshLimiter {
+  readonly #sessionIntervalMs: number;
+  readonly #globalIntervalMs: number;
+  readonly #now: () => number;
+  readonly #sessionRefreshes = new Map<string, number>();
+  #lastRefreshAt = Number.NEGATIVE_INFINITY;
+
+  constructor(options: NativePathDiscoveryRefreshLimiterOptions = {}) {
+    this.#sessionIntervalMs = options.sessionIntervalMs ?? SESSION_REFRESH_INTERVAL_MS;
+    this.#globalIntervalMs = options.globalIntervalMs ?? GLOBAL_REFRESH_INTERVAL_MS;
+    this.#now = options.now ?? (() => performance.now());
+  }
+
+  accept(agentSessionId: string): boolean {
+    const now = this.#now();
+    for (const [sessionId, refreshedAt] of this.#sessionRefreshes) {
+      const elapsed = now - refreshedAt;
+      if (elapsed < 0 || elapsed >= this.#sessionIntervalMs) {
+        this.#sessionRefreshes.delete(sessionId);
+      }
+    }
+    if (this.#sessionRefreshes.has(agentSessionId)) return false;
+
+    const globalElapsed = now - this.#lastRefreshAt;
+    if (globalElapsed >= 0 && globalElapsed < this.#globalIntervalMs) return false;
+
+    this.#lastRefreshAt = now;
+    this.#sessionRefreshes.set(agentSessionId, now);
+    return true;
+  }
+}

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -20,6 +20,7 @@ import { buildApprovalMessage, buildApprovalResponse, createPendingApproval, isA
 import { CodexAppServerClient, CodexAppServerRpcError, type CodexAppServerClientOptions, type CodexAppServerMetric } from './client.js';
 import { convertCodexAppServerLiveItem, convertCodexRawCodeModeItem } from './converter.js';
 import { waitForMaterializedThread } from './durability.js';
+import { NativePathDiscoveryRefreshLimiter, type NativePathDiscoveryRefreshLimiterOptions } from './native-path-discovery-refresh.js';
 import { IdleSessionPurger } from '@garcon/server-agent-common/shared/idle-session-purger';
 import type {
   ErrorNotification,
@@ -118,6 +119,7 @@ export interface CodexAppServerRuntimeOptions {
   materializationTimeoutMs?: number;
   capacityRetryDelaysMs?: readonly number[];
   capacityRetryDelay?: (delayMs: number) => Promise<void>;
+  nativePathDiscoveryRefresh?: NativePathDiscoveryRefreshLimiterOptions;
   logger?: AgentLogger;
   skillDiscovery?: CodexSkillDiscovery;
 }
@@ -134,6 +136,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #materializationTimeoutMs: number;
   #capacityRetryDelaysMs: readonly number[];
   #capacityRetryDelay: (delayMs: number) => Promise<void>;
+  #nativePathDiscoveryRefresh: NativePathDiscoveryRefreshLimiter;
   #logger: AgentLogger;
   #skillDiscovery: CodexSkillDiscovery;
   #history: CodexHistoryService;
@@ -155,6 +158,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     this.#capacityRetryDelaysMs = (options.capacityRetryDelaysMs ?? CAPACITY_RETRY_DELAYS_MS)
       .slice(0, MAX_CAPACITY_RETRIES);
     this.#capacityRetryDelay = options.capacityRetryDelay ?? delay;
+    this.#nativePathDiscoveryRefresh =
+      new NativePathDiscoveryRefreshLimiter(options.nativePathDiscoveryRefresh);
     this.#logger = options.logger ?? NOOP_LOGGER;
     this.#history = new CodexHistoryService({
       createClient: this.#createClient,
@@ -802,18 +807,16 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   async resolveNativePath(session: CodexChatEntry): Promise<string | null> {
     if (!session.agentSessionId) return null;
 
-    const hadCachedThreadList = this.#threadListCaches.has(false);
-    const cachedPath = await this.#accessibleNativePath(
-      await this.#getThreadListCache(false),
-      session.agentSessionId,
-    );
-    if (cachedPath || !hadCachedThreadList) return cachedPath;
-
-    this.#threadListCaches.delete(false);
     return this.#accessibleNativePath(
       await this.#getThreadListCache(false),
       session.agentSessionId,
     );
+  }
+
+  requestNativePathDiscoveryRefresh(agentSessionId: string): void {
+    // Bounds each session heavily while keeping unrelated chat retries responsive.
+    if (!this.#nativePathDiscoveryRefresh.accept(agentSessionId)) return;
+    this.#threadListCaches.delete(false);
   }
 
   async resolvePermission(permissionRequestId: string, decision: { allow: boolean; alwaysAllow?: boolean }): Promise<void> {

--- a/server-agents/codex/src/agents/codex/transcript.ts
+++ b/server-agents/codex/src/agents/codex/transcript.ts
@@ -12,7 +12,11 @@ import { resolveCodexNativePath } from './native-path.js';
 
 type CodexTranscriptRuntime = Pick<
   CodexAppServerRuntime,
-  'getPreview' | 'loadMessagePage' | 'loadMessages' | 'resolveNativePath'
+  | 'getPreview'
+  | 'loadMessagePage'
+  | 'loadMessages'
+  | 'requestNativePathDiscoveryRefresh'
+  | 'resolveNativePath'
 >;
 
 export function createCodexTranscript(
@@ -54,9 +58,6 @@ export function createCodexTranscript(
     const value = reference(chat);
     const nativePath = await resolvePath(chat, signal);
     if (value.agentSessionId && !nativePath) {
-      logger.warn('Codex transcript path could not be resolved', {
-        agentSessionId: value.agentSessionId,
-      });
       throw new AgentIntegrationError(
         'TRANSCRIPT_UNAVAILABLE',
         'Codex native transcript could not be resolved',
@@ -70,10 +71,33 @@ export function createCodexTranscript(
     }
     return { ...value, nativePath };
   };
+  const retryableReference = async (
+    chat: Parameters<AgentTranscript['load']>[0]['chat'],
+    signal: AbortSignal,
+  ) => {
+    const value = reference(chat);
+    try {
+      return await resolvedReference(chat, signal);
+    } catch (error) {
+      if (
+        error instanceof AgentIntegrationError &&
+        error.code === 'TRANSCRIPT_UNAVAILABLE' &&
+        error.details?.reason === 'not-found' &&
+        value.agentSessionId
+      ) {
+        runtime.requestNativePathDiscoveryRefresh(value.agentSessionId);
+      }
+      throw error;
+    }
+  };
   const loadMessages = async (
     chat: Parameters<AgentTranscript['load']>[0]['chat'],
     signal: AbortSignal,
   ) => runtime.loadMessages(await resolvedReference(chat, signal), signal);
+  const loadRetryableMessages = async (
+    chat: Parameters<AgentTranscript['load']>[0]['chat'],
+    signal: AbortSignal,
+  ) => runtime.loadMessages(await retryableReference(chat, signal), signal);
   const resolveIndexSource = async (
     chat: Parameters<AgentTranscript['load']>[0]['chat'],
     signal: AbortSignal,
@@ -104,7 +128,16 @@ export function createCodexTranscript(
       const agentSessionId = chat.agentSessionId ?? current.agentSessionId;
       if (!agentSessionId) return null;
       const nativePath = await resolvePath(chat, signal);
-      if (!nativePath) return null;
+      if (!nativePath) {
+        if (
+          chat.nativeSession &&
+          !current.path &&
+          current.agentSessionId === agentSessionId
+        ) {
+          return chat.nativeSession;
+        }
+        return null;
+      }
       if (current.path === nativePath && chat.nativeSession) {
         return chat.nativeSession;
       }
@@ -116,12 +149,12 @@ export function createCodexTranscript(
     },
     async load({ chat, signal }) {
       signal.throwIfAborted();
-      const messages = await loadMessages(chat, signal);
+      const messages = await loadRetryableMessages(chat, signal);
       return { messages, revision: computeAgentTranscriptRevision(messages) };
     },
     async loadPage({ chat, page, signal }) {
       signal.throwIfAborted();
-      return runtime.loadMessagePage(await resolvedReference(chat, signal), page, signal);
+      return runtime.loadMessagePage(await retryableReference(chat, signal), page, signal);
     },
     async preview({ chat, signal }) {
       signal.throwIfAborted();


### PR DESCRIPTION
Codex path discovery misses were invalidating the shared thread-list cache once per legacy pathless chat, turning startup reconciliation into repeated paginated scans and preventing the server from listening. This change reuses one startup discovery snapshot, preserves exact pathless native-session references on clean misses, upgrades sessions when a validated path is discoverable, and rate-limits later transcript-triggered refreshes while keeping unresolved reads fail-closed; regression coverage verifies that 100 pathless chats start with one scan and no preservation-warning flood.