### PR TITLE
Preserve Claude chats when changing project paths

### DIFF
--- a/integration-tests/support/fake-claude-cli.ts
+++ b/integration-tests/support/fake-claude-cli.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+import {
+  accessSync,
+  appendFileSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const MAX_SANITIZED_LENGTH = 200;
+const args = process.argv.slice(2);
+
+if (args.includes('--version')) {
+  console.log('2.1.220 (Claude Code)');
+} else if (args[0] === 'auth' && args[1] === 'status') {
+  console.log(JSON.stringify({ loggedIn: true, authMethod: 'api_key' }));
+} else {
+  await runStreamSession();
+}
+
+async function runStreamSession(): Promise<void> {
+  const sessionId = argumentValue('--session-id') ?? argumentValue('--resume');
+  if (!sessionId) {
+    writeOutput({ type: 'system', subtype: 'init', slash_commands: [] });
+    return;
+  }
+
+  const nativePath = claudeNativePath(process.cwd(), sessionId);
+  const isResume = argumentValue('--resume') !== null;
+  if (isResume) {
+    try {
+      accessSync(nativePath);
+    } catch {
+      console.error(`No conversation found with session ID: ${sessionId}`);
+      process.exitCode = 1;
+      return;
+    }
+  } else {
+    initializeSessionArtifacts(nativePath, sessionId);
+  }
+
+  writeOutput({
+    type: 'system',
+    subtype: 'init',
+    session_id: sessionId,
+    model: argumentValue('--model') ?? 'claude-haiku-4-5-20251001',
+    slash_commands: [],
+  });
+
+  const decoder = new TextDecoder();
+  let buffered = '';
+  for await (const chunk of Bun.stdin.stream()) {
+    buffered += decoder.decode(chunk, { stream: true });
+    let newline = buffered.indexOf('\n');
+    while (newline >= 0) {
+      handleInput(buffered.slice(0, newline), nativePath, sessionId);
+      buffered = buffered.slice(newline + 1);
+      newline = buffered.indexOf('\n');
+    }
+  }
+  buffered += decoder.decode();
+  if (buffered.trim()) handleInput(buffered, nativePath, sessionId);
+}
+
+function argumentValue(name: string): string | null {
+  const index = args.indexOf(name);
+  return index >= 0 && typeof args[index + 1] === 'string'
+    ? args[index + 1]!
+    : null;
+}
+
+function initializeSessionArtifacts(nativePath: string, sessionId: string): void {
+  const projectDirectory = resolve(nativePath, '..');
+  mkdirSync(join(projectDirectory, sessionId, 'subagents'), { recursive: true });
+  writeFileSync(nativePath, '');
+  writeFileSync(join(projectDirectory, `${sessionId}.queue.json`), '{"queued":[]}\n');
+  writeFileSync(
+    join(projectDirectory, sessionId, 'subagents', 'agent-integration.jsonl'),
+    `${JSON.stringify({ sessionId, type: 'summary', summary: 'integration support artifact' })}\n`,
+  );
+}
+
+function handleInput(line: string, nativePath: string, sessionId: string): void {
+  if (!line.trim()) return;
+  const input = JSON.parse(line) as {
+    type?: string;
+    message?: { role?: string; content?: unknown };
+  };
+  if (input.type !== 'user' || input.message?.role !== 'user') return;
+
+  const prompt = messageText(input.message.content);
+  const response = `echo:${prompt}`;
+  const userTimestamp = new Date().toISOString();
+  const assistantTimestamp = new Date(Date.now() + 1).toISOString();
+  appendFileSync(nativePath, [
+    JSON.stringify({
+      sessionId,
+      type: 'user',
+      uuid: randomUUID(),
+      timestamp: userTimestamp,
+      cwd: process.cwd(),
+      message: { role: 'user', content: prompt },
+    }),
+    JSON.stringify({
+      sessionId,
+      type: 'assistant',
+      uuid: randomUUID(),
+      timestamp: assistantTimestamp,
+      cwd: process.cwd(),
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: response }],
+      },
+    }),
+    '',
+  ].join('\n'));
+
+  writeOutput({
+    type: 'assistant',
+    session_id: sessionId,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: response }],
+    },
+  });
+  writeOutput({
+    type: 'result',
+    subtype: 'success',
+    session_id: sessionId,
+    is_error: false,
+    duration_ms: 1,
+    num_turns: 1,
+    result: response,
+  });
+}
+
+function messageText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .flatMap((part) => (
+      part
+      && typeof part === 'object'
+      && !Array.isArray(part)
+      && (part as { type?: unknown }).type === 'text'
+      && typeof (part as { text?: unknown }).text === 'string'
+        ? [(part as { text: string }).text]
+        : []
+    ))
+    .join('\n');
+}
+
+function claudeNativePath(projectPath: string, sessionId: string): string {
+  const configHome = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude');
+  const canonicalProjectPath = resolve(projectPath).normalize('NFC');
+  const sanitized = canonicalProjectPath.replace(/[^a-zA-Z0-9]/g, '-');
+  const projectKey = sanitized.length <= MAX_SANITIZED_LENGTH
+    ? sanitized
+    : `${sanitized.slice(0, MAX_SANITIZED_LENGTH)}-${simpleHash(canonicalProjectPath)}`;
+  return join(configHome.normalize('NFC'), 'projects', projectKey, `${sessionId}.jsonl`);
+}
+
+function simpleHash(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+function writeOutput(value: unknown): void {
+  console.log(JSON.stringify(value));
+}

--- a/integration-tests/support/garcon-client.ts
+++ b/integration-tests/support/garcon-client.ts
@@ -26,6 +26,8 @@ import type {
   QueueEntryMoveCommandRequest,
   QueueEntryReplaceCommandRequest,
   QueueMutationResponse,
+  ProjectPathPatchRequest,
+  ProjectPathPatchResponse,
   StartChatCommandRequest,
   StartChatCommandResponse,
 } from '../../common/chat-command-contracts.js';
@@ -499,6 +501,10 @@ export class GarconTestClient {
 
   switchAgentModel(request: AgentModelPatchRequest): Promise<AgentModelPatchResponse> {
     return this.patch<AgentModelPatchResponse>('/api/v1/chats/agent-model', request);
+  }
+
+  updateProjectPath(request: ProjectPathPatchRequest): Promise<ProjectPathPatchResponse> {
+    return this.patch<ProjectPathPatchResponse>('/api/v1/chats/project-path', request);
   }
 
   deleteChat(chatId: string): Promise<{ success: boolean }> {

--- a/integration-tests/tests/server/claude-project-path-relocation.test.ts
+++ b/integration-tests/tests/server/claude-project-path-relocation.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import {
+  access,
+  chmod,
+  mkdir,
+  readFile,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { AgentSettingsEnvelope } from '../../../common/agent-integration.js';
+import { assistantContents, userContents } from '../../support/chat-assertions.js';
+import {
+  type IntegrationFixture,
+  withIntegrationFixture,
+} from '../../support/integration-fixture.js';
+
+interface PersistedClaudeChat {
+  projectPath: string;
+  agentSessionId: string;
+  nativeSession: {
+    ownerId: string;
+    schemaVersion: number;
+    value: {
+      path: string;
+      agentSessionId: string;
+    };
+  };
+}
+
+describe('Claude project path relocation', () => {
+  test('moves native history before resuming from a new project and survives restart', async () => {
+    const environment: Record<string, string> = {};
+    await withIntegrationFixture(
+      'claude-project-path-relocation',
+      async (fixture) => {
+        const projectA = join(fixture.dirs.project, 'a');
+        const projectB = join(fixture.dirs.project, 'b');
+        await Promise.all([
+          mkdir(projectA, { recursive: true }),
+          mkdir(projectB, { recursive: true }),
+        ]);
+
+        const claude = (await fixture.client.listAgentCatalog()).agents.find(
+          (agent) => agent.id === 'claude',
+        );
+        if (!claude) throw new Error('Claude integration is missing from the agent catalog');
+
+        const chatId = fixture.newChatId();
+        const first = await fixture.client.startChat({
+          clientRequestId: randomUUID(),
+          clientMessageId: randomUUID(),
+          chatId,
+          agentId: claude.id,
+          projectPath: projectA,
+          model: claude.defaultModel,
+          permissionMode: 'default',
+          thinkingMode: 'none',
+          agentSettings: claude.defaultSettings,
+          command: 'relocation-turn-a',
+        });
+        expect((await fixture.client.waitForTurnTerminal(chatId, first.turnId)).type).toBe(
+          'agent-run-finished',
+        );
+
+        const before = await readClaudeChat(fixture.dirs.workspace, chatId);
+        const sourcePath = before.nativeSession.value.path;
+        const sourceQueuePath = queuePath(sourcePath, before.agentSessionId);
+        const sourceSupportPath = supportPath(sourcePath, before.agentSessionId);
+        await Promise.all([
+          access(sourcePath),
+          access(sourceQueuePath),
+          access(sourceSupportPath),
+        ]);
+
+        const updated = await fixture.client.updateProjectPath({
+          chatId,
+          projectPath: projectB,
+        });
+        expect(updated).toMatchObject({
+          success: true,
+          chatId,
+          projectPath: projectB,
+          previousProjectPath: projectA,
+        });
+
+        const relocated = await readClaudeChat(fixture.dirs.workspace, chatId);
+        const targetPath = relocated.nativeSession.value.path;
+        expect(relocated).toMatchObject({
+          projectPath: projectB,
+          agentSessionId: before.agentSessionId,
+          nativeSession: {
+            ownerId: 'claude',
+            schemaVersion: 1,
+            value: { agentSessionId: before.agentSessionId },
+          },
+        });
+        expect(targetPath).not.toBe(sourcePath);
+        await Promise.all([
+          access(targetPath),
+          access(queuePath(targetPath, before.agentSessionId)),
+          access(supportPath(targetPath, before.agentSessionId)),
+        ]);
+        await expectMissing(sourcePath);
+        await expectMissing(sourceQueuePath);
+        await expectMissing(sourceSupportPath);
+
+        const second = await runClaudeTurn(fixture, {
+          chatId,
+          content: 'relocation-turn-b',
+          model: claude.defaultModel,
+          settings: claude.defaultSettings,
+        });
+        expect((await fixture.client.waitForTurnTerminal(chatId, second.turnId)).type).toBe(
+          'agent-run-finished',
+        );
+        const afterMove = await fixture.client.getMessages(chatId);
+        expect(userContents(afterMove.messages)).toEqual([
+          'relocation-turn-a',
+          'relocation-turn-b',
+        ]);
+        expect(assistantContents(afterMove.messages)).toEqual([
+          'echo:relocation-turn-a',
+          'echo:relocation-turn-b',
+        ]);
+
+        await fixture.restartGarcon();
+        expect(await readClaudeChat(fixture.dirs.workspace, chatId)).toEqual(relocated);
+        const restored = await fixture.client.getMessages(chatId);
+        expect(userContents(restored.messages)).toEqual(userContents(afterMove.messages));
+        expect(assistantContents(restored.messages)).toEqual(assistantContents(afterMove.messages));
+
+        const third = await runClaudeTurn(fixture, {
+          chatId,
+          content: 'relocation-turn-c',
+          model: claude.defaultModel,
+          settings: claude.defaultSettings,
+        });
+        expect((await fixture.client.waitForTurnTerminal(chatId, third.turnId)).type).toBe(
+          'agent-run-finished',
+        );
+        const finalHistory = await fixture.client.getMessages(chatId);
+        expect(userContents(finalHistory.messages)).toEqual([
+          'relocation-turn-a',
+          'relocation-turn-b',
+          'relocation-turn-c',
+        ]);
+        expect(assistantContents(finalHistory.messages)).toEqual([
+          'echo:relocation-turn-a',
+          'echo:relocation-turn-b',
+          'echo:relocation-turn-c',
+        ]);
+      },
+      {
+        serverEnvironment: environment,
+        async prepareWorkspace(directories) {
+          const fakeModule = fileURLToPath(
+            new URL('../../support/fake-claude-cli.ts', import.meta.url),
+          );
+          const binaryPath = join(directories.root, 'claude');
+          await writeFile(
+            binaryPath,
+            `#!${process.execPath}\nimport ${JSON.stringify(pathToFileURL(fakeModule).href)};\n`,
+          );
+          await chmod(binaryPath, 0o755);
+          environment.CLAUDE_BINARY = binaryPath;
+          environment.CLAUDE_CONFIG_DIR = join(directories.home, '.claude-integration');
+          environment.ANTHROPIC_API_KEY = 'integration-fake-claude-key';
+        },
+      },
+    );
+  }, 30_000);
+});
+
+async function runClaudeTurn(
+  fixture: IntegrationFixture,
+  input: {
+    chatId: string;
+    content: string;
+    model: string;
+    settings: AgentSettingsEnvelope;
+  },
+) {
+  return fixture.client.runChat({
+    clientRequestId: randomUUID(),
+    clientMessageId: randomUUID(),
+    chatId: input.chatId,
+    command: input.content,
+    permissionMode: 'default',
+    thinkingMode: 'none',
+    agentSettings: input.settings,
+    model: input.model,
+  });
+}
+
+async function readClaudeChat(workspace: string, chatId: string): Promise<PersistedClaudeChat> {
+  const registry = JSON.parse(
+    await readFile(join(workspace, 'chats.json'), 'utf8'),
+  ) as { sessions: Record<string, PersistedClaudeChat> };
+  const chat = registry.sessions[chatId];
+  if (!chat) throw new Error(`Claude chat ${chatId} was not persisted`);
+  return chat;
+}
+
+function queuePath(nativePath: string, sessionId: string): string {
+  return join(dirname(nativePath), `${sessionId}.queue.json`);
+}
+
+function supportPath(nativePath: string, sessionId: string): string {
+  return join(dirname(nativePath), sessionId);
+}
+
+async function expectMissing(path: string): Promise<void> {
+  await expect(access(path)).rejects.toMatchObject({ code: 'ENOENT' });
+}

--- a/server-agents/claude/src/__tests__/integration.test.js
+++ b/server-agents/claude/src/__tests__/integration.test.js
@@ -30,6 +30,7 @@ describe('ClaudeAgentIntegration', () => {
     expect(ClaudeAgentIntegration.apiVersion).toBe(2);
     expect(ClaudeAgentIntegration.transcriptIndex.apiVersion).toBe(1);
     expect(integration.descriptor.id).toBe('claude');
+    expect(integration.descriptor.requiresNativePathForProjectPathUpdate).toBe(false);
     expect(integration.execution.prepareProjectPathUpdate).toBeDefined();
     expect(integration.transcriptSearch).toBeUndefined();
     expect(integration.forking).toMatchObject({

--- a/server-agents/claude/src/agents/claude/__tests__/agent.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/agent.test.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { AgentEventEmitterRuntime } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import { createPathNativeSessionCodec } from '@garcon/server-agent-common/native-session/path-native-session';
 import { ClaudeExecution } from '../execution.ts';
+import { createClaudeNativePath } from '../native-path.ts';
 
 function createLogger() {
   return {
@@ -26,6 +27,7 @@ function createClaudeStub(startError) {
   claude.setInternalPermissionMode = mock(() => undefined);
   claude.setInternalThinkingMode = mock(() => undefined);
   claude.setInternalClaudeThinkingMode = mock(() => undefined);
+  claude.prepareClaudeProjectPathUpdate = mock(() => Promise.resolve());
   claude.failClaudeInternalSession = mock((agentSessionId, chatId, errorMessage, metadata) => {
     claude.emitProcessing(chatId, false);
     claude.emitFailed(chatId, errorMessage, metadata);
@@ -146,5 +148,102 @@ describe('ClaudeExecution', () => {
     } finally {
       await fs.rm(projectPath, { recursive: true, force: true });
     }
+  });
+
+  it('returns a relocated native session while preserving the endpoint binding', async () => {
+    const rootDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-claude-relocation-'));
+    const configHomeDir = path.join(rootDirectory, 'config');
+    const previousProjectPath = path.join(rootDirectory, 'project-a');
+    const nextProjectPath = path.join(rootDirectory, 'project-b');
+    await fs.mkdir(previousProjectPath, { recursive: true });
+    await fs.mkdir(nextProjectPath, { recursive: true });
+    const sourcePath = await createClaudeNativePath(
+      previousProjectPath,
+      'session-1',
+      { configHomeDir },
+    );
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, 'transcript\n');
+
+    try {
+      const claude = createClaudeStub(new Error('unused'));
+      const execution = createExecution(claude, configHomeDir);
+      const preparation = await execution.prepareProjectPathUpdate({
+        chat: {
+          chatId: 'chat-1',
+          agentId: 'claude',
+          agentSessionId: 'session-1',
+          projectPath: previousProjectPath,
+          model: 'sonnet',
+          nativeSession: {
+            ownerId: 'claude',
+            schemaVersion: 1,
+            value: {
+              path: sourcePath,
+              agentSessionId: 'session-1',
+              modelEndpointId: 'endpoint-1',
+            },
+          },
+          carryOverRevision: 'carry-1',
+          settings: {
+            ownerId: 'claude',
+            schemaVersion: 1,
+            values: { claudeThinkingMode: 'auto' },
+          },
+        },
+        nextProjectPath,
+        signal: new AbortController().signal,
+      });
+
+      expect(claude.prepareClaudeProjectPathUpdate).toHaveBeenCalledWith({
+        chatId: 'chat-1',
+        agentSessionId: 'session-1',
+        previousProjectPath,
+        nextProjectPath,
+        nativePath: sourcePath,
+      });
+      expect(preparation.nativeSession).toMatchObject({
+        ownerId: 'claude',
+        value: {
+          agentSessionId: 'session-1',
+          modelEndpointId: 'endpoint-1',
+        },
+      });
+      expect(preparation.nativeSession.value.path).not.toBe(sourcePath);
+      expect(await fs.readFile(preparation.nativeSession.value.path, 'utf8')).toBe(
+        'transcript\n',
+      );
+
+      await preparation.rollback();
+      expect(await fs.readFile(sourcePath, 'utf8')).toBe('transcript\n');
+    } finally {
+      await fs.rm(rootDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not require a native transcript for an unstarted chat', async () => {
+    const claude = createClaudeStub(new Error('unused'));
+    const execution = createExecution(claude, '/tmp/config');
+
+    await expect(execution.prepareProjectPathUpdate({
+      chat: {
+        chatId: 'chat-1',
+        agentId: 'claude',
+        agentSessionId: null,
+        projectPath: '/old',
+        model: 'sonnet',
+        nativeSession: null,
+        carryOverRevision: 'carry-1',
+        settings: {
+          ownerId: 'claude',
+          schemaVersion: 1,
+          values: { claudeThinkingMode: 'auto' },
+        },
+      },
+      nextProjectPath: '/next',
+      signal: new AbortController().signal,
+    })).resolves.toBeUndefined();
+
+    expect(claude.prepareClaudeProjectPathUpdate).not.toHaveBeenCalled();
   });
 });

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -29,9 +29,17 @@ function deferred() {
   return { promise, resolve };
 }
 
-function createFakeClaudeProcess() {
+function createFakeClaudeProcess(options = {}) {
   let stdoutController;
+  let stdoutClosed = false;
   const exited = deferred();
+  const finish = (exitCode) => {
+    if (!stdoutClosed) {
+      stdoutClosed = true;
+      stdoutController.close();
+    }
+    exited.resolve(exitCode);
+  };
   const proc = {
     killed: false,
     stdin: {
@@ -49,10 +57,15 @@ function createFakeClaudeProcess() {
       },
     }),
     exited: exited.promise,
-    kill: mock(() => {
+    kill: mock((signal) => {
       proc.killed = true;
-      stdoutController.close();
-      exited.resolve(143);
+      if (options.onKill) {
+        const exitCode = options.onKill(signal);
+        if (exitCode === null) return;
+        finish(exitCode);
+        return;
+      }
+      finish(143);
     }),
   };
 
@@ -60,8 +73,7 @@ function createFakeClaudeProcess() {
     proc,
     stdout: stdoutController,
     exit(exitCode) {
-      stdoutController.close();
-      exited.resolve(exitCode);
+      finish(exitCode);
     },
   };
 }
@@ -300,6 +312,117 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       enqueueResult(fake);
       await expect(resumed).resolves.toBeUndefined();
     } finally {
+      runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('waits for the idle Claude process to exit before preparing a path update', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    let runtime;
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      runtime = createRuntime();
+      const start = runtime.startClaudeCliSession(startOptions());
+      enqueueResult(fake);
+      await start;
+
+      await expect(runtime.prepareClaudeProjectPathUpdate({
+        chatId: 'chat-1',
+        agentSessionId: 'expected-session',
+        previousProjectPath: '/tmp',
+        nextProjectPath: '/next',
+        nativePath: '/config/projects/tmp/expected-session.jsonl',
+      })).resolves.toBeUndefined();
+
+      expect(fake.proc.kill).toHaveBeenCalledTimes(1);
+    } finally {
+      runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('force-kills an idle process that ignores graceful termination', async () => {
+    const originalSpawn = Bun.spawn;
+    const originalSetTimeout = globalThis.setTimeout;
+    const fake = createFakeClaudeProcess({
+      onKill: (signal) => signal === 'SIGKILL' ? 137 : null,
+    });
+    let runtime;
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      runtime = createRuntime();
+      const start = runtime.startClaudeCliSession(startOptions());
+      enqueueResult(fake);
+      await start;
+      globalThis.setTimeout = mock((callback) => {
+        queueMicrotask(callback);
+        return 1;
+      });
+
+      await expect(runtime.prepareClaudeProjectPathUpdate({
+        chatId: 'chat-1',
+        agentSessionId: 'expected-session',
+        previousProjectPath: '/tmp',
+        nextProjectPath: '/next',
+        nativePath: '/config/projects/tmp/expected-session.jsonl',
+      })).resolves.toBeUndefined();
+
+      expect(fake.proc.kill.mock.calls).toEqual([
+        [],
+        ['SIGKILL'],
+      ]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('retains a stuck process so retries cannot bypass the exit guard', async () => {
+    const originalSpawn = Bun.spawn;
+    const originalSetTimeout = globalThis.setTimeout;
+    const fake = createFakeClaudeProcess({
+      onKill: () => null,
+    });
+    let runtime;
+    Bun.spawn = mock(() => fake.proc);
+    const request = {
+      chatId: 'chat-1',
+      agentSessionId: 'expected-session',
+      previousProjectPath: '/tmp',
+      nextProjectPath: '/next',
+      nativePath: '/config/projects/tmp/expected-session.jsonl',
+    };
+
+    try {
+      runtime = createRuntime();
+      const start = runtime.startClaudeCliSession(startOptions());
+      enqueueResult(fake);
+      await start;
+      globalThis.setTimeout = mock((callback) => {
+        queueMicrotask(callback);
+        return 1;
+      });
+
+      await expect(
+        runtime.prepareClaudeProjectPathUpdate(request),
+      ).rejects.toThrow('Claude process did not exit');
+      await expect(
+        runtime.prepareClaudeProjectPathUpdate(request),
+      ).rejects.toThrow('Claude process did not exit');
+
+      expect(fake.proc.kill.mock.calls).toEqual([
+        [],
+        ['SIGKILL'],
+        ['SIGKILL'],
+      ]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      fake.exit(137);
       runtime?.shutdown();
       Bun.spawn = originalSpawn;
     }

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -382,6 +382,96 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
     }
   });
 
+  it('waits for a process detached by a thinking-mode change', async () => {
+    const originalSpawn = Bun.spawn;
+    const originalSetTimeout = globalThis.setTimeout;
+    const fake = createFakeClaudeProcess({
+      onKill: (signal) => signal === 'SIGKILL' ? 137 : null,
+    });
+    let runtime;
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      runtime = createRuntime();
+      const start = runtime.startClaudeCliSession(startOptions());
+      enqueueResult(fake);
+      await start;
+      runtime.setInternalThinkingMode('expected-session', 'high');
+      globalThis.setTimeout = mock((callback) => {
+        queueMicrotask(callback);
+        return 1;
+      });
+
+      await expect(runtime.prepareClaudeProjectPathUpdate({
+        chatId: 'chat-1',
+        agentSessionId: 'expected-session',
+        previousProjectPath: '/tmp',
+        nextProjectPath: '/next',
+        nativePath: '/config/projects/tmp/expected-session.jsonl',
+      })).resolves.toBeUndefined();
+
+      expect(fake.proc.kill.mock.calls).toEqual([
+        [],
+        ['SIGKILL'],
+      ]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('waits for a process detached by idle-session eviction', async () => {
+    const originalSpawn = Bun.spawn;
+    const originalSetInterval = globalThis.setInterval;
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalDateNow = Date.now;
+    const fake = createFakeClaudeProcess({
+      onKill: (signal) => signal === 'SIGKILL' ? 137 : null,
+    });
+    let purgeIdleSessions;
+    let runtime;
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      globalThis.setInterval = mock((callback) => {
+        purgeIdleSessions = callback;
+        return 1;
+      });
+      runtime = createRuntime();
+      const start = runtime.startClaudeCliSession(startOptions());
+      enqueueResult(fake);
+      await start;
+      const idleSince = Date.now();
+      Date.now = mock(() => idleSince + 31 * 60 * 1000);
+      runtime.startPurgeTimer();
+      purgeIdleSessions();
+      globalThis.setTimeout = mock((callback) => {
+        queueMicrotask(callback);
+        return 1;
+      });
+
+      await expect(runtime.prepareClaudeProjectPathUpdate({
+        chatId: 'chat-1',
+        agentSessionId: 'expected-session',
+        previousProjectPath: '/tmp',
+        nextProjectPath: '/next',
+        nativePath: '/config/projects/tmp/expected-session.jsonl',
+      })).resolves.toBeUndefined();
+
+      expect(fake.proc.kill.mock.calls).toEqual([
+        [],
+        ['SIGKILL'],
+      ]);
+    } finally {
+      Date.now = originalDateNow;
+      globalThis.setInterval = originalSetInterval;
+      globalThis.setTimeout = originalSetTimeout;
+      runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
   it('retains a stuck process so retries cannot bypass the exit guard', async () => {
     const originalSpawn = Bun.spawn;
     const originalSetTimeout = globalThis.setTimeout;

--- a/server-agents/claude/src/agents/claude/__tests__/native-path.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/native-path.test.js
@@ -414,4 +414,31 @@ describe('prepareClaudeNativeSessionRelocation', () => {
       configHomeDir: path.join(rootDirectory, 'config'),
     })).rejects.toMatchObject({ code: 'TRANSCRIPT_UNAVAILABLE' });
   });
+
+  it('rejects session IDs that could escape recursive artifact cleanup', async () => {
+    const rootDirectory = await temporaryDirectory();
+    const configHomeDir = path.join(rootDirectory, 'config');
+    const projectPath = path.join(rootDirectory, 'project');
+    const projectDirectory = path.join(configHomeDir, 'projects', 'source');
+    const siblingDirectory = path.join(configHomeDir, 'projects', 'sibling');
+    const unsafePath = path.join(projectDirectory, '...jsonl');
+    await fs.mkdir(projectPath, { recursive: true });
+    await fs.mkdir(projectDirectory, { recursive: true });
+    await fs.mkdir(siblingDirectory, { recursive: true });
+    await fs.writeFile(unsafePath, 'unsafe\n');
+    await fs.writeFile(path.join(siblingDirectory, 'retained.txt'), 'retained\n');
+
+    await expect(prepareClaudeNativeSessionRelocation({
+      previousProjectPath: projectPath,
+      nextProjectPath: projectPath,
+      agentSessionId: '..',
+      nativePath: unsafePath,
+      configHomeDir,
+    })).rejects.toMatchObject({ code: 'TRANSCRIPT_UNAVAILABLE' });
+
+    expect(await pathExists(unsafePath)).toBe(true);
+    expect(await pathExists(path.join(siblingDirectory, 'retained.txt'))).toBe(
+      true,
+    );
+  });
 });

--- a/server-agents/claude/src/agents/claude/__tests__/native-path.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/native-path.test.js
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import {
   createClaudeNativePath,
+  prepareClaudeNativeSessionRelocation,
   resolveClaudeNativePath,
   sanitizeClaudeProjectPath,
 } from '../native-path.js';
@@ -45,11 +46,11 @@ describe('sanitizeClaudeProjectPath', () => {
   });
 
   it('uses Claude Code long-path truncation and hashing', () => {
-    const projectPath = `/${'a'.repeat(220)}`;
+    const projectPath = `/tmp/claude-long-hash-vector/${'a'.repeat(90)}/${'b'.repeat(90)}`;
     const sanitized = sanitizeClaudeProjectPath(projectPath);
 
     expect(sanitized).toBe(
-      `${projectPath.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200)}-${Bun.hash(projectPath).toString(36)}`,
+      `${projectPath.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200)}-m0kdax`,
     );
   });
 });
@@ -207,5 +208,210 @@ describe('resolveClaudeNativePath', () => {
       'Claude transcript search found multiple files and refused to choose',
       expect.objectContaining({ agentSessionId: 'session-1' }),
     );
+  });
+});
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function relocationFixture(options = {}) {
+  const rootDirectory = await temporaryDirectory();
+  const sourceConfigHome = path.join(rootDirectory, 'source-config');
+  const targetConfigHome = options.targetConfigHome
+    ?? sourceConfigHome;
+  const previousProjectPath = path.join(rootDirectory, 'project-a');
+  const nextProjectPath = path.join(rootDirectory, 'project-b');
+  await fs.mkdir(previousProjectPath, { recursive: true });
+  await fs.mkdir(nextProjectPath, { recursive: true });
+  const sourcePath = await createClaudeNativePath(
+    previousProjectPath,
+    'session-1',
+    { configHomeDir: sourceConfigHome },
+  );
+  await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+  await fs.writeFile(sourcePath, 'source transcript\n');
+  const sourceQueuePath = path.join(
+    path.dirname(sourcePath),
+    'session-1.queue.json',
+  );
+  const sourceSupportPath = path.join(
+    path.dirname(sourcePath),
+    'session-1',
+  );
+  await fs.writeFile(sourceQueuePath, '{"entries":[]}\n');
+  await fs.mkdir(path.join(sourceSupportPath, 'subagents'), { recursive: true });
+  await fs.writeFile(
+    path.join(sourceSupportPath, 'subagents', 'agent-1.jsonl'),
+    'subagent transcript\n',
+  );
+
+  return {
+    logger: createLogger(),
+    nextProjectPath,
+    previousProjectPath,
+    sourceConfigHome,
+    sourcePath,
+    sourceQueuePath,
+    sourceSupportPath,
+    targetConfigHome,
+  };
+}
+
+describe('prepareClaudeNativeSessionRelocation', () => {
+  it('copies all session artifacts before removing the source on commit', async () => {
+    const fixture = await relocationFixture();
+
+    const relocation = await prepareClaudeNativeSessionRelocation({
+      previousProjectPath: fixture.previousProjectPath,
+      nextProjectPath: fixture.nextProjectPath,
+      agentSessionId: 'session-1',
+      nativePath: fixture.sourcePath,
+      configHomeDir: fixture.targetConfigHome,
+      logger: fixture.logger,
+    });
+    const targetQueuePath = path.join(
+      path.dirname(relocation.nativePath),
+      'session-1.queue.json',
+    );
+    const targetSupportPath = path.join(
+      path.dirname(relocation.nativePath),
+      'session-1',
+    );
+
+    expect(await fs.readFile(relocation.nativePath, 'utf8')).toBe(
+      'source transcript\n',
+    );
+    expect(await fs.readFile(targetQueuePath, 'utf8')).toBe(
+      '{"entries":[]}\n',
+    );
+    expect(await fs.readFile(
+      path.join(targetSupportPath, 'subagents', 'agent-1.jsonl'),
+      'utf8',
+    )).toBe('subagent transcript\n');
+    expect(await pathExists(fixture.sourcePath)).toBe(true);
+
+    await relocation.commit();
+
+    expect(await pathExists(fixture.sourcePath)).toBe(false);
+    expect(await pathExists(fixture.sourceQueuePath)).toBe(false);
+    expect(await pathExists(fixture.sourceSupportPath)).toBe(false);
+    expect(await pathExists(relocation.nativePath)).toBe(true);
+  });
+
+  it('removes prepared destination artifacts on rollback', async () => {
+    const fixture = await relocationFixture();
+    const relocation = await prepareClaudeNativeSessionRelocation({
+      previousProjectPath: fixture.previousProjectPath,
+      nextProjectPath: fixture.nextProjectPath,
+      agentSessionId: 'session-1',
+      nativePath: fixture.sourcePath,
+      configHomeDir: fixture.targetConfigHome,
+      logger: fixture.logger,
+    });
+
+    await relocation.rollback();
+
+    expect(await pathExists(relocation.nativePath)).toBe(false);
+    expect(await pathExists(fixture.sourcePath)).toBe(true);
+    expect(await pathExists(fixture.sourceQueuePath)).toBe(true);
+    expect(await pathExists(fixture.sourceSupportPath)).toBe(true);
+  });
+
+  it('uses the current config home for the destination', async () => {
+    const rootDirectory = await temporaryDirectory();
+    const targetConfigHome = path.join(rootDirectory, 'current-config');
+    const fixture = await relocationFixture({ targetConfigHome });
+
+    const relocation = await prepareClaudeNativeSessionRelocation({
+      previousProjectPath: fixture.previousProjectPath,
+      nextProjectPath: fixture.nextProjectPath,
+      agentSessionId: 'session-1',
+      nativePath: fixture.sourcePath,
+      configHomeDir: targetConfigHome,
+      logger: fixture.logger,
+    });
+
+    expect(relocation.nativePath.startsWith(
+      path.join(targetConfigHome, 'projects'),
+    )).toBe(true);
+    await relocation.rollback();
+  });
+
+  it('replaces stale destination artifacts without merging them', async () => {
+    const fixture = await relocationFixture();
+    const targetPath = await createClaudeNativePath(
+      fixture.nextProjectPath,
+      'session-1',
+      { configHomeDir: fixture.targetConfigHome },
+    );
+    const targetSupportPath = path.join(path.dirname(targetPath), 'session-1');
+    await fs.mkdir(targetSupportPath, { recursive: true });
+    await fs.writeFile(targetPath, 'stale transcript\n');
+    await fs.writeFile(path.join(targetSupportPath, 'stale.txt'), 'stale\n');
+
+    const relocation = await prepareClaudeNativeSessionRelocation({
+      previousProjectPath: fixture.previousProjectPath,
+      nextProjectPath: fixture.nextProjectPath,
+      agentSessionId: 'session-1',
+      nativePath: fixture.sourcePath,
+      configHomeDir: fixture.targetConfigHome,
+      logger: fixture.logger,
+    });
+
+    expect(await fs.readFile(relocation.nativePath, 'utf8')).toBe(
+      'source transcript\n',
+    );
+    expect(await pathExists(path.join(targetSupportPath, 'stale.txt'))).toBe(
+      false,
+    );
+    await relocation.rollback();
+  });
+
+  it('returns a no-op relocation for the same canonical project', async () => {
+    const fixture = await relocationFixture();
+
+    const relocation = await prepareClaudeNativeSessionRelocation({
+      previousProjectPath: fixture.previousProjectPath,
+      nextProjectPath: fixture.previousProjectPath,
+      agentSessionId: 'session-1',
+      nativePath: fixture.sourcePath,
+      configHomeDir: fixture.targetConfigHome,
+      logger: fixture.logger,
+    });
+
+    await relocation.commit();
+    await relocation.rollback();
+    expect(relocation.nativePath).toBe(fixture.sourcePath);
+    expect(await pathExists(fixture.sourcePath)).toBe(true);
+  });
+
+  it('rejects missing and structurally unsafe source transcripts', async () => {
+    const rootDirectory = await temporaryDirectory();
+    const projectPath = path.join(rootDirectory, 'project');
+    await fs.mkdir(projectPath, { recursive: true });
+
+    await expect(prepareClaudeNativeSessionRelocation({
+      previousProjectPath: projectPath,
+      nextProjectPath: projectPath,
+      agentSessionId: 'missing-session',
+      nativePath: null,
+      configHomeDir: path.join(rootDirectory, 'config'),
+    })).rejects.toMatchObject({ code: 'TRANSCRIPT_UNAVAILABLE' });
+
+    const unsafePath = path.join(rootDirectory, 'unsafe-session.jsonl');
+    await fs.writeFile(unsafePath, 'unsafe\n');
+    await expect(prepareClaudeNativeSessionRelocation({
+      previousProjectPath: projectPath,
+      nextProjectPath: projectPath,
+      agentSessionId: 'unsafe-session',
+      nativePath: unsafePath,
+      configHomeDir: path.join(rootDirectory, 'config'),
+    })).rejects.toMatchObject({ code: 'TRANSCRIPT_UNAVAILABLE' });
   });
 });

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -42,6 +42,9 @@ const NOOP_LOGGER: AgentLogger = {
   error() {},
 };
 
+const CLAUDE_PROCESS_EXIT_GRACE_MS = 5_000;
+const CLAUDE_PROCESS_EXIT_FORCE_MS = 5_000;
+
 interface CompactMetadata {
   trigger?: string;
   pre_tokens?: number;
@@ -148,6 +151,26 @@ interface ClaudeRunningSession {
   // that follows it so both can be emitted as a single CompactionMessage.
   pendingCompaction?: { trigger: CompactionTrigger; preTokens?: number; postTokens?: number };
   eventMetadata: ReturnType<typeof claudeEventMetadata>;
+}
+
+async function waitForClaudeProcessExit(
+  subprocess: ReturnType<typeof Bun.spawn>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      subprocess.exited.then(
+        () => true,
+        () => false,
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 function mergeClaudeSessionOptions(
@@ -828,9 +851,24 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       }
     }
 
-    session.options = { ...session.options, projectPath: request.nextProjectPath };
-    if (session.process) {
-      this.#killSessionProcess(session);
+    const subprocess = session.process;
+    if (!subprocess) return;
+
+    this.#clearAbortTimer(session);
+    if (!subprocess.killed) subprocess.kill();
+    if (await waitForClaudeProcessExit(
+      subprocess,
+      CLAUDE_PROCESS_EXIT_GRACE_MS,
+    )) {
+      return;
+    }
+
+    subprocess.kill('SIGKILL');
+    if (!await waitForClaudeProcessExit(
+      subprocess,
+      CLAUDE_PROCESS_EXIT_FORCE_MS,
+    )) {
+      throw new Error('Claude process did not exit for project-path update');
     }
   }
 

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -34,6 +34,7 @@ import { IdleSessionPurger } from '@garcon/server-agent-common/shared/idle-sessi
 import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 import { runClaudeSingleQueryProcess } from './single-query-process.js';
 import { pipeClaudeProcessOutput } from './cli-stdio.js';
+import { ClaudeProjectPathProcessTracker } from './project-path-processes.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -41,9 +42,6 @@ const NOOP_LOGGER: AgentLogger = {
   warn() {},
   error() {},
 };
-
-const CLAUDE_PROCESS_EXIT_GRACE_MS = 5_000;
-const CLAUDE_PROCESS_EXIT_FORCE_MS = 5_000;
 
 interface CompactMetadata {
   trigger?: string;
@@ -151,26 +149,6 @@ interface ClaudeRunningSession {
   // that follows it so both can be emitted as a single CompactionMessage.
   pendingCompaction?: { trigger: CompactionTrigger; preTokens?: number; postTokens?: number };
   eventMetadata: ReturnType<typeof claudeEventMetadata>;
-}
-
-async function waitForClaudeProcessExit(
-  subprocess: ReturnType<typeof Bun.spawn>,
-  timeoutMs: number,
-): Promise<boolean> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      subprocess.exited.then(
-        () => true,
-        () => false,
-      ),
-      new Promise<boolean>((resolve) => {
-        timeout = setTimeout(() => resolve(false), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
 }
 
 function mergeClaudeSessionOptions(
@@ -480,10 +458,7 @@ function buildClaudeCLIArgs({
 
 class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   #runningSessions = new Map<string, ClaudeRunningSession>();
-  #exitingProcesses = new Map<string, {
-    chatId: string;
-    processes: Set<ReturnType<typeof Bun.spawn>>;
-  }>();
+  #projectPathProcesses = new ClaudeProjectPathProcessTracker();
   #pendingPermissions = new Map<string, PendingPermission>();
   #pendingControlRequests = new Map<string, PendingControlRequest>();
   #idlePurger: IdleSessionPurger<ClaudeRunningSession>;
@@ -774,30 +749,9 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     const proc = session.process;
     if (!proc) return;
     session.process = null;
-    let exiting = this.#exitingProcesses.get(session.id);
-    if (!exiting) {
-      exiting = { chatId: session.chatId, processes: new Set() };
-      this.#exitingProcesses.set(session.id, exiting);
-    }
-    exiting.processes.add(proc);
-    void proc.exited.then(
-      () => this.#forgetExitingProcess(session.id, proc),
-      () => this.#forgetExitingProcess(session.id, proc),
-    );
+    this.#projectPathProcesses.trackDetached(session.id, session.chatId, proc);
     if (!proc.killed) {
       proc.kill();
-    }
-  }
-
-  #forgetExitingProcess(
-    agentSessionId: string,
-    proc: ReturnType<typeof Bun.spawn>,
-  ): void {
-    const exiting = this.#exitingProcesses.get(agentSessionId);
-    if (!exiting) return;
-    exiting.processes.delete(proc);
-    if (exiting.processes.size === 0) {
-      this.#exitingProcesses.delete(agentSessionId);
     }
   }
 
@@ -864,12 +818,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     if (!agentSessionId) return;
 
     const session = this.#runningSessions.get(agentSessionId);
-    const exiting = this.#exitingProcesses.get(agentSessionId);
-    if (!session && !exiting) return;
     if (session && session.chatId !== request.chatId) {
-      throw new Error('Chat ID mismatch');
-    }
-    if (exiting && exiting.chatId !== request.chatId) {
       throw new Error('Chat ID mismatch');
     }
     if (session?.isRunning) {
@@ -881,25 +830,12 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       }
     }
 
-    const subprocesses = [...(exiting?.processes ?? [])];
-    if (session?.process) subprocesses.push(session.process);
-    if (subprocesses.length === 0) return;
-
     if (session) this.#clearAbortTimer(session);
-    for (const subprocess of subprocesses) {
-      if (!subprocess.killed) subprocess.kill();
-    }
-    const gracefulExits = await Promise.all(subprocesses.map((subprocess) =>
-      waitForClaudeProcessExit(subprocess, CLAUDE_PROCESS_EXIT_GRACE_MS)
-    ));
-    const remaining = subprocesses.filter((_, index) => !gracefulExits[index]);
-    for (const subprocess of remaining) subprocess.kill('SIGKILL');
-    const forcedExits = await Promise.all(remaining.map((subprocess) =>
-      waitForClaudeProcessExit(subprocess, CLAUDE_PROCESS_EXIT_FORCE_MS)
-    ));
-    if (forcedExits.some((exited) => !exited)) {
-      throw new Error('Claude process did not exit for project-path update');
-    }
+    await this.#projectPathProcesses.stopForUpdate({
+      agentSessionId,
+      chatId: request.chatId,
+      activeProcess: session?.process ?? null,
+    });
   }
 
   setInternalPermissionMode(agentSessionId: string, mode: PermissionMode): void {

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -480,6 +480,10 @@ function buildClaudeCLIArgs({
 
 class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   #runningSessions = new Map<string, ClaudeRunningSession>();
+  #exitingProcesses = new Map<string, {
+    chatId: string;
+    processes: Set<ReturnType<typeof Bun.spawn>>;
+  }>();
   #pendingPermissions = new Map<string, PendingPermission>();
   #pendingControlRequests = new Map<string, PendingControlRequest>();
   #idlePurger: IdleSessionPurger<ClaudeRunningSession>;
@@ -770,8 +774,30 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     const proc = session.process;
     if (!proc) return;
     session.process = null;
+    let exiting = this.#exitingProcesses.get(session.id);
+    if (!exiting) {
+      exiting = { chatId: session.chatId, processes: new Set() };
+      this.#exitingProcesses.set(session.id, exiting);
+    }
+    exiting.processes.add(proc);
+    void proc.exited.then(
+      () => this.#forgetExitingProcess(session.id, proc),
+      () => this.#forgetExitingProcess(session.id, proc),
+    );
     if (!proc.killed) {
       proc.kill();
+    }
+  }
+
+  #forgetExitingProcess(
+    agentSessionId: string,
+    proc: ReturnType<typeof Bun.spawn>,
+  ): void {
+    const exiting = this.#exitingProcesses.get(agentSessionId);
+    if (!exiting) return;
+    exiting.processes.delete(proc);
+    if (exiting.processes.size === 0) {
+      this.#exitingProcesses.delete(agentSessionId);
     }
   }
 
@@ -838,11 +864,15 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     if (!agentSessionId) return;
 
     const session = this.#runningSessions.get(agentSessionId);
-    if (!session) return;
-    if (session.chatId !== request.chatId) {
+    const exiting = this.#exitingProcesses.get(agentSessionId);
+    if (!session && !exiting) return;
+    if (session && session.chatId !== request.chatId) {
       throw new Error('Chat ID mismatch');
     }
-    if (session.isRunning) {
+    if (exiting && exiting.chatId !== request.chatId) {
+      throw new Error('Chat ID mismatch');
+    }
+    if (session?.isRunning) {
       throw new Error('Cannot update project path while Claude is running');
     }
     for (const pending of this.#pendingPermissions.values()) {
@@ -851,23 +881,23 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       }
     }
 
-    const subprocess = session.process;
-    if (!subprocess) return;
+    const subprocesses = [...(exiting?.processes ?? [])];
+    if (session?.process) subprocesses.push(session.process);
+    if (subprocesses.length === 0) return;
 
-    this.#clearAbortTimer(session);
-    if (!subprocess.killed) subprocess.kill();
-    if (await waitForClaudeProcessExit(
-      subprocess,
-      CLAUDE_PROCESS_EXIT_GRACE_MS,
-    )) {
-      return;
+    if (session) this.#clearAbortTimer(session);
+    for (const subprocess of subprocesses) {
+      if (!subprocess.killed) subprocess.kill();
     }
-
-    subprocess.kill('SIGKILL');
-    if (!await waitForClaudeProcessExit(
-      subprocess,
-      CLAUDE_PROCESS_EXIT_FORCE_MS,
-    )) {
+    const gracefulExits = await Promise.all(subprocesses.map((subprocess) =>
+      waitForClaudeProcessExit(subprocess, CLAUDE_PROCESS_EXIT_GRACE_MS)
+    ));
+    const remaining = subprocesses.filter((_, index) => !gracefulExits[index]);
+    for (const subprocess of remaining) subprocess.kill('SIGKILL');
+    const forcedExits = await Promise.all(remaining.map((subprocess) =>
+      waitForClaudeProcessExit(subprocess, CLAUDE_PROCESS_EXIT_FORCE_MS)
+    ));
+    if (forcedExits.some((exited) => !exited)) {
       throw new Error('Claude process did not exit for project-path update');
     }
   }

--- a/server-agents/claude/src/agents/claude/execution.ts
+++ b/server-agents/claude/src/agents/claude/execution.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
   type AgentHost,
   type AgentLogger,
+  type AgentProjectPathUpdatePreparation,
 } from '@garcon/server-agent-interface';
 import { AgentExecutionEventChannel } from '@garcon/server-agent-common/execution/event-channel';
 import { AgentOperationTracker } from '@garcon/server-agent-common/execution/operation-tracker';
@@ -16,7 +17,10 @@ import {
   buildClaudeEndpointRuntime,
   buildClaudeHostEnvironment,
 } from './endpoint-runtime.js';
-import { createClaudeNativePath } from './native-path.js';
+import {
+  createClaudeNativePath,
+  prepareClaudeNativeSessionRelocation,
+} from './native-path.js';
 import { claudeEventMetadata } from './runtime-types.js';
 import type { ClaudeCliRuntime } from './claude-cli.js';
 import type { ClaudeConfig } from '../../config.js';
@@ -167,16 +171,39 @@ export class ClaudeExecution implements AgentExecution {
 
   async prepareProjectPathUpdate(
     request: Parameters<NonNullable<AgentExecution['prepareProjectPathUpdate']>>[0],
-  ): Promise<void> {
+  ): Promise<AgentProjectPathUpdatePreparation | void> {
     request.signal.throwIfAborted();
+    const agentSessionId = request.chat.agentSessionId;
+    if (!agentSessionId) return;
+
     const native = this.nativeSessions.decode(request.chat.nativeSession);
     await this.runtime.prepareClaudeProjectPathUpdate({
       chatId: request.chat.chatId,
-      agentSessionId: request.chat.agentSessionId,
+      agentSessionId,
       previousProjectPath: request.chat.projectPath,
       nextProjectPath: request.nextProjectPath,
       nativePath: native.path,
     });
+    request.signal.throwIfAborted();
+
+    const relocation = await prepareClaudeNativeSessionRelocation({
+      previousProjectPath: request.chat.projectPath,
+      nextProjectPath: request.nextProjectPath,
+      agentSessionId,
+      nativePath: native.path,
+      configHomeDir: this.config.configHomeDir() ?? undefined,
+      logger: this.logger,
+    });
+
+    return {
+      nativeSession: this.nativeSessions.encode({
+        path: relocation.nativePath,
+        agentSessionId,
+        modelEndpointId: native.modelEndpointId,
+      }),
+      commit: relocation.commit,
+      rollback: relocation.rollback,
+    };
   }
 
   subscribe(listener: Parameters<AgentExecution['subscribe']>[0]): () => void {

--- a/server-agents/claude/src/agents/claude/native-path.ts
+++ b/server-agents/claude/src/agents/claude/native-path.ts
@@ -1,7 +1,10 @@
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import type { AgentLogger } from '@garcon/server-agent-interface';
+import {
+  AgentIntegrationError,
+  type AgentLogger,
+} from '@garcon/server-agent-interface';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -21,6 +24,12 @@ export interface ClaudeNativePathSession {
   projectPath: string;
   agentSessionId?: string | null;
   nativePath?: string | null;
+}
+
+export interface ClaudeNativeSessionRelocation {
+  readonly nativePath: string;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
 }
 
 function simpleHash(value: string): string {
@@ -75,10 +84,7 @@ async function isFile(filePath: string): Promise<boolean> {
 export function sanitizeClaudeProjectPath(projectPath: string): string {
   const sanitized = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
   if (sanitized.length <= MAX_SANITIZED_LENGTH) return sanitized;
-  const hash = typeof Bun !== 'undefined'
-    ? Bun.hash(projectPath).toString(36)
-    : simpleHash(projectPath);
-  return `${sanitized.slice(0, MAX_SANITIZED_LENGTH)}-${hash}`;
+  return `${sanitized.slice(0, MAX_SANITIZED_LENGTH)}-${simpleHash(projectPath)}`;
 }
 
 export async function createClaudeNativePath(
@@ -185,4 +191,155 @@ export async function resolveClaudeNativePath(
     });
   }
   return null;
+}
+
+interface ClaudeSessionArtifacts {
+  readonly transcriptPath: string;
+  readonly queuePath: string;
+  readonly supportPath: string;
+}
+
+function sessionArtifacts(
+  transcriptPath: string,
+  agentSessionId: string,
+): ClaudeSessionArtifacts {
+  const projectDirectory = path.dirname(transcriptPath);
+  return {
+    transcriptPath,
+    queuePath: path.join(projectDirectory, `${agentSessionId}.queue.json`),
+    supportPath: path.join(projectDirectory, agentSessionId),
+  };
+}
+
+async function isDirectory(directoryPath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(directoryPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function removeClaudeSessionArtifacts(
+  artifacts: ClaudeSessionArtifacts,
+): Promise<void> {
+  await Promise.all([
+    fs.rm(artifacts.transcriptPath, { force: true }),
+    fs.rm(artifacts.queuePath, { force: true }),
+    fs.rm(artifacts.supportPath, { recursive: true, force: true }),
+  ]);
+}
+
+function relocationError(
+  logger: AgentLogger,
+  operation: string,
+  error: unknown,
+): AgentIntegrationError {
+  logger.error('Claude session artifact relocation failed', {
+    operation,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  return new AgentIntegrationError(
+    'TRANSCRIPT_UNAVAILABLE',
+    'Claude session transcript could not be preserved for project-path update',
+    false,
+  );
+}
+
+export async function prepareClaudeNativeSessionRelocation(input: {
+  readonly previousProjectPath: string;
+  readonly nextProjectPath: string;
+  readonly agentSessionId: string;
+  readonly nativePath: string | null;
+  readonly configHomeDir?: string;
+  readonly logger?: AgentLogger;
+}): Promise<ClaudeNativeSessionRelocation> {
+  const logger = input.logger ?? NOOP_LOGGER;
+  const sourcePath = await resolveClaudeNativePath({
+    projectPath: input.previousProjectPath,
+    agentSessionId: input.agentSessionId,
+    nativePath: input.nativePath,
+  }, {
+    configHomeDir: input.configHomeDir,
+    logger,
+  });
+  if (!sourcePath) {
+    throw new AgentIntegrationError(
+      'TRANSCRIPT_UNAVAILABLE',
+      'Claude session transcript could not be resolved for project-path update',
+      false,
+    );
+  }
+  if (!configHomeDirFromNativePath(sourcePath, input.agentSessionId)) {
+    throw new AgentIntegrationError(
+      'TRANSCRIPT_UNAVAILABLE',
+      'Claude session transcript is outside the expected project-state directory',
+      false,
+    );
+  }
+
+  const targetPath = await createClaudeNativePath(
+    input.nextProjectPath,
+    input.agentSessionId,
+    { configHomeDir: input.configHomeDir, logger },
+  );
+  if (!targetPath) {
+    throw new AgentIntegrationError(
+      'TRANSCRIPT_UNAVAILABLE',
+      'Claude session destination could not be resolved',
+      false,
+    );
+  }
+  if (sourcePath === targetPath) {
+    return {
+      nativePath: targetPath,
+      async commit() {},
+      async rollback() {},
+    };
+  }
+
+  const source = sessionArtifacts(sourcePath, input.agentSessionId);
+  const target = sessionArtifacts(targetPath, input.agentSessionId);
+  try {
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await removeClaudeSessionArtifacts(target);
+    await fs.copyFile(source.transcriptPath, target.transcriptPath);
+    if (await isFile(source.queuePath)) {
+      await fs.copyFile(source.queuePath, target.queuePath);
+    }
+    if (await isDirectory(source.supportPath)) {
+      await fs.cp(source.supportPath, target.supportPath, {
+        recursive: true,
+        force: true,
+        preserveTimestamps: true,
+      });
+    }
+  } catch (error) {
+    await removeClaudeSessionArtifacts(target).catch((cleanupError) => {
+      logger.warn('Claude session relocation rollback failed', {
+        operation: 'prepare',
+        error: cleanupError instanceof Error
+          ? cleanupError.message
+          : String(cleanupError),
+      });
+    });
+    throw relocationError(logger, 'prepare', error);
+  }
+
+  return {
+    nativePath: targetPath,
+    async commit() {
+      try {
+        await removeClaudeSessionArtifacts(source);
+      } catch (error) {
+        throw relocationError(logger, 'commit', error);
+      }
+    },
+    async rollback() {
+      try {
+        await removeClaudeSessionArtifacts(target);
+      } catch (error) {
+        throw relocationError(logger, 'rollback', error);
+      }
+    },
+  };
 }

--- a/server-agents/claude/src/agents/claude/native-path.ts
+++ b/server-agents/claude/src/agents/claude/native-path.ts
@@ -63,6 +63,15 @@ function transcriptFileName(agentSessionId: string): string {
   return `${agentSessionId}.jsonl`;
 }
 
+function isSafeSessionPathSegment(agentSessionId: string): boolean {
+  return (
+    agentSessionId.length > 0
+    && agentSessionId !== '.'
+    && agentSessionId !== '..'
+    && path.basename(agentSessionId) === agentSessionId
+  );
+}
+
 function configHomeDirFromNativePath(
   nativePath: string,
   agentSessionId: string,
@@ -254,6 +263,13 @@ export async function prepareClaudeNativeSessionRelocation(input: {
   readonly logger?: AgentLogger;
 }): Promise<ClaudeNativeSessionRelocation> {
   const logger = input.logger ?? NOOP_LOGGER;
+  if (!isSafeSessionPathSegment(input.agentSessionId)) {
+    throw new AgentIntegrationError(
+      'TRANSCRIPT_UNAVAILABLE',
+      'Claude session transcript is outside the expected project-state directory',
+      false,
+    );
+  }
   const sourcePath = await resolveClaudeNativePath({
     projectPath: input.previousProjectPath,
     agentSessionId: input.agentSessionId,

--- a/server-agents/claude/src/agents/claude/project-path-processes.ts
+++ b/server-agents/claude/src/agents/claude/project-path-processes.ts
@@ -1,0 +1,89 @@
+const CLAUDE_PROCESS_EXIT_GRACE_MS = 5_000;
+const CLAUDE_PROCESS_EXIT_FORCE_MS = 5_000;
+
+type ClaudeSubprocess = ReturnType<typeof Bun.spawn>;
+
+interface ExitingProcessGroup {
+  readonly chatId: string;
+  readonly processes: Set<ClaudeSubprocess>;
+}
+
+async function waitForClaudeProcessExit(
+  subprocess: ClaudeSubprocess,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      subprocess.exited.then(
+        () => true,
+        () => false,
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export class ClaudeProjectPathProcessTracker {
+  readonly #exitingProcesses = new Map<string, ExitingProcessGroup>();
+
+  trackDetached(
+    agentSessionId: string,
+    chatId: string,
+    subprocess: ClaudeSubprocess,
+  ): void {
+    let exiting = this.#exitingProcesses.get(agentSessionId);
+    if (!exiting) {
+      exiting = { chatId, processes: new Set() };
+      this.#exitingProcesses.set(agentSessionId, exiting);
+    }
+    exiting.processes.add(subprocess);
+    void subprocess.exited.then(
+      () => this.#forget(agentSessionId, subprocess),
+      () => this.#forget(agentSessionId, subprocess),
+    );
+  }
+
+  async stopForUpdate(input: {
+    readonly agentSessionId: string;
+    readonly chatId: string;
+    readonly activeProcess: ClaudeSubprocess | null;
+  }): Promise<void> {
+    const exiting = this.#exitingProcesses.get(input.agentSessionId);
+    if (exiting && exiting.chatId !== input.chatId) {
+      throw new Error('Chat ID mismatch');
+    }
+
+    const subprocesses = [...(exiting?.processes ?? [])];
+    if (input.activeProcess) subprocesses.push(input.activeProcess);
+    if (subprocesses.length === 0) return;
+
+    for (const subprocess of subprocesses) {
+      if (!subprocess.killed) subprocess.kill();
+    }
+    const gracefulExits = await Promise.all(subprocesses.map((subprocess) =>
+      waitForClaudeProcessExit(subprocess, CLAUDE_PROCESS_EXIT_GRACE_MS)
+    ));
+    const remaining = subprocesses.filter((_, index) => !gracefulExits[index]);
+    for (const subprocess of remaining) subprocess.kill('SIGKILL');
+    const forcedExits = await Promise.all(remaining.map((subprocess) =>
+      waitForClaudeProcessExit(subprocess, CLAUDE_PROCESS_EXIT_FORCE_MS)
+    ));
+    if (forcedExits.some((exited) => !exited)) {
+      throw new Error('Claude process did not exit for project-path update');
+    }
+  }
+
+  #forget(agentSessionId: string, subprocess: ClaudeSubprocess): void {
+    const exiting = this.#exitingProcesses.get(agentSessionId);
+    if (!exiting) return;
+    exiting.processes.delete(subprocess);
+    if (exiting.processes.size === 0) {
+      this.#exitingProcesses.delete(agentSessionId);
+    }
+  }
+}

--- a/server-agents/interface/src/contracts/execution.ts
+++ b/server-agents/interface/src/contracts/execution.ts
@@ -22,7 +22,9 @@ export interface AgentExecution {
     permissionRequestId: string,
     decision: PermissionDecisionPayload,
   ): Promise<void>;
-  prepareProjectPathUpdate?(request: AgentProjectPathUpdateRequest): Promise<void>;
+  prepareProjectPathUpdate?(
+    request: AgentProjectPathUpdateRequest,
+  ): Promise<AgentProjectPathUpdatePreparation | void>;
   subscribe(listener: (event: AgentExecutionEvent) => void): () => void;
 }
 
@@ -71,6 +73,12 @@ export interface AgentProjectPathUpdateRequest {
   readonly chat: AgentChatReference;
   readonly nextProjectPath: string;
   readonly signal: AbortSignal;
+}
+
+export interface AgentProjectPathUpdatePreparation {
+  readonly nativeSession: AgentNativeSessionRef | null;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
 }
 
 export interface AgentOperationIdentity {

--- a/server/agents/__tests__/runtime-router-project-path.test.js
+++ b/server/agents/__tests__/runtime-router-project-path.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { AgentRuntimeRouter } from '../runtime-router.ts';
+
+const storedNativeSession = {
+  ownerId: 'claude',
+  schemaVersion: 1,
+  value: { path: '/old/session.jsonl' },
+};
+const resolvedNativeSession = {
+  ownerId: 'claude',
+  schemaVersion: 1,
+  value: { path: '/recovered/session.jsonl' },
+};
+
+function makeRouter(overrides = {}) {
+  const preparation = {
+    nativeSession: resolvedNativeSession,
+    commit: mock(() => Promise.resolve()),
+    rollback: mock(() => Promise.resolve()),
+  };
+  const prepareProjectPathUpdate = mock(() => Promise.resolve(preparation));
+  const entry = {
+    agentId: 'claude',
+    agentSessionId: 'session-1',
+    nativeSession: storedNativeSession,
+    projectPath: '/old',
+    model: 'sonnet',
+    agentSettingsById: {},
+    ...overrides.entry,
+  };
+  const integration = {
+    descriptor: { id: 'claude' },
+    settings: {
+      defaults: mock(() => ({
+        ownerId: 'claude',
+        schemaVersion: 1,
+        values: {},
+      })),
+      parse: mock((settings) => settings),
+    },
+    execution: { prepareProjectPathUpdate },
+  };
+  const router = new AgentRuntimeRouter({
+    registry: {
+      getChat: mock(() => entry),
+    },
+    directory: {
+      require: mock(() => integration),
+    },
+    endpointResolver: {},
+    events: {},
+    getCarryOverRevision: () => 'carry-1',
+    loadCarryOver: () => [],
+  });
+
+  return { entry, preparation, prepareProjectPathUpdate, router };
+}
+
+describe('AgentRuntimeRouter project-path preparation', () => {
+  it('forwards the resolved native session and preserves the preparation result', async () => {
+    const fixture = makeRouter();
+
+    const result = await fixture.router.prepareProjectPathUpdate('claude', {
+      chatId: 'chat-1',
+      agentSessionId: 'session-1',
+      previousProjectPath: '/old',
+      nextProjectPath: '/next',
+      nativeSession: resolvedNativeSession,
+    });
+
+    expect(result).toBe(fixture.preparation);
+    expect(fixture.prepareProjectPathUpdate).toHaveBeenCalledWith({
+      chat: expect.objectContaining({
+        chatId: 'chat-1',
+        agentSessionId: 'session-1',
+        projectPath: '/old',
+        nativeSession: resolvedNativeSession,
+      }),
+      nextProjectPath: '/next',
+      signal: expect.any(AbortSignal),
+    });
+    expect(fixture.entry.nativeSession).toBe(storedNativeSession);
+  });
+
+  it('rejects a stale request before calling the provider', async () => {
+    const fixture = makeRouter({
+      entry: { projectPath: '/changed' },
+    });
+
+    await expect(fixture.router.prepareProjectPathUpdate('claude', {
+      chatId: 'chat-1',
+      agentSessionId: 'session-1',
+      previousProjectPath: '/old',
+      nextProjectPath: '/next',
+      nativeSession: resolvedNativeSession,
+    })).rejects.toThrow('Session changed while preparing project path');
+
+    expect(fixture.prepareProjectPathUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/server/agents/project-path-update-transaction.ts
+++ b/server/agents/project-path-update-transaction.ts
@@ -4,7 +4,7 @@ import {
   type AgentNativeSessionRef,
   type AgentProjectPathUpdatePreparation,
 } from '@garcon/server-agent-interface';
-import { CommandValidationError } from '../lib/command-validation-error.js';
+import { DomainError } from '../lib/domain-error.js';
 import { errorMessage } from '../lib/errors.js';
 
 async function rollbackPreparation(
@@ -43,14 +43,14 @@ export async function runProjectPathUpdateTransaction<T>(input: {
       error instanceof AgentIntegrationError
       && error.code === 'TRANSCRIPT_UNAVAILABLE'
     ) {
-      throw new CommandValidationError(
+      throw new DomainError(
         'PROJECT_PATH_NATIVE_PATH_UNRESOLVED',
         error.message,
         409,
         error.retryable,
       );
     }
-    throw new CommandValidationError(
+    throw new DomainError(
       'CHAT_NOT_IDLE',
       errorMessage(error),
       409,

--- a/server/agents/project-path-update-transaction.ts
+++ b/server/agents/project-path-update-transaction.ts
@@ -1,0 +1,85 @@
+import {
+  AgentIntegrationError,
+  type AgentLogger,
+  type AgentNativeSessionRef,
+  type AgentProjectPathUpdatePreparation,
+} from '@garcon/server-agent-interface';
+import { CommandValidationError } from '../lib/command-validation-error.js';
+import { errorMessage } from '../lib/errors.js';
+
+async function rollbackPreparation(
+  preparation: AgentProjectPathUpdatePreparation | void,
+  input: {
+    readonly chatId: string;
+    readonly agentId: string;
+    readonly logger: AgentLogger;
+  },
+): Promise<void> {
+  if (!preparation) return;
+  await preparation.rollback().catch((error) => {
+    input.logger.warn('Project-path preparation rollback failed', {
+      chatId: input.chatId,
+      agentId: input.agentId,
+      error: errorMessage(error),
+    });
+  });
+}
+
+export async function runProjectPathUpdateTransaction<T>(input: {
+  readonly chatId: string;
+  readonly agentId: string;
+  readonly fallbackNativeSession: AgentNativeSessionRef | null | undefined;
+  readonly prepare: () => Promise<AgentProjectPathUpdatePreparation | void>;
+  readonly persist: (
+    nativeSession: AgentNativeSessionRef | null | undefined,
+  ) => Promise<T | null>;
+  readonly logger: AgentLogger;
+}): Promise<T | null> {
+  let preparation: AgentProjectPathUpdatePreparation | void;
+  try {
+    preparation = await input.prepare();
+  } catch (error) {
+    if (
+      error instanceof AgentIntegrationError
+      && error.code === 'TRANSCRIPT_UNAVAILABLE'
+    ) {
+      throw new CommandValidationError(
+        'PROJECT_PATH_NATIVE_PATH_UNRESOLVED',
+        error.message,
+        409,
+        error.retryable,
+      );
+    }
+    throw new CommandValidationError(
+      'CHAT_NOT_IDLE',
+      errorMessage(error),
+      409,
+      true,
+    );
+  }
+
+  let updated: T | null;
+  try {
+    updated = await input.persist(
+      preparation ? preparation.nativeSession : input.fallbackNativeSession,
+    );
+  } catch (error) {
+    await rollbackPreparation(preparation, input);
+    throw error;
+  }
+  if (!updated) {
+    await rollbackPreparation(preparation, input);
+    return null;
+  }
+
+  if (preparation) {
+    await preparation.commit().catch((error) => {
+      input.logger.warn('Project-path preparation cleanup failed', {
+        chatId: input.chatId,
+        agentId: input.agentId,
+        error: errorMessage(error),
+      });
+    });
+  }
+  return updated;
+}

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -1,5 +1,9 @@
-import type { AgentTranscriptPage, AgentTranscriptSourceLocation } from '@garcon/server-agent-interface';
-import type { AgentNativeSessionRef } from '@garcon/server-agent-interface';
+import type {
+  AgentNativeSessionRef,
+  AgentProjectPathUpdatePreparation,
+  AgentTranscriptPage,
+  AgentTranscriptSourceLocation,
+} from '@garcon/server-agent-interface';
 import type { ChatMessage } from '@garcon/common/chat-types';
 import type { PermissionDecisionPayload } from '../../common/chat-command-contracts.js';
 import type { PermissionMode, ThinkingMode } from '../../common/chat-modes.js';
@@ -75,7 +79,10 @@ export interface AgentRegistryServiceContract {
   runSingleQuery(prompt: string, options: RunSingleQueryOptions): Promise<string>;
   getSlashCommands(agentId: string, projectPath: string): Promise<SlashCommand[]>;
   resolvePermission(chatId: string, permissionRequestId: string, decision: PermissionDecisionPayload): void;
-  prepareProjectPathUpdate(agentId: string, request: PrepareProjectPathUpdateRequest): Promise<void>;
+  prepareProjectPathUpdate(
+    agentId: string,
+    request: PrepareProjectPathUpdateRequest,
+  ): Promise<AgentProjectPathUpdatePreparation | void>;
   resolveNativeSession(session: AgentChatEntry, chatId?: string): Promise<AgentNativeSessionRef | null>;
   describeTranscriptSource(
     session: AgentChatEntry,
@@ -188,7 +195,10 @@ export class AgentRegistry implements AgentRegistryServiceContract {
   resolvePermission(chatId: string, permissionRequestId: string, decision: PermissionDecisionPayload): void {
     this.#runtime.resolvePermission(chatId, permissionRequestId, decision);
   }
-  prepareProjectPathUpdate(agentId: string, request: PrepareProjectPathUpdateRequest): Promise<void> {
+  prepareProjectPathUpdate(
+    agentId: string,
+    request: PrepareProjectPathUpdateRequest,
+  ): Promise<AgentProjectPathUpdatePreparation | void> {
     return this.#runtime.prepareProjectPathUpdate(agentId, request);
   }
   forkAgentSession(args: {

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -4,6 +4,7 @@ import {
   computeAgentTranscriptRevisions,
   type AgentExecutionContext,
   type AgentOperationIdentity,
+  type AgentProjectPathUpdatePreparation,
 } from '@garcon/server-agent-interface';
 import type { AgentSettingsEnvelope } from '@garcon/common/agent-integration';
 import type { ChatMessage } from '@garcon/common/chat-types';
@@ -261,16 +262,23 @@ export class AgentRuntimeRouter {
   async prepareProjectPathUpdate(
     agentId: string,
     request: PrepareProjectPathUpdateRequest,
-  ): Promise<void> {
+  ): Promise<AgentProjectPathUpdatePreparation | void> {
     const integration = this.#directory.require(agentId);
     if (!integration.execution.prepareProjectPathUpdate) return;
     const entry = this.#registry.getChat(request.chatId);
     if (!entry) throw new Error(`Session not found: ${request.chatId}`);
-    await integration.execution.prepareProjectPathUpdate({
+    if (
+      entry.agentId !== agentId
+      || entry.agentSessionId !== request.agentSessionId
+      || entry.projectPath !== request.previousProjectPath
+    ) {
+      throw new Error(`Session changed while preparing project path: ${request.chatId}`);
+    }
+    return integration.execution.prepareProjectPathUpdate({
       chat: toAgentChatReference(
         integration,
         request.chatId,
-        entry,
+        { ...entry, nativeSession: request.nativeSession },
         this.#getCarryOverRevision(request.chatId),
       ),
       nextProjectPath: request.nextProjectPath,

--- a/server/chats/__tests__/store.test.js
+++ b/server/chats/__tests__/store.test.js
@@ -156,6 +156,29 @@ describe('ChatRegistry', () => {
     });
   });
 
+  it('restores project-path fields in memory when persistence fails', async () => {
+    const originalNativeSession = nativeSession('test');
+    registry.addChat(newChat({ nativeSession: originalNativeSession }));
+    const saveRegistry = registry.saveRegistry.bind(registry);
+    registry.saveRegistry = mock(() => Promise.reject(new Error('disk full')));
+
+    await expect(registry.updateProjectPath(CHAT_ID, {
+      chatId: CHAT_ID,
+      projectPath: '/next',
+      effectiveProjectKey: '/next',
+      previousProjectPath: '/repo',
+      previousEffectiveProjectKey: '/repo',
+      nativeSession: nativeSession('test', { path: '/tmp/next.jsonl' }),
+    }, { flush: true })).rejects.toThrow('disk full');
+
+    expect(registry.getChat(CHAT_ID)).toMatchObject({
+      projectPath: '/repo',
+      nativeSession: originalNativeSession,
+    });
+
+    registry.saveRegistry = saveRegistry;
+  });
+
   it('removes records, indexes, and emits the removal identity', () => {
     registry.addChat(newChat({ agentSessionId: 'native-1' }));
     const removed = mock(() => undefined);

--- a/server/chats/store.ts
+++ b/server/chats/store.ts
@@ -479,6 +479,8 @@ export class ChatRegistry extends EventEmitter<ChatRegistryEvents> implements IC
     if (update.chatId !== id) {
       throw new Error(`Project path update identity mismatch: ${id}`);
     }
+    const previousProjectPath = existing.projectPath;
+    const previousNativeSession = existing.nativeSession;
     existing.projectPath = update.projectPath;
     if ('nativeSession' in update) {
       if (update.nativeSession?.ownerId !== existing.agentId && update.nativeSession !== null) {
@@ -486,7 +488,13 @@ export class ChatRegistry extends EventEmitter<ChatRegistryEvents> implements IC
       }
       existing.nativeSession = update.nativeSession ?? null;
     }
-    await this.#flushRegistrySave();
+    try {
+      await this.#flushRegistrySave();
+    } catch (error) {
+      existing.projectPath = previousProjectPath;
+      existing.nativeSession = previousNativeSession;
+      throw error;
+    }
     this.#emitChatProjectPathUpdated({
       chatId: update.chatId,
       projectPath: update.projectPath,

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { randomUUID } from 'crypto';
+import { AgentIntegrationError } from '@garcon/server-agent-interface';
 
 import { ChatCommandService } from '../chat-command-service.ts';
 import { CommandLedger, commandLedgerKey } from '../command-ledger.ts';
@@ -165,6 +166,7 @@ function makeService(overrides = {}) {
       return Promise.resolve(next);
     }),
     removeChat: mock((chatId) => sessions.delete(chatId)),
+    ...overrides.chats,
   };
   const executionTasks = new Set();
   const queue = overrides.queueService ?? {
@@ -2354,6 +2356,175 @@ describe('ChatCommandService', () => {
       { flush: true },
     );
     expect(sessions.get(SOURCE_CHAT_ID).projectPath).toBe(realNextPath);
+  });
+
+  it('persists a prepared native session before provider cleanup', async () => {
+    const relocated = {
+      ownerId: 'claude',
+      schemaVersion: 1,
+      value: {
+        path: '/tmp/relocated.jsonl',
+        agentSessionId: 'agent-1',
+      },
+    };
+    let sessions;
+    const commit = mock(async () => {
+      expect(sessions.get(SOURCE_CHAT_ID).nativeSession).toEqual(relocated);
+    });
+    const rollback = mock(() => Promise.resolve());
+    const fixture = makeService({
+      agents: {
+        prepareProjectPathUpdate: mock(() => Promise.resolve({
+          nativeSession: relocated,
+          commit,
+          rollback,
+        })),
+      },
+    });
+    sessions = fixture.sessions;
+    const nextPath = path.join(projectBaseDir, 'prepared-native');
+    await fs.mkdir(nextPath, { recursive: true });
+
+    await expect(fixture.service.updateProjectPath({
+      chatId: SOURCE_CHAT_ID,
+      projectPath: nextPath,
+    })).resolves.toMatchObject({ success: true });
+
+    expect(fixture.chats.updateProjectPath).toHaveBeenCalledWith(
+      SOURCE_CHAT_ID,
+      expect.objectContaining({ nativeSession: relocated }),
+      { flush: true },
+    );
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(rollback).not.toHaveBeenCalled();
+  });
+
+  it('rolls back provider preparation when registry persistence fails', async () => {
+    const commit = mock(() => Promise.resolve());
+    const rollback = mock(() => Promise.resolve());
+    const fixture = makeService({
+      agents: {
+        prepareProjectPathUpdate: mock(() => Promise.resolve({
+          nativeSession: {
+            ownerId: 'claude',
+            schemaVersion: 1,
+            value: { path: '/tmp/relocated.jsonl' },
+          },
+          commit,
+          rollback,
+        })),
+      },
+      chats: {
+        updateProjectPath: mock(() => Promise.reject(new Error('disk full'))),
+      },
+    });
+    const nextPath = path.join(projectBaseDir, 'failed-persistence');
+    await fs.mkdir(nextPath, { recursive: true });
+
+    await expect(fixture.service.updateProjectPath({
+      chatId: SOURCE_CHAT_ID,
+      projectPath: nextPath,
+    })).rejects.toThrow('disk full');
+
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back preparation and preserves the typed error when the chat disappears', async () => {
+    const commit = mock(() => Promise.resolve());
+    const rollback = mock(() => Promise.resolve());
+    const fixture = makeService({
+      agents: {
+        prepareProjectPathUpdate: mock(() => Promise.resolve({
+          nativeSession: null,
+          commit,
+          rollback,
+        })),
+      },
+      chats: {
+        updateProjectPath: mock(() => Promise.resolve(null)),
+      },
+    });
+    const nextPath = path.join(projectBaseDir, 'removed-chat');
+    await fs.mkdir(nextPath, { recursive: true });
+
+    await expect(fixture.service.updateProjectPath({
+      chatId: SOURCE_CHAT_ID,
+      projectPath: nextPath,
+    })).rejects.toMatchObject({
+      code: 'SESSION_NOT_FOUND',
+      status: 404,
+    });
+
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('does not report durable project-path updates as failed when cleanup fails', async () => {
+    const commit = mock(() => Promise.reject(new Error('cleanup failed')));
+    const fixture = makeService({
+      agents: {
+        prepareProjectPathUpdate: mock(() => Promise.resolve({
+          nativeSession: null,
+          commit,
+          rollback: mock(() => Promise.resolve()),
+        })),
+      },
+    });
+    const nextPath = path.join(projectBaseDir, 'cleanup-warning');
+    await fs.mkdir(nextPath, { recursive: true });
+
+    await expect(fixture.service.updateProjectPath({
+      chatId: SOURCE_CHAT_ID,
+      projectPath: nextPath,
+    })).resolves.toMatchObject({ success: true });
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps unavailable provider transcripts to the project-path error contract', async () => {
+    const fixture = makeService({
+      agents: {
+        prepareProjectPathUpdate: mock(() => Promise.reject(
+          new AgentIntegrationError(
+            'TRANSCRIPT_UNAVAILABLE',
+            'Claude session transcript could not be resolved for project-path update',
+            false,
+          ),
+        )),
+      },
+    });
+    const nextPath = path.join(projectBaseDir, 'missing-transcript');
+    await fs.mkdir(nextPath, { recursive: true });
+
+    await expect(fixture.service.updateProjectPath({
+      chatId: SOURCE_CHAT_ID,
+      projectPath: nextPath,
+    })).rejects.toMatchObject({
+      code: 'PROJECT_PATH_NATIVE_PATH_UNRESOLVED',
+      status: 409,
+      retryable: false,
+    });
+
+    expect(fixture.chats.updateProjectPath).not.toHaveBeenCalled();
+  });
+
+  it('allows an unstarted Claude chat to change project path', async () => {
+    const fixture = makeService({
+      session: {
+        agentSessionId: null,
+        nativeSession: null,
+      },
+    });
+    const nextPath = path.join(projectBaseDir, 'unstarted-chat');
+    await fs.mkdir(nextPath, { recursive: true });
+
+    await expect(fixture.service.updateProjectPath({
+      chatId: SOURCE_CHAT_ID,
+      projectPath: nextPath,
+    })).resolves.toMatchObject({ success: true });
+
+    expect(fixture.agents.resolveNativeSession).toHaveBeenCalledTimes(1);
+    expect(fixture.agents.prepareProjectPathUpdate).toHaveBeenCalledTimes(1);
   });
 
   it('rejects project path updates while a turn is running', async () => {

--- a/server/commands/command-support.ts
+++ b/server/commands/command-support.ts
@@ -32,6 +32,7 @@ import type { PathCache } from '../chats/path-cache.js';
 import type { PendingUserInputServiceContract } from '../chats/pending-user-input-service.js';
 import type { ChatRegistryEntry, IChatRegistry } from '../chats/store.js';
 import { DomainError } from '../lib/domain-error.js';
+import { CommandValidationError } from '../lib/command-validation-error.js';
 import { KeyedPromiseLock } from '../lib/keyed-lock.js';
 import { ChatCommandSettlement } from './chat-command-settlement.ts';
 import type { CommandLedger, CommandLedgerRecord } from './command-ledger.js';
@@ -219,17 +220,7 @@ export interface AcceptedRunPreparation {
   compensate(): Promise<void>;
 }
 
-export class CommandValidationError extends Error {
-  constructor(
-    readonly code: CommandErrorCode,
-    message: string,
-    readonly status = 400,
-    readonly retryable = false,
-  ) {
-    super(message);
-    this.name = 'CommandValidationError';
-  }
-}
+export { CommandValidationError };
 
 export class CommandExecutionControlError extends CommandValidationError {
   constructor(

--- a/server/commands/session-commands.ts
+++ b/server/commands/session-commands.ts
@@ -1,16 +1,24 @@
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
+import {
+  AgentIntegrationError,
+  type AgentProjectPathUpdatePreparation,
+} from '@garcon/server-agent-interface';
 import type {
   AgentInterruptAndSendResponse,
   AgentStopResponse,
   CommandAcceptedResponse,
   ProjectPathPatchResponse,
 } from '../../common/chat-command-contracts.js';
-import type { ChatRegistryEntry } from '../chats/store.js';
+import type {
+  ChatRegistryEntry,
+  ChatRegistryResolvedEntry,
+} from '../chats/store.js';
 import {
   toClientChatExecutionControlState,
 } from '../chat-execution/control-state.ts';
 import { createLogger } from '../lib/log.js';
+import { errorMessage } from '../lib/errors.js';
 import { assertRealWithinProjectBase, isProjectBoundaryError } from '../lib/path-boundary.js';
 import {
   CommandSupport,
@@ -308,8 +316,9 @@ export class SessionCommands {
     await this.assertChatIdleForProjectPathUpdate(input.chatId, chat);
     const nativeSession = await this.nativeSessionForProjectPathUpdate(input.chatId, chat);
 
+    let preparation: AgentProjectPathUpdatePreparation | void;
     try {
-      await this.deps.agents.prepareProjectPathUpdate(chat.agentId, {
+      preparation = await this.deps.agents.prepareProjectPathUpdate(chat.agentId, {
         chatId: input.chatId,
         agentSessionId: chat.agentSessionId,
         previousProjectPath: chat.projectPath,
@@ -317,9 +326,20 @@ export class SessionCommands {
         nativeSession,
       });
     } catch (error) {
+      if (
+        error instanceof AgentIntegrationError
+        && error.code === 'TRANSCRIPT_UNAVAILABLE'
+      ) {
+        throw new CommandValidationError(
+          'PROJECT_PATH_NATIVE_PATH_UNRESOLVED',
+          error.message,
+          409,
+          error.retryable,
+        );
+      }
       throw new CommandValidationError(
         'CHAT_NOT_IDLE',
-        error instanceof Error ? error.message : String(error),
+        errorMessage(error),
         409,
         true,
       );
@@ -331,11 +351,47 @@ export class SessionCommands {
       effectiveProjectKey,
       previousProjectPath: chat.projectPath,
       previousEffectiveProjectKey: previousStatus.effectiveProjectKey,
-      ...(nativeSession !== chat.nativeSession ? { nativeSession } : {}),
+      ...(preparation
+        ? { nativeSession: preparation.nativeSession }
+        : nativeSession !== chat.nativeSession
+          ? { nativeSession }
+          : {}),
     };
-    const updated = await this.deps.chats.updateProjectPath(input.chatId, event, { flush: true });
-    if (!updated) {
-      throw new CommandValidationError('SESSION_NOT_FOUND', 'Session not found', 404);
+    let updated: ChatRegistryResolvedEntry | null;
+    try {
+      updated = await this.deps.chats.updateProjectPath(
+        input.chatId,
+        event,
+        { flush: true },
+      );
+      if (!updated) {
+        throw new CommandValidationError(
+          'SESSION_NOT_FOUND',
+          'Session not found',
+          404,
+        );
+      }
+    } catch (error) {
+      if (preparation) {
+        await preparation.rollback().catch((rollbackError) => {
+          logger.warn('Project-path preparation rollback failed', {
+            chatId: input.chatId,
+            agentId: chat.agentId,
+            error: errorMessage(rollbackError),
+          });
+        });
+      }
+      throw error;
+    }
+
+    if (preparation) {
+      await preparation.commit().catch((error) => {
+        logger.warn('Project-path preparation cleanup failed', {
+          chatId: input.chatId,
+          agentId: chat.agentId,
+          error: errorMessage(error),
+        });
+      });
     }
 
     return {

--- a/server/commands/session-commands.ts
+++ b/server/commands/session-commands.ts
@@ -1,24 +1,17 @@
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
-import {
-  AgentIntegrationError,
-  type AgentProjectPathUpdatePreparation,
-} from '@garcon/server-agent-interface';
 import type {
   AgentInterruptAndSendResponse,
   AgentStopResponse,
   CommandAcceptedResponse,
   ProjectPathPatchResponse,
 } from '../../common/chat-command-contracts.js';
-import type {
-  ChatRegistryEntry,
-  ChatRegistryResolvedEntry,
-} from '../chats/store.js';
+import type { ChatRegistryEntry } from '../chats/store.js';
+import { runProjectPathUpdateTransaction } from '../agents/project-path-update-transaction.js';
 import {
   toClientChatExecutionControlState,
 } from '../chat-execution/control-state.ts';
 import { createLogger } from '../lib/log.js';
-import { errorMessage } from '../lib/errors.js';
 import { assertRealWithinProjectBase, isProjectBoundaryError } from '../lib/path-boundary.js';
 import {
   CommandSupport,
@@ -316,82 +309,39 @@ export class SessionCommands {
     await this.assertChatIdleForProjectPathUpdate(input.chatId, chat);
     const nativeSession = await this.nativeSessionForProjectPathUpdate(input.chatId, chat);
 
-    let preparation: AgentProjectPathUpdatePreparation | void;
-    try {
-      preparation = await this.deps.agents.prepareProjectPathUpdate(chat.agentId, {
-        chatId: input.chatId,
-        agentSessionId: chat.agentSessionId,
-        previousProjectPath: chat.projectPath,
-        nextProjectPath,
-        nativeSession,
-      });
-    } catch (error) {
-      if (
-        error instanceof AgentIntegrationError
-        && error.code === 'TRANSCRIPT_UNAVAILABLE'
-      ) {
-        throw new CommandValidationError(
-          'PROJECT_PATH_NATIVE_PATH_UNRESOLVED',
-          error.message,
-          409,
-          error.retryable,
-        );
-      }
-      throw new CommandValidationError(
-        'CHAT_NOT_IDLE',
-        errorMessage(error),
-        409,
-        true,
-      );
-    }
-
     const event = {
       chatId: input.chatId,
       projectPath: nextProjectPath,
       effectiveProjectKey,
       previousProjectPath: chat.projectPath,
       previousEffectiveProjectKey: previousStatus.effectiveProjectKey,
-      ...(preparation
-        ? { nativeSession: preparation.nativeSession }
-        : nativeSession !== chat.nativeSession
-          ? { nativeSession }
-          : {}),
     };
-    let updated: ChatRegistryResolvedEntry | null;
-    try {
-      updated = await this.deps.chats.updateProjectPath(
+    const updated = await runProjectPathUpdateTransaction({
+      chatId: input.chatId,
+      agentId: chat.agentId,
+      fallbackNativeSession:
+        nativeSession !== chat.nativeSession ? nativeSession : undefined,
+      prepare: () => this.deps.agents.prepareProjectPathUpdate(chat.agentId, {
+        chatId: input.chatId,
+        agentSessionId: chat.agentSessionId,
+        previousProjectPath: chat.projectPath,
+        nextProjectPath,
+        nativeSession,
+      }),
+      persist: (nextNativeSession) => this.deps.chats.updateProjectPath(
         input.chatId,
-        event,
+        {
+          ...event,
+          ...(nextNativeSession !== undefined
+            ? { nativeSession: nextNativeSession }
+            : {}),
+        },
         { flush: true },
-      );
-      if (!updated) {
-        throw new CommandValidationError(
-          'SESSION_NOT_FOUND',
-          'Session not found',
-          404,
-        );
-      }
-    } catch (error) {
-      if (preparation) {
-        await preparation.rollback().catch((rollbackError) => {
-          logger.warn('Project-path preparation rollback failed', {
-            chatId: input.chatId,
-            agentId: chat.agentId,
-            error: errorMessage(rollbackError),
-          });
-        });
-      }
-      throw error;
-    }
-
-    if (preparation) {
-      await preparation.commit().catch((error) => {
-        logger.warn('Project-path preparation cleanup failed', {
-          chatId: input.chatId,
-          agentId: chat.agentId,
-          error: errorMessage(error),
-        });
-      });
+      ),
+      logger,
+    });
+    if (!updated) {
+      throw new CommandValidationError('SESSION_NOT_FOUND', 'Session not found', 404);
     }
 
     return {

--- a/server/lib/command-validation-error.ts
+++ b/server/lib/command-validation-error.ts
@@ -1,0 +1,13 @@
+import type { CommandErrorCode } from '../../common/chat-command-contracts.js';
+
+export class CommandValidationError extends Error {
+  constructor(
+    readonly code: CommandErrorCode,
+    message: string,
+    readonly status = 400,
+    readonly retryable = false,
+  ) {
+    super(message);
+    this.name = 'CommandValidationError';
+  }
+}


### PR DESCRIPTION
Claude Code resolves resumed sessions within the current project, so changing an existing chat's project path could leave its transcript behind and make the next turn fail. This change relocates Claude session artifacts transactionally, persists the updated native transcript binding, waits for all relevant Claude processes to exit before copying, matches Claude's long-path key encoding, and adds restart-aware integration coverage to ensure the conversation continues from the new project.