### PR TITLE
Consolidate sidebar chat activity indicators

### DIFF
--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -504,7 +504,7 @@ export class SpaDriver {
         const summary = [...document.querySelectorAll<HTMLElement>('[data-slot="sidebar-chat-summary"]')]
           .find((element) => element.innerText.includes(chatMarker));
         if (!summary) return false;
-        return Boolean(summary.querySelector('[aria-label="Unread"]')) === shouldBeUnread;
+        return Boolean(summary.querySelector('[data-slot="sidebar-chat-unread-status"]')) === shouldBeUnread;
       },
       { timeout: 20_000 },
       chatText,

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -103,7 +103,6 @@
 	--color-tag-orange: hsl(var(--tag-orange-bg));
 	--color-tag-orange-foreground: hsl(var(--tag-orange-foreground));
 	--color-tag-orange-border: hsl(var(--tag-orange-border));
-	--color-indicator-unread: hsl(var(--indicator-unread));
 	--color-indicator-attention: hsl(var(--indicator-attention));
 	--color-status-processing: hsl(var(--status-processing));
 	--color-status-processing-foreground: hsl(var(--status-processing-foreground));
@@ -296,7 +295,6 @@
 	--tag-orange-bg: 28 92% 92% / 0.5;
 	--tag-orange-foreground: 24 82% 30%;
 	--tag-orange-border: 24 52% 74% / 0.5;
-	--indicator-unread: 214 90% 48%;
 	--indicator-attention: 0 78% 54%;
 	--status-processing: 214 90% 48%;
 	--status-processing-foreground: 214 85% 32%;
@@ -513,7 +511,6 @@
 	--tag-orange-bg: 24 42% 22% / 0.3;
 	--tag-orange-foreground: 24 88% 86%;
 	--tag-orange-border: 24 34% 40% / 0.4;
-	--indicator-unread: 214 95% 68%;
 	--indicator-attention: 0 82% 66%;
 	--status-processing: 214 95% 68%;
 	--status-processing-foreground: 214 95% 86%;
@@ -975,6 +972,27 @@
 		--composer-thinking-composer-background: hsl(var(--card));
 		--composer-thinking-composer-border: hsl(var(--border));
 		--composer-thinking-status-border: hsl(var(--border));
+	}
+}
+
+@keyframes sidebar-processing-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.4;
+	}
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.sidebar-processing-indicator {
+		animation: sidebar-processing-pulse 1.6s ease-in-out infinite;
+	}
+
+	.sidebar-reduce-motion .sidebar-processing-indicator {
+		animation: none;
 	}
 }
 

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -418,7 +418,14 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -- container delegates bubbled Escape handling for the sidebar subtree; follow-up: CLEANUP_ROUND_TWO.md#a11y-suppression-register -->
-<div class="h-full flex flex-col bg-card md:select-none relative" onkeydown={handleSidebarKeydown}>
+<div
+	data-slot="sidebar"
+	class={[
+		'h-full flex flex-col bg-card md:select-none relative',
+		localSettings.reduceMotion && 'sidebar-reduce-motion',
+	]}
+	onkeydown={handleSidebarKeydown}
+>
 	<div class="order-1 flex-shrink-0">
 		<SidebarSearchDock
 			{isLoading}

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -604,6 +604,7 @@
 	onRetryTranscriptSearch={() => {
 		transcriptSearchRetryVersion += 1;
 	}}
+	reduceMotion={localSettings.reduceMotion}
 	onClose={() => sidebarSearch.closeSearchDialog()}
 />
 

--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -251,7 +251,7 @@
 {/snippet}
 
 {#snippet chatSummary()}
-	<div class={cn('relative flex-1 min-w-0', !isMobile && 'pr-8')}>
+	<div class="relative flex-1 min-w-0">
 		<SidebarChatSummary
 			{session}
 			{isSelected}

--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -251,7 +251,7 @@
 {/snippet}
 
 {#snippet chatSummary()}
-	<div class="relative flex-1 min-w-0">
+	<div class={cn('relative flex-1 min-w-0', !isMobile && 'pr-8')}>
 		<SidebarChatSummary
 			{session}
 			{isSelected}
@@ -277,7 +277,6 @@
 					isSelected &&
 					'bg-sidebar-chat-item-selected-bg text-sidebar-chat-item-selected-foreground',
 				isMultiSelectMode && isMultiSelected && 'bg-primary/8',
-				!isMultiSelectMode && isProcessing && 'border-l-[3px] border-l-status-processing',
 			)}
 		>
 			<button
