### PR TITLE
Detect stale Git comparisons on re-entry

### DIFF
--- a/integration-tests/tests/e2e/git-comparison.test.ts
+++ b/integration-tests/tests/e2e/git-comparison.test.ts
@@ -106,28 +106,20 @@ describe('Lightpanda Git comparison', () => {
         '[data-git-virtual-row]',
 				(rows) => rows.length,
 			);
-				expect(mountedRows).toBeLessThan(30);
+			expect(mountedRows).toBeLessThan(30);
 
-				await app.selectMainWorkspaceSurface('Chat');
-				await fixture.page.waitForFunction(() =>
-					[...document.querySelectorAll<HTMLButtonElement>('[role="tab"]')].some(
-						(tab) =>
-							(tab.getAttribute('aria-label') || tab.textContent?.trim()) === 'Chat'
-							&& tab.getAttribute('aria-selected') === 'true',
-					),
-				);
-				await writeFile(join(project, 'large.txt'), `${refreshed}\n`, 'utf8');
-				await app.selectMainWorkspaceSurface('Git');
-				await fixture.page.waitForFunction(() =>
-					[...document.querySelectorAll<HTMLButtonElement>('[role="tab"]')].some(
-						(tab) =>
-							(tab.getAttribute('aria-label') || tab.textContent?.trim()) === 'Git'
-							&& tab.getAttribute('aria-selected') === 'true',
-					),
-				);
-				await fixture.page.waitForFunction(
-					() => document.body.textContent?.includes('The Working Tree changed.'),
-					{ timeout: 5_000 },
+			await app.selectMainWorkspaceSurface('Chat');
+			await fixture.page.waitForSelector(
+				'[role="tabpanel"][data-workspace-surface-id="singleton:chat"][aria-hidden="false"]',
+			);
+			await writeFile(join(project, 'large.txt'), `${refreshed}\n`, 'utf8');
+			await app.selectMainWorkspaceSurface('Git');
+			await fixture.page.waitForSelector(
+				'[role="tabpanel"][data-workspace-surface-id="singleton:git"][aria-hidden="false"]',
+			);
+			await fixture.page.waitForFunction(
+				() => document.body.textContent?.includes('The Working Tree changed.'),
+				{ timeout: 5_000 },
 			);
 			expect(await fixture.page.$eval('body', (element) => element.textContent)).toContain(
 				'large after marker',

--- a/integration-tests/tests/e2e/git-comparison.test.ts
+++ b/integration-tests/tests/e2e/git-comparison.test.ts
@@ -106,12 +106,28 @@ describe('Lightpanda Git comparison', () => {
         '[data-git-virtual-row]',
 				(rows) => rows.length,
 			);
-			expect(mountedRows).toBeLessThan(30);
+				expect(mountedRows).toBeLessThan(30);
 
-			await writeFile(join(project, 'large.txt'), `${refreshed}\n`, 'utf8');
-			await fixture.page.waitForFunction(
-				() => document.body.textContent?.includes('The Working Tree changed.'),
-				{ timeout: 25_000 },
+				await app.selectMainWorkspaceSurface('Chat');
+				await fixture.page.waitForFunction(() =>
+					[...document.querySelectorAll<HTMLButtonElement>('[role="tab"]')].some(
+						(tab) =>
+							(tab.getAttribute('aria-label') || tab.textContent?.trim()) === 'Chat'
+							&& tab.getAttribute('aria-selected') === 'true',
+					),
+				);
+				await writeFile(join(project, 'large.txt'), `${refreshed}\n`, 'utf8');
+				await app.selectMainWorkspaceSurface('Git');
+				await fixture.page.waitForFunction(() =>
+					[...document.querySelectorAll<HTMLButtonElement>('[role="tab"]')].some(
+						(tab) =>
+							(tab.getAttribute('aria-label') || tab.textContent?.trim()) === 'Git'
+							&& tab.getAttribute('aria-selected') === 'true',
+					),
+				);
+				await fixture.page.waitForFunction(
+					() => document.body.textContent?.includes('The Working Tree changed.'),
+					{ timeout: 5_000 },
 			);
 			expect(await fixture.page.$eval('body', (element) => element.textContent)).toContain(
 				'large after marker',

--- a/web/src/lib/components/git/__tests__/git-freshness-polling.test.ts
+++ b/web/src/lib/components/git/__tests__/git-freshness-polling.test.ts
@@ -28,7 +28,7 @@ describe('git freshness polling', () => {
 		vi.useRealTimers();
 	});
 
-	it('polls on the configured interval without an immediate first tick', () => {
+	it('polls immediately and on the configured interval', async () => {
 		vi.useFakeTimers();
 		const checkFreshness = vi.fn();
 		const documentRef = makeDocumentRef('visible');
@@ -40,11 +40,14 @@ describe('git freshness polling', () => {
 			intervalMs: 15_000,
 		});
 
-		expect(checkFreshness).not.toHaveBeenCalled();
+		await vi.runAllTicks();
+		expect(checkFreshness).toHaveBeenCalledOnce();
+		expect(checkFreshness).toHaveBeenLastCalledWith('/project');
 		vi.advanceTimersByTime(14_999);
-		expect(checkFreshness).not.toHaveBeenCalled();
+		expect(checkFreshness).toHaveBeenCalledOnce();
 		vi.advanceTimersByTime(1);
-		expect(checkFreshness).toHaveBeenCalledWith('/project');
+		expect(checkFreshness).toHaveBeenCalledTimes(2);
+		expect(checkFreshness).toHaveBeenLastCalledWith('/project');
 
 		cleanup();
 	});

--- a/web/src/lib/components/git/git-freshness-polling.ts
+++ b/web/src/lib/components/git/git-freshness-polling.ts
@@ -36,6 +36,7 @@ export function startGitFreshnessPolling({
 	return startVisibilityPolling({
 		intervalMs,
 		poll: () => checkFreshness(projectPath),
+		pollImmediately: true,
 		documentRef,
 		setIntervalFn,
 		clearIntervalFn,


### PR DESCRIPTION
Working Tree comparisons preserve frozen rows until an explicit refresh, but returning to Git could leave an outdated comparison appearing current until the next polling interval. This change checks freshness immediately whenever Git becomes visible, promptly surfaces the stale-comparison banner, and keeps the existing stable-row and explicit-refresh behavior intact.