### PR TITLE
Add Claude Opus 5 support

### DIFF
--- a/common/__tests__/models.test.js
+++ b/common/__tests__/models.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { CLAUDE_MODELS } from '../models.ts';
+
+describe('CLAUDE_MODELS', () => {
+  test('exposes Opus 5 as the default while retaining the legacy alias', () => {
+    expect(CLAUDE_MODELS.DEFAULT).toBe('claude-opus-5');
+    expect(CLAUDE_MODELS.OPTIONS).toContainEqual({
+      value: 'claude-opus-5',
+      label: 'Opus 5',
+      supportsImages: true,
+    });
+    expect(CLAUDE_MODELS.OPTIONS).toContainEqual({
+      value: 'opus',
+      label: 'Opus',
+      supportsImages: true,
+    });
+  });
+});

--- a/common/models.ts
+++ b/common/models.ts
@@ -9,12 +9,13 @@ export interface SharedModelOption {
 
 export const CLAUDE_MODELS = {
   OPTIONS: [
+    { value: 'claude-opus-5', label: 'Opus 5', supportsImages: true },
     { value: 'opus', label: 'Opus', supportsImages: true },
     { value: 'sonnet', label: 'Sonnet', supportsImages: true },
     { value: 'haiku', label: 'Haiku', supportsImages: true },
     { value: 'fable', label: 'Fable 5', supportsImages: true },
   ] satisfies SharedModelOption[],
-  DEFAULT: 'opus',
+  DEFAULT: 'claude-opus-5',
 };
 
 export const CODEX_MODELS = {


### PR DESCRIPTION
## Problem

Garcon's static Claude catalog exposes only the legacy `opus` alias. Claude Code currently resolves that alias to an older Opus model, so users cannot explicitly select Claude Opus 5.

Closes #398.

## Fix

- Add canonical `claude-opus-5` model option.
- Make Opus 5 the default for new Claude chats.
- Retain the legacy `opus` option for persisted chats.
- Add a catalog regression test.

## Testing

- `bun test common/__tests__/models.test.js server/routes/__tests__/models.test.js` — **11 passed**
- `bun run check` — ESLint and Svelte checks passed with **0 errors / 0 warnings**
- `bun run build` — production web build passed
- Claude Code probe resolved `claude-opus-5` to `claude-opus-5-20260724`
