### PR TITLE
Add live Codex lifecycle conformance tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,6 +66,7 @@ jobs:
           ANTHROPIC_TESTING_KEY: ${{ secrets.ANTHROPIC_TESTING_KEY }}
         run: |
           if [ -n "$ANTHROPIC_TESTING_KEY" ]; then
+            echo "::add-mask::$ANTHROPIC_TESTING_KEY"
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "ANTHROPIC_TESTING_KEY is unavailable; skipping live Claude tests."
@@ -102,6 +103,60 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: claude-live-integration-diagnostics
+          path: integration-tests/artifacts/server/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  codex-live:
+    name: Live Codex conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check for OpenAI testing key
+        id: openai-key
+        shell: bash
+        env:
+          OPENAI_TESTING_KEY: ${{ secrets.OPENAI_TESTING_KEY }}
+        run: |
+          if [ -n "$OPENAI_TESTING_KEY" ]; then
+            echo "::add-mask::$OPENAI_TESTING_KEY"
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "OPENAI_TESTING_KEY is unavailable; skipping live Codex tests."
+          fi
+
+      - name: Check out repository
+        if: steps.openai-key.outputs.available == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        if: steps.openai-key.outputs.available == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install server dependencies
+        if: steps.openai-key.outputs.available == 'true'
+        working-directory: server
+        run: bun install --frozen-lockfile
+
+      - name: Install integration-test dependencies
+        if: steps.openai-key.outputs.available == 'true'
+        working-directory: integration-tests
+        run: bun install --frozen-lockfile
+
+      - name: Run live Codex conformance tests
+        if: steps.openai-key.outputs.available == 'true'
+        env:
+          OPENAI_TESTING_KEY: ${{ secrets.OPENAI_TESTING_KEY }}
+        run: bun run test:live:codex
+
+      - name: Upload live Codex diagnostics
+        if: failure() && steps.openai-key.outputs.available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-live-integration-diagnostics
           path: integration-tests/artifacts/server/
           if-no-files-found: ignore
           retention-days: 7

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -99,7 +99,7 @@ Lightpanda validates DOM, routing, events, and browser/server coordination. It d
 - Assert `fixture.assertNoBrowserErrors()` in successful E2E workflows. Do not swallow console, protocol, cleanup, or shutdown failures.
 - Do not commit generated files under `artifacts/`. Successful runs remove their temporary directories automatically.
 
-Set `KEEP_INTEGRATION_ARTIFACTS=1` to retain isolated fixture directories for investigation. Failed server tests write diagnostics under `artifacts/server/`; failed E2E tests write the DOM snapshot, browser errors, Lightpanda logs, server exchanges, WebSocket events, and provider requests under `artifacts/e2e/`.
+Set `KEEP_INTEGRATION_ARTIFACTS=1` to retain isolated non-credential fixture directories for investigation. Credential-backed fixtures always remove their temporary provider homes and transcripts. Failed server tests write diagnostics under `artifacts/server/`; failed E2E tests write the DOM snapshot, browser errors, Lightpanda logs, server exchanges, WebSocket events, and provider requests under `artifacts/e2e/`.
 
 ## Running Tests
 
@@ -110,6 +110,7 @@ bun run typecheck
 bun run test:integration:server
 
 ANTHROPIC_TESTING_KEY=... bun run test:live:claude
+OPENAI_TESTING_KEY=... bun run test:live:codex
 
 bun run build
 LIGHTPANDA_BIN=/path/to/lightpanda bun run test:integration:e2e