@@ -312,13 +311,10 @@
 				oncontextmenu={handleRightClick}
 				class={cn(
 					'w-full justify-start pr-2 h-auto font-normal text-left rounded-none bg-sidebar-chat-item-bg hover:bg-sidebar-chat-item-hover-bg transition-colors duration-200',
-					isMultiSelectMode
-						? 'py-[5px] pl-1 border-l-0'
-						: 'py-[5px] pl-[7px] border-l-2 border-l-transparent',
+					isMultiSelectMode ? 'py-[5px] pl-1 border-l-0' : 'py-[5px] pl-[9px]',
 					!isMultiSelectMode &&
 						isSelected &&
 						'bg-sidebar-chat-item-selected-bg text-sidebar-chat-item-selected-foreground',
-					!isMultiSelectMode && isProcessing && 'border-l-[3px] border-l-status-processing',
 					isMultiSelectMode && isMultiSelected && 'bg-primary/8',
 				)}
 				onclick={handleItemClick}

--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -255,8 +255,6 @@
 		<SidebarChatSummary
 			{session}
 			{isSelected}
-			{isPinned}
-			{isArchived}
 			{currentTime}
 			showTimestamp={true}
 			showProjectPath={!displayOptions.groupByProject || showProjectPathInGroup}

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -31,6 +31,7 @@
 	}: SidebarChatSummaryProps = $props();
 
 	let isUnread = $derived(session.isUnread && !isSelected);
+	let isProcessing = $derived(session.isProcessing);
 	let chatName = $derived(session.title || m.sidebar_chats_new_chat());
 	let lastMessage = $derived(session.lastMessage || '');
 	let projectPath = $derived(showProjectPath ? session.projectPath || '' : '');
@@ -47,17 +48,31 @@
 	<div class="min-w-0 flex-1">
 		<div
 			class={cn(
-				'flex min-w-0 items-center gap-1.5 truncate text-[14px] font-medium leading-[1.3]',
+				'flex min-w-0 items-center gap-1 text-[14px] leading-[1.3]',
 				isSelected ? 'text-sidebar-chat-item-selected-foreground' : 'text-foreground',
 			)}
 		>
