### PR TITLE
Keep virtual Git diffs loading across view changes

### DIFF
--- a/integration-tests/tests/e2e/git-virtual-demand-lifecycle.test.ts
+++ b/integration-tests/tests/e2e/git-virtual-demand-lifecycle.test.ts
@@ -242,7 +242,23 @@ describe('Lightpanda Git virtual demand lifecycle', () => {
       expect(retainedBefore.firstIndex).toBeGreaterThan(0);
 
       await switchToChat(fixture.page);
+      await fixture.page.waitForFunction(
+        () =>
+          document
+            .querySelector('[data-git-virtual-diff-root]')
+            ?.closest('[data-workspace-surface-id]')
+            ?.getAttribute('aria-hidden') === 'true',
+        { timeout: 20_000 },
+      );
       await switchToGit(fixture.page);
+      await fixture.page.waitForFunction(
+        () =>
+          document
+            .querySelector('[data-git-virtual-diff-root]')
+            ?.closest('[data-workspace-surface-id]')
+            ?.getAttribute('aria-hidden') === 'false',
+        { timeout: 20_000 },
+      );
       await showWorkbenchDiff(fixture.page);
       const retainedAfter = await fixture.page.evaluate(() => {
         const viewport = document.querySelector<HTMLElement>('[data-git-virtual-diff-root]');
@@ -303,7 +319,7 @@ describe('Lightpanda Git virtual demand lifecycle', () => {
       );
       const visiblePath = heldPaths[0] ?? '';
       expect(visiblePath).toBeTruthy();
-      expect(Number(/file-(\d+)\.txt$/.exec(visiblePath)?.[1])).toBeGreaterThan(40);
+      expect(Number(/file-(\d+)\.txt$/.exec(visiblePath)?.[1])).toBeGreaterThanOrEqual(40);
 
       await fixture.page.evaluate(() => {
         const scope = globalThis as typeof globalThis & {

--- a/integration-tests/tests/e2e/git-virtual-demand-lifecycle.test.ts
+++ b/integration-tests/tests/e2e/git-virtual-demand-lifecycle.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test } from 'bun:test';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Page } from 'puppeteer-core';
+import { withE2eFixture } from '../../support/e2e-fixture.js';
+import { SpaDriver } from '../../support/spa-driver.js';
+
+async function runGit(projectPath: string, args: string[]): Promise<void> {
+  const process = Bun.spawn(['git', ...args], {
+    cwd: projectPath,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`git ${args[0]} failed: ${stderr.trim()}`);
+}
+
+async function switchWorkspaceSurface(
+  page: Page,
+  commandLabel: string,
+  readySelector: string,
+): Promise<void> {
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p', ctrlKey: true, bubbles: true }));
+  });
+  await page.waitForSelector('[role="dialog"][aria-label="Command palette"]');
+  await page.evaluate((label) => {
+    const option = [...document.querySelectorAll<HTMLButtonElement>('[role="option"]')].find(
+      (button) => button.textContent?.includes(label),
+    );
+    if (!option) throw new Error(`Missing ${label} command.`);
+    option.click();
+  }, commandLabel);
+  await page.waitForSelector(readySelector);
+}
+
+async function switchToGit(page: Page): Promise<void> {
+  await switchWorkspaceSurface(page, 'Switch to Git', '[data-git-virtual-diff-root]');
+}
+
+async function switchToChat(page: Page): Promise<void> {
+  await switchWorkspaceSurface(page, 'Switch to Chat', 'textarea[placeholder="Reply..."]');
+}
+
+async function showWorkbenchDiff(page: Page): Promise<void> {
+  const isHidden = await page.$eval(
+    '[data-git-diff-pane]',
+    (pane) => pane.getAttribute('aria-hidden') === 'true',
+  );
+  if (isHidden) {
+    await page.evaluate(() => {
+      const button = [
+        ...document.querySelectorAll<HTMLButtonElement>('[data-git-segmented-navigation] button'),
+      ].find((candidate) => candidate.textContent?.trim() === 'Diff');
+      if (!button) throw new Error('Missing narrow Git Diff pane control.');
+      button.click();
+    });
+  }
+  await page.waitForSelector('[data-git-diff-pane][aria-hidden="false"]');
+}
+
+describe('Lightpanda Git virtual demand lifecycle', () => {
+  test('continues loading far visible rows after the retained Git surface is hidden and restored', async () => {
+    await withE2eFixture('git-virtual-demand-lifecycle', async (fixture) => {
+      const project = fixture.integration.dirs.project;
+      await runGit(project, ['init', '-b', 'main']);
+      await runGit(project, ['config', 'user.email', 'test@example.com']);
+      await runGit(project, ['config', 'user.name', 'E2E Test']);
+      const fileCount = 120;
+      const lineCount = 30;
+      await Promise.all(
+        Array.from({ length: fileCount }, (_, fileIndex) => {
+          const name = `file-${String(fileIndex).padStart(3, '0')}.txt`;
+          const content = Array.from(
+            { length: lineCount },
+            (_, lineIndex) => `before ${fileIndex} line ${lineIndex}`,
+          ).join('\n');
+          return writeFile(join(project, name), `${content}\n`, 'utf8');
+        }),
+      );
+      await runGit(project, ['add', '.']);
+      await runGit(project, ['commit', '-m', 'base']);
+      await Promise.all(
+        Array.from({ length: fileCount }, (_, fileIndex) => {
+          const name = `file-${String(fileIndex).padStart(3, '0')}.txt`;
+          const content = Array.from(
+            { length: lineCount },
+            (_, lineIndex) => `after ${fileIndex} line ${lineIndex}`,
+          ).join('\n');
+          return writeFile(join(project, name), `${content}\n`, 'utf8');
+        }),
+      );
+
+      await fixture.page.evaluateOnNewDocument(() => {
+        localStorage.setItem('garcon.gitReviewDemandTrace', '1');
+        const scope = globalThis as typeof globalThis & {
+          __garconHoldFarGitBodyRequest?: boolean;
+          __garconHeldGitBodyRequest?: {
+            files: string[];
+            purpose: string;
+          } | null;
+          __garconReleaseGitBodyRequest?: (() => void) | null;
+          __garconGitBodyRequestsInFlight?: number;
+          __garconHeldGitBodyCompleted?: boolean;
+          __garconHeldGitBodyStatus?: number | null;
+        };
+        const nativeFetch = globalThis.fetch.bind(globalThis);
+        scope.__garconHoldFarGitBodyRequest = false;
+        scope.__garconHeldGitBodyRequest = null;
+        scope.__garconReleaseGitBodyRequest = null;
+        scope.__garconGitBodyRequestsInFlight = 0;
+        scope.__garconHeldGitBodyCompleted = false;
+        scope.__garconHeldGitBodyStatus = null;
+        globalThis.fetch = (async (input, init) => {
+          const url = new URL(
+            input instanceof Request ? input.url : String(input),
+            globalThis.location.href,
+          );
+          const isBodyRequest = url.pathname === '/api/v1/git/review-documents/files';
+          if (isBodyRequest)
+            scope.__garconGitBodyRequestsInFlight =
+              (scope.__garconGitBodyRequestsInFlight ?? 0) + 1;
+          let heldFarBodyRequest = false;
+          try {
+            if (
+              scope.__garconHoldFarGitBodyRequest &&
+              !scope.__garconHeldGitBodyRequest &&
+              isBodyRequest &&
+              typeof init?.body === 'string'
+            ) {
+              const body = JSON.parse(init.body) as {
+                files?: unknown;
+                purpose?: unknown;
+              };
+              const files = Array.isArray(body.files)
+                ? body.files.filter((file): file is string => typeof file === 'string')
+                : [];
+              const hasFarFile = files.some((file) => {
+                const match = /file-(\d+)\.txt$/.exec(file);
+                return match ? Number(match[1]) >= 40 : false;
+              });
+              if (body.purpose === 'visible' && hasFarFile) {
+                heldFarBodyRequest = true;
+                scope.__garconHeldGitBodyRequest = {
+                  files,
+                  purpose: body.purpose,
+                };
+                await new Promise<void>((resolve) => {
+                  scope.__garconReleaseGitBodyRequest = resolve;
+                });
+              }
+            }
+            const response = await nativeFetch(input, init);
+            if (heldFarBodyRequest) {
+              scope.__garconHeldGitBodyStatus = response.status;
+              scope.__garconHeldGitBodyCompleted = true;
+            }
+            return response;
+          } finally {
+            if (isBodyRequest)
+              scope.__garconGitBodyRequestsInFlight = Math.max(
+                0,
+                (scope.__garconGitBodyRequestsInFlight ?? 1) - 1,
+              );
+          }
+        }) as typeof globalThis.fetch;
+      });
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat('git-virtual-demand-seed');
+      await app.waitForText('echo:git-virtual-demand-seed');
+      await switchToGit(fixture.page);
+      await showWorkbenchDiff(fixture.page);
+      await fixture.page.waitForFunction(
+        () => document.querySelectorAll('[data-git-virtual-row]').length > 0,
+        { timeout: 20_000 },
+      );
+
+      await fixture.page.evaluate(() => {
+        const viewport = document.querySelector<HTMLElement>('[data-git-virtual-diff-root]');
+        if (!viewport) throw new Error('Missing Git virtual viewport.');
+        viewport.scrollTop = Math.max(2_000, viewport.scrollHeight * 0.2);
+        viewport.dispatchEvent(new Event('scroll'));
+      });
+      await fixture.page.waitForFunction(
+        () =>
+          Number(
+            document.querySelector<HTMLElement>('[data-git-virtual-row]')?.dataset.index ?? 0,
+          ) > 0,
+        { timeout: 20_000 },
+      );
+      await fixture.page.waitForFunction(
+        () => {
+          const scope = globalThis as typeof globalThis & {
+            __garconGitBodyRequestsInFlight?: number;
+          };
+          const hasLoadingPlaceholder = [
+            ...document.querySelectorAll<HTMLElement>('[data-git-placeholder-row]'),
+          ].some((row) => row.dataset.gitPlaceholderState === 'loading');
+          return (scope.__garconGitBodyRequestsInFlight ?? 0) === 0 && !hasLoadingPlaceholder;
+        },
+        { timeout: 20_000 },
+      );
+      await fixture.page.evaluate(() => {
+        const viewport = document.querySelector<HTMLElement>('[data-git-virtual-diff-root]');
+        if (!viewport) throw new Error('Missing settled Git virtual viewport.');
+        viewport.scrollTop = Math.max(2_000, viewport.scrollHeight * 0.2);
+        viewport.dispatchEvent(new Event('scroll'));
+      });
+      await fixture.page.waitForFunction(
+        () =>
+          Number(
+            document.querySelector<HTMLElement>('[data-git-virtual-row]')?.dataset.index ?? 0,
+          ) > 0,
+        { timeout: 20_000 },
+      );
+      await fixture.page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      const retainedBefore = await fixture.page.evaluate(() => {
+        const viewport = document.querySelector<HTMLElement>('[data-git-virtual-diff-root]');
+        const firstRow = document.querySelector<HTMLElement>('[data-git-virtual-row]');
+        const spacer = document.querySelector<HTMLElement>(
+          '[data-git-virtual-row-window]',
+        )?.parentElement;
+        return {
+          scrollTop: viewport?.scrollTop ?? -1,
+          firstIndex: Number(firstRow?.dataset.index ?? -1),
+          spacerHeight: spacer?.style.height ?? '',
+        };
+      });
+      expect(retainedBefore.scrollTop).toBeGreaterThan(0);
+      expect(retainedBefore.firstIndex).toBeGreaterThan(0);
+
+      await switchToChat(fixture.page);
+      await switchToGit(fixture.page);
+      await showWorkbenchDiff(fixture.page);
+      const retainedAfter = await fixture.page.evaluate(() => {
+        const viewport = document.querySelector<HTMLElement>('[data-git-virtual-diff-root]');
+        const firstRow = document.querySelector<HTMLElement>('[data-git-virtual-row]');
+        const spacer = document.querySelector<HTMLElement>(
+          '[data-git-virtual-row-window]',
+        )?.parentElement;
+        return {
+          scrollTop: viewport?.scrollTop ?? -1,
+          firstIndex: Number(firstRow?.dataset.index ?? -1),
+          spacerHeight: spacer?.style.height ?? '',
+        };
+      });
+      expect(retainedAfter.scrollTop).toBe(retainedBefore.scrollTop);
+      expect(retainedAfter.firstIndex).toBe(retainedBefore.firstIndex);
+      expect(retainedAfter.spacerHeight).toBeTruthy();
+
+      await fixture.page.evaluate(() => {
+        const scope = globalThis as typeof globalThis & {
+          __garconHoldFarGitBodyRequest?: boolean;
+        };
+        scope.__garconHoldFarGitBodyRequest = true;
+        const viewport = document.querySelector<HTMLElement>('[data-git-virtual-diff-root]');
+        if (!viewport) throw new Error('Missing restored Git virtual viewport.');
+        const rowWindow = viewport.querySelector<HTMLElement>('[data-git-virtual-row-window]');
+        const virtualHeight = Number.parseFloat(rowWindow?.parentElement?.style.height ?? '');
+        if (!Number.isFinite(virtualHeight) || virtualHeight <= 0)
+          throw new Error('Missing Git virtual spacer height.');
+        viewport.scrollTop = Math.max(60_000, virtualHeight * 0.75);
+        viewport.dispatchEvent(new Event('scroll'));
+      });
+      await fixture.page.waitForFunction(
+        (previousIndex) =>
+          Number(
+            document.querySelector<HTMLElement>('[data-git-virtual-row]')?.dataset.index ?? 0,
+          ) > previousIndex,
+        { timeout: 20_000 },
+        retainedAfter.firstIndex,
+      );
+      await fixture.page.waitForFunction(
+        () =>
+          Boolean(
+            (
+              globalThis as typeof globalThis & {
+                __garconHeldGitBodyRequest?: unknown;
+              }
+            ).__garconHeldGitBodyRequest,
+          ),
+        { timeout: 20_000 },
+      );
+      const heldPaths = await fixture.page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __garconHeldGitBodyRequest?: { files: string[] } | null;
+            }
+          ).__garconHeldGitBodyRequest?.files ?? [],
+      );
+      const visiblePath = heldPaths[0] ?? '';
+      expect(visiblePath).toBeTruthy();
+      expect(Number(/file-(\d+)\.txt$/.exec(visiblePath)?.[1])).toBeGreaterThan(40);
+
+      await fixture.page.evaluate(() => {
+        const scope = globalThis as typeof globalThis & {
+          __garconReleaseGitBodyRequest?: (() => void) | null;
+        };
+        const release = scope.__garconReleaseGitBodyRequest;
+        if (!release) throw new Error('The far visible body request was not retained.');
+        scope.__garconReleaseGitBodyRequest = null;
+        release();
+      });
+      await fixture.page.waitForFunction(
+        () =>
+          Boolean(
+            (
+              globalThis as typeof globalThis & {
+                __garconHeldGitBodyCompleted?: boolean;
+              }
+            ).__garconHeldGitBodyCompleted,
+        ),
+        { timeout: 20_000 },
+      );
+      const heldResponseStatus = await fixture.page.evaluate(
+        () =>
+          (
+            globalThis as typeof globalThis & {
+              __garconHeldGitBodyStatus?: number | null;
+            }
+          ).__garconHeldGitBodyStatus,
+      );
+      expect(heldResponseStatus).toBe(200);
+      const mountedRows = await fixture.page.$$eval(
+        '[data-git-virtual-row]',
+        (rows) => rows.length,
+      );
+      expect(mountedRows).toBeLessThan(200);
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});

--- a/web/src/lib/components/git/GitCommitDetailsScreen.svelte
+++ b/web/src/lib/components/git/GitCommitDetailsScreen.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { GitCommitFileSummary, GitCommitSnapshotReady } from '$lib/api/git.js';
-	import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
+	import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 	import type { GitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
 	import type {
 		CommentComposerState,
@@ -21,6 +21,7 @@
 		fileFilter: string;
 		focusedFilePath: string | null;
 		isMobile: boolean;
+		active?: boolean;
 		fontSize: number;
 		diffMode: DiffMode;
 		contextLines: number;
@@ -35,7 +36,7 @@
 		onSetDiffFontSize: (size: string) => void;
 		onSelectFile: (file: string) => void;
 		onFileFilterChange: (value: string) => void;
-		onVisibleRowsChange: (rows: GitVirtualReviewRow[]) => void;
+		onBodyDemand: (demand: GitReviewBodyDemand) => void;
 		onOpenInEditor?: (relativePath: string, line: number) => void;
 		composerState: CommentComposerState;
 		commentFeedback: {
@@ -95,6 +96,7 @@
 	fileFilter={props.fileFilter}
 	focusedFilePath={props.focusedFilePath}
 	isMobile={props.isMobile}
+	active={props.active ?? true}
 	fontSize={props.fontSize}
 	loadingLabel={m.git_commit_details_loading()}
 	emptyErrorLabel={m.git_commit_not_found()}
@@ -103,7 +105,7 @@
 	onRetry={props.onRetry}
 	onSelectFile={props.onSelectFile}
 	onFileFilterChange={props.onFileFilterChange}
-	onVisibleRowsChange={props.onVisibleRowsChange}
+	onBodyDemand={props.onBodyDemand}
 	onOpenInEditor={props.onOpenInEditor}
 	composerState={props.composerState}
 	commentFeedback={props.commentFeedback}

--- a/web/src/lib/components/git/GitCommitVirtualDiffSurface.svelte
+++ b/web/src/lib/components/git/GitCommitVirtualDiffSurface.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 	import type { GitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+	import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 	import type {
 		CommentComposerState,
 		GitDiffSeverity,
@@ -13,11 +14,12 @@
 
 	interface GitCommitVirtualDiffSurfaceProps {
 		documentId: string | null;
+		active?: boolean;
 		source: GitVirtualReviewRowSource;
 		fontSize: number;
 		scrollToRequest: { filePath: string; token: number } | null;
 		overscan?: number;
-		onVisibleRowsChange: (rows: GitVirtualReviewRow[]) => void;
+		onBodyDemand: (demand: GitReviewBodyDemand) => void;
 		onSelectFile: (filePath: string) => void;
 		onOpenInEditor?: (relativePath: string, line: number) => void;
 		composerState: CommentComposerState;
@@ -41,11 +43,12 @@
 
 	let {
 		documentId,
+		active = true,
 		source,
 		fontSize,
 		scrollToRequest,
 		overscan = 18,
-		onVisibleRowsChange,
+		onBodyDemand,
 		onSelectFile,
 		onOpenInEditor,
 		composerState,
@@ -89,12 +92,14 @@
 {/snippet}
 
 <GitVirtualDiffViewport
-	{documentId}
+	layoutIdentity={documentId}
+	reviewDocumentId={documentId}
+	{active}
 	{source}
 	{fontSize}
 	{scrollToRequest}
 	{overscan}
 	{emptyMessage}
-	{onVisibleRowsChange}
+	{onBodyDemand}
 	rowSnippet={renderCommitRow}
 />

--- a/web/src/lib/components/git/GitComparisonScreen.svelte
+++ b/web/src/lib/components/git/GitComparisonScreen.svelte
@@ -10,6 +10,7 @@
 	interface GitComparisonScreenProps {
 		comparison: GitComparisonController;
 		isMobile: boolean;
+		active?: boolean;
 		fontSize: number;
 		diffMode: DiffMode;
 		contextLines: number;
@@ -27,6 +28,7 @@
 	let {
 		comparison,
 		isMobile,
+		active = true,
 		fontSize,
 		diffMode,
 		contextLines,
@@ -95,6 +97,7 @@
 	fileFilter={comparison.document.fileFilter}
 	focusedFilePath={comparison.document.focusedFilePath}
 	{isMobile}
+	{active}
 	{fontSize}
 	loadingLabel={m.git_compare_loading()}
 	emptyErrorLabel={m.git_compare_load_failed()}
@@ -102,7 +105,7 @@
 	{onBack}
 	onSelectFile={(filePath) => comparison.focusFile(filePath)}
 	onFileFilterChange={(value) => comparison.setFileFilter(value)}
-	onVisibleRowsChange={(rows) => comparison.setVisibleRows(rows)}
+	onBodyDemand={(demand) => comparison.handleBodyDemand(demand)}
 	{onOpenInEditor}
 	composerState={comparison.document.commentComposer}
 	commentFeedback={comparison.document.commentFeedback}

--- a/web/src/lib/components/git/GitDiffDocumentScreen.svelte
+++ b/web/src/lib/components/git/GitDiffDocumentScreen.svelte
@@ -12,7 +12,7 @@
 		observeContainerWidth,
 		type ContainerPresentation,
 	} from '$lib/components/shared/container-presentation.js';
-	import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
+	import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 	import type { GitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
 	import {
 		clampGitFileTreeWidth,
@@ -44,6 +44,7 @@
 		fileFilter: string;
 		focusedFilePath: string | null;
 		isMobile: boolean;
+		active?: boolean;
 		fontSize: number;
 		loadingLabel: string;
 		emptyErrorLabel: string;
@@ -52,7 +53,7 @@
 		onRetry?: () => void;
 		onSelectFile: (file: string) => void;
 		onFileFilterChange: (value: string) => void;
-		onVisibleRowsChange: (rows: GitVirtualReviewRow[]) => void;
+		onBodyDemand: (demand: GitReviewBodyDemand) => void;
 		onOpenInEditor?: (relativePath: string, line: number) => void;
 		composerState: CommentComposerState;
 		commentFeedback: {
@@ -85,6 +86,7 @@
 		fileFilter,
 		focusedFilePath,
 		isMobile,
+		active = true,
 		fontSize,
 		loadingLabel,
 		emptyErrorLabel,
@@ -93,7 +95,7 @@
 		onRetry,
 		onSelectFile,
 		onFileFilterChange,
-		onVisibleRowsChange,
+		onBodyDemand,
 		onOpenInEditor,
 		composerState,
 		commentFeedback,
@@ -124,6 +126,7 @@
 	let filePaneHidden = $derived(
 		(isSinglePane && singlePane !== 'files') || (isWide && !fileTreeVisible),
 	);
+	let diffViewportActive = $derived(active && (!isSinglePane || singlePane === 'diff'));
 	let virtualEmptyMessage = $derived(
 		fileFilter.trim() ? m.git_diff_document_no_filter_matches() : emptyDocumentLabel,
 	);
@@ -243,11 +246,12 @@
 			>
 				<GitCommitVirtualDiffSurface
 					{documentId}
+					active={diffViewportActive}
 					{source}
 					{fontSize}
 					scrollToRequest={scrollRequest}
 					overscan={isSinglePane ? 3 : 18}
-					{onVisibleRowsChange}
+					{onBodyDemand}
 					onSelectFile={handleSelectFile}
 					{onOpenInEditor}
 					{composerState}

--- a/web/src/lib/components/git/GitHistoryView.svelte
+++ b/web/src/lib/components/git/GitHistoryView.svelte
@@ -22,6 +22,7 @@
 		projectPath: string | null;
 		effectiveProjectKey: string | null;
 		isMobile: boolean;
+		active?: boolean;
 		diffMode: DiffMode;
 		contextLines: number;
 		diffFontSize: number;
@@ -42,6 +43,7 @@
 		projectPath,
 		effectiveProjectKey,
 		isMobile,
+		active = true,
 		diffMode,
 		contextLines,
 		diffFontSize,
@@ -157,6 +159,7 @@
 		fileFilter={history.fileFilter}
 		focusedFilePath={history.focusedFilePath}
 		{isMobile}
+		{active}
 		fontSize={Number(diffFontSize) || 12}
 		{diffMode}
 		{contextLines}
@@ -181,7 +184,7 @@
 		{onSetDiffFontSize}
 		onSelectFile={(file) => history.focusFile(projectPath, file)}
 		onFileFilterChange={(value) => history.setFileFilter(value)}
-		onVisibleRowsChange={(rows) => history.setVisibleRows(projectPath, rows)}
+		onBodyDemand={(demand) => history.handleBodyDemand(demand)}
 		{onOpenInEditor}
 		composerState={history.document.commentComposer}
 		commentFeedback={history.document.commentFeedback}

--- a/web/src/lib/components/git/GitPanel.svelte
+++ b/web/src/lib/components/git/GitPanel.svelte
@@ -242,10 +242,10 @@
 			activeView === 'changes'
 				? wb.drafts
 				: activeView === 'comparison'
-				? comparison.document
-				: activeView === 'history' && history.screen === 'commit'
-					? history.document
-					: null;
+					? comparison.document
+					: activeView === 'history' && history.screen === 'commit'
+						? history.document
+						: null;
 		if (lines !== review.contextLines && activeDocument?.commentComposer.open) {
 			activeDocument.markContextChangeBlocked();
 			return;
@@ -421,6 +421,7 @@
 			<GitWorkbench
 				target={activeTarget ?? fallbackTarget}
 				{isMobile}
+				active={presentationVisible}
 				{wb}
 				{onAppendToChatDraft}
 				onOpenChat={() => void workspace.focusChat()}
@@ -437,6 +438,7 @@
 				projectPath={activeProjectPath}
 				{effectiveProjectKey}
 				{isMobile}
+				active={presentationVisible}
 				diffMode={review.diffMode}
 				contextLines={review.contextLines}
 				diffFontSize={gitDiffFontSize}
@@ -456,6 +458,7 @@
 			<GitComparisonScreen
 				{comparison}
 				{isMobile}
+				active={presentationVisible}
 				fontSize={gitDiffFontSize}
 				diffMode={review.diffMode}
 				contextLines={review.contextLines}

--- a/web/src/lib/components/git/GitVirtualDiffSurface.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffSurface.svelte
@@ -2,6 +2,7 @@
 	import type { GitDiffTab } from '$lib/api/git.js';
 	import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 	import type { GitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+	import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 	import type { GitDiffActionTarget } from '$lib/git/workbench/git-workbench-types.js';
 	import type {
 		CommentComposerState,
@@ -14,7 +15,9 @@
 	import type { GitDiffRowInteraction } from './git-diff-row-interaction.js';
 
 	interface GitVirtualDiffSurfaceProps {
-		documentId: string | null;
+		layoutIdentity: string | null;
+		reviewDocumentId: string | null;
+		active?: boolean;
 		source: GitVirtualReviewRowSource;
 		activeTab: GitDiffTab;
 		fontSize: number;
@@ -24,7 +27,7 @@
 		composerState: CommentComposerState;
 		showInlineCommentComposer: boolean;
 		overscan?: number;
-		onVisibleRowsChange: (rows: GitVirtualReviewRow[]) => void;
+		onBodyDemand: (demand: GitReviewBodyDemand) => void;
 		onSelectFile: (filePath: string) => void;
 		onToggleLineSelection: (key: string) => void;
 		onSelectLineRange: (startKey: string, endKey: string, allKeys: string[]) => void;
@@ -53,7 +56,9 @@
 	}
 
 	let {
-		documentId,
+		layoutIdentity,
+		reviewDocumentId,
+		active = true,
 		source,
 		activeTab,
 		fontSize,
@@ -63,7 +68,7 @@
 		composerState,
 		showInlineCommentComposer,
 		overscan = 18,
-		onVisibleRowsChange,
+		onBodyDemand,
 		onSelectFile,
 		onToggleLineSelection,
 		onSelectLineRange,
@@ -130,11 +135,13 @@
 {/snippet}
 
 <GitVirtualDiffViewport
-	{documentId}
+	{layoutIdentity}
+	{reviewDocumentId}
+	{active}
 	{source}
 	{fontSize}
 	{scrollToRequest}
 	{overscan}
-	{onVisibleRowsChange}
+	{onBodyDemand}
 	rowSnippet={renderWorkbenchRow}
 />

--- a/web/src/lib/components/git/GitVirtualDiffViewport.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffViewport.svelte
@@ -3,6 +3,11 @@
 	import { createVirtualizer } from '@tanstack/svelte-virtual';
 	import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 	import type { GitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+	import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
+	import {
+		isGitReviewDemandTraceEnabled,
+		traceGitReviewDemand,
+	} from '$lib/git/review/git-review-demand-trace.js';
 	import {
 		markGitReviewFirstRow,
 		markGitReviewViewportReady,
@@ -10,68 +15,84 @@
 	import { measureVirtualRow } from './git-virtual-row-measurement.js';
 
 	interface GitVirtualDiffViewportProps {
-		documentId?: string | null;
+		layoutIdentity?: string | null;
+		reviewDocumentId?: string | null;
+		active?: boolean;
 		source: GitVirtualReviewRowSource;
 		fontSize: number;
 		scrollToRequest: { filePath: string; token: number } | null;
 		overscan?: number;
 		emptyMessage?: string;
-		onVisibleRowsChange: (rows: GitVirtualReviewRow[]) => void;
+		onBodyDemand: (demand: GitReviewBodyDemand) => void;
 		rowSnippet: Snippet<[GitVirtualReviewRow]>;
 	}
 
 	let {
-		documentId = null,
+		layoutIdentity = null,
+		reviewDocumentId = null,
+		active = true,
 		source,
 		fontSize,
 		scrollToRequest,
 		overscan = 18,
 		emptyMessage = 'No files match the current filters.',
-		onVisibleRowsChange,
+		onBodyDemand,
 		rowSnippet,
 	}: GitVirtualDiffViewportProps = $props();
 
 	let viewportRef = $state<HTMLDivElement | null>(null);
-	let lastVisibleRequestKey = '';
 	let lastScrollRequestKey = '';
+	let pendingScrollRequestKey = '';
+	let scrollRequestSequence = 0;
 	let servicedScrollRequestId = '';
 	let servicedScrollRequestState: 'pending' | 'resolved' | 'terminal' | null = null;
 	let completedScrollRequestId = '';
-	let measuredDocumentId: string | null = null;
+	let measuredLayoutIdentity: string | null = null;
 	let performanceFrame: number | null = null;
+	let configuredMeasurementKey = '';
+	let demandEffectRuns = 0;
+	let demandPublications = 0;
 	let rowLineHeight = $derived(Math.max(18, Math.round(fontSize * 1.5)));
 	const scrollKeys = new Set(['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' ']);
 
-	function estimateRowHeight(index: number): number {
-		return source.estimateRowHeight(index, rowLineHeight);
-	}
+	let estimateSizeForOptions = (index: number): number =>
+		source.estimateRowHeight(index, rowLineHeight);
+	let itemKeyForOptions = (index: number): string | number => source.rowKey(index);
 
 	const virtualizer = createVirtualizer<HTMLElement, HTMLDivElement>({
 		count: untrack(() => source.rowCount),
 		getScrollElement: () => viewportRef,
-		estimateSize: estimateRowHeight,
+		estimateSize: estimateSizeForOptions,
 		measureElement: measureVirtualRow,
 		initialRect: { width: 0, height: 720 },
 		overscan: 18,
-		getItemKey: (index) => source.rowKey(index),
+		getItemKey: itemKeyForOptions,
 	});
 
 	let virtualItems = $derived($virtualizer.getVirtualItems());
 	let totalHeight = $derived($virtualizer.getTotalSize());
 	let windowStart = $derived(virtualItems[0]?.start ?? 0);
-	let visibleRows = $derived.by(() =>
-		virtualItems
-			.map((virtualItem) => source.rowAt(virtualItem.index))
-			.filter((row): row is GitVirtualReviewRow => Boolean(row)),
+	let renderedVirtualItems = $derived.by(() =>
+		virtualItems.flatMap((virtualItem) => {
+			const row = source.rowAt(virtualItem.index);
+			return row ? [{ virtualItem, row }] : [];
+		}),
 	);
+	let demandedFilePaths = $derived.by(() => {
+		const first = virtualItems[0]?.index;
+		const last = virtualItems.at(-1)?.index;
+		if (first === undefined || last === undefined) return [];
+		return source.filePathsInRange(first, last + 1);
+	});
 
 	$effect(() => {
-		const nextDocumentId = documentId;
+		const nextLayoutIdentity = layoutIdentity;
 		const scrollElement = viewportRef;
-		if (!scrollElement || nextDocumentId === measuredDocumentId) return;
-		measuredDocumentId = nextDocumentId;
-		lastVisibleRequestKey = '';
+		if (!scrollElement || nextLayoutIdentity === measuredLayoutIdentity) return;
+		measuredLayoutIdentity = nextLayoutIdentity;
 		lastScrollRequestKey = '';
+		pendingScrollRequestKey = '';
+		scrollRequestSequence += 1;
 		servicedScrollRequestId = '';
 		servicedScrollRequestState = null;
 		completedScrollRequestId = '';
@@ -82,22 +103,27 @@
 	});
 
 	$effect(() => {
-		const activeSource = source;
+		const measurementRevision = source.measurementRevision;
 		const count = source.rowCount;
 		const scrollElement = viewportRef;
 		const rowOverscan = overscan;
 		const lineHeight = rowLineHeight;
 		untrack(() => {
+			const measurementKey = `${measurementRevision}\0${lineHeight}`;
+			if (measurementKey !== configuredMeasurementKey) {
+				configuredMeasurementKey = measurementKey;
+				const measurementSource = source;
+				estimateSizeForOptions = (index) => measurementSource.estimateRowHeight(index, lineHeight);
+				itemKeyForOptions = (index) => measurementSource.rowKey(index);
+			}
 			$virtualizer.setOptions({
 				count,
 				getScrollElement: () => scrollElement,
-				estimateSize: (index) => {
-					return activeSource.estimateRowHeight(index, lineHeight);
-				},
+				estimateSize: estimateSizeForOptions,
 				measureElement: measureVirtualRow,
 				initialRect: { width: 0, height: 720 },
 				overscan: rowOverscan,
-				getItemKey: (index) => activeSource.rowKey(index),
+				getItemKey: itemKeyForOptions,
 			});
 		});
 	});
@@ -124,20 +150,37 @@
 	});
 
 	$effect(() => {
-		const key = visibleRows.map((row) => row.id).join('\0');
-		if (key === lastVisibleRequestKey) return;
-		lastVisibleRequestKey = key;
-		const rowsForLoad = visibleRows;
-		untrack(() => onVisibleRowsChange(rowsForLoad));
+		demandEffectRuns += 1;
+		const isActive = active;
+		const documentId = reviewDocumentId;
+		const filePaths = demandedFilePaths;
+		if (!isActive || !documentId || filePaths.length === 0) return;
+		demandPublications += 1;
+		untrack(() => {
+			traceGitReviewDemand({
+				stage: 'viewport-demand',
+				documentId,
+				kind: 'viewport',
+				fileCount: filePaths.length,
+				firstFile: filePaths[0] ?? null,
+				lastFile: filePaths.at(-1) ?? null,
+			});
+			onBodyDemand({
+				kind: 'viewport',
+				documentId,
+				filePaths,
+			});
+		});
 	});
 
 	$effect(() => {
-		const activeDocumentId = documentId;
-		if (!activeDocumentId || visibleRows.length === 0) return;
-		const hasPendingFile = visibleRows.some(
+		const activeDocumentId = reviewDocumentId;
+		const rows = renderedVirtualItems.map(({ row }) => row);
+		if (!activeDocumentId || rows.length === 0) return;
+		const hasPendingFile = rows.some(
 			(row) => row.filePath && source.fileState(row.filePath) === 'pending',
 		);
-		const hasRealDiffRow = visibleRows.some(
+		const hasRealDiffRow = rows.some(
 			(row) => row.kind === 'unified-row' || row.kind === 'split-row',
 		);
 		if (hasPendingFile || (!hasRealDiffRow && source.rowCount === 0)) return;
@@ -146,7 +189,7 @@
 			if (performanceFrame !== null) cancelAnimationFrame(performanceFrame);
 			performanceFrame = requestAnimationFrame(() => {
 				performanceFrame = null;
-				if (documentId !== readyDocumentId) return;
+				if (reviewDocumentId !== readyDocumentId) return;
 				if (hasRealDiffRow) markGitReviewFirstRow(readyDocumentId);
 				markGitReviewViewportReady(readyDocumentId);
 			});
@@ -160,7 +203,13 @@
 	});
 
 	$effect(() => {
-		if (!scrollToRequest) return;
+		if (!scrollToRequest) {
+			pendingScrollRequestKey = '';
+			scrollRequestSequence += 1;
+			return;
+		}
+		const isActive = active;
+		if (!isActive) return;
 		const requestId = `${scrollToRequest.token}\0${scrollToRequest.filePath}`;
 		if (requestId === completedScrollRequestId) return;
 		const targetIndex = source.fileStart(scrollToRequest.filePath);
@@ -175,22 +224,91 @@
 			return;
 		}
 		const requestKey = `${requestId}\0${targetIndex}\0${targetState}`;
-		if (requestKey === lastScrollRequestKey) return;
-		lastScrollRequestKey = requestKey;
+		if (requestKey === lastScrollRequestKey || requestKey === pendingScrollRequestKey) return;
+		pendingScrollRequestKey = requestKey;
+		const requestSequence = ++scrollRequestSequence;
 		const start = Math.max(0, targetIndex - 6);
 		const end = Math.min(source.rowCount, targetIndex + 36);
-		const priorityRows = source.rowsInRange(start, end);
+		const priorityFilePaths = source.filePathsInRange(start, end);
+		const documentId = reviewDocumentId;
 		untrack(() => {
-			onVisibleRowsChange(priorityRows);
+			if (documentId && priorityFilePaths.length > 0) {
+				traceGitReviewDemand({
+					stage: 'viewport-demand',
+					documentId,
+					kind: 'navigation',
+					fileCount: priorityFilePaths.length,
+					firstFile: priorityFilePaths[0] ?? null,
+					lastFile: priorityFilePaths.at(-1) ?? null,
+				});
+				onBodyDemand({
+					kind: 'navigation',
+					documentId,
+					filePaths: priorityFilePaths,
+				});
+			}
 			void tick().then(() => {
-				if (lastScrollRequestKey !== requestKey) return;
+				if (requestSequence !== scrollRequestSequence || pendingScrollRequestKey !== requestKey) {
+					return;
+				}
+				if (!active) {
+					pendingScrollRequestKey = '';
+					return;
+				}
+				if (
+					!scrollToRequest ||
+					`${scrollToRequest.token}\0${scrollToRequest.filePath}` !== requestId
+				) {
+					pendingScrollRequestKey = '';
+					return;
+				}
 				const scrollElement = viewportRef;
-				if (!scrollElement) return;
+				if (!scrollElement) {
+					pendingScrollRequestKey = '';
+					return;
+				}
+				pendingScrollRequestKey = '';
+				lastScrollRequestKey = requestKey;
 				$virtualizer.scrollToIndex(targetIndex, { align: 'start' });
 				servicedScrollRequestId = requestId;
 				servicedScrollRequestState = targetState;
 			});
 		});
+	});
+
+	$effect(() => {
+		const isActive = active;
+		const scrollElement = viewportRef;
+		if (!scrollElement || !isGitReviewDemandTraceEnabled()) return;
+		let rangeFrame: number | null = null;
+		const emitRange = () => {
+			const items = virtualItems;
+			traceGitReviewDemand({
+				stage: 'viewport-range',
+				layoutIdentity,
+				documentId: reviewDocumentId,
+				active: isActive,
+				startIndex: items[0]?.index ?? null,
+				endIndex: items.at(-1)?.index ?? null,
+				rowCount: source.rowCount,
+				scrollTop: scrollElement.scrollTop,
+				demandEffectRuns,
+				publications: demandPublications,
+			});
+		};
+		const handleScroll = () => {
+			if (rangeFrame !== null) return;
+			rangeFrame = requestAnimationFrame(() => {
+				rangeFrame = null;
+				emitRange();
+			});
+		};
+		if (isActive) untrack(emitRange);
+		scrollElement.addEventListener('scroll', handleScroll, { passive: true });
+		return () => {
+			scrollElement.removeEventListener('scroll', handleScroll);
+			if (rangeFrame !== null) cancelAnimationFrame(rangeFrame);
+		};
 	});
 
 	function measureRow(
@@ -222,28 +340,25 @@
 		<div class="relative w-full" style:height={`${totalHeight}px`}>
 			<!-- Keeps adjacent diff backgrounds in one flow layout; per-row transforms create fractional-DPR paint seams. -->
 			<div class="absolute inset-x-0" style:top={`${windowStart}px`} data-git-virtual-row-window>
-				{#each virtualItems as virtualItem (virtualItem.key)}
-					{@const row = source.rowAt(virtualItem.index)}
-					{#if row}
-						<div
-							data-index={virtualItem.index}
-							data-git-virtual-row
-							use:measureRow={virtualItem.index}
-						>
-							<svelte:boundary>
-								{@render rowSnippet(row)}
-								{#snippet failed(error)}
-									<div
-										class="border border-status-error-border bg-status-error/10 px-3 py-2 text-xs text-status-error-foreground"
-									>
-										Failed to render diff row: {error instanceof Error
-											? error.message
-											: String(error)}
-									</div>
-								{/snippet}
-							</svelte:boundary>
-						</div>
-					{/if}
+				{#each renderedVirtualItems as rendered (rendered.virtualItem.key)}
+					<div
+						data-index={rendered.virtualItem.index}
+						data-git-virtual-row
+						use:measureRow={rendered.virtualItem.index}
+					>
+						<svelte:boundary>
+							{@render rowSnippet(rendered.row)}
+							{#snippet failed(error)}
+								<div
+									class="border border-status-error-border bg-status-error/10 px-3 py-2 text-xs text-status-error-foreground"
+								>
+									Failed to render diff row: {error instanceof Error
+										? error.message
+										: String(error)}
+								</div>
+							{/snippet}
+						</svelte:boundary>
+					</div>
 				{/each}
 			</div>
 		</div>

--- a/web/src/lib/components/git/GitVirtualPlaceholderRow.svelte
+++ b/web/src/lib/components/git/GitVirtualPlaceholderRow.svelte
@@ -9,9 +9,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 
 	type PlaceholderRow =
-		| GitVirtualFilePlaceholderRow
-		| GitVirtualFileLimitRow
-		| GitVirtualCollectionLimitRow;
+		GitVirtualFilePlaceholderRow | GitVirtualFileLimitRow | GitVirtualCollectionLimitRow;
 
 	interface GitVirtualPlaceholderRowProps {
 		row: PlaceholderRow;
@@ -39,6 +37,12 @@
 <div
 	class="flex min-h-[96px] items-start gap-2 px-3 py-5 text-xs text-muted-foreground"
 	data-git-placeholder-row
+	data-git-placeholder-file={row.filePath || undefined}
+	data-git-placeholder-state={row.kind === 'file-placeholder'
+		? row.loadState === 'loading'
+			? 'loading'
+			: 'unloaded'
+		: 'terminal'}
 >
 	{#if isLoading}
 		<LoaderCircle class="mt-0.5 h-4 w-4 shrink-0 animate-spin" />

--- a/web/src/lib/components/git/GitWorkbench.svelte
+++ b/web/src/lib/components/git/GitWorkbench.svelte
@@ -23,7 +23,7 @@
 		GitDiffActionTarget,
 		GitWorkbenchTarget,
 	} from '$lib/git/workbench/git-workbench-types.js';
-	import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
+	import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 	import type { GitInspectorView } from '$lib/git/workbench/git-porcelain.svelte.js';
 	import type { ConfirmAction } from '$lib/api/git.js';
 	import type { ChatDraftAppend } from '$lib/chat/composer/chat-draft-append.js';
@@ -43,6 +43,7 @@
 		projectPath?: string | null;
 		target?: GitWorkbenchTarget | null;
 		isMobile: boolean;
+		active?: boolean;
 		wb: GitWorkbenchStore;
 		diffFontSize: number;
 		onAppendToChatDraft?: ChatDraftAppend;
@@ -55,6 +56,7 @@
 		projectPath = null,
 		target = null,
 		isMobile,
+		active = true,
 		wb,
 		diffFontSize,
 		onAppendToChatDraft,
@@ -75,7 +77,7 @@
 	);
 	let activeTarget = $derived(target ?? fallbackTarget);
 	let activeProjectPath = $derived(activeTarget?.projectPath ?? null);
-	let viewportDocumentId = $derived(
+	let viewportLayoutIdentity = $derived(
 		activeTarget
 			? `workbench:${JSON.stringify([activeTarget.repoRoot, activeTarget.worktreePath])}`
 			: null,
@@ -111,10 +113,12 @@
 			? 'narrow'
 			: 'wide',
 	);
+	let diffViewportActive = $derived(
+		active && (containerPresentation === 'wide' || singlePane === 'diff'),
+	);
 
-	function handleVisibleRowsChange(rows: GitVirtualReviewRow[]): void {
-		if (!activeProjectPath) return;
-		wb.handleVisibleReviewRows(activeProjectPath, rows);
+	function handleBodyDemand(demand: GitReviewBodyDemand): void {
+		wb.handleReviewBodyDemand(demand);
 	}
 
 	function handleSelectFile(path: string): void {
@@ -154,11 +158,7 @@
 				tab: files.activeTab,
 				side: composer.side,
 				line: composer.line,
-				contextLines: buildGitReviewBodyCommentContext(
-					loadedBody,
-					composer.side,
-					composer.line,
-				),
+				contextLines: buildGitReviewBodyCommentContext(loadedBody, composer.side, composer.line),
 				body: composer.body,
 				severity: composer.severity,
 			}),
@@ -409,7 +409,9 @@
 		{onCompareRevisions}
 	/>
 	<GitVirtualDiffSurface
-		documentId={viewportDocumentId}
+		layoutIdentity={viewportLayoutIdentity}
+		reviewDocumentId={review.summary?.documentId ?? null}
+		active={diffViewportActive}
 		source={review.rowSource}
 		activeTab={files.activeTab}
 		fontSize={diffFontSize}
@@ -419,7 +421,7 @@
 		composerState={drafts.commentComposer}
 		showInlineCommentComposer={!isMobile}
 		{overscan}
-		onVisibleRowsChange={handleVisibleRowsChange}
+		onBodyDemand={handleBodyDemand}
 		onSelectFile={handleSelectFile}
 		onToggleLineSelection={(key) => selection.toggleLineSelection(key)}
 		onSelectLineRange={(start, end, selectAll) => selection.selectLineRange(start, end, selectAll)}

--- a/web/src/lib/components/git/__tests__/GitCommitVirtualDiffSurface.test.ts
+++ b/web/src/lib/components/git/__tests__/GitCommitVirtualDiffSurface.test.ts
@@ -123,7 +123,7 @@ describe('GitCommitVirtualDiffSurface', () => {
 				commentFeedback: null,
 				commentError: null,
 				commentCopyText: null,
-				onVisibleRowsChange: vi.fn(),
+				onBodyDemand: vi.fn(),
 				onSelectFile: vi.fn(),
 				onAddComment,
 				onComposerBodyChange: vi.fn(),

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
@@ -164,7 +164,8 @@ describe('Git virtual diff refresh', () => {
 		const initialRows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
 		const replacementRows = [makeHeaderRow(2)];
 		const props = {
-			documentId: 'doc-a',
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
 			source: arrayGitVirtualReviewRowSource(initialRows),
 			activeTab: 'unstaged' as const,
 			fontSize: 12,
@@ -181,7 +182,7 @@ describe('Git virtual diff refresh', () => {
 				severity: 'note' as const,
 			},
 			showInlineCommentComposer: true,
-			onVisibleRowsChange: vi.fn(),
+			onBodyDemand: vi.fn(),
 			onSelectFile: vi.fn(),
 			onToggleLineSelection: vi.fn(),
 			onSelectLineRange: vi.fn(),
@@ -225,7 +226,8 @@ describe('Git virtual diff refresh', () => {
 	it('repositions a requested file when preceding rows move its index', async () => {
 		const initialRows = makeUnloadedRows();
 		const props = {
-			documentId: 'doc-a',
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
 			source: arrayGitVirtualReviewRowSource(initialRows, fileIndexes(initialRows)),
 			activeTab: 'unstaged' as const,
 			fontSize: 12,
@@ -242,7 +244,7 @@ describe('Git virtual diff refresh', () => {
 				severity: 'note' as const,
 			},
 			showInlineCommentComposer: true,
-			onVisibleRowsChange: vi.fn(),
+			onBodyDemand: vi.fn(),
 			onSelectFile: vi.fn(),
 			onToggleLineSelection: vi.fn(),
 			onSelectLineRange: vi.fn(),
@@ -282,7 +284,8 @@ describe('Git virtual diff refresh', () => {
 	it('repositions a requested file after its lazy body expands in place', async () => {
 		const initialRows = makeUnloadedRows();
 		const props = {
-			documentId: 'doc-a',
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
 			source: arrayGitVirtualReviewRowSource(initialRows, fileIndexes(initialRows)),
 			activeTab: 'unstaged' as const,
 			fontSize: 12,
@@ -299,7 +302,7 @@ describe('Git virtual diff refresh', () => {
 				severity: 'note' as const,
 			},
 			showInlineCommentComposer: true,
-			onVisibleRowsChange: vi.fn(),
+			onBodyDemand: vi.fn(),
 			onSelectFile: vi.fn(),
 			onToggleLineSelection: vi.fn(),
 			onSelectLineRange: vi.fn(),
@@ -360,7 +363,8 @@ describe('Git virtual diff refresh', () => {
 	it('does not replay a serviced scroll when a pending file becomes stale', async () => {
 		const initialRows = makeUnloadedRows();
 		const props = {
-			documentId: 'doc-a',
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
 			source: arrayGitVirtualReviewRowSource(initialRows, fileIndexes(initialRows)),
 			activeTab: 'unstaged' as const,
 			fontSize: 12,
@@ -377,7 +381,7 @@ describe('Git virtual diff refresh', () => {
 				severity: 'note' as const,
 			},
 			showInlineCommentComposer: true,
-			onVisibleRowsChange: vi.fn(),
+			onBodyDemand: vi.fn(),
 			onSelectFile: vi.fn(),
 			onToggleLineSelection: vi.fn(),
 			onSelectLineRange: vi.fn(),
@@ -404,12 +408,64 @@ describe('Git virtual diff refresh', () => {
 		expect(scrollToIndexCalls).toEqual([4]);
 	});
 
-	it('resets scroll and measurements when the document identity changes', async () => {
-		const initialRows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
-		const onVisibleRowsChange = vi.fn();
+	it('defers an inactive navigation request until the viewport becomes active', async () => {
+		const rows = makeUnloadedRows();
 		const props = {
-			documentId: 'doc-a',
-			source: arrayGitVirtualReviewRowSource(initialRows),
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
+			active: false,
+			source: arrayGitVirtualReviewRowSource(rows, fileIndexes(rows)),
+			activeTab: 'unstaged' as const,
+			fontSize: 12,
+			selectedLineKeys: new Set<string>(),
+			operationPending: false,
+			scrollToRequest: { filePath: 'file-2.ts', token: 1 },
+			composerState: {
+				open: false,
+				focusPending: false,
+				filePath: '',
+				side: 'after' as const,
+				line: 0,
+				body: '',
+				severity: 'note' as const,
+			},
+			showInlineCommentComposer: true,
+			onBodyDemand: vi.fn(),
+			onSelectFile: vi.fn(),
+			onToggleLineSelection: vi.fn(),
+			onSelectLineRange: vi.fn(),
+			onStageHunk: vi.fn(),
+			onUnstageHunk: vi.fn(),
+			onStageLine: vi.fn(),
+			onUnstageLine: vi.fn(),
+			onStageFile: vi.fn(),
+			onUnstageFile: vi.fn(),
+			onAddCommentForFile: vi.fn(),
+			commentFeedback: null,
+			commentError: null,
+			commentCopyText: null,
+			onOpenChat: vi.fn(),
+		};
+		const { rerender } = render(GitVirtualDiffSurface, { props });
+
+		await waitFor(() => expect(measureCalls).toBe(1));
+		expect(scrollToIndexCalls).toEqual([]);
+		expect(props.onBodyDemand).not.toHaveBeenCalled();
+
+		await rerender({ ...props, active: true });
+
+		await waitFor(() => expect(scrollToIndexCalls).toEqual([4]));
+		expect(props.onBodyDemand).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: 'navigation', documentId: 'doc-a' }),
+		);
+	});
+
+	it('keeps measurement callbacks stable for presentation-only source rebuilds', async () => {
+		const rows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
+		const props = {
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
+			source: arrayGitVirtualReviewRowSource(rows),
 			activeTab: 'unstaged' as const,
 			fontSize: 12,
 			selectedLineKeys: new Set<string>(),
@@ -425,7 +481,62 @@ describe('Git virtual diff refresh', () => {
 				severity: 'note' as const,
 			},
 			showInlineCommentComposer: true,
-			onVisibleRowsChange,
+			onBodyDemand: vi.fn(),
+			onSelectFile: vi.fn(),
+			onToggleLineSelection: vi.fn(),
+			onSelectLineRange: vi.fn(),
+			onStageHunk: vi.fn(),
+			onUnstageHunk: vi.fn(),
+			onStageLine: vi.fn(),
+			onUnstageLine: vi.fn(),
+			onStageFile: vi.fn(),
+			onUnstageFile: vi.fn(),
+			onAddCommentForFile: vi.fn(),
+			commentFeedback: null,
+			commentError: null,
+			commentCopyText: null,
+			onOpenChat: vi.fn(),
+		};
+		const { rerender } = render(GitVirtualDiffSurface, { props });
+		await waitFor(() => expect(refreshedVirtualizerOptions?.estimateSize).toBeTruthy());
+		const estimateSize = refreshedVirtualizerOptions?.estimateSize;
+		const getItemKey = refreshedVirtualizerOptions?.getItemKey;
+
+		await rerender({
+			...props,
+			source: arrayGitVirtualReviewRowSource(
+				rows.map((row, index) => ({ ...row, isFocused: index === 0 })),
+			),
+		});
+
+		expect(refreshedVirtualizerOptions?.estimateSize).toBe(estimateSize);
+		expect(refreshedVirtualizerOptions?.getItemKey).toBe(getItemKey);
+		expect(measureCalls).toBe(1);
+	});
+
+	it('republishes a new review document without resetting the layout scroll', async () => {
+		const rows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
+		const onBodyDemand = vi.fn();
+		const props = {
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
+			source: arrayGitVirtualReviewRowSource(rows),
+			activeTab: 'unstaged' as const,
+			fontSize: 12,
+			selectedLineKeys: new Set<string>(),
+			operationPending: false,
+			scrollToRequest: null,
+			composerState: {
+				open: false,
+				focusPending: false,
+				filePath: '',
+				side: 'after' as const,
+				line: 0,
+				body: '',
+				severity: 'note' as const,
+			},
+			showInlineCommentComposer: true,
+			onBodyDemand,
 			onSelectFile: vi.fn(),
 			onToggleLineSelection: vi.fn(),
 			onSelectLineRange: vi.fn(),
@@ -444,8 +555,63 @@ describe('Git virtual diff refresh', () => {
 		const { container, rerender } = render(GitVirtualDiffSurface, { props });
 		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
 		viewport.scrollTop = 300;
-		await waitFor(() => expect(onVisibleRowsChange).toHaveBeenCalled());
-		onVisibleRowsChange.mockClear();
+		await waitFor(() => expect(onBodyDemand).toHaveBeenCalled());
+		onBodyDemand.mockClear();
+
+		await rerender({ ...props, reviewDocumentId: 'doc-b' });
+
+		await waitFor(() =>
+			expect(onBodyDemand).toHaveBeenCalledWith(
+				expect.objectContaining({ kind: 'viewport', documentId: 'doc-b' }),
+			),
+		);
+		expect(viewport.scrollTop).toBe(300);
+		expect(measureCalls).toBe(1);
+	});
+
+	it('resets scroll and measurements when the layout identity changes', async () => {
+		const initialRows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
+		const onBodyDemand = vi.fn();
+		const props = {
+			layoutIdentity: 'layout-a',
+			reviewDocumentId: 'doc-a',
+			source: arrayGitVirtualReviewRowSource(initialRows),
+			activeTab: 'unstaged' as const,
+			fontSize: 12,
+			selectedLineKeys: new Set<string>(),
+			operationPending: false,
+			scrollToRequest: null,
+			composerState: {
+				open: false,
+				focusPending: false,
+				filePath: '',
+				side: 'after' as const,
+				line: 0,
+				body: '',
+				severity: 'note' as const,
+			},
+			showInlineCommentComposer: true,
+			onBodyDemand,
+			onSelectFile: vi.fn(),
+			onToggleLineSelection: vi.fn(),
+			onSelectLineRange: vi.fn(),
+			onStageHunk: vi.fn(),
+			onUnstageHunk: vi.fn(),
+			onStageLine: vi.fn(),
+			onUnstageLine: vi.fn(),
+			onStageFile: vi.fn(),
+			onUnstageFile: vi.fn(),
+			onAddCommentForFile: vi.fn(),
+			commentFeedback: null,
+			commentError: null,
+			commentCopyText: null,
+			onOpenChat: vi.fn(),
+		};
+		const { container, rerender } = render(GitVirtualDiffSurface, { props });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+		viewport.scrollTop = 300;
+		await waitFor(() => expect(onBodyDemand).toHaveBeenCalled());
+		onBodyDemand.mockClear();
 
 		const replacementRows = [
 			makeHeaderRow(0, 'doc-b'),
@@ -454,12 +620,13 @@ describe('Git virtual diff refresh', () => {
 		];
 		await rerender({
 			...props,
-			documentId: 'doc-b',
+			layoutIdentity: 'layout-b',
+			reviewDocumentId: 'doc-b',
 			source: arrayGitVirtualReviewRowSource(replacementRows),
 		});
 
 		expect(viewport.scrollTop).toBe(0);
 		expect(measureCalls).toBeGreaterThanOrEqual(2);
-		await waitFor(() => expect(onVisibleRowsChange).toHaveBeenCalled());
+		await waitFor(() => expect(onBodyDemand).toHaveBeenCalled());
 	});
 });

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffSurface.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffSurface.test.ts
@@ -42,7 +42,8 @@ function renderSurface(
 	overrides: Partial<GitVirtualDiffSurfaceProps> = {},
 ) {
 	const props = {
-		documentId: 'doc',
+		layoutIdentity: 'layout',
+		reviewDocumentId: 'doc',
 		source: arrayGitVirtualReviewRowSource(rows),
 		activeTab: 'unstaged' as const,
 		fontSize: 12,
@@ -59,7 +60,7 @@ function renderSurface(
 			severity: 'note' as const,
 		},
 		showInlineCommentComposer: true,
-		onVisibleRowsChange: vi.fn(),
+		onBodyDemand: vi.fn(),
 		onSelectFile: vi.fn(),
 		onToggleLineSelection: vi.fn(),
 		onSelectLineRange: vi.fn(),
@@ -84,6 +85,18 @@ function renderSurface(
 	};
 }
 
+function firstMountedIndex(container: HTMLElement): number {
+	const first = container.querySelector<HTMLElement>('[data-git-virtual-row]');
+	return first ? Number(first.dataset.index) : -1;
+}
+
+function lastViewportDemand(callback: ReturnType<typeof vi.fn>) {
+	return callback.mock.calls
+		.map(([demand]) => demand)
+		.filter((demand) => demand.kind === 'viewport')
+		.at(-1);
+}
+
 describe('GitVirtualDiffSurface', () => {
 	beforeEach(() => {
 		vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(1024);
@@ -91,7 +104,11 @@ describe('GitVirtualDiffSurface', () => {
 		vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
 			this: HTMLElement,
 		) {
-			const height = this.hasAttribute('data-git-virtual-diff-root') ? 720 : 42;
+			const height = this.hasAttribute('data-git-virtual-diff-root')
+				? 720
+				: this.dataset.index === '0' || this.dataset.index === '101'
+					? 64
+					: 42;
 			return {
 				width: 1024,
 				height,
@@ -171,6 +188,92 @@ describe('GitVirtualDiffSurface', () => {
 			expect(container.querySelectorAll('[data-git-virtual-row]')).toHaveLength(1);
 		});
 		expect(screen.getByText('file-2.ts')).toBeTruthy();
+	});
+
+	it('advances the real virtual range and body demand when the browser scrolls', async () => {
+		const rows = Array.from({ length: 1_000 }, (_, index) => makeHeaderRow(index));
+		const onBodyDemand = vi.fn();
+		const { container } = renderSurface(rows, { onBodyDemand });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+
+		await waitFor(() => expect(lastViewportDemand(onBodyDemand)).toBeTruthy());
+		const initialDemand = lastViewportDemand(onBodyDemand);
+		onBodyDemand.mockClear();
+		viewport.scrollTop = 8_400;
+		await fireEvent.scroll(viewport);
+
+		await waitFor(() => expect(firstMountedIndex(container)).toBeGreaterThan(100));
+		await waitFor(() => expect(lastViewportDemand(onBodyDemand)).toBeTruthy());
+		const scrolledDemand = lastViewportDemand(onBodyDemand);
+		expect(scrolledDemand.filePaths).not.toEqual(initialDemand.filePaths);
+		expect(scrolledDemand.filePaths.some((path: string) => path === 'file-200.ts')).toBe(true);
+	});
+
+	it('republishes retained demand without losing virtualizer geometry on activation', async () => {
+		const rows = Array.from({ length: 1_000 }, (_, index) => makeHeaderRow(index));
+		const onBodyDemand = vi.fn();
+		const { container, props, rerender } = renderSurface(rows, { onBodyDemand, active: true });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+		viewport.scrollTop = 4_200;
+		await fireEvent.scroll(viewport);
+		await waitFor(() => expect(firstMountedIndex(container)).toBeGreaterThan(40));
+		const measuredRow = container.querySelector<HTMLElement>('[data-index="101"]');
+		expect(measuredRow).toBeTruthy();
+		expect(measuredRow?.getBoundingClientRect().height).toBe(64);
+		const firstIndex = firstMountedIndex(container);
+		const spacer = container.querySelector<HTMLElement>(
+			'[data-git-virtual-row-window]',
+		)?.parentElement;
+		const spacerHeight = spacer?.style.height;
+		expect(Number.parseFloat(spacerHeight ?? '')).toBeGreaterThan(rows.length * 42);
+		const demand = lastViewportDemand(onBodyDemand);
+
+		await rerender({ ...props, active: false });
+		onBodyDemand.mockClear();
+		await rerender({ ...props, active: true });
+
+		await waitFor(() => expect(lastViewportDemand(onBodyDemand)).toEqual(demand));
+		expect(viewport.scrollTop).toBe(4_200);
+		expect(firstMountedIndex(container)).toBe(firstIndex);
+		expect(spacer?.style.height).toBe(spacerHeight);
+	});
+
+	it('republishes for a new server document without resetting the stable layout', async () => {
+		const rows = Array.from({ length: 1_000 }, (_, index) => makeHeaderRow(index));
+		const onBodyDemand = vi.fn();
+		const { container, props, rerender } = renderSurface(rows, { onBodyDemand });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+		viewport.scrollTop = 4_200;
+		await fireEvent.scroll(viewport);
+		await waitFor(() => expect(firstMountedIndex(container)).toBeGreaterThan(40));
+		const firstIndex = firstMountedIndex(container);
+		onBodyDemand.mockClear();
+
+		await rerender({ ...props, reviewDocumentId: 'doc-b' });
+
+		await waitFor(() =>
+			expect(lastViewportDemand(onBodyDemand)).toMatchObject({ documentId: 'doc-b' }),
+		);
+		expect(viewport.scrollTop).toBe(4_200);
+		expect(firstMountedIndex(container)).toBe(firstIndex);
+	});
+
+	it('republishes when presentation-only source state rebuilds the same visible paths', async () => {
+		const rows = Array.from({ length: 20 }, (_, index) => makeHeaderRow(index));
+		const onBodyDemand = vi.fn();
+		const { props, rerender } = renderSurface(rows, { onBodyDemand });
+		await waitFor(() => expect(lastViewportDemand(onBodyDemand)).toBeTruthy());
+		const initialDemand = lastViewportDemand(onBodyDemand);
+		onBodyDemand.mockClear();
+
+		await rerender({
+			...props,
+			source: arrayGitVirtualReviewRowSource(
+				rows.map((row, index) => ({ ...row, isFocused: index === 0 })),
+			),
+		});
+
+		await waitFor(() => expect(lastViewportDemand(onBodyDemand)).toEqual(initialDemand));
 	});
 
 	it('stages the current file from the virtual file header in the unstaged tab', async () => {

--- a/web/src/lib/components/git/__tests__/GitWorkbench.test.ts
+++ b/web/src/lib/components/git/__tests__/GitWorkbench.test.ts
@@ -126,7 +126,7 @@ function makeWorkbenchStub(target: GitWorkbenchTarget | null = null): GitWorkben
 		setActiveTab: vi.fn(),
 		setHideGenerated: vi.fn(),
 		setHideOtherTabFiles: vi.fn(),
-		handleVisibleReviewRows: vi.fn(),
+		handleReviewBodyDemand: vi.fn(),
 		dismissError: vi.fn(),
 	} as unknown as GitWorkbenchStore;
 }

--- a/web/src/lib/components/pr/PullRequestVirtualDiffSurface.svelte
+++ b/web/src/lib/components/pr/PullRequestVirtualDiffSurface.svelte
@@ -65,10 +65,11 @@
 {/snippet}
 
 <GitVirtualDiffViewport
-	{documentId}
+	layoutIdentity={documentId}
+	reviewDocumentId={documentId}
 	{source}
 	fontSize={12}
 	scrollToRequest={null}
-	onVisibleRowsChange={() => undefined}
+	onBodyDemand={() => undefined}
 	rowSnippet={renderRow}
 />

--- a/web/src/lib/git/history/__tests__/git-history.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history.test.ts
@@ -7,7 +7,6 @@ import {
 } from '$lib/api/git.js';
 import { GitHistoryController } from '$lib/git/history/git-history.svelte.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
-import type { GitVirtualFileHeaderRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 
 vi.mock('$lib/api/git.js', () => ({
 	getGitHistoryCommits: vi.fn(),
@@ -108,16 +107,16 @@ function bodiesForPaths(paths: string[], fingerprintForPath = (path: string) => 
 				(() => {
 					const patch = `diff --git a/${path} b/${path}\n@@ -0,0 +1 @@\n+next\n`;
 					return {
-					path,
-					bodyFingerprint: fingerprintForPath(path),
-					bodyState: 'loaded' as const,
-					category: 'normal' as const,
-					isBinary: false,
-					isTooLarge: false,
-					renderedRowCount: 2,
-					patchBytes: patch.length,
-					patch,
-					patchIndex: createGitPatchIndex(patch),
+						path,
+						bodyFingerprint: fingerprintForPath(path),
+						bodyState: 'loaded' as const,
+						category: 'normal' as const,
+						isBinary: false,
+						isTooLarge: false,
+						renderedRowCount: 2,
+						patchBytes: patch.length,
+						patch,
+						patchIndex: createGitPatchIndex(patch),
 					};
 				})(),
 			]),
@@ -270,21 +269,11 @@ describe('GitHistoryController', () => {
 		expect(vi.mocked(getGitCommitFileBodies).mock.calls[0]?.[4]?.purpose).toBe('visible');
 		expect(vi.mocked(getGitCommitFileBodies).mock.calls[1]?.[4]?.purpose).toBe('prefetch');
 		const firstSignal = vi.mocked(getGitCommitFileBodies).mock.calls[0]?.[4]?.signal;
-		const ninthFile = files[8];
-		history.setVisibleRows('/project', [
-			{
-				kind: 'file-header',
-				filePath: ninthFile.path,
-				id: `header:${ninthFile.path}`,
-				estimatedHeight: 42,
-				file: {
-					...ninthFile,
-					indexStatus: 'M',
-					workTreeStatus: ' ',
-				},
-				isFocused: false,
-			} satisfies GitVirtualFileHeaderRow,
-		]);
+		history.handleBodyDemand({
+			kind: 'viewport',
+			documentId: history.commitSnapshot!.documentId,
+			filePaths: [files[8].path],
+		});
 
 		expect(firstSignal?.aborted).toBe(false);
 		expect(getGitCommitFileBodies).toHaveBeenCalledTimes(2);
@@ -348,20 +337,11 @@ describe('GitHistoryController', () => {
 
 		history.openCommit('/project', 'abcdef123');
 		await flushPromises();
-		history.setVisibleRows('/project', [
-			{
-				kind: 'file-header',
-				filePath: 'a.ts',
-				id: 'row',
-				estimatedHeight: 42,
-				file: {
-					...commitSnapshot.files[0],
-					indexStatus: 'M',
-					workTreeStatus: ' ',
-				},
-				isFocused: true,
-			} satisfies GitVirtualFileHeaderRow,
-		]);
+		history.handleBodyDemand({
+			kind: 'viewport',
+			documentId: commitSnapshot.documentId,
+			filePaths: ['a.ts'],
+		});
 		await flushPromises();
 		history.backToList();
 

--- a/web/src/lib/git/history/git-history.svelte.ts
+++ b/web/src/lib/git/history/git-history.svelte.ts
@@ -8,7 +8,7 @@ import {
 	type GitHistoryCommitListItem,
 } from '$lib/api/git.js';
 import { GitDiffDocumentController } from '$lib/git/review/git-diff-document.svelte.js';
-import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
+import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
 import * as m from '$lib/paraglide/messages.js';
 import { isAbortError } from '$lib/utils/is-abort-error.js';
@@ -219,8 +219,8 @@ export class GitHistoryController {
 		this.document.focusFile(filePath);
 	}
 
-	setVisibleRows(_projectPath: string, rows: GitVirtualReviewRow[]): void {
-		this.document.setVisibleRows(rows);
+	handleBodyDemand(demand: GitReviewBodyDemand): void {
+		this.document.handleBodyDemand(demand);
 	}
 
 	setFileFilter(value: string): void {
@@ -322,12 +322,7 @@ export class GitHistoryController {
 							return;
 						}
 						this.documentRecoveryAttempted = true;
-						this.loadCommitSnapshot(
-							projectPath,
-							result.commit.hash,
-							result.selectedParent,
-							true,
-						);
+						this.loadCommitSnapshot(projectPath, result.commit.hash, result.selectedParent, true);
 					},
 				});
 			})

--- a/web/src/lib/git/pull-requests/__tests__/pull-request-virtual-row-source.test.ts
+++ b/web/src/lib/git/pull-requests/__tests__/pull-request-virtual-row-source.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { PullRequestThread } from '$lib/api/pull-requests.js';
 import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git.js';
 import { buildPullRequestVirtualRowSource } from '../pull-request-virtual-row-source.js';
@@ -119,6 +119,50 @@ function expectEveryRowPresent(rowSource: GitVirtualReviewRowSource): void {
 }
 
 describe('pull request virtual row source', () => {
+	it('resolves demanded file paths without materializing base rows', () => {
+		const reviewFile = file('src/app.ts');
+		const reviewBody = body(reviewFile.path);
+		const base = buildGitVirtualReviewRowSource({
+			summary: {
+				documentId: 'pull-request:1',
+				project: '',
+				context: 3,
+				files: [reviewFile],
+				limits,
+			},
+			visibleFilePaths: [reviewFile.path],
+			fileBodies: { [reviewFile.path]: reviewBody },
+			loadingBodies: new Set(),
+			focusedFilePath: null,
+			diffMode: 'unified',
+			contextLines: 3,
+			interaction: { kind: 'read-only' },
+		});
+		const rowAt = vi.fn((index: number) => base.rowAt(index));
+		const observedBase: GitVirtualReviewRowSource = {
+			rowCount: base.rowCount,
+			measurementRevision: base.measurementRevision,
+			rowAt,
+			rowKey: (index) => base.rowKey(index),
+			estimateRowHeight: (index, lineHeight) => base.estimateRowHeight(index, lineHeight),
+			fileStart: (filePath) => base.fileStart(filePath),
+			fileState: (filePath) => base.fileState(filePath),
+			filePathAt: (index) => base.filePathAt(index),
+			filePathsInRange: (start, end) => base.filePathsInRange(start, end),
+			rowsInRange: (start, end) => base.rowsInRange(start, end),
+		};
+		const decorated = buildPullRequestVirtualRowSource({
+			baseSource: observedBase,
+			files: [reviewFile],
+			fileBodies: { [reviewFile.path]: reviewBody },
+			threads: [thread(reviewFile.path, 2)],
+			collapsedFilePaths: new Set(),
+		});
+
+		expect(decorated.filePathsInRange(0, decorated.rowCount)).toEqual([reviewFile.path]);
+		expect(rowAt).not.toHaveBeenCalled();
+	});
+
 	it('inserts a thread after its matching diff line', () => {
 		const reviewFile = file('src/app.ts');
 		const reviewBody = body(reviewFile.path);

--- a/web/src/lib/git/pull-requests/pull-request-virtual-row-source.ts
+++ b/web/src/lib/git/pull-requests/pull-request-virtual-row-source.ts
@@ -50,6 +50,7 @@ export function buildPullRequestVirtualRowSource(
 
 class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 	readonly rowCount: number;
+	readonly measurementRevision: string;
 	private readonly runs: DecoratedRun[];
 	private readonly baseRuns: BaseRun[];
 	private readonly fileStarts = new Map<string, number>();
@@ -62,6 +63,13 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 		this.runs = buildRuns(baseSource.rowCount, insertions);
 		this.baseRuns = this.runs.filter((run): run is BaseRun => run.kind === 'base');
 		this.rowCount = this.runs.reduce((total, run) => total + run.count, 0);
+		this.measurementRevision = JSON.stringify([
+			baseSource.measurementRevision,
+			insertions.map((insertion) => [
+				insertion.afterBaseIndex,
+				insertion.rows.map((row) => [row.id, row.estimatedHeight]),
+			]),
+		]);
 		for (const file of files) {
 			const baseStart = baseSource.fileStart(file.path);
 			if (baseStart === undefined) continue;
@@ -76,7 +84,7 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 		const localIndex = index - run.start;
 		return run.kind === 'base'
 			? this.baseSource.rowAt(run.baseStart + localIndex)
-			: run.rows[localIndex] ?? null;
+			: (run.rows[localIndex] ?? null);
 	}
 
 	rowKey(index: number): string | number {
@@ -85,7 +93,7 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 		const localIndex = index - run.start;
 		return run.kind === 'base'
 			? this.baseSource.rowKey(run.baseStart + localIndex)
-			: run.rows[localIndex]?.id ?? index;
+			: (run.rows[localIndex]?.id ?? index);
 	}
 
 	estimateRowHeight(index: number, lineHeight: number): number {
@@ -94,7 +102,7 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 		const localIndex = index - run.start;
 		return run.kind === 'base'
 			? this.baseSource.estimateRowHeight(run.baseStart + localIndex, lineHeight)
-			: run.rows[localIndex]?.estimatedHeight ?? lineHeight;
+			: (run.rows[localIndex]?.estimatedHeight ?? lineHeight);
 	}
 
 	fileStart(filePath: string): number | undefined {
@@ -103,6 +111,21 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 
 	fileState(filePath: string): 'pending' | 'resolved' | 'terminal' {
 		return this.baseSource.fileState(filePath);
+	}
+
+	filePathAt(index: number): string | null {
+		return this.rowAt(index)?.filePath || null;
+	}
+
+	filePathsInRange(start: number, end: number): string[] {
+		const paths = new Set<string>();
+		const safeStart = Math.min(this.rowCount, Math.max(0, Math.trunc(start)));
+		const safeEnd = Math.min(this.rowCount, Math.max(0, Math.trunc(end)));
+		for (let index = safeStart; index < safeEnd; index += 1) {
+			const filePath = this.filePathAt(index);
+			if (filePath) paths.add(filePath);
+		}
+		return Array.from(paths);
 	}
 
 	rowsInRange(start: number, end: number): GitVirtualReviewRow[] {
@@ -143,9 +166,7 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 	}
 }
 
-function buildThreadInsertions(
-	options: PullRequestVirtualRowSourceOptions,
-): ThreadInsertion[] {
+function buildThreadInsertions(options: PullRequestVirtualRowSourceOptions): ThreadInsertion[] {
 	const fileOrder = new Map(options.files.map((file, index) => [file.path, index]));
 	const threadsByFile = new Map<string, PullRequestThread[]>();
 	for (const thread of options.threads) {
@@ -234,10 +255,7 @@ function threadRow(
 	};
 }
 
-function buildRuns(
-	baseRowCount: number,
-	insertions: readonly ThreadInsertion[],
-): DecoratedRun[] {
+function buildRuns(baseRowCount: number, insertions: readonly ThreadInsertion[]): DecoratedRun[] {
 	const runs: DecoratedRun[] = [];
 	let baseStart = 0;
 	let start = 0;

--- a/web/src/lib/git/pull-requests/pull-request-virtual-row-source.ts
+++ b/web/src/lib/git/pull-requests/pull-request-virtual-row-source.ts
@@ -114,7 +114,12 @@ class PullRequestVirtualRowSource implements GitVirtualReviewRowSource {
 	}
 
 	filePathAt(index: number): string | null {
-		return this.rowAt(index)?.filePath || null;
+		const run = this.runAt(index);
+		if (!run) return null;
+		const localIndex = index - run.start;
+		return run.kind === 'base'
+			? this.baseSource.filePathAt(run.baseStart + localIndex)
+			: (run.rows[localIndex]?.filePath ?? null);
 	}
 
 	filePathsInRange(start: number, end: number): string[] {

--- a/web/src/lib/git/review/__tests__/git-diff-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-document.test.ts
@@ -174,7 +174,7 @@ describe('GitDiffDocumentController', () => {
 		expect(controller.getDemandDebugSnapshot().loadingPaths).toEqual(['viewport.ts', 'target.ts']);
 	});
 
-	it('promotes an active prefetch response when its file becomes visible', async () => {
+	it('protects an active prefetch response when its file becomes visible', async () => {
 		const controller = new GitDiffDocumentController();
 		const visible = deferred<ReturnType<typeof bodyResponse>>();
 		const prefetch = deferred<ReturnType<typeof bodyResponse>>();
@@ -207,6 +207,86 @@ describe('GitDiffDocumentController', () => {
 		await vi.waitFor(() => expect(controller.aggregateLimit).not.toBeNull());
 		expect(controller.fileBodies['visible.ts']?.bodyState).toBe('loaded');
 		expect(controller.fileBodies['initial.ts']?.bodyState).toBe('too-large');
+	});
+
+	it('applies a demanded body after stopping an over-budget prefetch response', async () => {
+		const controller = new GitDiffDocumentController();
+		const prefetch = deferred<ReturnType<typeof bodyResponse>>();
+		const constrainedLimits = { ...limits, maxLoadedRows: 6 };
+		const loadBodies = vi.fn(
+			(_snapshot: unknown, requested: Array<{ path: string }>, purpose: string) =>
+				purpose === 'prefetch'
+					? prefetch.promise
+					: Promise.resolve(
+							bodyResponse(
+								'doc',
+								requested.map(({ path }) => path),
+							),
+						),
+		);
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('initial.ts'), file('blocked.ts'), file('visible.ts')],
+				limits: constrainedLimits,
+				firstBodyCandidates: ['initial.ts', 'blocked.ts', 'visible.ts'],
+			},
+			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+		);
+		await vi.waitFor(() => expect(controller.fileBodies['initial.ts']?.bodyState).toBe('loaded'));
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['visible.ts'],
+		});
+		prefetch.resolve(bodyResponse('doc', ['blocked.ts', 'visible.ts']));
+
+		await vi.waitFor(() => expect(controller.fileBodies['visible.ts']?.bodyState).toBe('loaded'));
+		expect(controller.fileBodies['initial.ts']).toBeUndefined();
+		expect(controller.fileBodies['blocked.ts']).toBeUndefined();
+		expect(controller.aggregateLimit).toBeNull();
+	});
+
+	it('recycles a previously visible body after viewport demand moves away', async () => {
+		const controller = new GitDiffDocumentController();
+		const loadBodies = vi.fn(async (_snapshot: unknown, requested: Array<{ path: string }>) =>
+			bodyResponse(
+				'doc',
+				requested.map(({ path }) => path),
+			),
+		);
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('old-visible.ts'), file('new-visible.ts')],
+				limits: { ...limits, maxLoadedRows: 6 },
+				firstBodyCandidates: [],
+			},
+			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+		);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['old-visible.ts'],
+		});
+		await vi.waitFor(() =>
+			expect(controller.fileBodies['old-visible.ts']?.bodyState).toBe('loaded'),
+		);
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['new-visible.ts'],
+		});
+
+		await vi.waitFor(() =>
+			expect(controller.fileBodies['new-visible.ts']?.bodyState).toBe('loaded'),
+		);
+		expect(controller.fileBodies['old-visible.ts']).toBeUndefined();
+		expect(controller.aggregateLimit).toBeNull();
 	});
 
 	it('starts a selected lazy body after the initial body batch settles', async () => {
@@ -390,7 +470,7 @@ describe('GitDiffDocumentController', () => {
 		expect(controller.commentComposer.body).toBe('No full document rebuild');
 	});
 
-	it('stops speculative loading before enforcing the aggregate limit on user-visible files', async () => {
+	it('recycles speculative loading before enforcing the aggregate limit', async () => {
 		const controller = new GitDiffDocumentController();
 		const loadBodies = vi.fn(async (_snapshot, requested: Array<{ path: string }>) => ({
 			status: 'ready' as const,
@@ -421,11 +501,9 @@ describe('GitDiffDocumentController', () => {
 
 		controller.focusFile('b.ts');
 
-		await vi.waitFor(() =>
-			expect(controller.aggregateLimit?.reason).toBe('collection-too-many-rows'),
-		);
-		expect(controller.fileBodies['a.ts']?.bodyState).toBe('loaded');
-		expect(controller.fileBodies['b.ts']?.bodyState).toBe('too-large');
+		await vi.waitFor(() => expect(controller.fileBodies['b.ts']?.bodyState).toBe('loaded'));
+		expect(controller.fileBodies['a.ts']).toBeUndefined();
+		expect(controller.aggregateLimit).toBeNull();
 	});
 
 	it('honors a collection budget limit emitted by the server', async () => {
@@ -541,7 +619,12 @@ describe('GitDiffDocumentController', () => {
 		const loadBodies = vi.fn(async (_snapshot, requested: Array<{ path: string }>) => ({
 			status: 'ready' as const,
 			documentId: 'doc',
-			files: Object.fromEntries(requested.map(({ path }) => [path, body(path)])),
+			files: Object.fromEntries(
+				requested.map(({ path }) => [
+					path,
+					path === 'b.ts' ? { ...body(path), renderedRowCount: 12 } : body(path),
+				]),
+			),
 			errors: {},
 		}));
 

--- a/web/src/lib/git/review/__tests__/git-diff-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-document.test.ts
@@ -56,7 +56,159 @@ function body(path: string): GitReviewFileBody {
 	};
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function bodyResponse(documentId: string, paths: readonly string[]) {
+	return {
+		status: 'ready' as const,
+		documentId,
+		files: Object.fromEntries(paths.map((path) => [path, body(path)])),
+		errors: {},
+	};
+}
+
 describe('GitDiffDocumentController', () => {
+	it('reconciles retained viewport demand when the matching document becomes ready', async () => {
+		const controller = new GitDiffDocumentController();
+		const loadBodies = vi.fn(async (_snapshot: unknown, requested: Array<{ path: string }>) =>
+			bodyResponse(
+				'doc',
+				requested.map(({ path }) => path),
+			),
+		);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['visible.ts'],
+		});
+
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('visible.ts')],
+				limits,
+				firstBodyCandidates: [],
+			},
+			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+		);
+
+		await vi.waitFor(() => expect(loadBodies).toHaveBeenCalledOnce());
+		expect(loadBodies.mock.calls[0]?.[1]).toEqual([{ path: 'visible.ts' }]);
+		expect(controller.getDemandDebugSnapshot()).toMatchObject({
+			documentId: 'doc',
+			demandedPaths: ['visible.ts'],
+			readinessGeneration: 1,
+		});
+	});
+
+	it('rejects stale demand and deduplicates repeated matching demand', async () => {
+		const controller = new GitDiffDocumentController();
+		const pending = deferred<ReturnType<typeof bodyResponse>>();
+		const loadBodies = vi.fn(() => pending.promise);
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('visible.ts')],
+				limits,
+				firstBodyCandidates: [],
+			},
+			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+		);
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'old-doc',
+			filePaths: ['visible.ts'],
+		});
+		expect(loadBodies).not.toHaveBeenCalled();
+
+		const demand = {
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['visible.ts'],
+		} as const;
+		controller.handleBodyDemand(demand);
+		controller.handleBodyDemand({ ...demand, filePaths: [...demand.filePaths] });
+
+		expect(loadBodies).toHaveBeenCalledOnce();
+		expect(controller.getDemandDebugSnapshot().schedulerPendingByPath).toEqual({
+			'visible.ts': true,
+		});
+		pending.resolve(bodyResponse('doc', ['visible.ts']));
+	});
+
+	it('keeps navigation demand separate from retained viewport demand', () => {
+		const controller = new GitDiffDocumentController();
+		const loadBodies = vi.fn(() => new Promise<ReturnType<typeof bodyResponse>>(() => {}));
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('viewport.ts'), file('target.ts')],
+				limits,
+				firstBodyCandidates: [],
+			},
+			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+		);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['viewport.ts'],
+		});
+
+		controller.handleBodyDemand({
+			kind: 'navigation',
+			documentId: 'doc',
+			filePaths: ['target.ts'],
+		});
+
+		expect(controller.getDemandDebugSnapshot().demandedPaths).toEqual(['viewport.ts']);
+		expect(controller.getDemandDebugSnapshot().loadingPaths).toEqual(['viewport.ts', 'target.ts']);
+	});
+
+	it('promotes an active prefetch response when its file becomes visible', async () => {
+		const controller = new GitDiffDocumentController();
+		const visible = deferred<ReturnType<typeof bodyResponse>>();
+		const prefetch = deferred<ReturnType<typeof bodyResponse>>();
+		const constrainedLimits = { ...limits, maxLoadedRows: 6 };
+		const loadBodies = vi
+			.fn()
+			.mockReturnValueOnce(visible.promise)
+			.mockReturnValueOnce(prefetch.promise);
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('initial.ts'), file('visible.ts')],
+				limits: constrainedLimits,
+				firstBodyCandidates: ['initial.ts', 'visible.ts'],
+			},
+			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+		);
+		await vi.waitFor(() => expect(loadBodies).toHaveBeenCalledTimes(2));
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['visible.ts'],
+		});
+		prefetch.resolve(bodyResponse('doc', ['visible.ts']));
+		await vi.waitFor(() => expect(controller.fileBodies['visible.ts']?.bodyState).toBe('loaded'));
+
+		visible.resolve(bodyResponse('doc', ['initial.ts']));
+		await vi.waitFor(() => expect(controller.aggregateLimit).not.toBeNull());
+		expect(controller.fileBodies['visible.ts']?.bodyState).toBe('loaded');
+		expect(controller.fileBodies['initial.ts']?.bodyState).toBe('too-large');
+	});
+
 	it('starts a selected lazy body after the initial body batch settles', async () => {
 		const controller = new GitDiffDocumentController();
 		let resolveInitial!: (value: {
@@ -307,11 +459,7 @@ describe('GitDiffDocumentController', () => {
 					documentId: 'doc',
 					files: Object.fromEntries(
 						requested.flatMap(({ path }) =>
-							path === 'a.ts'
-								? [[path, body(path)]]
-								: path === 'b.ts'
-									? [[path, limitedBody]]
-									: [],
+							path === 'a.ts' ? [[path, body(path)]] : path === 'b.ts' ? [[path, limitedBody]] : [],
 						),
 					),
 					errors: {},
@@ -375,9 +523,7 @@ describe('GitDiffDocumentController', () => {
 			},
 		);
 
-		await vi.waitFor(() =>
-			expect(controller.fileBodies['prefetch.ts']?.bodyState).toBe('loaded'),
-		);
+		await vi.waitFor(() => expect(controller.fileBodies['prefetch.ts']?.bodyState).toBe('loaded'));
 		resolveVisible({
 			status: 'ready',
 			documentId: 'doc',
@@ -385,9 +531,7 @@ describe('GitDiffDocumentController', () => {
 			errors: {},
 		});
 
-		await vi.waitFor(() =>
-			expect(controller.fileBodies['selected.ts']?.bodyState).toBe('loaded'),
-		);
+		await vi.waitFor(() => expect(controller.fileBodies['selected.ts']?.bodyState).toBe('loaded'));
 		expect(controller.fileBodies['prefetch.ts']).toBeUndefined();
 		expect(controller.aggregateLimit).toBeNull();
 	});
@@ -744,9 +888,11 @@ describe('GitDiffDocumentController', () => {
 		expect(loadBodies).toHaveBeenCalledOnce();
 
 		const loadedBodies = controller.fileBodies;
-		const visibleHeader = controller.rowSource.rowAt(0);
-		expect(visibleHeader).toBeTruthy();
-		controller.setVisibleRows([visibleHeader!]);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: documentSnapshot.documentId,
+			filePaths: ['a.ts'],
+		});
 
 		expect(controller.fileBodies).toBe(loadedBodies);
 	});

--- a/web/src/lib/git/review/__tests__/git-review-body-budget.test.ts
+++ b/web/src/lib/git/review/__tests__/git-review-body-budget.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { GitReviewBodyPurpose, GitReviewFileBody } from '$lib/api/git.js';
+import type { GitReviewFileBody } from '$lib/api/git.js';
 import {
 	collectionLimitDecisionFromGitReviewBody,
 	decideGitReviewBodyBudget,
@@ -42,10 +42,7 @@ describe('Git review body budget', () => {
 			body('selected.ts', 6, 60),
 			'visible',
 			current,
-			new Map<string, GitReviewBodyPurpose>([
-				['a.ts', 'prefetch'],
-				['b.ts', 'visible'],
-			]),
+			new Set(['b.ts']),
 			limits,
 		);
 
@@ -63,7 +60,7 @@ describe('Git review body budget', () => {
 			body('b.ts', 4, 40),
 			'prefetch',
 			current,
-			new Map<string, GitReviewBodyPurpose>([['a.ts', 'visible']]),
+			new Set(),
 			limits,
 		);
 
@@ -71,6 +68,21 @@ describe('Git review body budget', () => {
 			accept: false,
 			evictedPaths: [],
 			reason: 'collection-too-many-rows',
+		});
+	});
+
+	it('lets visible loading recycle any body that is no longer pinned', () => {
+		const decision = decideGitReviewBodyBudget(
+			body('new-visible.ts', 6, 60),
+			'visible',
+			{ 'old-visible.ts': body('old-visible.ts', 6, 60) },
+			new Set(),
+			limits,
+		);
+
+		expect(decision).toMatchObject({
+			accept: true,
+			evictedPaths: ['old-visible.ts'],
 		});
 	});
 

--- a/web/src/lib/git/review/__tests__/git-review-body-demand.logic.test.ts
+++ b/web/src/lib/git/review/__tests__/git-review-body-demand.logic.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+	normalizeGitReviewDemandFilePaths,
+	sameGitReviewViewportDemand,
+	type GitReviewViewportDemand,
+} from '$lib/git/review/git-review-body-demand.js';
+
+function viewportDemand(documentId: string, filePaths: readonly string[]): GitReviewViewportDemand {
+	return { kind: 'viewport', documentId, filePaths };
+}
+
+describe('Git review body demand', () => {
+	it('normalizes paths without changing their priority order', () => {
+		expect(
+			normalizeGitReviewDemandFilePaths(['a.ts', null, 'b.ts', 'a.ts', undefined, '', 'c.ts']),
+		).toEqual(['a.ts', 'b.ts', 'c.ts']);
+	});
+
+	it('compares the document, path order, and path membership', () => {
+		const demand = viewportDemand('doc-a', ['a.ts', 'b.ts']);
+
+		expect(sameGitReviewViewportDemand(null, demand)).toBe(false);
+		expect(sameGitReviewViewportDemand(viewportDemand('doc-a', ['a.ts', 'b.ts']), demand)).toBe(
+			true,
+		);
+		expect(sameGitReviewViewportDemand(viewportDemand('doc-b', ['a.ts', 'b.ts']), demand)).toBe(
+			false,
+		);
+		expect(sameGitReviewViewportDemand(viewportDemand('doc-a', ['b.ts', 'a.ts']), demand)).toBe(
+			false,
+		);
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-review-body-scheduler.test.ts
+++ b/web/src/lib/git/review/__tests__/git-review-body-scheduler.test.ts
@@ -43,6 +43,7 @@ describe('GitReviewBodyScheduler', () => {
 	it('promotes queued prefetch paths into the visible lane', async () => {
 		const firstPrefetch = deferred<string>();
 		const calls: Array<{ paths: string[]; purpose: string }> = [];
+		const onDispatch = vi.fn();
 		const scheduler = new GitReviewBodyScheduler({
 			maxBatchFiles: 1,
 			load: (paths, purpose) => {
@@ -52,16 +53,36 @@ describe('GitReviewBodyScheduler', () => {
 			onResult: vi.fn(),
 			onError: vi.fn(),
 			onLoadingChange: vi.fn(),
+			onDispatch,
 		});
 
-		scheduler.requestPrefetch(['a.ts', 'b.ts']);
-		scheduler.requestVisible(['b.ts']);
+		expect(scheduler.requestPrefetch(['a.ts', 'b.ts'])).toBe(true);
+		expect(scheduler.requestVisible(['b.ts'])).toBe(true);
 
-		await vi.waitFor(() =>
-			expect(calls).toContainEqual({ paths: ['b.ts'], purpose: 'visible' }),
-		);
+		await vi.waitFor(() => expect(calls).toContainEqual({ paths: ['b.ts'], purpose: 'visible' }));
 		expect(calls[0]).toEqual({ paths: ['a.ts'], purpose: 'prefetch' });
+		expect(onDispatch).toHaveBeenCalledWith(['a.ts'], 'prefetch');
+		expect(onDispatch).toHaveBeenCalledWith(['b.ts'], 'visible');
 		firstPrefetch.resolve('prefetched');
+	});
+
+	it('does not duplicate an active prefetch when it becomes visible', () => {
+		const prefetch = deferred<string>();
+		const load = vi.fn(() => prefetch.promise);
+		const scheduler = new GitReviewBodyScheduler({
+			maxBatchFiles: 1,
+			load,
+			onResult: vi.fn(),
+			onError: vi.fn(),
+			onLoadingChange: vi.fn(),
+		});
+
+		expect(scheduler.requestPrefetch(['a.ts'])).toBe(true);
+		expect(scheduler.requestVisible(['a.ts'])).toBe(false);
+
+		expect(load).toHaveBeenCalledOnce();
+		expect(load).toHaveBeenCalledWith(['a.ts'], 'prefetch', expect.any(AbortSignal));
+		prefetch.resolve('prefetched');
 	});
 
 	it('cancels speculative work without interrupting the visible lane', async () => {

--- a/web/src/lib/git/review/__tests__/git-review-demand-reconciler.logic.test.ts
+++ b/web/src/lib/git/review/__tests__/git-review-demand-reconciler.logic.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+	GitReviewBodyDemand,
+	GitReviewDemandOutcome,
+} from '$lib/git/review/git-review-body-demand.js';
+import { GitReviewDemandReconciler } from '$lib/git/review/git-review-demand-reconciler.js';
+
+function createHarness(initialDocumentId: string | null = null) {
+	let documentId = initialDocumentId;
+	const viewport = vi.fn<(filePaths: readonly string[]) => GitReviewDemandOutcome>(
+		() => 'scheduled',
+	);
+	const navigation = vi.fn<(filePaths: readonly string[]) => GitReviewDemandOutcome>(
+		() => 'scheduled',
+	);
+	const outcomes: Array<{ demand: GitReviewBodyDemand; outcome: GitReviewDemandOutcome }> = [];
+	const reconciler = new GitReviewDemandReconciler({
+		currentDocumentId: () => documentId,
+		requestViewportPaths: viewport,
+		requestNavigationPaths: navigation,
+		reportOutcome: (demand, outcome) => outcomes.push({ demand, outcome }),
+	});
+	return {
+		reconciler,
+		viewport,
+		navigation,
+		outcomes,
+		setDocumentId: (nextDocumentId: string | null) => {
+			documentId = nextDocumentId;
+		},
+	};
+}
+
+describe('GitReviewDemandReconciler', () => {
+	it('retains stale demand and reconciles it after readiness changes', () => {
+		const harness = createHarness();
+		const demand = {
+			kind: 'viewport',
+			documentId: 'doc-a',
+			filePaths: ['visible.ts'],
+		} as const;
+
+		harness.reconciler.handle(demand);
+		expect(harness.viewport).not.toHaveBeenCalled();
+		expect(harness.outcomes.at(-1)?.outcome).toBe('stale-document');
+
+		harness.setDocumentId('doc-a');
+		harness.reconciler.markReadinessChanged();
+
+		expect(harness.viewport).toHaveBeenCalledOnce();
+		expect(harness.viewport).toHaveBeenCalledWith(['visible.ts']);
+		expect(harness.outcomes.at(-1)?.outcome).toBe('scheduled');
+	});
+
+	it('does not call the request sink twice for identical demand at one generation', () => {
+		const harness = createHarness('doc-a');
+		const demand = {
+			kind: 'viewport',
+			documentId: 'doc-a',
+			filePaths: ['visible.ts'],
+		} as const;
+
+		harness.reconciler.handle(demand);
+		harness.reconciler.handle({
+			...demand,
+			filePaths: [...demand.filePaths],
+		});
+
+		expect(harness.viewport).toHaveBeenCalledOnce();
+		expect(harness.outcomes.map(({ outcome }) => outcome)).toEqual([
+			'scheduled',
+			'already-satisfied',
+		]);
+	});
+
+	it('reconciles identical retained demand once for each readiness generation', () => {
+		const harness = createHarness('doc-a');
+		const demand = {
+			kind: 'viewport',
+			documentId: 'doc-a',
+			filePaths: ['visible.ts'],
+		} as const;
+
+		harness.reconciler.handle(demand);
+		harness.reconciler.markReadinessChanged();
+		harness.reconciler.handle(demand);
+
+		expect(harness.viewport).toHaveBeenCalledTimes(2);
+		expect(harness.outcomes.at(-1)?.outcome).toBe('already-satisfied');
+		expect(harness.reconciler.snapshot()).toEqual({
+			documentId: 'doc-a',
+			filePaths: ['visible.ts'],
+			readinessGeneration: 1,
+		});
+	});
+
+	it('routes navigation without replacing retained viewport demand', () => {
+		const harness = createHarness('doc-a');
+		harness.reconciler.handle({
+			kind: 'viewport',
+			documentId: 'doc-a',
+			filePaths: ['viewport.ts'],
+		});
+		harness.reconciler.handle({
+			kind: 'navigation',
+			documentId: 'doc-a',
+			filePaths: ['target.ts'],
+		});
+		harness.reconciler.markReadinessChanged();
+
+		expect(harness.navigation).toHaveBeenCalledOnce();
+		expect(harness.navigation).toHaveBeenCalledWith(['target.ts']);
+		expect(harness.viewport).toHaveBeenNthCalledWith(2, ['viewport.ts']);
+		expect(harness.reconciler.snapshot().filePaths).toEqual(['viewport.ts']);
+		expect(harness.reconciler.demandsPath('doc-a', 'viewport.ts')).toBe(true);
+		expect(harness.reconciler.demandsPath('doc-b', 'viewport.ts')).toBe(false);
+	});
+
+	it('clears retained demand and readiness state', () => {
+		const harness = createHarness('doc-a');
+		harness.reconciler.handle({
+			kind: 'viewport',
+			documentId: 'doc-a',
+			filePaths: ['visible.ts'],
+		});
+		harness.reconciler.markReadinessChanged();
+		harness.viewport.mockClear();
+
+		harness.reconciler.clear();
+		harness.reconciler.markReadinessChanged();
+
+		expect(harness.viewport).not.toHaveBeenCalled();
+		expect(harness.reconciler.snapshot()).toEqual({
+			documentId: null,
+			filePaths: [],
+			readinessGeneration: 1,
+		});
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-review-demand-trace.logic.test.ts
+++ b/web/src/lib/git/review/__tests__/git-review-demand-trace.logic.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { unownedGitReviewLoadingPaths } from '$lib/git/review/git-review-demand-trace.js';
+
+describe('Git review demand diagnostics', () => {
+	it('identifies loading paths that have no scheduler owner', () => {
+		const pending = new Set(['owned.ts']);
+
+		expect(
+			unownedGitReviewLoadingPaths(new Set(['owned.ts', 'orphaned.ts']), (filePath) =>
+				pending.has(filePath),
+			),
+		).toEqual(['orphaned.ts']);
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-virtual-review-row-source.test.ts
+++ b/web/src/lib/git/review/__tests__/git-virtual-review-row-source.test.ts
@@ -165,9 +165,7 @@ describe('Git virtual review row source', () => {
 		};
 
 		const source = buildGitVirtualReviewRowSource(splitOptions);
-		const unifiedSource = buildGitVirtualReviewRowSource(
-			options([file], { 'file.txt': body }),
-		);
+		const unifiedSource = buildGitVirtualReviewRowSource(options([file], { 'file.txt': body }));
 
 		expect(source.rowCount).toBe(5);
 		expect(source.rowKey(1)).not.toBe(unifiedSource.rowKey(1));
@@ -196,5 +194,93 @@ describe('Git virtual review row source', () => {
 		expect(source.estimateRowHeight(1, 18)).toBe(28);
 		expect(source.estimateRowHeight(2, 18)).toBe(18);
 		expect(source.estimateRowHeight(2, 24)).toBe(24);
+	});
+
+	it('reads ordered file paths from clamped row ranges without materializing rows', () => {
+		const pending = summary('pending.txt', 4);
+		const loaded = summary('loaded.txt', 2);
+		const source = buildGitVirtualReviewRowSource(
+			options([pending, loaded], { 'loaded.txt': indexedBody('loaded.txt', 2) }),
+		);
+
+		expect(source.filePathAt(-1)).toBeNull();
+		expect(source.filePathAt(0)).toBe('pending.txt');
+		expect(source.filePathAt(1)).toBe('pending.txt');
+		expect(source.filePathAt(2)).toBe('loaded.txt');
+		expect(source.filePathAt(source.rowCount)).toBeNull();
+		expect(source.filePathsInRange(-100, 3)).toEqual(['pending.txt', 'loaded.txt']);
+		expect(source.filePathsInRange(1, 2)).toEqual(['pending.txt']);
+		expect(source.filePathsInRange(2, 10_000)).toEqual(['loaded.txt']);
+		expect(source.filePathsInRange(4, 4)).toEqual([]);
+	});
+
+	it('changes measurement revision only for structural or height-affecting inputs', () => {
+		const file = summary('file.txt', 2);
+		const baseOptions = options([file], {});
+		const baseRevision = buildGitVirtualReviewRowSource(baseOptions).measurementRevision;
+		const withLoading = {
+			...baseOptions,
+			loadingBodies: new Set(['file.txt']),
+		};
+		const withFocus = {
+			...baseOptions,
+			focusedFilePath: 'file.txt',
+		};
+
+		expect(buildGitVirtualReviewRowSource(withLoading).measurementRevision).toBe(baseRevision);
+		expect(buildGitVirtualReviewRowSource(withFocus).measurementRevision).toBe(baseRevision);
+
+		const changedDocument = options([file], {});
+		changedDocument.summary.documentId = 'document-b';
+		expect(buildGitVirtualReviewRowSource(changedDocument).measurementRevision).not.toBe(
+			baseRevision,
+		);
+
+		const changedMode = { ...baseOptions, diffMode: 'split' as const };
+		expect(buildGitVirtualReviewRowSource(changedMode).measurementRevision).not.toBe(baseRevision);
+
+		const changedContext = { ...baseOptions, contextLines: 12 };
+		expect(buildGitVirtualReviewRowSource(changedContext).measurementRevision).not.toBe(
+			baseRevision,
+		);
+
+		const changedEstimate = options([{ ...file, estimatedRows: 20 }], {});
+		expect(buildGitVirtualReviewRowSource(changedEstimate).measurementRevision).not.toBe(
+			baseRevision,
+		);
+
+		const loaded = options([file], { 'file.txt': indexedBody('file.txt', 2) });
+		expect(buildGitVirtualReviewRowSource(loaded).measurementRevision).not.toBe(baseRevision);
+
+		const composerClosed = {
+			...loaded,
+			interaction: {
+				kind: 'commentable' as const,
+				composerState: {
+					open: false,
+					focusPending: false,
+					filePath: '',
+					side: 'after' as const,
+					line: 0,
+					body: '',
+					severity: 'note' as const,
+				},
+			},
+		};
+		const composerOpen = {
+			...composerClosed,
+			interaction: {
+				...composerClosed.interaction,
+				composerState: {
+					...composerClosed.interaction.composerState,
+					open: true,
+					filePath: 'file.txt',
+					line: 1,
+				},
+			},
+		};
+		expect(buildGitVirtualReviewRowSource(composerOpen).measurementRevision).not.toBe(
+			buildGitVirtualReviewRowSource(composerClosed).measurementRevision,
+		);
 	});
 });

--- a/web/src/lib/git/review/git-comparison.svelte.ts
+++ b/web/src/lib/git/review/git-comparison.svelte.ts
@@ -6,7 +6,7 @@ import {
 	type GitComparisonSnapshotReady,
 } from '$lib/api/git-comparison.js';
 import { GitDiffDocumentController } from '$lib/git/review/git-diff-document.svelte.js';
-import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
+import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
 import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
 import * as m from '$lib/paraglide/messages.js';
 import { isAbortError } from '$lib/utils/is-abort-error.js';
@@ -348,8 +348,8 @@ export class GitComparisonController {
 		this.document.focusFile(filePath);
 	}
 
-	setVisibleRows(rows: GitVirtualReviewRow[]): void {
-		this.document.setVisibleRows(rows);
+	handleBodyDemand(demand: GitReviewBodyDemand): void {
+		this.document.handleBodyDemand(demand);
 	}
 
 	setFileFilter(value: string): void {

--- a/web/src/lib/git/review/git-diff-document.svelte.ts
+++ b/web/src/lib/git/review/git-diff-document.svelte.ts
@@ -14,7 +14,6 @@ import {
 	type CommentComposerState,
 	type GitDiffSeverity,
 } from '$lib/git/review/git-inline-comment.svelte.js';
-import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
 import type {
 	ChatDraftAppend,
@@ -36,6 +35,17 @@ import {
 	emptyGitVirtualReviewRowSource,
 	type GitVirtualReviewRowSource,
 } from './git-virtual-review-row-source.js';
+import {
+	normalizeGitReviewDemandFilePaths,
+	type GitReviewBodyDemand,
+	type GitReviewDemandOutcome,
+} from './git-review-body-demand.js';
+import { GitReviewDemandReconciler } from './git-review-demand-reconciler.js';
+import {
+	assertGitReviewLoadingOwnership,
+	traceGitReviewDemand,
+	type GitReviewDemandDebugSnapshot,
+} from './git-review-demand-trace.js';
 import * as m from '$lib/paraglide/messages.js';
 
 const MAX_CACHED_FILE_BODIES = 128;
@@ -84,6 +94,7 @@ export class GitDiffDocumentController {
 	staleMessage = $state<string | null>(null);
 
 	private bodyScheduler: GitReviewBodyScheduler<GitDiffDocumentBodyResponse> | null = null;
+	private readonly demandReconciler: GitReviewDemandReconciler;
 	private summariesByPath = new Map<string, GitCommitFileSummary>();
 	private bodyCache = new Map<string, GitReviewFileBody>();
 	private bodyPurposes = new Map<string, GitReviewBodyPurpose>();
@@ -96,6 +107,23 @@ export class GitDiffDocumentController {
 	private onStale: ((message: string) => void) | null = null;
 	private onExpired: ((message: string) => void) | null = null;
 	private commentSource: GitReviewCommentSource | null = null;
+
+	constructor() {
+		this.demandReconciler = new GitReviewDemandReconciler({
+			currentDocumentId: () => this.snapshot?.documentId ?? null,
+			requestViewportPaths: (filePaths) => this.requestBodies(filePaths, 'visible'),
+			requestNavigationPaths: (filePaths) => this.requestBodies(filePaths, 'visible'),
+			reportOutcome: (demand, outcome) => {
+				traceGitReviewDemand({
+					stage: 'controller',
+					owner: 'document',
+					documentId: demand.documentId,
+					fileCount: demand.filePaths.length,
+					outcome,
+				});
+			},
+		});
+	}
 
 	get commentComposer(): CommentComposerState {
 		return this.inlineComment.composer;
@@ -128,7 +156,7 @@ export class GitDiffDocumentController {
 	private virtualSummary = $derived.by(() => {
 		const snapshot = this.snapshot;
 		if (!snapshot) return null;
-			const collectionLimit = snapshot.collectionLimit ?? this.aggregateLimit;
+		const collectionLimit = snapshot.collectionLimit ?? this.aggregateLimit;
 		return {
 			documentId: snapshot.documentId,
 			project: snapshot.project,
@@ -206,10 +234,19 @@ export class GitDiffDocumentController {
 			},
 			onResult: (result, paths, purpose) =>
 				this.applyBodyResult(result, paths, purpose, generation, snapshot),
-			onError: (error) =>
-				this.onError?.(error instanceof Error ? error.message : String(error)),
+			onError: (error) => this.onError?.(error instanceof Error ? error.message : String(error)),
 			onLoadingChange: (paths, loading) => this.markLoading(paths, loading),
+			onDispatch: (paths, purpose) => {
+				traceGitReviewDemand({
+					stage: 'scheduler',
+					owner: 'document',
+					documentId: snapshot.documentId,
+					fileCount: paths.length,
+					purpose,
+				});
+			},
 		});
+		this.demandReconciler.markReadinessChanged();
 		const [priority, ...prefetch] = snapshot.firstBodyCandidates;
 		if (priority) this.requestBodies([priority], 'visible');
 		this.requestBodies(prefetch, 'prefetch');
@@ -228,11 +265,24 @@ export class GitDiffDocumentController {
 		this.scrollRequest = { filePath, token: this.scrollToken };
 	}
 
-	setVisibleRows(rows: GitVirtualReviewRow[]): void {
-		this.requestBodies(
-			Array.from(new Set(rows.map((row) => row.filePath).filter(Boolean))),
-			'visible',
-		);
+	handleBodyDemand(demand: GitReviewBodyDemand): void {
+		this.demandReconciler.handle(demand);
+	}
+
+	getDemandDebugSnapshot(): GitReviewDemandDebugSnapshot {
+		const demand = this.demandReconciler.snapshot();
+		return {
+			documentId: this.snapshot?.documentId ?? null,
+			demandedPaths: demand.filePaths,
+			loadingPaths: Array.from(this.loadingBodies),
+			schedulerPendingByPath: Object.fromEntries(
+				Array.from(this.loadingBodies, (filePath) => [
+					filePath,
+					this.bodyScheduler?.hasPending(filePath) === true,
+				]),
+			),
+			readinessGeneration: demand.readinessGeneration,
+		};
 	}
 
 	setFileFilter(value: string): void {
@@ -321,18 +371,33 @@ export class GitDiffDocumentController {
 		this.onExpired = null;
 		this.commentSource = null;
 		if (!options.preserveCache) this.clearBodyCache();
+		this.demandReconciler.clear();
 	}
 
-	private requestBodies(filePaths: string[], purpose: GitReviewBodyPurpose): void {
+	private requestBodies(
+		filePaths: readonly string[],
+		purpose: GitReviewBodyPurpose,
+	): GitReviewDemandOutcome {
 		const snapshot = this.snapshot;
-		if (!snapshot || !this.bodyScheduler || this.aggregateLimit || this.isStale) return;
-		if (purpose === 'prefetch' && this.prefetchStopped) return;
-		const uniquePaths = Array.from(new Set(filePaths)).filter(Boolean);
+		if (!snapshot || !this.bodyScheduler || this.isStale) return 'not-ready';
+		if (this.aggregateLimit) return 'limited';
+		if (purpose === 'prefetch' && this.prefetchStopped) return 'already-satisfied';
+		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
 		this.seedCachedBodies(uniquePaths, purpose);
+		if (purpose === 'visible') this.promoteLoadedBodiesToVisible(uniquePaths);
+		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath));
-		if (toFetch.length === 0) return;
-		if (purpose === 'visible') this.bodyScheduler.requestVisible(toFetch);
-		else this.bodyScheduler.requestPrefetch(toFetch);
+		const pending = uniquePaths.filter(
+			(filePath) =>
+				this.loadingBodies.has(filePath) &&
+				this.summaryForFile(filePath)?.bodyState === 'unloaded' &&
+				!this.fileBodies[filePath],
+		);
+		const scheduled =
+			purpose === 'visible'
+				? this.bodyScheduler.requestVisible([...toFetch, ...pending])
+				: this.bodyScheduler.requestPrefetch(toFetch);
+		return scheduled ? 'scheduled' : 'already-satisfied';
 	}
 
 	private applyBodyResult(
@@ -343,10 +408,7 @@ export class GitDiffDocumentController {
 		snapshot: GitDiffDocumentSnapshot,
 	): void {
 		if (!this.isCurrent(generation, snapshot.documentId)) return;
-		if (
-			'status' in result &&
-			(result.status === 'stale' || result.status === 'document-expired')
-		) {
+		if ('status' in result && (result.status === 'stale' || result.status === 'document-expired')) {
 			this.markStale(result.message);
 			if (result.status === 'document-expired') this.onExpired?.(result.message);
 			return;
@@ -380,23 +442,23 @@ export class GitDiffDocumentController {
 			const serverLimit = collectionLimitDecisionFromGitReviewBody(body, next);
 			if (serverLimit) {
 				next[filePath] = body;
-				this.setAggregateLimit(
-					serverLimit,
-					Object.keys(next).length,
-					body.limitMessage,
-				);
+				this.setAggregateLimit(serverLimit, Object.keys(next).length, body.limitMessage);
 				break;
 			}
+			const effectivePurpose =
+				purpose === 'prefetch' && this.demandReconciler.demandsPath(snapshot.documentId, filePath)
+					? 'visible'
+					: purpose;
 			const decision = decideGitReviewBodyBudget(
 				body,
-				purpose,
+				effectivePurpose,
 				next,
 				this.bodyPurposes,
 				snapshot.limits,
 			);
 			this.evictActiveBodies(next, decision);
 			if (!decision.accept) {
-				if (purpose === 'prefetch') {
+				if (effectivePurpose === 'prefetch') {
 					this.stopPrefetch();
 					break;
 				}
@@ -405,7 +467,7 @@ export class GitDiffDocumentController {
 				break;
 			}
 			next[filePath] = body;
-			this.bodyPurposes.set(filePath, purpose);
+			this.bodyPurposes.set(filePath, effectivePurpose);
 			if (body.bodyState === 'loaded') {
 				this.cacheBody(file, body, snapshot.limits.maxLoadedPatchBytes);
 			}
@@ -533,6 +595,17 @@ export class GitDiffDocumentController {
 		if (changed) this.fileBodies = next;
 	}
 
+	private promoteLoadedBodiesToVisible(filePaths: readonly string[]): void {
+		for (const filePath of filePaths) {
+			if (
+				this.fileBodies[filePath]?.bodyState === 'loaded' &&
+				this.bodyPurposes.get(filePath) === 'prefetch'
+			) {
+				this.bodyPurposes.set(filePath, 'visible');
+			}
+		}
+	}
+
 	private markLoading(filePaths: string[], isLoading: boolean): void {
 		const next = new Set(this.loadingBodies);
 		for (const filePath of filePaths) {
@@ -540,6 +613,11 @@ export class GitDiffDocumentController {
 			else next.delete(filePath);
 		}
 		this.loadingBodies = next;
+		assertGitReviewLoadingOwnership(
+			next,
+			(filePath) => this.bodyScheduler?.hasPending(filePath) === true,
+			'document',
+		);
 	}
 
 	private cacheKey(file: GitCommitFileSummary): string {

--- a/web/src/lib/git/review/git-diff-document.svelte.ts
+++ b/web/src/lib/git/review/git-diff-document.svelte.ts
@@ -97,7 +97,6 @@ export class GitDiffDocumentController {
 	private readonly demandReconciler: GitReviewDemandReconciler;
 	private summariesByPath = new Map<string, GitCommitFileSummary>();
 	private bodyCache = new Map<string, GitReviewFileBody>();
-	private bodyPurposes = new Map<string, GitReviewBodyPurpose>();
 	private bodyCacheBytes = 0;
 	private prefetchStopped = false;
 	private generation = 0;
@@ -211,7 +210,6 @@ export class GitDiffDocumentController {
 		this.diffMode = options.diffMode;
 		this.contextLines = options.contextLines;
 		this.fileBodies = {};
-		this.bodyPurposes.clear();
 		this.prefetchStopped = false;
 		this.loadingBodies = new Set();
 		this.scrollRequest = null;
@@ -354,7 +352,6 @@ export class GitDiffDocumentController {
 		this.snapshot = null;
 		this.summariesByPath.clear();
 		this.fileBodies = {};
-		this.bodyPurposes.clear();
 		this.prefetchStopped = false;
 		this.loadingBodies = new Set();
 		this.scrollRequest = null;
@@ -384,7 +381,6 @@ export class GitDiffDocumentController {
 		if (purpose === 'prefetch' && this.prefetchStopped) return 'already-satisfied';
 		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
 		this.seedCachedBodies(uniquePaths, purpose);
-		if (purpose === 'visible') this.promoteLoadedBodiesToVisible(uniquePaths);
 		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath));
 		const pending = uniquePaths.filter(
@@ -415,6 +411,7 @@ export class GitDiffDocumentController {
 		}
 		this.onBodyLoadSuccess?.();
 		const next = { ...this.fileBodies };
+		const pinnedPaths = this.pinnedBodyPaths(snapshot.documentId);
 		for (const filePath of paths) {
 			const file = this.summaryForFile(filePath);
 			const body = result.files[filePath];
@@ -453,21 +450,20 @@ export class GitDiffDocumentController {
 				body,
 				effectivePurpose,
 				next,
-				this.bodyPurposes,
+				pinnedPaths,
 				snapshot.limits,
 			);
 			this.evictActiveBodies(next, decision);
 			if (!decision.accept) {
 				if (effectivePurpose === 'prefetch') {
 					this.stopPrefetch();
-					break;
+					continue;
 				}
 				next[filePath] = this.collectionLimitBody(body, decision);
 				this.setAggregateLimit(decision, Object.keys(next).length);
 				break;
 			}
 			next[filePath] = body;
-			this.bodyPurposes.set(filePath, effectivePurpose);
 			if (body.bodyState === 'loaded') {
 				this.cacheBody(file, body, snapshot.limits.maxLoadedPatchBytes);
 			}
@@ -524,7 +520,6 @@ export class GitDiffDocumentController {
 	): void {
 		for (const path of decision.evictedPaths) {
 			delete bodies[path];
-			this.bodyPurposes.delete(path);
 		}
 	}
 
@@ -546,7 +541,6 @@ export class GitDiffDocumentController {
 		this.fileBodies = Object.fromEntries(
 			Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
 		);
-		this.bodyPurposes.delete(filePath);
 	}
 
 	private shouldLoadBody(filePath: string): boolean {
@@ -559,6 +553,7 @@ export class GitDiffDocumentController {
 	private seedCachedBodies(filePaths: string[], purpose: GitReviewBodyPurpose): void {
 		if (this.bodyCache.size === 0) return;
 		const next = { ...this.fileBodies };
+		const pinnedPaths = this.pinnedBodyPaths(this.snapshot?.documentId ?? null);
 		let changed = false;
 		for (const filePath of filePaths) {
 			const file = this.summaryForFile(filePath);
@@ -572,7 +567,7 @@ export class GitDiffDocumentController {
 					cached,
 					purpose,
 					next,
-					this.bodyPurposes,
+					pinnedPaths,
 					this.snapshot!.limits,
 				);
 				this.evictActiveBodies(next, decision);
@@ -589,21 +584,18 @@ export class GitDiffDocumentController {
 				}
 				next[filePath] = cached;
 				changed = true;
-				this.bodyPurposes.set(filePath, purpose);
 			}
 		}
 		if (changed) this.fileBodies = next;
 	}
 
-	private promoteLoadedBodiesToVisible(filePaths: readonly string[]): void {
-		for (const filePath of filePaths) {
-			if (
-				this.fileBodies[filePath]?.bodyState === 'loaded' &&
-				this.bodyPurposes.get(filePath) === 'prefetch'
-			) {
-				this.bodyPurposes.set(filePath, 'visible');
-			}
+	private pinnedBodyPaths(documentId: string | null): Set<string> {
+		const pinned = new Set<string>();
+		const demand = this.demandReconciler.snapshot();
+		if (documentId && demand.documentId === documentId) {
+			for (const filePath of demand.filePaths) pinned.add(filePath);
 		}
+		return pinned;
 	}
 
 	private markLoading(filePaths: string[], isLoading: boolean): void {

--- a/web/src/lib/git/review/git-review-body-budget.ts
+++ b/web/src/lib/git/review/git-review-body-budget.ts
@@ -34,7 +34,7 @@ export function decideGitReviewBodyBudget(
 	body: GitReviewFileBody,
 	purpose: GitReviewBodyPurpose,
 	currentBodies: Readonly<Record<string, GitReviewFileBody>>,
-	bodyPurposes: ReadonlyMap<string, GitReviewBodyPurpose>,
+	pinnedPaths: ReadonlySet<string>,
 	limits: GitReviewDocumentLimits,
 ): GitReviewBodyBudgetDecision {
 	if (body.bodyState !== 'loaded') {
@@ -52,7 +52,7 @@ export function decideGitReviewBodyBudget(
 			loadedBytes + body.patchBytes > limits.maxLoadedPatchBytes)
 	) {
 		for (const [path, candidate] of loaded) {
-			if (bodyPurposes.get(path) !== 'prefetch') continue;
+			if (pinnedPaths.has(path)) continue;
 			evictedPaths.push(path);
 			loadedRows -= candidate.renderedRowCount;
 			loadedBytes -= candidate.patchBytes;

--- a/web/src/lib/git/review/git-review-body-demand.ts
+++ b/web/src/lib/git/review/git-review-body-demand.ts
@@ -1,0 +1,32 @@
+interface GitReviewBodyDemandBase {
+	documentId: string;
+	filePaths: readonly string[];
+}
+
+export interface GitReviewViewportDemand extends GitReviewBodyDemandBase {
+	kind: 'viewport';
+}
+
+export interface GitReviewNavigationDemand extends GitReviewBodyDemandBase {
+	kind: 'navigation';
+}
+
+export type GitReviewBodyDemand = GitReviewViewportDemand | GitReviewNavigationDemand;
+
+export type GitReviewDemandOutcome =
+	'scheduled' | 'not-ready' | 'stale-document' | 'already-satisfied' | 'limited';
+
+export function normalizeGitReviewDemandFilePaths(
+	filePaths: readonly (string | null | undefined)[],
+): string[] {
+	return Array.from(new Set(filePaths.filter((path): path is string => Boolean(path))));
+}
+
+export function sameGitReviewViewportDemand(
+	left: GitReviewViewportDemand | null,
+	right: GitReviewViewportDemand,
+): boolean {
+	if (!left || left.documentId !== right.documentId) return false;
+	if (left.filePaths.length !== right.filePaths.length) return false;
+	return left.filePaths.every((path, index) => path === right.filePaths[index]);
+}

--- a/web/src/lib/git/review/git-review-body-scheduler.ts
+++ b/web/src/lib/git/review/git-review-body-scheduler.ts
@@ -7,6 +7,7 @@ interface GitReviewBodySchedulerOptions<T> {
 	onResult: (result: T, paths: string[], purpose: GitReviewBodyPurpose) => void;
 	onError: (error: unknown) => void;
 	onLoadingChange: (paths: string[], loading: boolean) => void;
+	onDispatch?: (paths: string[], purpose: GitReviewBodyPurpose) => void;
 }
 
 interface ActiveLane {
@@ -23,19 +24,22 @@ export class GitReviewBodyScheduler<T> {
 
 	constructor(private readonly options: GitReviewBodySchedulerOptions<T>) {}
 
-	requestVisible(paths: readonly string[]): void {
-		const requested = this.unique(paths).filter((path) => !this.isVisiblePending(path));
-		if (requested.length === 0) return;
-		this.removeQueued(this.prefetchQueue, requested);
+	requestVisible(paths: readonly string[]): boolean {
+		const uniquePaths = this.unique(paths);
+		this.removeQueued(this.prefetchQueue, uniquePaths);
+		const requested = uniquePaths.filter((path) => !this.hasPending(path));
+		if (requested.length === 0) return false;
 		this.enqueue(this.visibleQueue, requested, true);
 		this.pump('visible');
+		return true;
 	}
 
-	requestPrefetch(paths: readonly string[]): void {
+	requestPrefetch(paths: readonly string[]): boolean {
 		const requested = this.unique(paths).filter((path) => !this.hasPending(path));
-		if (requested.length === 0) return;
+		if (requested.length === 0) return false;
 		this.enqueue(this.prefetchQueue, requested, false);
 		this.pump('prefetch');
+		return true;
 	}
 
 	cancel(): void {
@@ -72,10 +76,6 @@ export class GitReviewBodyScheduler<T> {
 		return Array.from(new Set(paths.filter(Boolean)));
 	}
 
-	private isVisiblePending(path: string): boolean {
-		return this.visibleQueue.includes(path) || this.visibleActive?.paths.includes(path) === true;
-	}
-
 	private enqueue(queue: string[], paths: string[], prepend: boolean): void {
 		if (prepend) queue.unshift(...paths);
 		else queue.push(...paths);
@@ -99,6 +99,7 @@ export class GitReviewBodyScheduler<T> {
 		if (purpose === 'visible') this.visibleActive = lane;
 		else this.prefetchActive = lane;
 		const generation = this.generation;
+		this.options.onDispatch?.(paths, purpose);
 
 		void this.options
 			.load(paths, purpose, controller.signal)
@@ -107,7 +108,8 @@ export class GitReviewBodyScheduler<T> {
 				this.options.onResult(result, paths, purpose);
 			})
 			.catch((error) => {
-				if (generation !== this.generation || controller.signal.aborted || isAbortError(error)) return;
+				if (generation !== this.generation || controller.signal.aborted || isAbortError(error))
+					return;
 				this.options.onError(error);
 			})
 			.finally(() => {

--- a/web/src/lib/git/review/git-review-demand-reconciler.ts
+++ b/web/src/lib/git/review/git-review-demand-reconciler.ts
@@ -1,0 +1,102 @@
+import type {
+	GitReviewBodyDemand,
+	GitReviewDemandOutcome,
+	GitReviewViewportDemand,
+} from './git-review-body-demand.js';
+import { sameGitReviewViewportDemand } from './git-review-body-demand.js';
+
+interface GitReviewDemandReconcilerOptions {
+	currentDocumentId: () => string | null;
+	requestViewportPaths: (filePaths: readonly string[]) => GitReviewDemandOutcome;
+	requestNavigationPaths: (filePaths: readonly string[]) => GitReviewDemandOutcome;
+	reportOutcome: (demand: GitReviewBodyDemand, outcome: GitReviewDemandOutcome) => void;
+}
+
+export interface GitReviewDemandReconcilerSnapshot {
+	documentId: string | null;
+	filePaths: string[];
+	readinessGeneration: number;
+}
+
+export class GitReviewDemandReconciler {
+	private viewportDemand: GitReviewViewportDemand | null = null;
+	private readinessGeneration = 0;
+	private lastReconciledDemand: GitReviewViewportDemand | null = null;
+	private lastReconciledReadinessGeneration = -1;
+
+	constructor(private readonly options: GitReviewDemandReconcilerOptions) {}
+
+	handle(demand: GitReviewBodyDemand): void {
+		if (demand.kind === 'navigation') {
+			const outcome =
+				demand.documentId === this.options.currentDocumentId()
+					? this.options.requestNavigationPaths(demand.filePaths)
+					: 'stale-document';
+			this.options.reportOutcome(demand, outcome);
+			return;
+		}
+
+		if (!sameGitReviewViewportDemand(this.viewportDemand, demand)) {
+			this.viewportDemand = copyViewportDemand(demand);
+		}
+		this.reconcile();
+	}
+
+	markReadinessChanged(): void {
+		this.readinessGeneration += 1;
+		this.reconcile();
+	}
+
+	clear(): void {
+		this.viewportDemand = null;
+		this.lastReconciledDemand = null;
+		this.readinessGeneration = 0;
+		this.lastReconciledReadinessGeneration = -1;
+	}
+
+	demandsPath(documentId: string, filePath: string): boolean {
+		return (
+			this.viewportDemand?.documentId === documentId &&
+			this.viewportDemand.filePaths.includes(filePath)
+		);
+	}
+
+	snapshot(): GitReviewDemandReconcilerSnapshot {
+		return {
+			documentId: this.viewportDemand?.documentId ?? null,
+			filePaths: [...(this.viewportDemand?.filePaths ?? [])],
+			readinessGeneration: this.readinessGeneration,
+		};
+	}
+
+	private reconcile(): void {
+		const demand = this.viewportDemand;
+		if (!demand) return;
+		if (
+			sameGitReviewViewportDemand(this.lastReconciledDemand, demand) &&
+			this.lastReconciledReadinessGeneration === this.readinessGeneration
+		) {
+			this.options.reportOutcome(demand, 'already-satisfied');
+			return;
+		}
+
+		// Records the attempt before the sink can rebuild the reactive row source.
+		this.lastReconciledDemand = copyViewportDemand(demand);
+		this.lastReconciledReadinessGeneration = this.readinessGeneration;
+
+		if (demand.documentId !== this.options.currentDocumentId()) {
+			this.options.reportOutcome(demand, 'stale-document');
+			return;
+		}
+		const outcome = this.options.requestViewportPaths(demand.filePaths);
+		this.options.reportOutcome(demand, outcome);
+	}
+}
+
+function copyViewportDemand(demand: GitReviewViewportDemand): GitReviewViewportDemand {
+	return {
+		kind: 'viewport',
+		documentId: demand.documentId,
+		filePaths: [...demand.filePaths],
+	};
+}

--- a/web/src/lib/git/review/git-review-demand-trace.ts
+++ b/web/src/lib/git/review/git-review-demand-trace.ts
@@ -1,0 +1,79 @@
+import { readGarconDebugFlag } from '$lib/utils/debug-flags.js';
+import type { GitReviewBodyDemand, GitReviewDemandOutcome } from './git-review-body-demand.js';
+
+export const GIT_REVIEW_DEMAND_TRACE_STORAGE_KEY = 'garcon.gitReviewDemandTrace';
+
+export type GitReviewDemandTraceEvent =
+	| {
+			stage: 'viewport-range';
+			layoutIdentity: string | null;
+			documentId: string | null;
+			active: boolean;
+			startIndex: number | null;
+			endIndex: number | null;
+			rowCount: number;
+			scrollTop: number;
+			demandEffectRuns: number;
+			publications: number;
+	  }
+	| {
+			stage: 'viewport-demand';
+			documentId: string;
+			kind: GitReviewBodyDemand['kind'];
+			fileCount: number;
+			firstFile: string | null;
+			lastFile: string | null;
+	  }
+	| {
+			stage: 'controller';
+			owner: 'workbench' | 'document';
+			documentId: string;
+			fileCount: number;
+			outcome: GitReviewDemandOutcome;
+	  }
+	| {
+			stage: 'scheduler';
+			owner: 'workbench' | 'document';
+			documentId: string;
+			fileCount: number;
+			purpose: 'visible' | 'prefetch';
+	  };
+
+export interface GitReviewDemandDebugSnapshot {
+	documentId: string | null;
+	demandedPaths: string[];
+	loadingPaths: string[];
+	schedulerPendingByPath: Record<string, boolean>;
+	readinessGeneration: number;
+}
+
+export function isGitReviewDemandTraceEnabled(): boolean {
+	return readGarconDebugFlag(GIT_REVIEW_DEMAND_TRACE_STORAGE_KEY);
+}
+
+export function traceGitReviewDemand(event: GitReviewDemandTraceEvent): void {
+	try {
+		if (!isGitReviewDemandTraceEnabled()) return;
+		console.debug('git review demand', event);
+	} catch {
+		// Local diagnostics must not affect review loading.
+	}
+}
+
+export function unownedGitReviewLoadingPaths(
+	loadingPaths: ReadonlySet<string>,
+	hasPending: (filePath: string) => boolean,
+): string[] {
+	return Array.from(loadingPaths).filter((filePath) => !hasPending(filePath));
+}
+
+export function assertGitReviewLoadingOwnership(
+	loadingPaths: ReadonlySet<string>,
+	hasPending: (filePath: string) => boolean,
+	owner: string,
+): void {
+	if (!import.meta.env.DEV) return;
+	const unowned = unownedGitReviewLoadingPaths(loadingPaths, hasPending);
+	if (unowned.length === 0) return;
+	console.error(`Git review loading paths lost scheduler ownership in ${owner}.`, unowned);
+}

--- a/web/src/lib/git/review/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/git/review/git-virtual-review-document.svelte.ts
@@ -158,7 +158,6 @@ export class GitVirtualReviewDocumentController {
 	aggregateLimit = $state<GitReviewCollectionLimit | null>(null);
 
 	private bodyCache = new Map<BodyCacheKey, GitReviewFileBody>();
-	private bodyPurposes = new Map<string, GitReviewBodyPurpose>();
 	private bodyCacheBytes = 0;
 	private prefetchStopped = false;
 	private bodyScheduler: GitReviewBodyScheduler<GitReviewDocumentIndexedFileBodiesResponse> | null =
@@ -233,7 +232,6 @@ export class GitVirtualReviewDocumentController {
 			this.pruneBodiesToSummary(summary);
 		} else {
 			this.fileBodies = {};
-			this.bodyPurposes.clear();
 		}
 		this.demandReconciler.markReadinessChanged();
 	}
@@ -292,7 +290,6 @@ export class GitVirtualReviewDocumentController {
 		if (!this.bodyScheduler) return 'not-ready';
 		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
 		this.seedCachedBodies(uniquePaths, purpose, guard);
-		if (purpose === 'visible') this.promoteLoadedBodiesToVisible(uniquePaths);
 		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath, guard));
 		const pending = uniquePaths.filter(
@@ -317,7 +314,6 @@ export class GitVirtualReviewDocumentController {
 	clearForDisplayChange(): void {
 		this.summary = null;
 		this.fileBodies = {};
-		this.bodyPurposes.clear();
 		this.aggregateLimit = null;
 		this.prefetchStopped = false;
 		this.loadingBodies = new Set();
@@ -335,16 +331,12 @@ export class GitVirtualReviewDocumentController {
 		this.fileBodies = Object.fromEntries(
 			Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
 		);
-		this.bodyPurposes.delete(filePath);
 	}
 
 	pruneToFilePaths(paths: Set<string>): void {
 		this.fileBodies = Object.fromEntries(
 			Object.entries(this.fileBodies).filter(([filePath]) => paths.has(filePath)),
 		);
-		for (const filePath of this.bodyPurposes.keys()) {
-			if (!paths.has(filePath)) this.bodyPurposes.delete(filePath);
-		}
 		for (const key of Array.from(this.bodyCache.keys())) {
 			const filePath = key.split('|').slice(3).join('|');
 			if (!paths.has(filePath)) {
@@ -357,7 +349,6 @@ export class GitVirtualReviewDocumentController {
 	reset(): void {
 		this.summary = null;
 		this.fileBodies = {};
-		this.bodyPurposes.clear();
 		this.loadingBodies = new Set();
 		this.scrollRequest = null;
 		this.aggregateLimit = null;
@@ -404,9 +395,6 @@ export class GitVirtualReviewDocumentController {
 				);
 			}),
 		);
-		for (const filePath of this.bodyPurposes.keys()) {
-			if (!this.fileBodies[filePath]) this.bodyPurposes.delete(filePath);
-		}
 	}
 
 	private discardErrorBody(filePath: string): void {
@@ -414,7 +402,6 @@ export class GitVirtualReviewDocumentController {
 		this.fileBodies = Object.fromEntries(
 			Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
 		);
-		this.bodyPurposes.delete(filePath);
 	}
 
 	private shouldLoadBody(filePath: string, guard: GitWorkbenchLoadGuard): boolean {
@@ -432,6 +419,7 @@ export class GitVirtualReviewDocumentController {
 	): void {
 		if (this.bodyCache.size === 0) return;
 		const next = { ...this.fileBodies };
+		const pinnedPaths = this.pinnedBodyPaths();
 		let changed = false;
 		for (const filePath of filePaths) {
 			const file = this.summaryForFile(filePath);
@@ -442,7 +430,7 @@ export class GitVirtualReviewDocumentController {
 				cached,
 				purpose,
 				next,
-				this.bodyPurposes,
+				pinnedPaths,
 				this.summary!.limits,
 			);
 			this.evictActiveBodies(next, decision);
@@ -459,20 +447,8 @@ export class GitVirtualReviewDocumentController {
 			}
 			next[filePath] = cached;
 			changed = true;
-			this.bodyPurposes.set(filePath, purpose);
 		}
 		if (changed) this.fileBodies = next;
-	}
-
-	private promoteLoadedBodiesToVisible(filePaths: readonly string[]): void {
-		for (const filePath of filePaths) {
-			if (
-				this.fileBodies[filePath]?.bodyState === 'loaded' &&
-				this.bodyPurposes.get(filePath) === 'prefetch'
-			) {
-				this.bodyPurposes.set(filePath, 'visible');
-			}
-		}
 	}
 
 	private ensureBodyScheduler(projectPath: string, guard: GitWorkbenchLoadGuard): void {
@@ -523,6 +499,7 @@ export class GitVirtualReviewDocumentController {
 			return;
 		}
 		const next = { ...this.fileBodies };
+		const pinnedPaths = this.pinnedBodyPaths();
 		for (const filePath of paths) {
 			const file = this.summaryForFile(filePath);
 			const body = result.files[filePath];
@@ -546,14 +523,14 @@ export class GitVirtualReviewDocumentController {
 				body,
 				effectivePurpose,
 				next,
-				this.bodyPurposes,
+				pinnedPaths,
 				this.summary!.limits,
 			);
 			this.evictActiveBodies(next, decision);
 			if (!decision.accept) {
 				if (effectivePurpose === 'prefetch') {
 					this.stopPrefetch();
-					break;
+					continue;
 				}
 				next[filePath] = this.collectionLimitBody(body, decision);
 				this.setAggregateLimit(decision, Object.keys(next).length);
@@ -561,7 +538,6 @@ export class GitVirtualReviewDocumentController {
 			}
 			if (body.bodyState !== 'error') this.cacheSet(file, guard, body);
 			next[filePath] = body;
-			this.bodyPurposes.set(filePath, effectivePurpose);
 		}
 		this.fileBodies = next;
 	}
@@ -614,8 +590,17 @@ export class GitVirtualReviewDocumentController {
 	): void {
 		for (const path of decision.evictedPaths) {
 			delete bodies[path];
-			this.bodyPurposes.delete(path);
 		}
+	}
+
+	private pinnedBodyPaths(): Set<string> {
+		const pinned = new Set<string>();
+		const documentId = this.summary?.documentId;
+		const demand = this.demandReconciler.snapshot();
+		if (documentId && demand.documentId === documentId) {
+			for (const filePath of demand.filePaths) pinned.add(filePath);
+		}
+		return pinned;
 	}
 
 	private stopPrefetch(): void {

--- a/web/src/lib/git/review/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/git/review/git-virtual-review-document.svelte.ts
@@ -9,10 +9,7 @@ import {
 	type GitReviewFileSummary,
 	type GitReviewLimitReason,
 } from '$lib/api/git.js';
-import {
-	type SplitDiffRowView,
-	type UnifiedDiffRowView,
-} from '$lib/git/review/git-diff-rows.js';
+import { type SplitDiffRowView, type UnifiedDiffRowView } from '$lib/git/review/git-diff-rows.js';
 import * as m from '$lib/paraglide/messages.js';
 import type { DiffMode, GitDiffActionTarget } from '$lib/git/workbench/git-workbench-types.js';
 import type { CommentComposerState } from '$lib/git/review/git-inline-comment.svelte.js';
@@ -28,6 +25,17 @@ import {
 	emptyGitVirtualReviewRowSource,
 	type GitVirtualReviewRowSource,
 } from './git-virtual-review-row-source.js';
+import {
+	normalizeGitReviewDemandFilePaths,
+	type GitReviewBodyDemand,
+	type GitReviewDemandOutcome,
+} from './git-review-body-demand.js';
+import { GitReviewDemandReconciler } from './git-review-demand-reconciler.js';
+import {
+	assertGitReviewLoadingOwnership,
+	traceGitReviewDemand,
+	type GitReviewDemandDebugSnapshot,
+} from './git-review-demand-trace.js';
 
 export type GitVirtualReviewRow =
 	| GitVirtualFileHeaderRow
@@ -155,6 +163,7 @@ export class GitVirtualReviewDocumentController {
 	private prefetchStopped = false;
 	private bodyScheduler: GitReviewBodyScheduler<GitReviewDocumentIndexedFileBodiesResponse> | null =
 		null;
+	private readonly demandReconciler: GitReviewDemandReconciler;
 	private loadGeneration = 0;
 	private scrollToken = 0;
 
@@ -188,7 +197,22 @@ export class GitVirtualReviewDocumentController {
 		});
 	});
 
-	constructor(private readonly deps: GitVirtualReviewDocumentDeps) {}
+	constructor(private readonly deps: GitVirtualReviewDocumentDeps) {
+		this.demandReconciler = new GitReviewDemandReconciler({
+			currentDocumentId: () => this.summary?.documentId ?? null,
+			requestViewportPaths: (filePaths) => this.requestDemandPaths(filePaths),
+			requestNavigationPaths: (filePaths) => this.requestDemandPaths(filePaths),
+			reportOutcome: (demand, outcome) => {
+				traceGitReviewDemand({
+					stage: 'controller',
+					owner: 'workbench',
+					documentId: demand.documentId,
+					fileCount: demand.filePaths.length,
+					outcome,
+				});
+			},
+		});
+	}
 
 	get hasLoading(): boolean {
 		return this.loadingBodies.size > 0;
@@ -211,12 +235,31 @@ export class GitVirtualReviewDocumentController {
 			this.fileBodies = {};
 			this.bodyPurposes.clear();
 		}
+		this.demandReconciler.markReadinessChanged();
 	}
 
-	setVisibleRows(projectPath: string, rows: GitVirtualReviewRow[]): void {
-		if (!this.summary) return;
-		const filePaths = Array.from(new Set(rows.map((row) => row.filePath).filter(Boolean)));
-		this.requestBodies(projectPath, filePaths, 'visible');
+	handleBodyDemand(demand: GitReviewBodyDemand): void {
+		this.demandReconciler.handle(demand);
+	}
+
+	markDemandReadinessChanged(): void {
+		this.demandReconciler.markReadinessChanged();
+	}
+
+	getDemandDebugSnapshot(): GitReviewDemandDebugSnapshot {
+		const demand = this.demandReconciler.snapshot();
+		return {
+			documentId: this.summary?.documentId ?? null,
+			demandedPaths: demand.filePaths,
+			loadingPaths: Array.from(this.loadingBodies),
+			schedulerPendingByPath: Object.fromEntries(
+				Array.from(this.loadingBodies, (filePath) => [
+					filePath,
+					this.bodyScheduler?.hasPending(filePath) === true,
+				]),
+			),
+			readinessGeneration: demand.readinessGeneration,
+		};
 	}
 
 	focusFile(projectPath: string, filePath: string): void {
@@ -238,20 +281,31 @@ export class GitVirtualReviewDocumentController {
 
 	requestBodies(
 		projectPath: string,
-		filePaths: string[],
+		filePaths: readonly string[],
 		purpose: GitReviewBodyPurpose = 'visible',
-	): void {
-		if (!this.summary || this.aggregateLimit) return;
-		if (purpose === 'prefetch' && this.prefetchStopped) return;
+	): GitReviewDemandOutcome {
+		if (!this.summary) return 'not-ready';
+		if (this.aggregateLimit) return 'limited';
+		if (purpose === 'prefetch' && this.prefetchStopped) return 'already-satisfied';
 		const guard = this.createLoadGuard(projectPath);
 		this.ensureBodyScheduler(projectPath, guard);
-		const uniquePaths = unique(filePaths).filter(Boolean);
+		if (!this.bodyScheduler) return 'not-ready';
+		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
 		this.seedCachedBodies(uniquePaths, purpose, guard);
+		if (purpose === 'visible') this.promoteLoadedBodiesToVisible(uniquePaths);
+		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath, guard));
-		if (toFetch.length === 0) return;
-
-		if (purpose === 'visible') this.bodyScheduler?.requestVisible(toFetch);
-		else this.bodyScheduler?.requestPrefetch(toFetch);
+		const pending = uniquePaths.filter(
+			(filePath) =>
+				this.loadingBodies.has(filePath) &&
+				this.summaryForFile(filePath)?.bodyState === 'unloaded' &&
+				!this.fileBodies[filePath],
+		);
+		const scheduled =
+			purpose === 'visible'
+				? this.bodyScheduler.requestVisible([...toFetch, ...pending])
+				: this.bodyScheduler.requestPrefetch(toFetch);
+		return scheduled ? 'scheduled' : 'already-satisfied';
 	}
 
 	refreshAllData(): void {
@@ -312,6 +366,13 @@ export class GitVirtualReviewDocumentController {
 		this.bodyCacheBytes = 0;
 		this.loadGeneration++;
 		this.clearBodyInFlightLoads();
+		this.demandReconciler.clear();
+	}
+
+	private requestDemandPaths(filePaths: readonly string[]): GitReviewDemandOutcome {
+		const projectPath = this.deps.targetProjectPath();
+		if (!projectPath) return 'not-ready';
+		return this.requestBodies(projectPath, filePaths, 'visible');
 	}
 
 	private createLoadGuard(projectPath: string): GitWorkbenchLoadGuard {
@@ -339,9 +400,7 @@ export class GitVirtualReviewDocumentController {
 			Object.entries(this.fileBodies).filter(([filePath, body]) => {
 				const file = files.get(filePath);
 				return Boolean(
-					file &&
-						body.bodyState !== 'error' &&
-						file.bodyFingerprint === body.bodyFingerprint,
+					file && body.bodyState !== 'error' && file.bodyFingerprint === body.bodyFingerprint,
 				);
 			}),
 		);
@@ -371,6 +430,7 @@ export class GitVirtualReviewDocumentController {
 		purpose: GitReviewBodyPurpose,
 		guard: GitWorkbenchLoadGuard,
 	): void {
+		if (this.bodyCache.size === 0) return;
 		const next = { ...this.fileBodies };
 		let changed = false;
 		for (const filePath of filePaths) {
@@ -404,6 +464,17 @@ export class GitVirtualReviewDocumentController {
 		if (changed) this.fileBodies = next;
 	}
 
+	private promoteLoadedBodiesToVisible(filePaths: readonly string[]): void {
+		for (const filePath of filePaths) {
+			if (
+				this.fileBodies[filePath]?.bodyState === 'loaded' &&
+				this.bodyPurposes.get(filePath) === 'prefetch'
+			) {
+				this.bodyPurposes.set(filePath, 'visible');
+			}
+		}
+	}
+
 	private ensureBodyScheduler(projectPath: string, guard: GitWorkbenchLoadGuard): void {
 		if (this.bodyScheduler || !this.summary) return;
 		const summary = this.summary;
@@ -418,8 +489,7 @@ export class GitVirtualReviewDocumentController {
 					guard.contextLines,
 					{ purpose, signal },
 				),
-			onResult: (result, paths, purpose) =>
-				this.applyBodyResult(result, paths, purpose, guard),
+			onResult: (result, paths, purpose) => this.applyBodyResult(result, paths, purpose, guard),
 			onError: (error) => {
 				if (!this.isCurrentGuard(guard)) return;
 				this.deps.surfaceError(
@@ -429,6 +499,15 @@ export class GitVirtualReviewDocumentController {
 				);
 			},
 			onLoadingChange: (paths, loading) => this.markLoading(paths, loading),
+			onDispatch: (paths, purpose) => {
+				traceGitReviewDemand({
+					stage: 'scheduler',
+					owner: 'workbench',
+					documentId: summary.documentId,
+					fileCount: paths.length,
+					purpose,
+				});
+			},
 		});
 	}
 
@@ -455,23 +534,24 @@ export class GitVirtualReviewDocumentController {
 			const serverLimit = collectionLimitDecisionFromGitReviewBody(body, next);
 			if (serverLimit) {
 				next[filePath] = body;
-				this.setAggregateLimit(
-					serverLimit,
-					Object.keys(next).length,
-					body.limitMessage,
-				);
+				this.setAggregateLimit(serverLimit, Object.keys(next).length, body.limitMessage);
 				break;
 			}
+			const effectivePurpose =
+				purpose === 'prefetch' &&
+				this.demandReconciler.demandsPath(this.summary!.documentId, filePath)
+					? 'visible'
+					: purpose;
 			const decision = decideGitReviewBodyBudget(
 				body,
-				purpose,
+				effectivePurpose,
 				next,
 				this.bodyPurposes,
 				this.summary!.limits,
 			);
 			this.evictActiveBodies(next, decision);
 			if (!decision.accept) {
-				if (purpose === 'prefetch') {
+				if (effectivePurpose === 'prefetch') {
 					this.stopPrefetch();
 					break;
 				}
@@ -481,7 +561,7 @@ export class GitVirtualReviewDocumentController {
 			}
 			if (body.bodyState !== 'error') this.cacheSet(file, guard, body);
 			next[filePath] = body;
-			this.bodyPurposes.set(filePath, purpose);
+			this.bodyPurposes.set(filePath, effectivePurpose);
 		}
 		this.fileBodies = next;
 	}
@@ -550,6 +630,11 @@ export class GitVirtualReviewDocumentController {
 			else next.delete(filePath);
 		}
 		this.loadingBodies = next;
+		assertGitReviewLoadingOwnership(
+			next,
+			(filePath) => this.bodyScheduler?.hasPending(filePath) === true,
+			'workbench',
+		);
 	}
 
 	private cacheKey(file: GitReviewFileSummary, guard: GitWorkbenchLoadGuard): BodyCacheKey {

--- a/web/src/lib/git/review/git-virtual-review-row-source.ts
+++ b/web/src/lib/git/review/git-virtual-review-row-source.ts
@@ -34,11 +34,14 @@ interface RowSegment {
 
 export interface GitVirtualReviewRowSource {
 	readonly rowCount: number;
+	readonly measurementRevision: string;
 	rowAt(index: number): GitVirtualReviewRow | null;
 	rowKey(index: number): string | number;
 	estimateRowHeight(index: number, lineHeight: number): number;
 	fileStart(filePath: string): number | undefined;
 	fileState(filePath: string): 'pending' | 'resolved' | 'terminal';
+	filePathAt(index: number): string | null;
+	filePathsInRange(start: number, end: number): string[];
 	rowsInRange(start: number, end: number): GitVirtualReviewRow[];
 }
 
@@ -51,11 +54,14 @@ export function buildGitVirtualReviewRowSource(
 export function emptyGitVirtualReviewRowSource(): GitVirtualReviewRowSource {
 	return {
 		rowCount: 0,
+		measurementRevision: 'empty',
 		rowAt: () => null,
 		rowKey: (index) => index,
 		estimateRowHeight: (_index, lineHeight) => lineHeight,
 		fileStart: () => undefined,
 		fileState: () => 'terminal',
+		filePathAt: () => null,
+		filePathsInRange: () => [],
 		rowsInRange: () => [],
 	};
 }
@@ -73,6 +79,7 @@ export function arrayGitVirtualReviewRowSource(
 		);
 	return {
 		rowCount: rows.length,
+		measurementRevision: JSON.stringify(rows.map((row) => [row.id, row.kind, row.estimatedHeight])),
 		rowAt: (index) => rows[index] ?? null,
 		rowKey: (index) => rows[index]?.id ?? index,
 		estimateRowHeight: (index, lineHeight) => {
@@ -91,12 +98,16 @@ export function arrayGitVirtualReviewRowSource(
 			}
 			return 'terminal';
 		},
+		filePathAt: (index) => rows[index]?.filePath || null,
+		filePathsInRange: (start, end) =>
+			uniqueFilePaths(rows.slice(clampIndex(start, rows.length), clampIndex(end, rows.length))),
 		rowsInRange: (start, end) => rows.slice(start, end),
 	};
 }
 
 class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 	readonly rowCount: number;
+	readonly measurementRevision: string;
 	private readonly segments: RowSegment[] = [];
 	private readonly fileStarts = new Map<string, number>();
 	private readonly fileKeyBases = new Map<string, number>();
@@ -185,6 +196,7 @@ class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 			start += 1;
 		}
 		this.rowCount = start;
+		this.measurementRevision = buildMeasurementRevision(options, this.segments);
 	}
 
 	rowAt(index: number): GitVirtualReviewRow | null {
@@ -226,10 +238,7 @@ class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 		if (!segment) return lineHeight;
 		if (segment.kind === 'header') return 42;
 		if (segment.kind === 'placeholder') {
-			return Math.max(
-				96,
-				Math.min(720, (segment.file?.estimatedRows ?? 1) * DEFAULT_ROW_HEIGHT),
-			);
+			return Math.max(96, Math.min(720, (segment.file?.estimatedRows ?? 1) * DEFAULT_ROW_HEIGHT));
 		}
 		if (segment.kind === 'limit' || segment.kind === 'collection') return 112;
 		const localIndex = index - segment.start;
@@ -248,10 +257,33 @@ class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 		return this.fileStates.get(filePath) ?? 'terminal';
 	}
 
+	filePathAt(index: number): string | null {
+		if (index < 0 || index >= this.rowCount) return null;
+		return this.segmentAt(index)?.file?.path ?? null;
+	}
+
+	filePathsInRange(start: number, end: number): string[] {
+		const safeStart = clampIndex(start, this.rowCount);
+		const safeEnd = clampIndex(end, this.rowCount);
+		if (safeEnd <= safeStart) return [];
+		const paths: string[] = [];
+		const seen = new Set<string>();
+		const firstSegmentIndex = this.segmentIndexAt(safeStart);
+		for (let index = firstSegmentIndex; index < this.segments.length; index += 1) {
+			const segment = this.segments[index];
+			if (segment.start >= safeEnd) break;
+			const filePath = segment.file?.path;
+			if (!filePath || seen.has(filePath)) continue;
+			seen.add(filePath);
+			paths.push(filePath);
+		}
+		return paths;
+	}
+
 	rowsInRange(start: number, end: number): GitVirtualReviewRow[] {
 		const rows: GitVirtualReviewRow[] = [];
-		const safeStart = Math.max(0, start);
-		const safeEnd = Math.min(this.rowCount, end);
+		const safeStart = clampIndex(start, this.rowCount);
+		const safeEnd = clampIndex(end, this.rowCount);
 		for (let index = safeStart; index < safeEnd; index += 1) {
 			const row = this.rowAt(index);
 			if (row) rows.push(row);
@@ -260,6 +292,12 @@ class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 	}
 
 	private segmentAt(index: number): RowSegment | null {
+		const segmentIndex = this.segmentIndexAt(index);
+		return segmentIndex < 0 ? null : this.segments[segmentIndex];
+	}
+
+	private segmentIndexAt(index: number): number {
+		if (index < 0 || index >= this.rowCount) return -1;
 		let low = 0;
 		let high = this.segments.length - 1;
 		while (low <= high) {
@@ -267,9 +305,9 @@ class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 			const segment = this.segments[middle];
 			if (index < segment.start) high = middle - 1;
 			else if (index >= segment.start + segment.count) low = middle + 1;
-			else return segment;
+			else return middle;
 		}
-		return null;
+		return -1;
 	}
 
 	private headerRow(file: GitReviewFileSummary): GitVirtualReviewRow {
@@ -363,6 +401,35 @@ class IndexedGitVirtualReviewRowSource implements GitVirtualReviewRowSource {
 	}
 }
 
+function buildMeasurementRevision(
+	options: BuildVirtualRowsOptions,
+	segments: readonly RowSegment[],
+): string {
+	const composer =
+		options.interaction.kind === 'read-only' ? null : options.interaction.composerState;
+	return JSON.stringify([
+		options.summary.documentId,
+		options.diffMode,
+		options.contextLines,
+		segments.map((segment) => [
+			segment.file?.path ?? '',
+			segment.kind,
+			segment.count,
+			segment.file?.estimatedRows ?? 0,
+			segment.body?.bodyFingerprint ?? '',
+		]),
+		composer?.open ? [composer.filePath, composer.side, composer.line] : null,
+	]);
+}
+
+function clampIndex(index: number, rowCount: number): number {
+	return Math.min(rowCount, Math.max(0, Math.trunc(index)));
+}
+
+function uniqueFilePaths(rows: readonly GitVirtualReviewRow[]): string[] {
+	return Array.from(new Set(rows.map((row) => row.filePath).filter(Boolean)));
+}
+
 function terminalRow(
 	options: BuildVirtualRowsOptions,
 	file: GitReviewFileSummary,
@@ -447,9 +514,14 @@ function indexedSplitRow(
 	index: number,
 ): SplitDiffRow {
 	const entry = splitIndex.entryAt(index);
-	const left = entry.leftRowIndex === null ? null : renderUnifiedDiffRow(renderedRowAt(body, entry.leftRowIndex));
+	const left =
+		entry.leftRowIndex === null
+			? null
+			: renderUnifiedDiffRow(renderedRowAt(body, entry.leftRowIndex));
 	const right =
-		entry.rightRowIndex === null ? null : renderUnifiedDiffRow(renderedRowAt(body, entry.rightRowIndex));
+		entry.rightRowIndex === null
+			? null
+			: renderUnifiedDiffRow(renderedRowAt(body, entry.rightRowIndex));
 	if (left?.kind === 'hunk-header') return splitHeader(left);
 	if (left?.kind === 'context') return splitContext(left);
 	return splitPair(left, right, index);

--- a/web/src/lib/git/workbench/__tests__/git-workbench.test.ts
+++ b/web/src/lib/git/workbench/__tests__/git-workbench.test.ts
@@ -964,6 +964,41 @@ describe('GitWorkbenchStore', () => {
 			expect(wb.review.aggregateLimit).toBeNull();
 		});
 
+		it('applies a demanded body after stopping an over-budget prefetch response', async () => {
+			const paths = ['initial.ts', 'blocked.ts', 'visible.ts'];
+			const prefetch = deferred<ReturnType<typeof makeReviewBodies>>();
+			mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(
+				makeWorkbenchSnapshot({
+					root: paths.map((path) => makeTreeFile(path)),
+					summary: makeReviewSummary(paths, {
+						limits: {
+							...makeReviewSummary(paths).limits,
+							maxLoadedRows: 2,
+						},
+					}),
+					selectedFile: paths[0],
+					firstBodyCandidates: paths,
+				}),
+			);
+			mockedApi.getGitReviewFileBodies
+				.mockResolvedValueOnce(makeReviewBodies([paths[0]]))
+				.mockReturnValueOnce(prefetch.promise);
+
+			await wb.setTarget(makeTarget());
+			await vi.waitFor(() => expect(wb.review.fileBodies[paths[0]]?.bodyState).toBe('loaded'));
+			wb.handleReviewBodyDemand({
+				kind: 'viewport',
+				documentId: 'doc',
+				filePaths: [paths[2]],
+			});
+			prefetch.resolve(makeReviewBodies(paths.slice(1)));
+
+			await vi.waitFor(() => expect(wb.review.fileBodies[paths[2]]?.bodyState).toBe('loaded'));
+			expect(wb.review.fileBodies[paths[0]]).toBeUndefined();
+			expect(wb.review.fileBodies[paths[1]]).toBeUndefined();
+			expect(wb.review.aggregateLimit).toBeNull();
+		});
+
 		it('honors a collection budget limit emitted by the server', async () => {
 			const paths = ['a.ts', 'b.ts', 'c.ts'];
 			mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(

--- a/web/src/lib/git/workbench/__tests__/git-workbench.test.ts
+++ b/web/src/lib/git/workbench/__tests__/git-workbench.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GitWorkbenchStore } from '$lib/git/workbench/git-workbench.svelte.js';
 import { makeLineSelectionKey } from '$lib/git/review/git-line-selection.svelte.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
-import type { GitVirtualFileHeaderRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 import type {
 	GitDiffActionTarget,
 	GitWorkbenchTarget,
@@ -115,9 +114,7 @@ function makeReviewBody(
 	text = '',
 	fingerprint = `fingerprint:${path}`,
 ): GitReviewFileBody {
-	const patch = text
-		? `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n ${text}\n`
-		: '';
+	const patch = text ? `diff --git a/${path} b/${path}\n@@ -1 +1 @@\n ${text}\n` : '';
 	return {
 		path,
 		bodyFingerprint: fingerprint,
@@ -811,17 +808,11 @@ describe('GitWorkbenchStore', () => {
 			expect(mockedApi.getGitReviewFileBodies.mock.calls[0]?.[5]?.purpose).toBe('visible');
 			expect(mockedApi.getGitReviewFileBodies.mock.calls[1]?.[5]?.purpose).toBe('prefetch');
 			const firstSignal = mockedApi.getGitReviewFileBodies.mock.calls[0]?.[5]?.signal;
-			const ninthFile = makeReviewFileSummary(paths[8]);
-			wb.handleVisibleReviewRows('/project', [
-				{
-					kind: 'file-header',
-					id: `header:${ninthFile.path}`,
-					filePath: ninthFile.path,
-					estimatedHeight: 42,
-					file: ninthFile,
-					isFocused: false,
-				} satisfies GitVirtualFileHeaderRow,
-			]);
+			wb.handleReviewBodyDemand({
+				kind: 'viewport',
+				documentId: 'doc',
+				filePaths: [paths[8]],
+			});
 
 			expect(firstSignal?.aborted).toBe(false);
 			expect(mockedApi.getGitReviewFileBodies).toHaveBeenCalledTimes(2);
@@ -832,6 +823,59 @@ describe('GitWorkbenchStore', () => {
 			});
 			expect(mockedApi.getGitReviewFileBodies.mock.calls[2]?.[2]).toEqual([paths[8]]);
 			prefetch.resolve(makeReviewBodies(firstBodyCandidates.slice(1)));
+		});
+
+		it('rejects stale viewport demand and deduplicates the current visible range', async () => {
+			const pending = deferred<ReturnType<typeof makeReviewBodies>>();
+			mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(
+				makeWorkbenchSnapshot({
+					root: [makeTreeFile('initial.ts'), makeTreeFile('visible.ts')],
+					summary: makeReviewSummary(['initial.ts', 'visible.ts'], {
+						documentId: 'current-doc',
+					}),
+					firstBodyCandidates: [],
+				}),
+			);
+			mockedApi.getGitReviewFileBodies.mockResolvedValueOnce({
+				...makeReviewBodies(['initial.ts']),
+				documentId: 'current-doc',
+			});
+			await wb.setTarget(makeTarget());
+			await vi.waitFor(() => expect(wb.review.fileBodies['initial.ts']).toBeTruthy());
+			mockedApi.getGitReviewFileBodies.mockClear();
+			mockedApi.getGitReviewFileBodies.mockReturnValue(pending.promise);
+
+			wb.handleReviewBodyDemand({
+				kind: 'viewport',
+				documentId: 'old-doc',
+				filePaths: ['visible.ts'],
+			});
+			expect(mockedApi.getGitReviewFileBodies).not.toHaveBeenCalled();
+
+			const demand = {
+				kind: 'viewport',
+				documentId: 'current-doc',
+				filePaths: ['visible.ts'],
+			} as const;
+			wb.handleReviewBodyDemand(demand);
+			wb.handleReviewBodyDemand({ ...demand, filePaths: [...demand.filePaths] });
+
+			expect(mockedApi.getGitReviewFileBodies).toHaveBeenCalledOnce();
+			expect(mockedApi.getGitReviewFileBodies).toHaveBeenCalledWith(
+				'/project',
+				'current-doc',
+				['visible.ts'],
+				'unstaged',
+				5,
+				expect.objectContaining({ purpose: 'visible' }),
+			);
+			expect(wb.review.getDemandDebugSnapshot().schedulerPendingByPath).toEqual({
+				'visible.ts': true,
+			});
+			pending.resolve({
+				...makeReviewBodies(['visible.ts']),
+				documentId: 'current-doc',
+			});
 		});
 
 		it('retries a transient body error after a same-fingerprint summary refresh', async () => {
@@ -911,15 +955,11 @@ describe('GitWorkbenchStore', () => {
 			await wb.setTarget(makeTarget());
 			await vi.waitFor(() => expect(mockedApi.getGitReviewFileBodies).toHaveBeenCalledTimes(2));
 			prefetch.resolve(makeReviewBodies([paths[1]]));
-			await vi.waitFor(() =>
-				expect(wb.review.fileBodies[paths[1]]?.bodyState).toBe('loaded'),
-			);
+			await vi.waitFor(() => expect(wb.review.fileBodies[paths[1]]?.bodyState).toBe('loaded'));
 
 			visible.resolve(makeReviewBodies([paths[0]]));
 
-			await vi.waitFor(() =>
-				expect(wb.review.fileBodies[paths[0]]?.bodyState).toBe('loaded'),
-			);
+			await vi.waitFor(() => expect(wb.review.fileBodies[paths[0]]?.bodyState).toBe('loaded'));
 			expect(wb.review.fileBodies[paths[1]]).toBeUndefined();
 			expect(wb.review.aggregateLimit).toBeNull();
 		});
@@ -1052,9 +1092,9 @@ describe('GitWorkbenchStore', () => {
 
 			await vi.waitFor(() => {
 				expect(
-					wb.review.rowSource.rowsInRange(0, wb.review.rowSource.rowCount).some(
-						(row) => row.kind === 'unified-row' && row.view.text === 'new',
-					),
+					wb.review.rowSource
+						.rowsInRange(0, wb.review.rowSource.rowCount)
+						.some((row) => row.kind === 'unified-row' && row.view.text === 'new'),
 				).toBe(true);
 			});
 			expect(
@@ -2052,6 +2092,12 @@ describe('GitWorkbenchStore', () => {
 			const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
 			vi.spyOn(localStorage, 'getItem').mockImplementation((key) =>
 				key === 'garcon.gitWorkbenchTrace' ? '1' : 'claude',
+			);
+			globalThis.dispatchEvent(
+				new StorageEvent('storage', {
+					key: 'garcon.gitWorkbenchTrace',
+					storageArea: localStorage,
+				}),
 			);
 			mockedApi.getGitWorkbenchSnapshot.mockResolvedValue(
 				makeWorkbenchSnapshot({

--- a/web/src/lib/git/workbench/git-workbench.svelte.ts
+++ b/web/src/lib/git/workbench/git-workbench.svelte.ts
@@ -20,10 +20,9 @@ import {
 	type GitWorkbenchTarget,
 } from '$lib/git/workbench/git-workbench-types.js';
 import { GitWorktrees } from '$lib/git/targets/git-worktrees.svelte.js';
-import {
-	GitVirtualReviewDocumentController,
-	type GitVirtualReviewRow,
-} from '$lib/git/review/git-virtual-review-document.svelte.js';
+import { GitVirtualReviewDocumentController } from '$lib/git/review/git-virtual-review-document.svelte.js';
+import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
+import { readGarconDebugFlag } from '$lib/utils/debug-flags.js';
 
 export interface GitWorkbenchStoreOptions {
 	runMutation?: GitWorkbenchMutationRunner;
@@ -43,11 +42,7 @@ function elapsedMs(startedAt: number): number {
 }
 
 function shouldLogWorkbenchTrace(): boolean {
-	try {
-		return globalThis.localStorage?.getItem(WORKBENCH_TRACE_STORAGE_KEY) === '1';
-	} catch {
-		return false;
-	}
+	return readGarconDebugFlag(WORKBENCH_TRACE_STORAGE_KEY);
 }
 
 function logWorkbenchTrace(trace: WorkbenchLoadTrace): void {
@@ -228,6 +223,7 @@ export class GitWorkbenchStore {
 		const nextKey = targetKey(nextTarget);
 		if (nextKey === this.lastTargetKey) {
 			this.target = nextTarget;
+			this.virtualReview.markDemandReadinessChanged();
 			if (
 				nextTarget &&
 				this.treeState.tree.length === 0 &&
@@ -379,8 +375,8 @@ export class GitWorkbenchStore {
 		await this.openFile(projectPath, filePath);
 	}
 
-	handleVisibleReviewRows(projectPath: string, rows: GitVirtualReviewRow[]): void {
-		this.virtualReview.setVisibleRows(projectPath, rows);
+	handleReviewBodyDemand(demand: GitReviewBodyDemand): void {
+		this.virtualReview.handleBodyDemand(demand);
 	}
 
 	private refreshAllData(projectPath: string): void {

--- a/web/src/lib/utils/debug-flags.ts
+++ b/web/src/lib/utils/debug-flags.ts
@@ -1,0 +1,26 @@
+const cachedFlags = new Map<string, boolean>();
+let storageListenerInstalled = false;
+
+export function readGarconDebugFlag(key: string): boolean {
+	const cached = cachedFlags.get(key);
+	if (cached !== undefined) return cached;
+
+	let enabled = false;
+	try {
+		enabled = globalThis.localStorage?.getItem(key) === '1';
+		installStorageListener();
+	} catch {
+		// Debug flags must not affect application behavior when storage is unavailable.
+	}
+	cachedFlags.set(key, enabled);
+	return enabled;
+}
+
+function installStorageListener(): void {
+	if (storageListenerInstalled || typeof globalThis.addEventListener !== 'function') return;
+	storageListenerInstalled = true;
+	globalThis.addEventListener('storage', (event: StorageEvent) => {
+		if (event.storageArea !== globalThis.localStorage || !event.key) return;
+		cachedFlags.delete(event.key);
+	});
+}


### PR DESCRIPTION
Virtual Git diffs could permanently stop requesting visible file bodies after retained workbench, history, or comparison views changed lifecycle state, leaving placeholders stuck until a refresh. This change makes viewport demand durable and document-scoped, preserves virtualizer geometry across hidden and visible transitions, and keeps visible prefetched bodies protected while large diffs remain virtualized.