@@ -118,7 +119,7 @@ bun run check
 bun run test
 ```
 
-`bun run test:integration` runs the deterministic server integration lane but not the credential-backed live-provider or Lightpanda lanes. The root `bun run test` command runs the server and web unit suites, so run the integration commands explicitly while developing cross-boundary changes. Credential-backed suites use the separate `test:live` and `test:live:<provider>` commands; do not run them locally unless actively changing those tests, and rely on the PR CI live-provider gate otherwise. The live Claude lane requires `ANTHROPIC_TESTING_KEY`; it uses the pinned test-only Claude CLI, Haiku, low effort, a temporary Claude home without changing the user's CLI login, and redacted failure diagnostics that omit provider content and server logs. The E2E fixture requires a current production build at `web/build/index.html` and an executable `LIGHTPANDA_BIN`. CI pins and verifies the Lightpanda binary in `.github/workflows/integration-tests.yml`.
+`bun run test:integration` runs the deterministic server integration lane but not the credential-backed live-provider or Lightpanda lanes. The root `bun run test` command runs the server and web unit suites, so run the integration commands explicitly while developing cross-boundary changes. Credential-backed suites use the separate `test:live` and `test:live:<provider>` commands; do not run them locally unless actively changing those tests, and rely on the PR CI live-provider gate otherwise. The live Claude lane requires `ANTHROPIC_TESTING_KEY` and uses the pinned test-only Claude CLI, Haiku, and low effort. The live Codex lane requires `OPENAI_TESTING_KEY` and uses the pinned test-only Codex CLI, `gpt-5.4-nano`, and low effort. Both live lanes use a temporary provider home without changing the user's CLI login and redact failure diagnostics that omit provider content and server logs. The E2E fixture requires a current production build at `web/build/index.html` and an executable `LIGHTPANDA_BIN`. CI pins and verifies the Lightpanda binary in `.github/workflows/integration-tests.yml`.
 
 Focused runs are useful while iterating:
 

--- a/integration-tests/bun.lock
+++ b/integration-tests/bun.lock
@@ -6,6 +6,7 @@
       "name": "@garcon/integration-tests",
       "devDependencies": {
         "@anthropic-ai/claude-code": "2.1.220",
+        "@openai/codex": "0.144.6",
         "@types/bun": "1.3.14",
         "puppeteer-core": "25.3.0",
         "typescript": "7.0.2",
@@ -30,6 +31,20 @@
     "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.220", "", { "os": "win32", "cpu": "arm64" }, "sha512-APqZwFBn38DBUwB65uUTetW7lbtUqFfAfOWKvkmOyqFDswDEsInaINuIwqMCl44WYcch10SaHhEZdXJU9MG3aQ=="],
 
     "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.220", "", { "os": "win32", "cpu": "x64" }, "sha512-UGrjH8cGhC6PzhTyZSdgf/RpKxpfk9XJZ/RT/wsG2AJg9yEJLjLg6/TrnlL8RFbEv6Zahu0Quytc02UOpA/GiA=="],
+
+    "@openai/codex": ["@openai/codex@0.144.6", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.144.6-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.144.6-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.144.6-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.144.6-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.144.6-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.144.6-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -6,12 +6,14 @@
     "test": "bun run test:server",
     "test:server": "bun test --max-concurrency=1 --timeout=30000 tests/server",
     "test:e2e": "bun test --max-concurrency=1 --timeout=60000 tests/e2e",
-    "test:live": "bun run test:live:claude",
+    "test:live": "bun run test:live:claude && bun run test:live:codex",
     "test:live:claude": "bun test --max-concurrency=1 --timeout=120000 tests/live/claude",
+    "test:live:codex": "bun test --max-concurrency=1 --timeout=240000 tests/live/codex",
     "typecheck": "bunx tsc -p tsconfig.json"
   },
   "devDependencies": {
     "@anthropic-ai/claude-code": "2.1.220",
+    "@openai/codex": "0.144.6",
     "@types/bun": "1.3.14",
     "puppeteer-core": "25.3.0",
     "typescript": "7.0.2"

--- a/integration-tests/support/garcon-process.ts
+++ b/integration-tests/support/garcon-process.ts
@@ -12,9 +12,26 @@ export interface GarconProcessOptions {
   homeDir: string;
   startupTimeoutMs?: number;
   environment?: Record<string, string>;
+  redactEnvironmentValues?: boolean;
 }
 
 type GarconChild = Bun.Subprocess<'ignore', 'pipe', 'pipe'>;
+const SENSITIVE_ENVIRONMENT_NAME =
+  /(?:api[_-]?key|auth[_-]?token|credential|password|secret|token)/i;
+
+export function redactSensitiveEnvironmentText(
+  text: string,
+  environment: Record<string, string> = {},
+): string {
+  const values = Object.entries(environment)
+    .filter(([name, value]) => SENSITIVE_ENVIRONMENT_NAME.test(name) && value.length > 0)
+    .map(([, value]) => value)
+    .sort((left, right) => right.length - left.length);
+  return values.reduce(
+    (redacted, value) => redacted.replaceAll(value, '[REDACTED]'),
+    text,
+  );
+}
 
 function isolatedEnvironment(
   homeDir: string,
@@ -75,7 +92,11 @@ export class GarconProcess {
   #unexpectedExit: string | null = null;
   #exitCode: number | null = null;
 
-  private constructor(child: GarconChild, ready: Deferred<string>) {
+  private constructor(
+    child: GarconChild,
+    ready: Deferred<string>,
+    redactedEnvironment: Record<string, string>,
+  ) {
     this.#child = child;
     let readinessText = '';
     const inspectText = (text: string) => {
@@ -83,8 +104,11 @@ export class GarconProcess {
       const match = SERVER_READY_PATTERN.exec(readinessText);
       if (match) ready.resolve(match[1]);
     };
-    this.#stdoutPump = pumpLines(child.stdout, 'stdout', inspectText, (line) => this.#logs.push(line));
-    this.#stderrPump = pumpLines(child.stderr, 'stderr', inspectText, (line) => this.#logs.push(line));
+    const captureLine = (line: string) => {
+      this.#logs.push(redactSensitiveEnvironmentText(line, redactedEnvironment));
+    };
+    this.#stdoutPump = pumpLines(child.stdout, 'stdout', inspectText, captureLine);
+    this.#stderrPump = pumpLines(child.stderr, 'stderr', inspectText, captureLine);
     void child.exited.then((exitCode) => {
       this.#exitCode = exitCode;
       if (!this.#expectedExit) {
@@ -118,7 +142,11 @@ export class GarconProcess {
       stdout: 'pipe',
       stderr: 'pipe',
     });
-    const instance = new GarconProcess(child, ready);
+    const instance = new GarconProcess(
+      child,
+      ready,
+      options.redactEnvironmentValues ? options.environment ?? {} : {},
+    );
 
     try {
       instance.#baseUrl = await withTimeout(

--- a/integration-tests/support/integration-fixture.ts
+++ b/integration-tests/support/integration-fixture.ts
@@ -171,6 +171,7 @@ export class IntegrationFixture {
         projectDir: dirs.project,
         homeDir: dirs.home,
         environment: options.serverEnvironment,
+        redactEnvironmentValues: options.redactSensitiveDiagnostics,
       });
       client = await GarconTestClient.connect(garcon.baseUrl, {
         redactSensitiveDiagnostics: options.redactSensitiveDiagnostics,
@@ -431,7 +432,10 @@ export class IntegrationFixture {
     this.fakeProviders.openAiResponses.stop();
     this.fakeProviders.anthropic.stop();
 
-    if (errors.length === 0 && process.env.KEEP_INTEGRATION_ARTIFACTS !== '1') {
+    if (
+      this.#redactSensitiveDiagnostics
+      || (errors.length === 0 && process.env.KEEP_INTEGRATION_ARTIFACTS !== '1')
+    ) {
       await rm(this.dirs.root, { recursive: true, force: true });
     }
     if (errors.length > 0) {
@@ -450,6 +454,7 @@ export class IntegrationFixture {
       projectDir: this.dirs.project,
       homeDir: this.dirs.home,
       environment: this.#serverEnvironment,
+      redactEnvironmentValues: this.#redactSensitiveDiagnostics,
     });
     this.client = await GarconTestClient.connect(this.garcon.baseUrl, {
       redactSensitiveDiagnostics: this.#redactSensitiveDiagnostics,

--- a/integration-tests/support/live-agent.ts
+++ b/integration-tests/support/live-agent.ts
@@ -1,0 +1,76 @@
+import { expect } from 'bun:test';
+import type { ServerWsMessage } from '../../common/ws-events.js';
+import type { IntegrationFixture } from './integration-fixture.js';
+
+export const LIVE_TURN_TIMEOUT_MS = 90_000;
+
+export function liveMarker(label: string): string {
+  return `GARCON_LIVE_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+}
+
+export function exactReplyPrompt(value: string): string {
+  return `Reply with exactly ${value}. Do not use tools.`;
+}
+
+export function expectFinished(type: string): void {
+  expect(type).toBe('agent-run-finished');
+}
+
+export function expectAssistantMarker(contents: readonly string[], value: string): void {
+  expect(contents.some((content) => content.includes(value))).toBe(true);
+}
+
+function expectVisibleResponseBeforeSettlement(input: {
+  events: readonly ServerWsMessage[];
+  chatId: string;
+  turnId: string | undefined;
+  marker: string;
+}): void {
+  const processingStarted = input.events.findIndex((event) =>
+    event.type === 'chat-processing-updated'
+    && event.chatId === input.chatId
+    && event.isProcessing);
+  const assistantResponse = input.events.findIndex((event) =>
+    event.type === 'chat-messages'
+    && event.chatId === input.chatId
+    && event.messages.some((entry) =>
+      entry.message.type === 'assistant-message'
+      && entry.message.content.includes(input.marker)));
+  const processingStopped = input.events.findIndex((event) =>
+    event.type === 'chat-processing-updated'
+    && event.chatId === input.chatId
+    && !event.isProcessing);
+  const terminal = input.events.findIndex((event) =>
+    (event.type === 'agent-run-finished' || event.type === 'agent-run-failed')
+    && event.chatId === input.chatId
+    && event.turnId === input.turnId);
+
+  expect(processingStarted).toBeGreaterThanOrEqual(0);
+  expect(assistantResponse).toBeGreaterThan(processingStarted);
+  expect(processingStopped).toBeGreaterThan(assistantResponse);
+  expect(terminal).toBeGreaterThan(assistantResponse);
+}
+
+export async function waitForVisibleResponse(input: {
+  fixture: IntegrationFixture;
+  chatId: string;
+  turnId: string | undefined;
+  marker: string;
+  afterIndex: number;
+}): Promise<void> {
+  expectFinished((await input.fixture.client.waitForTurnTerminal(
+    input.chatId,
+    input.turnId,
+    { afterIndex: input.afterIndex, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+  )).type);
+  await input.fixture.client.waitForProcessing(input.chatId, false, {
+    afterIndex: input.afterIndex,
+    timeoutMs: LIVE_TURN_TIMEOUT_MS,
+  });
+  expectVisibleResponseBeforeSettlement({
+    events: input.fixture.client.eventsSince(input.afterIndex),
+    chatId: input.chatId,
+    turnId: input.turnId,
+    marker: input.marker,
+  });
+}

--- a/integration-tests/support/live-codex.ts
+++ b/integration-tests/support/live-codex.ts
@@ -1,0 +1,164 @@
+import { constants } from 'node:fs';
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AgentSettingsEnvelope } from '../../common/agent-integration.js';
+import type {
+  AgentRunCommandRequest,
+  ForkRunCommandRequest,
+  StartChatCommandRequest,
+} from '../../common/chat-command-contracts.js';
+import type { IntegrationDirectories } from './integration-fixture.js';
+
+export const LIVE_CODEX_MODEL = 'gpt-5.4-nano';
+export const LIVE_CODEX_THINKING_MODE = 'low';
+
+const CODEX_BINARY = fileURLToPath(
+  new URL('../node_modules/.bin/codex', import.meta.url),
+);
+const CODEX_AGENT_SETTINGS: AgentSettingsEnvelope = {
+  ownerId: 'codex',
+  schemaVersion: 1,
+  values: {},
+};
+const SYSTEM_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+const LIVE_MODEL_CATALOG = {
+  models: [{
+    slug: LIVE_CODEX_MODEL,
+    prefer_websockets: false,
+    support_verbosity: false,
+    default_verbosity: null,
+    apply_patch_tool_type: 'freeform',
+    web_search_tool_type: 'text',
+    input_modalities: ['text'],
+    supports_image_detail_original: false,
+    truncation_policy: { mode: 'tokens', limit: 10_000 },
+    supports_parallel_tool_calls: true,
+    tool_mode: null,
+    multi_agent_version: null,
+    use_responses_lite: false,
+    include_skills_usage_instructions: false,
+    auto_review_model_override: null,
+    context_window: 272_000,
+    max_context_window: 272_000,
+    auto_compact_token_limit: null,
+    comp_hash: null,
+    reasoning_summary_format: 'experimental',
+    default_reasoning_summary: 'none',
+    display_name: 'GPT-5.4 Nano',
+    description: 'Low-cost model used by Garcon live integration tests.',
+    default_reasoning_level: LIVE_CODEX_THINKING_MODE,
+    supported_reasoning_levels: [{
+      effort: LIVE_CODEX_THINKING_MODE,
+      description: 'Lowest supported reasoning effort',
+    }],
+    shell_type: 'shell_command',
+    visibility: 'list',
+    supported_in_api: true,
+    availability_nux: null,
+    upgrade: null,
+    priority: 1,
+    model_messages: null,
+    experimental_supported_tools: [],
+    supports_search_tool: false,
+    default_service_tier: null,
+    service_tiers: [],
+    additional_speed_tiers: [],
+    supports_reasoning_summaries: true,
+    base_instructions: 'You are Codex, a coding agent. Follow the user request exactly.',
+  }],
+};
+
+export async function liveCodexServerEnvironment(): Promise<Record<string, string>> {
+  const testingKey = process.env.OPENAI_TESTING_KEY?.trim();
+  if (!testingKey) {
+    throw new Error('OPENAI_TESTING_KEY is required for live Codex integration tests.');
+  }
+  await access(CODEX_BINARY, constants.X_OK);
+  const nodeBinary = Bun.which('node');
+  if (!nodeBinary) {
+    throw new Error('Node.js is required to launch the pinned Codex package.');
+  }
+
+  // The temporary custom provider keeps the user's Codex home and login untouched.
+  return {
+    GARCON_CODEX_CLI: CODEX_BINARY,
+    OPENAI_API_KEY: testingKey,
+    PATH: `${dirname(nodeBinary)}:${SYSTEM_PATH}`,
+  };
+}
+
+export async function prepareLiveCodexHome(
+  directories: IntegrationDirectories,
+): Promise<void> {
+  const codexHome = join(directories.home, '.codex');
+  const catalogPath = join(codexHome, 'live-models.json');
+  await mkdir(codexHome, { recursive: true, mode: 0o700 });
+  await writeFile(catalogPath, JSON.stringify(LIVE_MODEL_CATALOG), { mode: 0o600 });
+  await writeFile(join(codexHome, 'config.toml'), [
+    'model_provider = "garcon-live-openai"',
+    `model_catalog_json = ${JSON.stringify(catalogPath)}`,
+    '',
+    '[model_providers.garcon-live-openai]',
+    'name = "Garcon Live OpenAI"',
+    'base_url = "https://api.openai.com/v1"',
+    'env_key = "OPENAI_API_KEY"',
+    'wire_api = "responses"',
+    '',
+  ].join('\n'), { mode: 0o600 });
+}
+
+export function liveCodexStartRequest(input: {
+  chatId: string;
+  projectPath: string;
+  command: string;
+  permissionMode?: StartChatCommandRequest['permissionMode'];
+}): StartChatCommandRequest {
+  return {
+    clientRequestId: crypto.randomUUID(),
+    clientMessageId: crypto.randomUUID(),
+    chatId: input.chatId,
+    agentId: 'codex',
+    projectPath: input.projectPath,
+    model: LIVE_CODEX_MODEL,
+    permissionMode: input.permissionMode ?? 'default',
+    thinkingMode: LIVE_CODEX_THINKING_MODE,
+    agentSettings: CODEX_AGENT_SETTINGS,
+    command: input.command,
+  };
+}
+
+export function liveCodexRunRequest(input: {
+  chatId: string;
+  command: string;
+  permissionMode?: AgentRunCommandRequest['permissionMode'];
+}): AgentRunCommandRequest {
+  return {
+    clientRequestId: crypto.randomUUID(),
+    clientMessageId: crypto.randomUUID(),
+    chatId: input.chatId,
+    command: input.command,
+    permissionMode: input.permissionMode ?? 'default',
+    thinkingMode: LIVE_CODEX_THINKING_MODE,
+    agentSettings: CODEX_AGENT_SETTINGS,
+    model: LIVE_CODEX_MODEL,
+  };
+}
+
+export function liveCodexForkRunRequest(input: {
+  sourceChatId: string;
+  chatId: string;
+  command: string;
+}): ForkRunCommandRequest {
+  return {
+    clientRequestId: crypto.randomUUID(),
+    clientMessageId: crypto.randomUUID(),
+    sourceChatId: input.sourceChatId,
+    chatId: input.chatId,
+    command: input.command,
+    permissionMode: 'default',
+    thinkingMode: LIVE_CODEX_THINKING_MODE,
+    agentSettings: CODEX_AGENT_SETTINGS,
+    model: LIVE_CODEX_MODEL,
+  };
+}

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path';
 import type {
   ChatMessagesMessage,
   PendingUserInputUpdatedMessage,
-  ServerWsMessage,
 } from '../../../../common/ws-events.js';
 import {
   assistantContents,
@@ -17,84 +16,19 @@ import {
   withIntegrationFixture,
 } from '../../../support/integration-fixture.js';
 import {
+  exactReplyPrompt,
+  expectAssistantMarker,
+  expectFinished,
+  liveMarker as marker,
+  LIVE_TURN_TIMEOUT_MS as TURN_TIMEOUT_MS,
+  waitForVisibleResponse as waitForVisibleClaudeResponse,
+} from '../../../support/live-agent.js';
+import {
   liveClaudeForkRunRequest,
   liveClaudeRunRequest,
   liveClaudeServerEnvironment,
   liveClaudeStartRequest,
 } from '../../../support/live-claude.js';
-
-const TURN_TIMEOUT_MS = 90_000;
-
-function marker(label: string): string {
-  return `GARCON_LIVE_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
-}
-
-function exactReplyPrompt(value: string): string {
-  return `Reply with exactly ${value}. Do not use tools.`;
-}
-
-function expectFinished(type: string): void {
-  expect(type).toBe('agent-run-finished');
-}
-
-function expectAssistantMarker(contents: readonly string[], value: string): void {
-  expect(contents.some((content) => content.includes(value))).toBe(true);
-}
-
-function expectVisibleResponseBeforeSettlement(input: {
-  events: readonly ServerWsMessage[];
-  chatId: string;
-  turnId: string | undefined;
-  marker: string;
-}): void {
-  const processingStarted = input.events.findIndex((event) =>
-    event.type === 'chat-processing-updated'
-    && event.chatId === input.chatId
-    && event.isProcessing);
-  const assistantResponse = input.events.findIndex((event) =>
-    event.type === 'chat-messages'
-    && event.chatId === input.chatId
-    && event.messages.some((entry) =>
-      entry.message.type === 'assistant-message'
-      && entry.message.content.includes(input.marker)));
-  const processingStopped = input.events.findIndex((event) =>
-    event.type === 'chat-processing-updated'
-    && event.chatId === input.chatId
-    && !event.isProcessing);
-  const terminal = input.events.findIndex((event) =>
-    (event.type === 'agent-run-finished' || event.type === 'agent-run-failed')
-    && event.chatId === input.chatId
-    && event.turnId === input.turnId);
-
-  expect(processingStarted).toBeGreaterThanOrEqual(0);
-  expect(assistantResponse).toBeGreaterThan(processingStarted);
-  expect(processingStopped).toBeGreaterThan(assistantResponse);
-  expect(terminal).toBeGreaterThan(assistantResponse);
-}
-
-async function waitForVisibleClaudeResponse(input: {
-  fixture: IntegrationFixture;
-  chatId: string;
-  turnId: string | undefined;
-  marker: string;
-  afterIndex: number;
-}): Promise<void> {
-  expectFinished((await input.fixture.client.waitForTurnTerminal(
-    input.chatId,
-    input.turnId,
-    { afterIndex: input.afterIndex, timeoutMs: TURN_TIMEOUT_MS },
-  )).type);
-  await input.fixture.client.waitForProcessing(input.chatId, false, {
-    afterIndex: input.afterIndex,
-    timeoutMs: TURN_TIMEOUT_MS,
-  });
-  expectVisibleResponseBeforeSettlement({
-    events: input.fixture.client.eventsSince(input.afterIndex),
-    chatId: input.chatId,
-    turnId: input.turnId,
-    marker: input.marker,
-  });
-}
 
 describe('live Claude lifecycle', () => {
   test('queues consecutive turns, forks immediately, and forks the fork', async () => {

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, test } from 'bun:test';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { PendingUserInputUpdatedMessage } from '../../../../common/ws-events.js';
+import {
+  assistantContents,
+  countUserContent,
+  messagesOfType,
+  userContents,
+} from '../../../support/chat-assertions.js';
+import {
+  type IntegrationFixture,
+  withIntegrationFixture,
+} from '../../../support/integration-fixture.js';
+import {
+  exactReplyPrompt,
+  expectAssistantMarker,
+  expectFinished,
+  liveMarker,
+  LIVE_TURN_TIMEOUT_MS,
+  waitForVisibleResponse,
+} from '../../../support/live-agent.js';
+import {
+  liveCodexForkRunRequest,
+  liveCodexRunRequest,
+  liveCodexServerEnvironment,
+  liveCodexStartRequest,
+  prepareLiveCodexHome,
+} from '../../../support/live-codex.js';
+
+describe('live Codex lifecycle', () => {
+  test('queues turns, forks immediately, reforks, and resumes after restart', async () => {
+    const serverEnvironment = await liveCodexServerEnvironment();
+    const toolOutput = liveMarker('CODEX_TOOL_OUTPUT');
+    const fixtureName = 'live-codex-input.txt';
+    const toolCommand = `sleep 2 && cat ${fixtureName}`;
+
+    await withIntegrationFixture('live-codex-queue-and-fork', async (fixture) => {
+      const parentChatId = fixture.newChatId();
+      const firstMarker = liveMarker('CODEX_PARENT_FIRST');
+      const secondMarker = liveMarker('CODEX_PARENT_SECOND');
+      const firstPrompt = [
+        `Use the shell tool to run exactly \`${toolCommand}\`.`,
+        `After it succeeds, reply with exactly ${firstMarker}.`,
+        'Do not run any other command.',
+      ].join(' ');
+      const secondPrompt = exactReplyPrompt(secondMarker);
+      const firstCursor = fixture.client.markEvents();
+      const first = await fixture.client.startChat(liveCodexStartRequest({
+        chatId: parentChatId,
+        projectPath: fixture.dirs.project,
+        command: firstPrompt,
+        permissionMode: 'bypassPermissions',
+      }));
+
+      const queueCursor = fixture.client.markEvents();
+      const queued = await fixture.client.enqueueNew(parentChatId, secondPrompt);
+      expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([secondPrompt]);
+
+      expectFinished((await fixture.client.waitForTurnTerminal(parentChatId, first.turnId, {
+        afterIndex: firstCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      })).type);
+      const secondInput = await fixture.client.waitForEvent(
+        (event): event is PendingUserInputUpdatedMessage =>
+          event.type === 'pending-user-input-updated'
+          && event.input.chatId === parentChatId
+          && event.input.content === secondPrompt
+          && typeof event.input.turnId === 'string',
+        'live Codex queued turn identity',
+        { afterIndex: queueCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      expectFinished((await fixture.client.waitForTurnTerminal(
+        parentChatId,
+        secondInput.input.turnId,
+        { afterIndex: queueCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      )).type);
+
+      const childChatId = fixture.newChatId();
+      const childMarker = liveMarker('CODEX_CHILD');
+      const childPrompt = exactReplyPrompt(childMarker);
+      const childCursor = fixture.client.markEvents();
+      const child = await fixture.client.forkRunChat(liveCodexForkRunRequest({
+        sourceChatId: parentChatId,
+        chatId: childChatId,
+        command: childPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: childChatId,
+        turnId: child.turnId,
+        marker: childMarker,
+        afterIndex: childCursor,
+      });
+
+      const parentAfterQueue = await fixture.client.getMessages(parentChatId);
+      const firstAssistant = parentAfterQueue.messages.find((entry) =>
+        entry.message.type === 'assistant-message'
+        && entry.message.content.includes(firstMarker));
+      if (!firstAssistant) throw new Error('Live Codex first response was not persisted.');
+      expectPersistedCommand(parentAfterQueue, toolCommand, toolOutput);
+
+      const pointChatId = fixture.newChatId();
+      await fixture.client.forkChat({
+        sourceChatId: parentChatId,
+        chatId: pointChatId,
+        upToSeq: firstAssistant.seq,
+      });
+      const pointMarker = liveMarker('CODEX_POINT_FORK');
+      const pointPrompt = exactReplyPrompt(pointMarker);
+      const pointCursor = fixture.client.markEvents();
+      const pointTurn = await fixture.client.runChat(liveCodexRunRequest({
+        chatId: pointChatId,
+        command: pointPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: pointChatId,
+        turnId: pointTurn.turnId,
+        marker: pointMarker,
+        afterIndex: pointCursor,
+      });
+
+      const grandchildChatId = fixture.newChatId();
+      const grandchildMarker = liveMarker('CODEX_GRANDCHILD');
+      const grandchildPrompt = exactReplyPrompt(grandchildMarker);
+      const grandchildCursor = fixture.client.markEvents();
+      const grandchild = await fixture.client.forkRunChat(liveCodexForkRunRequest({
+        sourceChatId: childChatId,
+        chatId: grandchildChatId,
+        command: grandchildPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: grandchildChatId,
+        turnId: grandchild.turnId,
+        marker: grandchildMarker,
+        afterIndex: grandchildCursor,
+      });
+
+      const parentContinuationMarker = liveMarker('CODEX_PARENT_CONTINUATION');
+      const parentContinuationPrompt = exactReplyPrompt(parentContinuationMarker);
+      const parentContinuationCursor = fixture.client.markEvents();
+      const parentContinuation = await fixture.client.runChat(liveCodexRunRequest({
+        chatId: parentChatId,
+        command: parentContinuationPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: parentChatId,
+        turnId: parentContinuation.turnId,
+        marker: parentContinuationMarker,
+        afterIndex: parentContinuationCursor,
+      });
+
+      await expectIndependentCodexSessions(fixture, [
+        parentChatId,
+        pointChatId,
+        childChatId,
+        grandchildChatId,
+      ]);
+
+      await fixture.restartGarcon();
+      const resumedMarker = liveMarker('CODEX_GRANDCHILD_RESUMED');
+      const resumedPrompt = exactReplyPrompt(resumedMarker);
+      const resumedCursor = fixture.client.markEvents();
+      const resumed = await fixture.client.runChat(liveCodexRunRequest({
+        chatId: grandchildChatId,
+        command: resumedPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: grandchildChatId,
+        turnId: resumed.turnId,
+        marker: resumedMarker,
+        afterIndex: resumedCursor,
+      });
+
+      const parent = await fixture.client.getMessages(parentChatId);
+      const pointTranscript = await fixture.client.getMessages(pointChatId);
+      const childTranscript = await fixture.client.getMessages(childChatId);
+      const grandchildTranscript = await fixture.client.getMessages(grandchildChatId);
+      expect(userContents(parent.messages)).toEqual([
+        firstPrompt,
+        secondPrompt,
+        parentContinuationPrompt,
+      ]);
+      expect(userContents(pointTranscript.messages)).toEqual([firstPrompt, pointPrompt]);
+      expect(userContents(childTranscript.messages)).toEqual([
+        firstPrompt,
+        secondPrompt,
+        childPrompt,
+      ]);
+      expect(userContents(grandchildTranscript.messages)).toEqual([
+        firstPrompt,
+        secondPrompt,
+        childPrompt,
+        grandchildPrompt,
+        resumedPrompt,
+      ]);
+      expectAssistantMarker(assistantContents(parent.messages), firstMarker);
+      expectAssistantMarker(assistantContents(parent.messages), secondMarker);
+      expectAssistantMarker(assistantContents(parent.messages), parentContinuationMarker);
+      expectAssistantMarker(assistantContents(pointTranscript.messages), pointMarker);
+      expect(assistantContents(pointTranscript.messages).join('\n')).not.toContain(secondMarker);
+      expectAssistantMarker(assistantContents(childTranscript.messages), childMarker);
+      expectAssistantMarker(assistantContents(grandchildTranscript.messages), grandchildMarker);
+      expectAssistantMarker(assistantContents(grandchildTranscript.messages), resumedMarker);
+      expect(userContents(grandchildTranscript.messages)).not.toContain(parentContinuationPrompt);
+      expectPersistedCommand(parent, toolCommand, toolOutput);
+      expect(countUserContent(parent.messages, firstPrompt)).toBe(1);
+      expect((await fixture.client.getExecutionControl(parentChatId)).queue.entries).toEqual([]);
+    }, {
+      redactSensitiveDiagnostics: true,
+      serverEnvironment,
+      prepareWorkspace: async (directories) => {
+        await prepareLiveCodexHome(directories);
+        await writeFile(join(directories.project, fixtureName), toolOutput, 'utf8');
+      },
+    });
+  });
+
+  test('interrupts and stops active tools while preserving later delivery', async () => {
+    const serverEnvironment = await liveCodexServerEnvironment();
+    await withIntegrationFixture('live-codex-interrupt-and-send', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const interruptedStarted = join(fixture.dirs.project, '.codex-interrupt-started');
+      const interruptedPrompt = [
+        'Use the shell tool now to run exactly `touch .codex-interrupt-started && sleep 30`.',
+        'Do not perform other work before the command finishes.',
+        'After it finishes, reply with exactly CODEX_SHOULD_NOT_COMPLETE.',
+      ].join(' ');
+      const successorMarker = liveMarker('CODEX_INTERRUPT_SUCCESSOR');
+      const successorPrompt = exactReplyPrompt(successorMarker);
+      await fixture.client.startChat(liveCodexStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: interruptedPrompt,
+        permissionMode: 'bypassPermissions',
+      }));
+
+      await waitForFile(interruptedStarted);
+      const queued = await fixture.client.enqueueNew(chatId, successorPrompt);
+      expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([successorPrompt]);
+
+      const interruptCursor = fixture.client.markEvents();
+      const interrupted = await fixture.client.interruptAndSend({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+      });
+      expect(interrupted.stopped).toBe(true);
+      const successorInput = await fixture.client.waitForEvent(
+        (event): event is PendingUserInputUpdatedMessage =>
+          event.type === 'pending-user-input-updated'
+          && event.input.chatId === chatId
+          && event.input.content === successorPrompt
+          && typeof event.input.turnId === 'string',
+        'live Codex interrupt successor identity',
+        { afterIndex: interruptCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      expectFinished((await fixture.client.waitForTurnTerminal(
+        chatId,
+        successorInput.input.turnId,
+        { afterIndex: interruptCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      )).type);
+
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(countUserContent(transcript.messages, successorPrompt)).toBe(1);
+      expectAssistantMarker(assistantContents(transcript.messages), successorMarker);
+      expect(assistantContents(transcript.messages).join('\n'))
+        .not.toContain('CODEX_SHOULD_NOT_COMPLETE');
+      expect((await fixture.client.getExecutionControl(chatId)).queue.entries).toEqual([]);
+
+      const stoppedStarted = join(fixture.dirs.project, '.codex-stop-started');
+      const stoppedPrompt = [
+        'Use the shell tool now to run exactly `touch .codex-stop-started && sleep 30`.',
+        'Do not perform other work before the command finishes.',
+        'After it finishes, reply with exactly CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE.',
+      ].join(' ');
+      const stopCursor = fixture.client.markEvents();
+      await fixture.client.runChat(liveCodexRunRequest({
+        chatId,
+        command: stoppedPrompt,
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForFile(stoppedStarted);
+      const stopped = await fixture.client.stopChat({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+      });
+      expect(stopped.stopped).toBe(true);
+      await fixture.client.waitForProcessing(chatId, false, {
+        afterIndex: stopCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      expect(assistantContents(
+        (await fixture.client.getMessages(chatId)).messages,
+      ).join('\n')).not.toContain('CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE');
+
+      const recoveryMarker = liveMarker('CODEX_POST_INTERRUPT');
+      const recoveryPrompt = exactReplyPrompt(recoveryMarker);
+      const recoveryCursor = fixture.client.markEvents();
+      const recovery = await fixture.client.runChat(liveCodexRunRequest({
+        chatId,
+        command: recoveryPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: recovery.turnId,
+        marker: recoveryMarker,
+        afterIndex: recoveryCursor,
+      });
+    }, {
+      redactSensitiveDiagnostics: true,
+      serverEnvironment,
+      prepareWorkspace: prepareLiveCodexHome,
+    });
+  });
+});
+
+function expectPersistedCommand(
+  transcript: Awaited<ReturnType<IntegrationFixture['client']['getMessages']>>,
+  command: string,
+  output: string,
+): void {
+  const bash = messagesOfType(transcript.messages, 'bash-tool-use').find(
+    (message) => message.command.includes(command),
+  );
+  if (!bash) throw new Error('Live Codex shell tool use was not rendered.');
+  const result = messagesOfType(transcript.messages, 'tool-result').find(
+    (message) => message.toolId === bash.toolId,
+  );
+  expect(result?.isError).toBe(false);
+  expect(JSON.stringify(result?.content)).toContain(output);
+  const bashSeq = transcript.messages.find((entry) =>
+    entry.message.type === 'bash-tool-use' && entry.message.toolId === bash.toolId)?.seq;
+  const resultSeq = transcript.messages.find((entry) =>
+    entry.message.type === 'tool-result' && entry.message.toolId === bash.toolId)?.seq;
+  expect(resultSeq).toBeGreaterThan(bashSeq ?? Number.MAX_SAFE_INTEGER);
+}
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (await Bun.file(path).exists()) return;
+    await Bun.sleep(25);
+  }
+  throw new Error('Timed out waiting for the live Codex command marker.');
+}
+
+interface PersistedCodexChat {
+  agentSessionId: string;
+  nativeSession: {
+    ownerId: string;
+    schemaVersion: number;
+    value: {
+      path: string;
+      agentSessionId: string;
+    };
+  };
+}
+
+interface CodexNativeSession {
+  sessionId: string;
+  path: string;
+}
+
+async function expectIndependentCodexSessions(
+  fixture: IntegrationFixture,
+  chatIds: readonly string[],
+): Promise<void> {
+  const sessions = await Promise.all(chatIds.map((chatId) =>
+    readCodexNativeSession(fixture.dirs.workspace, chatId)));
+  expect(new Set(sessions.map((session) => session.sessionId)).size).toBe(sessions.length);
+  expect(new Set(sessions.map((session) => session.path)).size).toBe(sessions.length);
+}
+
+async function readCodexNativeSession(
+  workspace: string,
+  chatId: string,
+): Promise<CodexNativeSession> {
+  const registry = JSON.parse(
+    await readFile(join(workspace, 'chats.json'), 'utf8'),
+  ) as { sessions?: Record<string, PersistedCodexChat> };
+  const chat = registry.sessions?.[chatId];
+  if (
+    !chat
+    || chat.nativeSession.ownerId !== 'codex'
+    || chat.nativeSession.schemaVersion !== 1
+    || chat.nativeSession.value.agentSessionId !== chat.agentSessionId
+  ) {
+    throw new Error(`Live Codex chat ${chatId} has invalid native session metadata.`);
+  }
+
+  const nativePath = chat.nativeSession.value.path;
+  const sessionMeta = (await readFile(nativePath, 'utf8'))
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+    .find((row) => row.type === 'session_meta');
+  const payload = sessionMeta?.payload;
+  expect(
+    typeof payload === 'object'
+    && payload !== null
+    && (payload as Record<string, unknown>).id,
+  ).toBe(chat.agentSessionId);
+
+  return { sessionId: chat.agentSessionId, path: nativePath };
+}

--- a/integration-tests/tests/server/support-contract.test.ts
+++ b/integration-tests/tests/server/support-contract.test.ts
@@ -5,6 +5,7 @@ import { FakeAnthropicServer } from '../../support/fake-anthropic-server.js';
 import { FakeOpenAiServer } from '../../support/fake-openai-server.js';
 import { FakeOpenAiResponsesServer } from '../../support/fake-openai-responses-server.js';
 import { GarconTestClient } from '../../support/garcon-client.js';
+import { redactSensitiveEnvironmentText } from '../../support/garcon-process.js';
 import { fakeAnthropicRequestHeaders } from '../../support/anthropic-test-contract.js';
 import {
   createCodexRolloutFileName,
@@ -56,6 +57,15 @@ function anthropicStreamText(body: string): string {
 }
 
 describe('integration support contracts', () => {
+  test('redacts credential environment values from process diagnostics', () => {
+    const text = 'key=sk-testing-secret token=auth-testing-secret path=/tmp/test-home';
+    expect(redactSensitiveEnvironmentText(text, {
+      OPENAI_API_KEY: 'sk-testing-secret',
+      ANTHROPIC_AUTH_TOKEN: 'auth-testing-secret',
+      HOME: '/tmp/test-home',
+    })).toBe('key=[REDACTED] token=[REDACTED] path=/tmp/test-home');
+  });
+
   test('settles deferred values only once', async () => {
     const deferred = new Deferred<string>();
     expect(deferred.resolve('first')).toBe(true);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:integration:e2e": "bun run --cwd integration-tests test:e2e",
     "test:live": "bun run --cwd integration-tests test:live",
     "test:live:claude": "bun run --cwd integration-tests test:live:claude",
+    "test:live:codex": "bun run --cwd integration-tests test:live:codex",
     "lint": "bun run --cwd web lint",
     "check": "bun run lint && bun run --cwd web check",
     "typecheck": "bun run --filter '@garcon/server-agent-*' --if-present typecheck && bun run --cwd server typecheck && bun run --cwd web check && bun run --cwd integration-tests typecheck",


### PR DESCRIPTION
Codex lifecycle behavior now has credential-backed integration coverage to catch provider regressions in queueing, execution visibility, interruption, persistence, and forking. This adds an isolated `gpt-5.4-nano` low-effort live suite and dedicated CI gate, pins the test CLI, and hardens live-provider diagnostics and cleanup so testing does not use or modify developer Codex state or expose credentials.