+			<span class={cn('min-w-0 flex-1 truncate', isUnread ? 'font-semibold' : 'font-medium')}>
+				{chatName}
+			</span>
 			{#if isUnread}
-				<span
-					class="h-1.5 w-1.5 shrink-0 rounded-full bg-indicator-unread"
-					aria-label={m.sidebar_chat_unread()}
-				></span>
+				<span class="sr-only">{m.sidebar_chat_unread()}</span>
 			{/if}
-			<span class="truncate">{chatName}</span>
+			{#if isProcessing}
+				<span class="sr-only">{m.chat_pane_processing()}</span>
+			{/if}
+			<span
+				class="flex size-3 shrink-0 items-center justify-center"
+				aria-hidden="true"
+				data-slot="sidebar-chat-processing-slot"
+			>
+				{#if isProcessing}
+					<span
+						class="sidebar-processing-indicator size-2 rounded-full bg-status-processing"
+						data-slot="sidebar-chat-processing-indicator"
+					></span>
+				{/if}
+			</span>
 		</div>
 
 		{#if projectPath || formattedTimestamp}

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -9,8 +9,7 @@
 	interface SidebarChatSummaryProps {
 		session: ChatSessionRecord;
 		isSelected: boolean;
-		isPinned: boolean;
-		isArchived: boolean;
+		suppressUnread?: boolean;
 		currentTime?: Date;
 		showTimestamp?: boolean;
 		showProjectPath?: boolean;
@@ -22,6 +21,7 @@
 	let {
 		session,
 		isSelected,
+		suppressUnread,
 		currentTime = new Date(),
 		showTimestamp = false,
 		showProjectPath = true,
@@ -30,7 +30,7 @@
 		onManageTags,
 	}: SidebarChatSummaryProps = $props();
 
-	let isUnread = $derived(session.isUnread && !isSelected);
+	let isUnread = $derived(session.isUnread && !(suppressUnread ?? isSelected));
 	let isProcessing = $derived(session.isProcessing);
 	let chatName = $derived(session.title || m.sidebar_chats_new_chat());
 	let lastMessage = $derived(session.lastMessage || '');

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -56,7 +56,9 @@
 				{chatName}
 			</span>
 			{#if isUnread}
-				<span class="sr-only">{m.sidebar_chat_unread()}</span>
+				<span class="sr-only" data-slot="sidebar-chat-unread-status">
+					{m.sidebar_chat_unread()}
+				</span>
 			{/if}
 			{#if isProcessing}
 				<span class="sr-only">{m.chat_pane_processing()}</span>

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -48,11 +48,11 @@
 	<div class="min-w-0 flex-1">
 		<div
 			class={cn(
-				'flex min-w-0 items-center gap-1 text-[14px] leading-[1.3]',
+				'flex min-w-0 items-center gap-1.5 text-[14px] leading-[1.3]',
 				isSelected ? 'text-sidebar-chat-item-selected-foreground' : 'text-foreground',
 			)}
 		>
-			<span class={cn('min-w-0 flex-1 truncate', isUnread ? 'font-semibold' : 'font-medium')}>
+			<span class={cn('min-w-0 truncate', isUnread ? 'font-semibold' : 'font-medium')}>
 				{chatName}
 			</span>
 			{#if isUnread}
@@ -63,18 +63,13 @@
 			{#if isProcessing}
 				<span class="sr-only">{m.chat_pane_processing()}</span>
 			{/if}
-			<span
-				class="flex size-3 shrink-0 items-center justify-center"
-				aria-hidden="true"
-				data-slot="sidebar-chat-processing-slot"
-			>
-				{#if isProcessing}
-					<span
-						class="sidebar-processing-indicator size-2 rounded-full bg-status-processing"
-						data-slot="sidebar-chat-processing-indicator"
-					></span>
-				{/if}
-			</span>
+			{#if isProcessing}
+				<span
+					class="sidebar-processing-indicator size-2 shrink-0 rounded-full bg-status-processing"
+					aria-hidden="true"
+					data-slot="sidebar-chat-processing-indicator"
+				></span>
+			{/if}
 		</div>
 
 		{#if projectPath || formattedTimestamp}

--- a/web/src/lib/components/sidebar/SidebarSearchDialog.svelte
+++ b/web/src/lib/components/sidebar/SidebarSearchDialog.svelte
@@ -37,6 +37,7 @@
 		onRetryTranscriptSearch?: () => void;
 		onClose: () => void;
 		showSavedSearchActions?: boolean;
+		reduceMotion?: boolean;
 		overlayClass?: string;
 		backdropTreatment?: 'standard' | 'interaction-only';
 		contentRole?: 'dialog' | 'presentation';
@@ -64,6 +65,7 @@
 		onRetryTranscriptSearch = () => {},
 		onClose,
 		showSavedSearchActions = true,
+		reduceMotion = false,
 		overlayClass,
 		backdropTreatment = 'standard',
 		contentRole = 'dialog',
@@ -148,6 +150,7 @@
 		class={cn(
 			'fixed inset-0 z-50',
 			backdropTreatment === 'standard' && 'transient-backdrop',
+			reduceMotion && 'sidebar-reduce-motion',
 			overlayClass,
 		)}
 		role="presentation"

--- a/web/src/lib/components/sidebar/SidebarSearchResultRow.svelte
+++ b/web/src/lib/components/sidebar/SidebarSearchResultRow.svelte
@@ -51,8 +51,7 @@
 	<SidebarChatSummary
 		session={chat}
 		isSelected={isHighlighted}
-		isPinned={chat.isPinned}
-		isArchived={chat.isArchived}
+		suppressUnread={false}
 		{currentTime}
 		showTimestamp={true}
 	/>

--- a/web/src/lib/components/sidebar/SidebarSearchResultRow.svelte
+++ b/web/src/lib/components/sidebar/SidebarSearchResultRow.svelte
@@ -41,9 +41,8 @@
 	role="option"
 	aria-selected={isHighlighted}
 	class={cn(
-		'h-full min-w-0 w-full border-l-2 border-l-transparent bg-transparent px-3 py-1.5 text-left font-normal transition-colors duration-150',
+		'h-full min-w-0 w-full bg-transparent px-3 py-1.5 text-left font-normal transition-colors duration-150',
 		isHighlighted ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/40',
-		chat.isProcessing && 'border-l-[3px] border-l-status-processing',
 	)}
 	style={`min-height:${SEARCH_RESULT_ROW_HEIGHT}px;`}
 	onclick={() => onSelectChat(chat.id)}

--- a/web/src/lib/components/sidebar/__tests__/SidebarHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarHost.svelte
@@ -28,6 +28,7 @@
 		sidebarGroupByProject?: boolean;
 		sidebarGroupNestedProjectPaths?: boolean;
 		sidebarCompactChatItems?: boolean;
+		reduceMotion?: boolean;
 		collapsedProjectKeys?: Set<string>;
 	}
 
@@ -41,6 +42,7 @@
 		sidebarGroupByProject = true,
 		sidebarGroupNestedProjectPaths = false,
 		sidebarCompactChatItems = false,
+		reduceMotion = false,
 		collapsedProjectKeys = new Set<string>(),
 	}: SidebarHostProps = $props();
 
@@ -90,6 +92,9 @@
 		},
 		get sidebarCompactChatItems() {
 			return sidebarCompactChatItems;
+		},
+		get reduceMotion() {
+			return reduceMotion;
 		},
 		toggle(
 			key: 'sidebarGroupByProject' | 'sidebarGroupNestedProjectPaths' | 'sidebarCompactChatItems',

--- a/web/src/lib/components/sidebar/__tests__/SidebarSearchDialogHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarSearchDialogHost.svelte
@@ -12,6 +12,7 @@
 		onCreateSavedSearch?: () => void;
 		onOpenManager?: () => void;
 		onClose?: () => void;
+		reduceMotion?: boolean;
 	}
 
 	let {
@@ -23,6 +24,7 @@
 		onCreateSavedSearch,
 		onOpenManager,
 		onClose,
+		reduceMotion = false,
 	}: SidebarSearchDialogHostProps = $props();
 
 	let query = $state('');
@@ -52,6 +54,7 @@
 	{savedSearches}
 	{currentTime}
 	{highlightedIndex}
+	{reduceMotion}
 	onQueryChange={handleQueryChange}
 	onSelectChat={(chatId) => onSelectChat?.(chatId)}
 	onApplySavedSearch={handleApplySavedSearch}

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 
 import SidebarChatItemHost from './SidebarChatItemHost.svelte';
 import SidebarSearchDialogHost from './SidebarSearchDialogHost.svelte';
 
 import type { ChatSessionRecord } from '$lib/types/chat-session';
+
+const appCss = readFileSync('src/app.css', 'utf8');
 
 function createChat(overrides: Partial<ChatSessionRecord> = {}): ChatSessionRecord {
 	return {
@@ -70,10 +73,13 @@ describe('shared sidebar chat row', () => {
 		expect(document.querySelectorAll('[data-slot="sidebar-chat-summary"]')).toHaveLength(1);
 		const pinnedBadges = document.querySelectorAll('.border-sidebar-badge-pinned-border');
 		expect(pinnedBadges).toHaveLength(1);
-		expect(screen.getByText('Shared row chat')).toBeTruthy();
-		expect(screen.getByLabelText('Unread')).toBeTruthy();
+		const title = screen.getByText('Shared row chat');
+		expect(title.className).toContain('font-semibold');
+		expect(screen.getByText('Unread').className).toContain('sr-only');
+		expect(document.querySelector('.bg-indicator-unread')).toBeNull();
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeNull();
 		expect(screen.getByText('3h ago')).toBeTruthy();
-		expect(screen.getByText('Shared row chat').parentElement?.className).toContain('leading-[1.3]');
+		expect(title.parentElement?.className).toContain('leading-[1.3]');
 		expect(screen.getByText('3h ago').className).toContain('font-normal');
 		expect(screen.getByText('3h ago').className).not.toContain('md:group-hover:opacity-0');
 		expect(screen.queryByText('Jan 1')).toBeNull();
@@ -103,7 +109,7 @@ describe('shared sidebar chat row', () => {
 			expect(badge.querySelector('svg')?.getAttribute('class')).toContain('size-2.5');
 			expect(badge.closest('button')).not.toBe(desktopMenuTrigger);
 			expect(badge.parentElement?.className).toContain('relative flex-1 min-w-0');
-			expect(badge.parentElement?.className).not.toContain('pr-');
+			expect(badge.parentElement?.className).toContain('pr-8');
 		}
 
 		await fireEvent.click(screen.getByRole('button', { name: 'ops' }));
@@ -111,6 +117,51 @@ describe('shared sidebar chat row', () => {
 
 		await fireEvent.click(screen.getByRole('button', { name: '+1' }));
 		expect(onManageTags).toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-1' }));
+	});
+
+	it('uses independent title weight and activity treatments for unread and processing states', async () => {
+		const { rerender } = render(SidebarChatItemHost, {
+			session: createChat({ isUnread: true, isProcessing: true }),
+		});
+
+		const title = screen.getByText('Shared row chat');
+		const processingSlot = document.querySelector('[data-slot="sidebar-chat-processing-slot"]');
+		expect(title.className).toContain('font-semibold');
+		expect(screen.getByText('Unread').className).toContain('sr-only');
+		expect(screen.getByText('Chat is processing').className).toContain('sr-only');
+		expect(processingSlot?.className).toContain('size-3');
+		expect(
+			processingSlot?.querySelector('[data-slot="sidebar-chat-processing-indicator"]'),
+		).toBeTruthy();
+		expect(title.closest('button')?.className).not.toContain('border-l-status-processing');
+
+		await rerender({
+			session: createChat({ isUnread: false, isProcessing: true }),
+		});
+
+		expect(title.className).toContain('font-medium');
+		expect(title.className).not.toContain('font-semibold');
+		expect(screen.queryByText('Unread')).toBeNull();
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
+
+		await rerender({
+			session: createChat({ isUnread: true, isProcessing: true }),
+			selectedChatId: 'chat-1',
+		});
+
+		expect(title.className).toContain('font-medium');
+		expect(title.className).not.toContain('font-semibold');
+		expect(screen.queryByText('Unread')).toBeNull();
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
+
+		await rerender({
+			session: createChat({ isUnread: false, isProcessing: false }),
+			selectedChatId: null,
+		});
+
+		expect(screen.queryByText('Chat is processing')).toBeNull();
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeNull();
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-slot"]')).toBeTruthy();
 	});
 
 	it('sizes archived badges to the same metadata pill height', () => {
@@ -171,6 +222,9 @@ describe('shared sidebar chat row', () => {
 
 		expect(document.querySelectorAll('[data-slot="sidebar-chat-summary"]')).toHaveLength(1);
 		expect(screen.getByRole('button', { name: 'Chat actions' })).toBeTruthy();
+		expect(
+			document.querySelector('[data-slot="sidebar-chat-summary"]')?.parentElement?.className,
+		).not.toContain('pr-8');
 		expect(
 			document.querySelector('[data-slot="dropdown-menu-trigger"][aria-label="Chat actions"]'),
 		).toBeNull();
@@ -250,18 +304,21 @@ describe('shared sidebar chat row', () => {
 
 	it('renders the same chat summary content inside the search dialog rows', async () => {
 		render(SidebarSearchDialogHost, {
-			filteredChats: [createChat({ isPinned: true })],
+			filteredChats: [createChat({ isPinned: true, isProcessing: true })],
 		});
 
 		const option = await screen.findByRole('option');
 		expect(option.className).toContain('bg-accent');
 		expect(option.className).toContain('px-3');
+		expect(option.className).not.toContain('border-l-status-processing');
 		expect(option.parentElement?.className).toContain('divide-y');
 
 		expect(option.querySelector('[data-slot="sidebar-chat-summary"]')).toBeTruthy();
 		expect(option.querySelector('.border-sidebar-badge-pinned-border')).toBeNull();
 		expect(screen.getByText('Shared row chat')).toBeTruthy();
 		expect(screen.queryByLabelText('Unread')).toBeNull();
+		expect(screen.getByText('Chat is processing').className).toContain('sr-only');
+		expect(option.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
 		expect(screen.queryByText('Jan 1')).toBeNull();
 		expect(screen.queryByText('12:00 AM')).toBeNull();
 		expect(screen.getByText('3h ago')).toBeTruthy();
@@ -273,6 +330,16 @@ describe('shared sidebar chat row', () => {
 		expect(screen.getByText('prod')).toBeTruthy();
 		expect(screen.queryByRole('button', { name: '+1' })).toBeNull();
 		expect(screen.getByText('+1')).toBeTruthy();
+	});
+
+	it('pulses processing only when system and local motion preferences allow it', () => {
+		expect(appCss).toContain('@keyframes sidebar-processing-pulse');
+		expect(appCss).toMatch(
+			/@media \(prefers-reduced-motion: no-preference\)\s*\{[\s\S]*?\.sidebar-processing-indicator\s*\{[\s\S]*?animation: sidebar-processing-pulse 1\.6s ease-in-out infinite;[\s\S]*?\}/,
+		);
+		expect(appCss).toMatch(
+			/\.sidebar-reduce-motion \.sidebar-processing-indicator\s*\{\s*animation: none;\s*\}/,
+		);
 	});
 
 	it('updates relative timestamps when currentTime changes', async () => {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -305,6 +305,7 @@ describe('shared sidebar chat row', () => {
 	it('renders the same chat summary content inside the search dialog rows', async () => {
 		render(SidebarSearchDialogHost, {
 			filteredChats: [createChat({ isPinned: true, isProcessing: true })],
+			reduceMotion: true,
 		});
 
 		const option = await screen.findByRole('option');
@@ -316,9 +317,14 @@ describe('shared sidebar chat row', () => {
 		expect(option.querySelector('[data-slot="sidebar-chat-summary"]')).toBeTruthy();
 		expect(option.querySelector('.border-sidebar-badge-pinned-border')).toBeNull();
 		expect(screen.getByText('Shared row chat')).toBeTruthy();
-		expect(screen.queryByLabelText('Unread')).toBeNull();
+		expect(screen.getByText('Unread').className).toContain('sr-only');
 		expect(screen.getByText('Chat is processing').className).toContain('sr-only');
-		expect(option.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
+		const processingIndicator = option.querySelector(
+			'[data-slot="sidebar-chat-processing-indicator"]',
+		);
+		expect(processingIndicator).toBeTruthy();
+		expect(processingIndicator?.closest('.sidebar-reduce-motion')).toBeTruthy();
+		expect(screen.getByText('Shared row chat').className).toContain('font-semibold');
 		expect(screen.queryByText('Jan 1')).toBeNull();
 		expect(screen.queryByText('12:00 AM')).toBeNull();
 		expect(screen.getByText('3h ago')).toBeTruthy();

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -75,7 +75,9 @@ describe('shared sidebar chat row', () => {
 		expect(pinnedBadges).toHaveLength(1);
 		const title = screen.getByText('Shared row chat');
 		expect(title.className).toContain('font-semibold');
-		expect(screen.getByText('Unread').className).toContain('sr-only');
+		const unreadStatus = screen.getByText('Unread');
+		expect(unreadStatus.className).toContain('sr-only');
+		expect(unreadStatus.getAttribute('data-slot')).toBe('sidebar-chat-unread-status');
 		expect(document.querySelector('.bg-indicator-unread')).toBeNull();
 		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeNull();
 		expect(screen.getByText('3h ago')).toBeTruthy();

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -111,7 +111,7 @@ describe('shared sidebar chat row', () => {
 			expect(badge.querySelector('svg')?.getAttribute('class')).toContain('size-2.5');
 			expect(badge.closest('button')).not.toBe(desktopMenuTrigger);
 			expect(badge.parentElement?.className).toContain('relative flex-1 min-w-0');
-			expect(badge.parentElement?.className).toContain('pr-8');
+			expect(badge.parentElement?.className).not.toContain('pr-8');
 		}
 
 		await fireEvent.click(screen.getByRole('button', { name: 'ops' }));
@@ -127,14 +127,17 @@ describe('shared sidebar chat row', () => {
 		});
 
 		const title = screen.getByText('Shared row chat');
-		const processingSlot = document.querySelector('[data-slot="sidebar-chat-processing-slot"]');
+		const processingIndicator = document.querySelector(
+			'[data-slot="sidebar-chat-processing-indicator"]',
+		);
 		expect(title.className).toContain('font-semibold');
+		expect(title.className).not.toContain('flex-1');
+		expect(title.parentElement?.className).toContain('gap-1.5');
 		expect(screen.getByText('Unread').className).toContain('sr-only');
 		expect(screen.getByText('Chat is processing').className).toContain('sr-only');
-		expect(processingSlot?.className).toContain('size-3');
-		expect(
-			processingSlot?.querySelector('[data-slot="sidebar-chat-processing-indicator"]'),
-		).toBeTruthy();
+		expect(processingIndicator?.className).toContain('shrink-0');
+		expect(processingIndicator?.parentElement).toBe(title.parentElement);
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-slot"]')).toBeNull();
 		expect(title.closest('button')?.className).not.toContain('border-l-status-processing');
 
 		await rerender({
@@ -163,7 +166,7 @@ describe('shared sidebar chat row', () => {
 
 		expect(screen.queryByText('Chat is processing')).toBeNull();
 		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeNull();
-		expect(document.querySelector('[data-slot="sidebar-chat-processing-slot"]')).toBeTruthy();
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-slot"]')).toBeNull();
 	});
 
 	it('sizes archived badges to the same metadata pill height', () => {
@@ -326,7 +329,9 @@ describe('shared sidebar chat row', () => {
 		);
 		expect(processingIndicator).toBeTruthy();
 		expect(processingIndicator?.closest('.sidebar-reduce-motion')).toBeTruthy();
-		expect(screen.getByText('Shared row chat').className).toContain('font-semibold');
+		const searchTitle = screen.getByText('Shared row chat');
+		expect(searchTitle.className).toContain('font-semibold');
+		expect(processingIndicator?.parentElement).toBe(searchTitle.parentElement);
 		expect(screen.queryByText('Jan 1')).toBeNull();
 		expect(screen.queryByText('12:00 AM')).toBeNull();
 		expect(screen.getByText('3h ago')).toBeTruthy();

--- a/web/src/lib/components/sidebar/__tests__/sidebar-search-flow.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-search-flow.test.ts
@@ -189,6 +189,10 @@ describe('sidebar search dialog flow', () => {
 		expect(document.querySelector('[data-slot="sidebar"]')?.className).toContain(
 			'sidebar-reduce-motion',
 		);
-		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
+		const processingIndicator = document.querySelector(
+			'[data-slot="sidebar-chat-processing-indicator"]',
+		);
+		expect(processingIndicator).toBeTruthy();
+		expect(processingIndicator?.closest('.sidebar-reduce-motion')).toBeTruthy();
 	});
 });

--- a/web/src/lib/components/sidebar/__tests__/sidebar-search-flow.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-search-flow.test.ts
@@ -179,4 +179,16 @@ describe('sidebar search dialog flow', () => {
 			expect(screen.queryByText('First chat preview')).toBeNull();
 		});
 	});
+
+	it('marks the sidebar to suppress activity animation when motion is reduced', () => {
+		render(SidebarHost, {
+			chats: [createChat('chat-a', 'Chat A', { isProcessing: true })],
+			reduceMotion: true,
+		});
+
+		expect(document.querySelector('[data-slot="sidebar"]')?.className).toContain(
+			'sidebar-reduce-motion',
+		);
+		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
+	});
 });


### PR DESCRIPTION
Unread and active processing are distinct states, so the sidebar now communicates unread work with semibold chat titles and processing with a blue pulse immediately after the title, replacing the competing unread dot and left-edge activity line without reserving a right-side slot. The same treatment applies in search results, represents combined states clearly, provides screen-reader status text, and becomes a static dot when either system or in-app reduced motion is enabled.