### PR TITLE
Fix Compare startup loading state

### DIFF
--- a/web/src/lib/components/git/GitComparePanel.svelte
+++ b/web/src/lib/components/git/GitComparePanel.svelte
@@ -107,6 +107,7 @@
 
 	<GitComparisonScreen
 		{comparison}
+		isLoading={controller.isLoading}
 		isMobile={presentation === 'mobile'}
 		active={presentationVisible}
 		fontSize={diffFontSize}

--- a/web/src/lib/components/git/GitCompareToolbar.svelte
+++ b/web/src/lib/components/git/GitCompareToolbar.svelte
@@ -42,8 +42,8 @@
 			label: m.git_header_refresh(),
 			icon: RefreshCw,
 			onclick: onRefresh,
-			disabled: controller.comparison.isLoading,
-			busy: controller.comparison.isLoading,
+			disabled: controller.isLoading,
+			busy: controller.isLoading,
 			priority: 1,
 		},
 	]);

--- a/web/src/lib/components/git/GitComparisonScreen.svelte
+++ b/web/src/lib/components/git/GitComparisonScreen.svelte
@@ -8,6 +8,7 @@
 
 	interface GitComparisonScreenProps {
 		comparison: GitComparisonController;
+		isLoading: boolean;
 		isMobile: boolean;
 		active?: boolean;
 		fontSize: number;
@@ -20,6 +21,7 @@
 
 	let {
 		comparison,
+		isLoading,
 		isMobile,
 		active = true,
 		fontSize,
@@ -53,7 +55,7 @@
 				<button
 					type="button"
 					class="rounded border border-status-warning-border px-2 py-1 font-medium hover:bg-status-warning/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-					disabled={comparison.isLoading}
+					disabled={isLoading}
 					onclick={onRefresh}>{m.git_compare_refresh()}</button
 				>
 			</div>
@@ -77,7 +79,7 @@
 	documentId={comparison.snapshot?.documentId ?? null}
 	documentAvailable={Boolean(comparison.snapshot)}
 	files={comparison.document.visibleFiles}
-	isLoading={comparison.isLoading}
+	{isLoading}
 	error={comparison.documentError}
 	onDismissError={() => comparison.dismissDocumentError()}
 	source={comparison.document.rowSource}

--- a/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
+++ b/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GitComparisonController } from '$lib/git/review/git-comparison.svelte.js';
+import GitComparisonScreen from '../GitComparisonScreen.svelte';
+
+function renderScreen(comparison: GitComparisonController, isLoading: boolean): void {
+	render(GitComparisonScreen, {
+		comparison,
+		isLoading,
+		isMobile: false,
+		fontSize: 12,
+		onEdit: vi.fn(),
+		onRefresh: vi.fn(),
+		onOpenChat: vi.fn(),
+	});
+}
+
+describe('GitComparisonScreen', () => {
+	afterEach(cleanup);
+
+	it('shows initialization as loading instead of a comparison error', () => {
+		renderScreen(new GitComparisonController(), true);
+
+		expect(screen.getByText('Loading comparison')).toBeTruthy();
+		expect(screen.queryByText('Comparison could not be loaded.')).toBeNull();
+	});
+
+	it('preserves a real comparison failure after initialization', () => {
+		const comparison = new GitComparisonController();
+		comparison.error = 'Revision HEAD was not found.';
+
+		renderScreen(comparison, false);
+
+		expect(screen.getByText('Revision HEAD was not found.')).toBeTruthy();
+		expect(screen.queryByText('Loading comparison')).toBeNull();
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
+++ b/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
@@ -12,6 +12,14 @@ vi.mock('$lib/api/git.js', () => ({
 
 const api = vi.mocked(await import('$lib/api/git.js'));
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
 function candidate(
 	projectPath = '/project',
 	overrides: Partial<GitTargetCandidate> = {},
@@ -62,6 +70,26 @@ describe('GitCompareSurfaceController', () => {
 		expect(controller.comparison.toKind).toBe('working-tree');
 		expect(controller.comparison.mode).toBe('direct');
 		expect(controller.comparison.dialogOpen).toBe(false);
+	});
+
+	it('reports loading while target discovery delays the initial comparison', async () => {
+		const targets = deferred<{ targets: GitTargetCandidate[] }>();
+		api.getGitTargetCandidates.mockReturnValueOnce(targets.promise);
+		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller);
+
+		controller.setPresentationVisible(true);
+
+		expect(controller.target.isLoadingTargets).toBe(true);
+		expect(controller.isLoading).toBe(true);
+		expect(compare).not.toHaveBeenCalled();
+
+		targets.resolve({ targets: [candidate()] });
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		expect(controller.isLoading).toBe(false);
 	});
 
 	it('preserves edited endpoints and issues no request on generic refocus', async () => {

--- a/web/src/lib/git/review/git-compare-surface.svelte.ts
+++ b/web/src/lib/git/review/git-compare-surface.svelte.ts
@@ -34,6 +34,14 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 	#externalTargetApplications = 0;
 	#unregisterReviewDisplay: () => void;
 
+	get isLoading(): boolean {
+		return (
+			this.comparison.isLoading ||
+			(!this.comparison.snapshot &&
+				(this.target.projectIdentityPending || this.target.isLoadingTargets))
+		);
+	}
+
 	constructor(private readonly deps: GitSurfaceControllerDeps) {
 		this.target = new GitTargetSessionController({
 			kind: 'git-compare',


### PR DESCRIPTION
Prevents the standalone Compare surface from briefly presenting its generic failure state while repository target discovery is still in progress by exposing a combined initialization state to the content view and refresh control, while preserving real comparison errors and adding regression coverage for delayed target resolution.