### PR TITLE
Keep Claude turns active through background continuations

### DIFF
--- a/integration-tests/support/fake-claude-cli.ts
+++ b/integration-tests/support/fake-claude-cli.ts
@@ -170,6 +170,12 @@ function handleInput(line: string, nativePath: string, sessionId: string): void 
     session_id: sessionId,
   });
   writeOutput({
+    type: 'system',
+    subtype: 'session_state_changed',
+    state: 'running',
+    session_id: sessionId,
+  });
+  writeOutput({
     type: 'command_lifecycle',
     command_uuid: input.uuid,
     state: 'started',
@@ -203,6 +209,12 @@ function handleInput(line: string, nativePath: string, sessionId: string): void 
     type: 'command_lifecycle',
     command_uuid: input.uuid,
     state: 'completed',
+    session_id: sessionId,
+  });
+  writeOutput({
+    type: 'system',
+    subtype: 'session_state_changed',
+    state: 'idle',
     session_id: sessionId,
   });
 }

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -97,6 +97,93 @@ async function waitForVisibleClaudeResponse(input: {
 }
 
 describe('live Claude lifecycle', () => {
+  test('holds queue ownership across a background Bash continuation', async () => {
+    const serverEnvironment = await liveClaudeServerEnvironment();
+    await withIntegrationFixture('live-claude-background-continuation', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const launchedMarker = marker('BACKGROUND_LAUNCHED');
+      const completedMarker = marker('BACKGROUND_COMPLETED');
+      const successorMarker = marker('BACKGROUND_SUCCESSOR');
+      const prompt = [
+        'Use the Bash tool exactly once with run_in_background set to true.',
+        `Run exactly \`sleep 20; printf done\`.`,
+        `As soon as Bash reports that the command started in the background, reply with exactly ${launchedMarker} and end that model turn.`,
+        'Do not call TaskOutput, poll, sleep in another tool, or wait synchronously.',
+        `When the background task completion notification arrives, reply with exactly ${completedMarker}.`,
+      ].join(' ');
+      const cursor = fixture.client.markEvents();
+      const first = await fixture.client.startChat(liveClaudeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: prompt,
+        permissionMode: 'bypassPermissions',
+      }));
+
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'assistant-message'
+            && entry.message.content.includes(launchedMarker)),
+        'live Claude background launch response',
+        { afterIndex: cursor, timeoutMs: TURN_TIMEOUT_MS },
+      );
+      expect(fixture.client.eventsSince(cursor)).not.toContainEqual(expect.objectContaining({
+        type: 'agent-run-finished',
+        chatId,
+        turnId: first.turnId,
+      }));
+
+      const queueCursor = fixture.client.markEvents();
+      const successorPrompt = exactReplyPrompt(successorMarker);
+      const queued = await fixture.client.enqueueNew(chatId, successorPrompt);
+      expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([
+        successorPrompt,
+      ]);
+
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'assistant-message'
+            && entry.message.content.includes(completedMarker)),
+        'live Claude background completion response',
+        { afterIndex: cursor, timeoutMs: TURN_TIMEOUT_MS },
+      );
+      expectFinished((await fixture.client.waitForTurnTerminal(chatId, first.turnId, {
+        afterIndex: cursor,
+        timeoutMs: TURN_TIMEOUT_MS,
+      })).type);
+
+      const successor = await fixture.client.waitForEvent(
+        (event): event is PendingUserInputUpdatedMessage =>
+          event.type === 'pending-user-input-updated'
+          && event.input.chatId === chatId
+          && event.input.content === successorPrompt
+          && typeof event.input.turnId === 'string',
+        'live Claude post-background successor identity',
+        { afterIndex: queueCursor, timeoutMs: TURN_TIMEOUT_MS },
+      );
+      expectFinished((await fixture.client.waitForTurnTerminal(
+        chatId,
+        successor.input.turnId,
+        { afterIndex: queueCursor, timeoutMs: TURN_TIMEOUT_MS },
+      )).type);
+
+      const transcript = await fixture.client.getMessages(chatId);
+      const contents = assistantContents(transcript.messages);
+      const launchedIndex = contents.findIndex((content) => content.includes(launchedMarker));
+      const completedIndex = contents.findIndex((content) => content.includes(completedMarker));
+      const successorIndex = contents.findIndex((content) => content.includes(successorMarker));
+      expect(launchedIndex).toBeGreaterThanOrEqual(0);
+      expect(completedIndex).toBeGreaterThan(launchedIndex);
+      expect(successorIndex).toBeGreaterThan(completedIndex);
+      expect((await fixture.client.getExecutionControl(chatId)).queue.entries).toEqual([]);
+    }, { redactSensitiveDiagnostics: true, serverEnvironment });
+  });
+
   test('queues consecutive turns, forks immediately, and forks the fork', async () => {
     const serverEnvironment = await liveClaudeServerEnvironment();
     await withIntegrationFixture('live-claude-queue-and-fork', async (fixture) => {

--- a/integration-tests/tests/server/claude-turn-correlation.test.ts
+++ b/integration-tests/tests/server/claude-turn-correlation.test.ts
@@ -6,11 +6,14 @@ import type {
   ChatMessagesMessage,
   PendingUserInputUpdatedMessage,
 } from '../../../common/ws-events.js';
+import { GarconApiError } from '../../support/garcon-client.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
 
 function fakeClaudeSource(): string {
   return `#!${process.execPath}
-const { appendFileSync, existsSync } = await import('node:fs');
+const { appendFileSync, existsSync, mkdirSync, writeFileSync } = await import('node:fs');
+const { randomUUID } = await import('node:crypto');
+const { dirname, join, resolve } = await import('node:path');
 const args = process.argv.slice(2);
 
 if (args.includes('--version')) {
@@ -24,6 +27,19 @@ if (args[0] === 'auth' && args[1] === 'status') {
 }
 
 const emit = (message) => process.stdout.write(JSON.stringify(message) + '\\n');
+const argumentValue = (name) => {
+  const inline = args.find((value) => value.startsWith(name + '='));
+  if (inline) return inline.slice(name.length + 1);
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] ?? null : null;
+};
+const sessionId = argumentValue('--session-id') ?? argumentValue('--resume');
+const configHome = process.env.CLAUDE_CONFIG_DIR ?? join(process.env.HOME, '.claude');
+const projectKey = resolve(process.cwd()).normalize('NFC').replace(/[^a-zA-Z0-9]/g, '-');
+const nativePath = join(configHome, 'projects', projectKey, sessionId + '.jsonl');
+mkdirSync(dirname(nativePath), { recursive: true });
+if (!existsSync(nativePath)) writeFileSync(nativePath, '');
+
 const decoder = new TextDecoder();
 let buffer = '';
 let firstUserMessage = true;
@@ -37,6 +53,49 @@ const receivedPath = process.env.CLAUDE_TEST_RECEIVED_PATH;
 const releasePath = process.env.CLAUDE_TEST_RELEASE_PATH;
 const internalResultPath = process.env.CLAUDE_TEST_INTERNAL_RESULT_PATH;
 const startedPath = process.env.CLAUDE_TEST_STARTED_PATH;
+const continuationResultPath = process.env.CLAUDE_TEST_CONTINUATION_RESULT_PATH;
+const continuationReleasePath = process.env.CLAUDE_TEST_CONTINUATION_RELEASE_PATH;
+let parentUuid = null;
+
+const appendTranscriptTurn = (input, response) => {
+  const assistantUuid = randomUUID();
+  appendFileSync(nativePath, [
+    JSON.stringify({
+      sessionId,
+      type: 'user',
+      uuid: input.uuid,
+      parentUuid,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+      message: { role: 'user', content: input.message?.content },
+    }),
+    JSON.stringify({
+      sessionId,
+      type: 'assistant',
+      uuid: assistantUuid,
+      parentUuid: input.uuid,
+      timestamp: new Date(Date.now() + 1).toISOString(),
+      cwd: process.cwd(),
+      message: { role: 'assistant', content: [{ type: 'text', text: response }] },
+    }),
+    '',
+  ].join('\\n'));
+  parentUuid = assistantUuid;
+};
+
+const appendContinuation = (response) => {
+  const assistantUuid = randomUUID();
+  appendFileSync(nativePath, JSON.stringify({
+    sessionId,
+    type: 'assistant',
+    uuid: assistantUuid,
+    parentUuid,
+    timestamp: new Date().toISOString(),
+    cwd: process.cwd(),
+    message: { role: 'assistant', content: [{ type: 'text', text: response }] },
+  }) + '\\n');
+  parentUuid = assistantUuid;
+};
 
 const recordInput = (input) => {
   if (!receivedPath) return;
@@ -58,6 +117,12 @@ const processInput = async (input) => {
     type: 'command_lifecycle',
     command_uuid: input.uuid,
     state: 'queued',
+    session_id: input.session_id,
+  });
+  emit({
+    type: 'system',
+    subtype: 'session_state_changed',
+    state: 'running',
     session_id: input.session_id,
   });
 
@@ -105,6 +170,12 @@ const processInput = async (input) => {
         state: 'cancelled',
         session_id: input.session_id,
       });
+      emit({
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'idle',
+        session_id: input.session_id,
+      });
       return;
     }
     emit({
@@ -117,8 +188,20 @@ const processInput = async (input) => {
       stop_reason: null,
       session_id: input.session_id,
     });
+    emit({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'requires_action',
+      session_id: input.session_id,
+    });
     await waitForRelease(input.uuid);
     if (interruptedInputs.has(input.uuid)) return;
+    emit({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'running',
+      session_id: input.session_id,
+    });
   }
 
   const content = input.message?.content;
@@ -133,6 +216,7 @@ const processInput = async (input) => {
   });
   startedInputs.add(input.uuid);
   if (startedPath) appendFileSync(startedPath, input.uuid + '\\n');
+  appendTranscriptTurn(input, response);
   emit({
     type: 'system',
     subtype: 'init',
@@ -166,10 +250,55 @@ const processInput = async (input) => {
     stop_reason: 'end_turn',
     session_id: input.session_id,
   });
+  if (content === 'trigger background continuation') {
+    if (continuationResultPath) appendFileSync(continuationResultPath, 'emitted\\n');
+    emit({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'requires_action',
+      session_id: input.session_id,
+    });
+    while (continuationReleasePath && !existsSync(continuationReleasePath)) await Bun.sleep(5);
+    const continuation = 'background continuation finished';
+    emit({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'running',
+      session_id: input.session_id,
+    });
+    emit({
+      type: 'system',
+      subtype: 'task_notification',
+      status: 'completed',
+      session_id: input.session_id,
+    });
+    appendContinuation(continuation);
+    emit({
+      type: 'assistant',
+      content: [{ type: 'text', text: continuation }],
+      session_id: input.session_id,
+    });
+    emit({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      duration_ms: 20,
+      num_turns: 1,
+      result: continuation,
+      stop_reason: 'end_turn',
+      session_id: input.session_id,
+    });
+  }
   emit({
     type: 'command_lifecycle',
     command_uuid: input.uuid,
     state: 'completed',
+    session_id: input.session_id,
+  });
+  emit({
+    type: 'system',
+    subtype: 'session_state_changed',
+    state: 'idle',
     session_id: input.session_id,
   });
 };
@@ -224,6 +353,12 @@ for await (const chunk of Bun.stdin.stream()) {
             response: { cancelled: [inputUuid], still_queued: [] },
           },
         });
+        emit({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
+          session_id: activeInput.session_id,
+        });
         continue;
       }
 
@@ -250,6 +385,12 @@ for await (const chunk of Bun.stdin.stream()) {
         type: 'command_lifecycle',
         command_uuid: inputUuid,
         state: 'cancelled',
+        session_id: activeInput.session_id,
+      });
+      emit({
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'idle',
         session_id: activeInput.session_id,
       });
       continue;
@@ -432,6 +573,115 @@ describe('Claude turn correlation', () => {
         serverEnvironment.CLAUDE_TEST_RECEIVED_PATH = receivedPath;
         serverEnvironment.CLAUDE_TEST_RELEASE_PATH = releasePath;
         serverEnvironment.CLAUDE_TEST_INTERNAL_RESULT_PATH = internalResultPath;
+      },
+    });
+  });
+
+  test('keeps queue and fork ownership through a post-result background continuation', async () => {
+    const serverEnvironment: Record<string, string> = {};
+    let receivedPath = '';
+    let continuationResultPath = '';
+    let continuationReleasePath = '';
+
+    await withIntegrationFixture('claude-background-continuation', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const firstCursor = fixture.client.markEvents();
+      const first = await fixture.client.startChat({
+        clientRequestId: crypto.randomUUID(),
+        clientMessageId: crypto.randomUUID(),
+        chatId,
+        agentId: 'claude',
+        projectPath: fixture.dirs.project,
+        model: 'haiku',
+        permissionMode: 'default',
+        thinkingMode: 'low',
+        agentSettings: {
+          ownerId: 'claude',
+          schemaVersion: 1,
+          values: {},
+        },
+        command: 'trigger background continuation',
+      });
+      await waitForFile(continuationResultPath);
+
+      expect(fixture.client.eventsSince(firstCursor)).not.toContainEqual(expect.objectContaining({
+        type: 'agent-run-finished',
+        chatId,
+        turnId: first.turnId,
+      }));
+      const queueCursor = fixture.client.markEvents();
+      const queued = await fixture.client.enqueueNew(chatId, 'after-background');
+      expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([
+        'after-background',
+      ]);
+      expect((await readFile(receivedPath, 'utf8')).trim().split('\n').map(
+        (line) => JSON.parse(line).content,
+      )).toEqual(['trigger background continuation']);
+
+      let busyFork: unknown;
+      try {
+        await fixture.client.forkChat({
+          sourceChatId: chatId,
+          chatId: fixture.newChatId(),
+        });
+      } catch (error) {
+        busyFork = error;
+      }
+      expect(busyFork).toBeInstanceOf(GarconApiError);
+      expect(busyFork).toMatchObject({
+        status: 409,
+        body: {
+          success: false,
+          errorCode: 'SESSION_BUSY',
+          retryable: true,
+        },
+      });
+
+      await writeFile(continuationReleasePath, 'release');
+      expect((await fixture.client.waitForTurnTerminal(chatId, first.turnId, {
+        afterIndex: firstCursor,
+      })).type).toBe('agent-run-finished');
+      const pending = await fixture.client.waitForEvent(
+        (event): event is PendingUserInputUpdatedMessage =>
+          event.type === 'pending-user-input-updated'
+          && event.input.chatId === chatId
+          && event.input.content === 'after-background',
+        'queued input after Claude background continuation',
+        { afterIndex: queueCursor },
+      );
+      expect((await fixture.client.waitForTurnTerminal(chatId, pending.input.turnId!, {
+        afterIndex: queueCursor,
+      })).type).toBe('agent-run-finished');
+
+      const forkChatId = fixture.newChatId();
+      await expect(fixture.client.forkChat({
+        sourceChatId: chatId,
+        chatId: forkChatId,
+      })).resolves.toMatchObject({ chat: { id: forkChatId } });
+      const forked = await fixture.client.getMessages(forkChatId);
+      expect(forked.messages.map((entry) => entry.message)).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          type: 'assistant-message',
+          content: 'background continuation finished',
+        }),
+        expect.objectContaining({
+          type: 'user-message',
+          content: 'after-background',
+        }),
+      ]));
+    }, {
+      serverEnvironment,
+      prepareWorkspace: async (directories) => {
+        const fakeClaude = join(directories.root, 'fake-claude');
+        receivedPath = join(directories.root, 'claude-received.jsonl');
+        continuationResultPath = join(directories.root, 'continuation-result-emitted');
+        continuationReleasePath = join(directories.root, 'release-continuation');
+        await writeFile(fakeClaude, fakeClaudeSource());
+        await chmod(fakeClaude, 0o755);
+        serverEnvironment.CLAUDE_BINARY = fakeClaude;
+        serverEnvironment.CLAUDE_TEST_RECEIVED_PATH = receivedPath;
+        serverEnvironment.CLAUDE_TEST_CONTINUATION_RESULT_PATH = continuationResultPath;
+        serverEnvironment.CLAUDE_TEST_CONTINUATION_RELEASE_PATH = continuationReleasePath;
       },
     });
   });

--- a/integration-tests/tests/server/claude-turn-correlation.test.ts
+++ b/integration-tests/tests/server/claude-turn-correlation.test.ts
@@ -234,6 +234,14 @@ const processInput = async (input) => {
     while (!interruptedInputs.has(input.uuid)) await Bun.sleep(5);
     return;
   }
+  if (content === 'trigger background continuation') {
+    emit({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [{ task_id: 'background-build', task_type: 'local_bash' }],
+      session_id: input.session_id,
+    });
+  }
   emit({
     type: 'assistant',
     content: [{ type: 'text', text: response }],
@@ -255,21 +263,27 @@ const processInput = async (input) => {
     emit({
       type: 'system',
       subtype: 'session_state_changed',
-      state: 'requires_action',
+      state: 'idle',
       session_id: input.session_id,
     });
     while (continuationReleasePath && !existsSync(continuationReleasePath)) await Bun.sleep(5);
     const continuation = 'background continuation finished';
     emit({
       type: 'system',
-      subtype: 'session_state_changed',
-      state: 'running',
+      subtype: 'background_tasks_changed',
+      tasks: [],
       session_id: input.session_id,
     });
     emit({
       type: 'system',
       subtype: 'task_notification',
       status: 'completed',
+      session_id: input.session_id,
+    });
+    emit({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'running',
       session_id: input.session_id,
     });
     appendContinuation(continuation);

--- a/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
@@ -282,7 +282,8 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
   it('settles cleanly when an interrupt ends a fenced background wait', async () => {
     const runtime = createRuntime();
     const ctrl = createControllableProc();
-    spawnMock.mockReturnValue(ctrl.proc);
+    const nextCtrl = createControllableProc();
+    spawnMock.mockReturnValueOnce(ctrl.proc).mockReturnValueOnce(nextCtrl.proc);
     const failures = [];
     const finishes = [];
     runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
@@ -321,10 +322,21 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     ctrl.push(IDLE);
     await turn;
+    await flush();
     expect(cleared).toContain(completionFallback.id);
     expect(ctrl.proc.killed).toBe(false);
+    expect(ctrl.proc.ended).toBe(true);
     expect(failures).toEqual([]);
     expect(finishes).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
+
+    const nextTurn = runtime.runClaudeTurn(startOptions({ command: 'after stop' }));
+    await flush();
+    nextCtrl.push(INIT);
+    nextCtrl.startLatestInput();
+    nextCtrl.push({ type: 'assistant', content: [{ type: 'text', text: 'continued' }] });
+    settleTurn(nextCtrl);
+    await nextTurn;
+    expect(spawnMock).toHaveBeenCalledTimes(2);
   });
 
   it('cancels a queued submitted input when an internal turn is interrupted', async () => {

--- a/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
@@ -279,6 +279,54 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     }]);
   });
 
+  it('settles cleanly when an interrupt ends a fenced background wait', async () => {
+    const runtime = createRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+    const failures = [];
+    const finishes = [];
+    runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
+    runtime.onFinished((chatId, exitCode) => finishes.push({ chatId, exitCode }));
+
+    const turn = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+    ctrl.startLatestInput();
+    ctrl.push({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [{ task_id: 'background-build', task_type: 'local_bash' }],
+    });
+    ctrl.push({ type: 'assistant', content: [{ type: 'text', text: 'started' }] });
+    ctrl.push(RESULT);
+    ctrl.push(IDLE);
+    await flush();
+    expect(runtime.isClaudeInternalSessionRunning('session-1')).toBe(true);
+
+    await runtime.abortClaudeInternalSession('session-1');
+    const interrupt = ctrl.writes
+      .map((line) => JSON.parse(line))
+      .find((message) => message.request?.subtype === 'interrupt');
+    ctrl.push({
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: interrupt.request_id,
+        response: { cancelled: [], still_queued: [] },
+      },
+    });
+    await flush();
+    const completionFallback = scheduled.find((entry) => entry.ms === 15_000);
+    expect(completionFallback).toBeDefined();
+
+    ctrl.push(IDLE);
+    await turn;
+    expect(cleared).toContain(completionFallback.id);
+    expect(ctrl.proc.killed).toBe(false);
+    expect(failures).toEqual([]);
+    expect(finishes).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
+  });
+
   it('cancels a queued submitted input when an internal turn is interrupted', async () => {
     const runtime = createRuntime();
     const ctrl = createControllableProc();

--- a/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
@@ -246,6 +246,39 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     expect(failures).toEqual([]);
   });
 
+  it('retains the force-kill fallback until provider idle follows an abort result', async () => {
+    const runtime = createRuntime();
+    const ctrl = createControllableProc();
+    spawnMock.mockReturnValue(ctrl.proc);
+    const failures = [];
+    runtime.onFailed((chatId, message) => failures.push({ chatId, message }));
+
+    const turn = runtime.startClaudeCliSession(startOptions());
+    ctrl.push(INIT);
+    await flush();
+    ctrl.startLatestInput();
+
+    await runtime.abortClaudeInternalSession('session-1');
+    const fallback = scheduled.find((entry) => entry.ms === 5000);
+    expect(fallback).toBeDefined();
+    ctrl.push({
+      type: 'result',
+      subtype: 'error_during_execution',
+      terminal_reason: 'aborted_streaming',
+      is_error: true,
+    });
+    await flush();
+
+    expect(cleared).not.toContain(fallback.id);
+    fallback.fn();
+    await turn;
+    expect(ctrl.proc.killed).toBe(true);
+    expect(failures).toEqual([{
+      chatId: 'chat-1',
+      message: 'Claude CLI did not confirm the interrupt.',
+    }]);
+  });
+
   it('cancels a queued submitted input when an internal turn is interrupted', async () => {
     const runtime = createRuntime();
     const ctrl = createControllableProc();

--- a/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
@@ -118,7 +118,13 @@ function startOptions(overrides = {}) {
 }
 
 const INIT = { type: 'system', subtype: 'init', session_id: 'session-1', model: 'sonnet' };
-const RESULT = { type: 'result', is_error: false };
+const RESULT = { type: 'result', is_error: false, result: 'done' };
+const IDLE = { type: 'system', subtype: 'session_state_changed', state: 'idle' };
+
+function settleTurn(ctrl, result = RESULT) {
+  ctrl.push(result);
+  ctrl.push(IDLE);
+}
 
 describe('ClaudeCliRuntime abort force-kill fallback', () => {
   let originalSpawn;
@@ -179,7 +185,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     await flush();
     ctrl.startLatestInput();
     ctrl.push(INIT);
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await retry;
     expect(processing).toEqual([true, false]);
     runtime.shutdown();
@@ -227,7 +233,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     // Interrupt acknowledged: the CLI ends the turn with a result while the
     // persistent process stays alive for follow-up turns.
-    ctrl.push({
+    settleTurn(ctrl, {
       type: 'result',
       subtype: 'error_during_execution',
       terminal_reason: 'aborted_streaming',
@@ -364,7 +370,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     ctrl.push({ type: 'assistant', content: [{ type: 'text', text: 'first output' }] });
     await runtime.abortClaudeInternalSession('session-1');
     const [abortTimerId] = abortTimerIds();
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await first;
 
     ctrl.push({ type: 'assistant', content: [{ type: 'text', text: 'trailing output' }] });
@@ -385,7 +391,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     ctrl.startLatestInput();
     ctrl.push({ type: 'assistant', content: [{ type: 'text', text: 'second output' }] });
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await second;
 
     expect(ctrl.proc.killed).toBe(false);
@@ -453,7 +459,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     expect(runtime.isClaudeInternalSessionRunning('session-1')).toBe(true);
 
     secondCtrl.push({ type: 'assistant', content: [{ type: 'text', text: 'replacement output' }] });
-    secondCtrl.push(RESULT);
+    settleTurn(secondCtrl);
     await second;
     expect(finishes).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
     expect(failures).toEqual([]);
@@ -480,7 +486,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     ctrl.startLatestInput();
     ctrl.push(INIT);
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await start;
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -496,7 +502,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     ctrl.push(INIT);
     await flush();
     ctrl.startLatestInput();
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await start;
 
     let firstResolved = false;
@@ -513,7 +519,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     await secondRejected;
 
     ctrl.startLatestInput();
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await first;
 
     expect(firstResolved).toBe(true);
@@ -531,7 +537,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     ctrl.push(INIT);
     await flush();
     ctrl.startLatestInput();
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await start;
 
     let firstResolved = false;
@@ -547,7 +553,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
       .toEqual(['initial', 'winner']);
 
     ctrl.startLatestInput();
-    ctrl.push(RESULT);
+    settleTurn(ctrl);
     await first;
     expect(firstResolved).toBe(true);
   });

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -459,6 +459,33 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
     }
   });
 
+  it('preserves a structured result failure when stdout ends before idle', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      const runtime = createRuntime();
+      const failures = [];
+      runtime.onFailed((_chatId, message) => failures.push(message));
+      const start = runtime.startClaudeCliSession(startOptions());
+      await enqueueInputStarted(fake);
+      fake.stdout.enqueue(encoder.encode(JSON.stringify({
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        result: 'Provider request failed',
+      }) + '\n'));
+      fake.closeStdout();
+
+      await expect(start).resolves.toBe('expected-session');
+      expect(failures).toEqual(['Provider request failed']);
+      await runtime.shutdown();
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+
   it('handles a terminal result without a trailing newline', async () => {
     const originalSpawn = Bun.spawn;
     const fake = createFakeClaudeProcess();
@@ -618,6 +645,11 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       enqueueProviderState(fake, 'running');
       fake.stdout.enqueue(encoder.encode([
         JSON.stringify({
+          type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: [{ task_id: 'background-build', task_type: 'local_bash' }],
+        }),
+        JSON.stringify({
           type: 'assistant',
           content: [{ type: 'text', text: 'Background build started.' }],
         }),
@@ -630,8 +662,19 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         }),
         JSON.stringify({
           type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: [],
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'task_notification',
+          task_id: 'background-build',
+          status: 'completed',
+        }),
+        JSON.stringify({
+          type: 'system',
           subtype: 'session_state_changed',
-          state: 'requires_action',
+          state: 'idle',
         }),
       ].join('\n') + '\n'));
       await Promise.resolve();
@@ -673,6 +716,42 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         { chatId: 'chat-1', isProcessing: true },
         { chatId: 'chat-1', isProcessing: false },
       ]);
+      await runtime.shutdown();
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('logs and retires provider activity without an active Garcon turn', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    const logger = createLogger();
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      const runtime = createRuntime(logger);
+      const start = runtime.startClaudeCliSession(startOptions());
+      await enqueueResult(fake);
+      await start;
+
+      enqueueProviderState(fake, 'running');
+      enqueueProviderState(fake, 'idle');
+      for (
+        let attempt = 0;
+        attempt < 20 && fake.proc.stdin.end.mock.calls.length === 0;
+        attempt += 1
+      ) {
+        await Promise.resolve();
+      }
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Claude CLI emitted provider activity without an active Garcon turn',
+        expect.objectContaining({
+          chatId: 'chat-1',
+          next: 'running',
+        }),
+      );
+      expect(fake.proc.stdin.end).toHaveBeenCalledTimes(1);
       await runtime.shutdown();
     } finally {
       Bun.spawn = originalSpawn;

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -650,17 +650,6 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           tasks: [{ task_id: 'background-build', task_type: 'local_bash' }],
         }),
         JSON.stringify({
-          type: 'assistant',
-          content: [{ type: 'text', text: 'Background build started.' }],
-        }),
-        JSON.stringify({
-          type: 'result',
-          subtype: 'success',
-          is_error: false,
-          user_message_uuid: input.uuid,
-          result: 'Background build started.',
-        }),
-        JSON.stringify({
           type: 'system',
           subtype: 'background_tasks_changed',
           tasks: [],
@@ -672,9 +661,15 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           status: 'completed',
         }),
         JSON.stringify({
-          type: 'system',
-          subtype: 'session_state_changed',
-          state: 'idle',
+          type: 'assistant',
+          content: [{ type: 'text', text: 'Background build started.' }],
+        }),
+        JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          user_message_uuid: input.uuid,
+          result: 'Background build started.',
         }),
       ].join('\n') + '\n'));
       await Promise.resolve();
@@ -684,11 +679,6 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       expect(processing).not.toContainEqual({ chatId: 'chat-1', isProcessing: false });
 
       fake.stdout.enqueue(encoder.encode([
-        JSON.stringify({
-          type: 'system',
-          subtype: 'session_state_changed',
-          state: 'running',
-        }),
         JSON.stringify({
           type: 'assistant',
           content: [{ type: 'text', text: 'Background build finished.' }],
@@ -735,6 +725,9 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       await start;
 
       enqueueProviderState(fake, 'running');
+      enqueueProviderState(fake, 'requires_action');
+      await Promise.resolve();
+      expect(fake.proc.stdin.end).not.toHaveBeenCalled();
       enqueueProviderState(fake, 'idle');
       for (
         let attempt = 0;

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -126,6 +126,16 @@ async function enqueueResult(fake) {
   fake.stdout.enqueue(new TextEncoder().encode(JSON.stringify({
     type: 'result',
     is_error: false,
+    result: 'done',
+  }) + '\n'));
+  enqueueProviderState(fake, 'idle');
+}
+
+function enqueueProviderState(fake, state) {
+  fake.stdout.enqueue(encoder.encode(JSON.stringify({
+    type: 'system',
+    subtype: 'session_state_changed',
+    state,
   }) + '\n'));
 }
 
@@ -194,9 +204,12 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         stop_reason: 'end_turn',
         permission_denials: [],
       }) + '\n'));
+      enqueueProviderState(fake, 'idle');
 
       await expect(start).resolves.toBe('expected-session');
-      expect(logger.info).toHaveBeenCalledWith('Claude CLI turn completed', {
+      expect(logger.info).toHaveBeenCalledWith(
+        'Claude CLI input result received; awaiting provider idle',
+        {
         chatId: 'chat-1',
         turnId: null,
         sessionId: 'expected',
@@ -213,7 +226,8 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         outputMessages: 0,
         hasResult: true,
         permissionDenials: 0,
-      });
+        },
+      );
       expect(JSON.stringify(logger.info.mock.calls)).not.toContain('private result content');
       runtime.shutdown();
     } finally {
@@ -248,6 +262,32 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       await enqueueResult(fake);
 
       await expect(start).resolves.toBe('expected-session');
+      await runtime.shutdown();
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('forces Claude session-state events after inherited endpoint overrides', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      const runtime = createRuntime();
+      const start = runtime.startClaudeCliSession(startOptions({
+        envOverrides: {
+          ANTHROPIC_BASE_URL: 'https://example.test',
+          CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '0',
+        },
+      }));
+      await enqueueResult(fake);
+      await start;
+
+      expect(Bun.spawn.mock.calls[0][1].env).toMatchObject({
+        ANTHROPIC_BASE_URL: 'https://example.test',
+        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+      });
       await runtime.shutdown();
     } finally {
       Bun.spawn = originalSpawn;
@@ -395,6 +435,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         result: 'Provider request failed',
         num_turns: 0,
       }) + '\n'));
+      enqueueProviderState(fake, 'idle');
 
       await expect(start).resolves.toBe('expected-session');
       expect(failures).toEqual([{
@@ -403,7 +444,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       }]);
       expect(finishes).toEqual([]);
       expect(logger.warn).toHaveBeenCalledWith(
-        'Claude CLI turn completed with an error',
+        'Claude CLI input result received; awaiting provider idle',
         expect.objectContaining({
           outcome: 'error_during_execution',
           isError: true,
@@ -427,11 +468,19 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       const runtime = createRuntime();
       const start = runtime.startClaudeCliSession(startOptions());
       await enqueueInputStarted(fake);
-      fake.stdout.enqueue(new TextEncoder().encode(JSON.stringify({
-        type: 'result',
-        subtype: 'success',
-        is_error: false,
-      })));
+      fake.stdout.enqueue(new TextEncoder().encode([
+        JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: 'done',
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
+        }),
+      ].join('\n')));
       fake.exit(0);
 
       await expect(start).resolves.toBe('expected-session');
@@ -475,6 +524,11 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           result: '',
           stop_reason: null,
         }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
+        }),
       ].join('\n') + '\n'));
       await Promise.resolve();
 
@@ -513,6 +567,11 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           result: 'actual user response',
           stop_reason: 'end_turn',
         }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
+        }),
       ].join('\n') + '\n'));
 
       await expect(start).resolves.toBe('expected-session');
@@ -532,6 +591,113 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         }),
       );
       runtime.shutdown();
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('keeps routing continuation output until Claude reports provider idle', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      const runtime = createRuntime();
+      const messages = [];
+      const finishes = [];
+      const processing = [];
+      runtime.onMessages((_chatId, emitted) => messages.push(...emitted));
+      runtime.onFinished((chatId, exitCode) => finishes.push({ chatId, exitCode }));
+      runtime.onProcessing((chatId, isProcessing) => processing.push({ chatId, isProcessing }));
+
+      const start = runtime.startClaudeCliSession(startOptions());
+      const input = await enqueueInputStarted(fake);
+      for (let attempt = 0; attempt < 10 && processing.length === 0; attempt += 1) {
+        await Promise.resolve();
+      }
+      enqueueProviderState(fake, 'running');
+      fake.stdout.enqueue(encoder.encode([
+        JSON.stringify({
+          type: 'assistant',
+          content: [{ type: 'text', text: 'Background build started.' }],
+        }),
+        JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          user_message_uuid: input.uuid,
+          result: 'Background build started.',
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'requires_action',
+        }),
+      ].join('\n') + '\n'));
+      await Promise.resolve();
+
+      expect(finishes).toEqual([]);
+      expect(runtime.isClaudeInternalSessionRunning('expected-session')).toBe(true);
+      expect(processing).not.toContainEqual({ chatId: 'chat-1', isProcessing: false });
+
+      fake.stdout.enqueue(encoder.encode([
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'running',
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          content: [{ type: 'text', text: 'Background build finished.' }],
+        }),
+        JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: 'Background build finished.',
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
+        }),
+      ].join('\n') + '\n'));
+
+      await expect(start).resolves.toBe('expected-session');
+      expect(messages).toMatchObject([
+        { type: 'assistant-message', content: 'Background build started.' },
+        { type: 'assistant-message', content: 'Background build finished.' },
+      ]);
+      expect(finishes).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
+      expect(processing).toEqual([
+        { chatId: 'chat-1', isProcessing: true },
+        { chatId: 'chat-1', isProcessing: false },
+      ]);
+      await runtime.shutdown();
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('fails closed when Claude becomes idle after input start without a result', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      const runtime = createRuntime();
+      const failures = [];
+      runtime.onFailed((_chatId, message) => failures.push(message));
+      const start = runtime.startClaudeCliSession(startOptions());
+      await enqueueInputStarted(fake);
+
+      enqueueProviderState(fake, 'idle');
+
+      await expect(start).resolves.toBe('expected-session');
+      expect(failures).toEqual([
+        'Claude CLI became idle before the submitted message produced a terminal result.',
+      ]);
+      expect(fake.proc.stdin.end).toHaveBeenCalledTimes(1);
     } finally {
       Bun.spawn = originalSpawn;
     }
@@ -571,6 +737,11 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           subtype: 'success',
           is_error: false,
           result: 'done',
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
         }),
       ].join('\n') + '\n'));
 
@@ -616,6 +787,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         user_message_uuid: input.uuid,
         result: 'correlated response',
       }) + '\n'));
+      enqueueProviderState(fake, 'idle');
 
       await expect(start).resolves.toBe('expected-session');
       expect(finishes).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
@@ -673,6 +845,11 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           subtype: 'success',
           is_error: false,
           result: 'retry succeeded',
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
         }),
       ].join('\n') + '\n'));
       await retry;
@@ -736,6 +913,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         result: '',
         stop_reason: null,
       }) + '\n'));
+      enqueueProviderState(fake, 'idle');
 
       await expect(start).resolves.toBe('expected-session');
       expect(failures).toEqual([{
@@ -772,6 +950,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         ],
         num_turns: 0,
       }) + '\n'));
+      enqueueProviderState(fake, 'idle');
 
       await expect(start).resolves.toBe('expected-session');
       expect(failures).toEqual([{
@@ -813,6 +992,11 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
           is_error: false,
           num_turns: 0,
           result: '',
+        }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'session_state_changed',
+          state: 'idle',
         }),
       ].join('\n') + '\n'));
 
@@ -883,6 +1067,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
         is_error: false,
         result: 'done',
       }) + '\n'));
+      enqueueProviderState(fake, 'idle');
       await start;
       runtime.shutdown();
     } finally {
@@ -893,11 +1078,14 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
   for (const [name, settle] of [
     [
       'successful result',
-      (fake) => fake.stdout.enqueue(encoder.encode(JSON.stringify({
-        type: 'result',
-        is_error: false,
-        result: 'done',
-      }) + '\n')),
+      (fake) => {
+        fake.stdout.enqueue(encoder.encode(JSON.stringify({
+          type: 'result',
+          is_error: false,
+          result: 'done',
+        }) + '\n'));
+        enqueueProviderState(fake, 'idle');
+      },
     ],
     [
       'stdout failure',

--- a/server-agents/claude/src/agents/claude/__tests__/cli.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { buildClaudeCLIArgs, buildClaudePermissionApprovalResponse, convertCLIMessageToChatMessages } from '../claude-cli.js';
 import {
   ClaudeTurnState,
+  claudeBackgroundTaskCount,
   claudeProviderSessionState,
   claudeResultFailureMessage,
 } from '../cli-protocol.js';
@@ -370,6 +371,24 @@ describe('Claude provider run boundaries', () => {
     })).toBeNull();
   });
 
+  it('decodes background task snapshots as a level count', () => {
+    expect(claudeBackgroundTaskCount({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [{ task_id: 'one' }, { task_id: 'two' }],
+    })).toBe(2);
+    expect(claudeBackgroundTaskCount({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [],
+    })).toBe(0);
+    expect(claudeBackgroundTaskCount({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: 'malformed',
+    })).toBeNull();
+  });
+
   it('treats later results as continuations of the accepted input', () => {
     const turn = new ClaudeTurnState('input-1');
     turn.observeInput({
@@ -391,6 +410,27 @@ describe('Claude provider run boundaries', () => {
       type: 'result',
       user_message_uuid: 'provider-owned-continuation',
     })).toBe('continuation');
+  });
+
+  it('keeps a background continuation fenced through its completion turn', () => {
+    const turn = new ClaudeTurnState('input-1');
+    turn.observeInput({
+      type: 'command_lifecycle',
+      command_uuid: 'input-1',
+      state: 'started',
+    });
+    turn.observeBackgroundTaskCount(1);
+    turn.recordAcceptedResult({
+      type: 'result',
+      user_message_uuid: 'input-1',
+      is_error: false,
+    });
+    expect(turn.backgroundContinuationPending).toBe(true);
+
+    turn.observeBackgroundTaskCount(0);
+    turn.observeProviderSessionState('running', 0);
+    turn.recordAcceptedResult({ type: 'result', is_error: false });
+    expect(turn.backgroundContinuationPending).toBe(false);
   });
 });
 

--- a/server-agents/claude/src/agents/claude/__tests__/cli.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli.test.js
@@ -413,13 +413,12 @@ describe('Claude provider run boundaries', () => {
   });
 
   it('keeps a background continuation fenced through its completion turn', () => {
-    const turn = new ClaudeTurnState('input-1');
+    const turn = new ClaudeTurnState('input-1', 1);
     turn.observeInput({
       type: 'command_lifecycle',
       command_uuid: 'input-1',
       state: 'started',
     });
-    turn.observeBackgroundTaskCount(1);
     turn.recordAcceptedResult({
       type: 'result',
       user_message_uuid: 'input-1',
@@ -428,7 +427,6 @@ describe('Claude provider run boundaries', () => {
     expect(turn.backgroundContinuationPending).toBe(true);
 
     turn.observeBackgroundTaskCount(0);
-    turn.observeProviderSessionState('running', 0);
     turn.recordAcceptedResult({ type: 'result', is_error: false });
     expect(turn.backgroundContinuationPending).toBe(false);
   });

--- a/server-agents/claude/src/agents/claude/__tests__/cli.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli.test.js
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'bun:test';
 import { buildClaudeCLIArgs, buildClaudePermissionApprovalResponse, convertCLIMessageToChatMessages } from '../claude-cli.js';
-import { claudeResultFailureMessage } from '../cli-protocol.js';
+import {
+  ClaudeTurnState,
+  claudeProviderSessionState,
+  claudeResultFailureMessage,
+} from '../cli-protocol.js';
 import { convertClaudePermissionTool } from '../permission-tool-converter.js';
 import { AskUserQuestionToolUseMessage, BashToolUseMessage, ExitPlanModeToolUseMessage } from '@garcon/common/chat-types';
 
@@ -339,6 +343,54 @@ describe('claudeResultFailureMessage', () => {
         '[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null',
       ],
     })).toBe('Claude CLI turn failed: error_during_execution');
+  });
+});
+
+describe('Claude provider run boundaries', () => {
+  it('decodes only recognized session state events', () => {
+    expect(claudeProviderSessionState({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'running',
+    })).toBe('running');
+    expect(claudeProviderSessionState({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'idle',
+    })).toBe('idle');
+    expect(claudeProviderSessionState({
+      type: 'system',
+      subtype: 'session_state_changed',
+      state: 'future-state',
+    })).toBeNull();
+    expect(claudeProviderSessionState({
+      type: 'assistant',
+      subtype: 'session_state_changed',
+      state: 'idle',
+    })).toBeNull();
+  });
+
+  it('treats later results as continuations of the accepted input', () => {
+    const turn = new ClaudeTurnState('input-1');
+    turn.observeInput({
+      type: 'command_lifecycle',
+      command_uuid: 'input-1',
+      state: 'started',
+    });
+    expect(turn.correlateResult({
+      type: 'result',
+      user_message_uuid: 'another-input',
+    })).toBe('mismatched');
+
+    const inputResult = { type: 'result', user_message_uuid: 'input-1', is_error: false };
+    expect(turn.correlateResult(inputResult)).toBe('input');
+    turn.addOutputMessages(1, true);
+    turn.recordAcceptedResult(inputResult);
+
+    expect(turn.correlateResult({
+      type: 'result',
+      user_message_uuid: 'provider-owned-continuation',
+    })).toBe('continuation');
   });
 });
 

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -47,8 +47,10 @@ import {
   claudeResultFailureMessage,
   convertCLIMessageToChatMessages,
   type ClaudeCLIMessage,
+  type ClaudeProviderSessionState,
   type ClaudeTurnTerminalState,
 } from './cli-protocol.js';
+import { handleClaudeProviderStateMessage } from './cli-session-state.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -66,6 +68,7 @@ interface ClaudeRunningSession {
   initialization: Promise<void> | null;
   completeInitialization: (() => void) | null;
   lastActivityAt: number;
+  providerState: ClaudeProviderSessionState;
   activeTurn: ClaudeActiveTurn | null;
   process: ReturnType<typeof Bun.spawn> | null;
   transport: ClaudeProcessTransport<ClaudeCLIMessage> | null;
@@ -268,6 +271,13 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   }
 
   #handleSystemMessage(session: ClaudeRunningSession, msg: ClaudeCLIMessage): void {
+    if (handleClaudeProviderStateMessage(msg, session, {
+      logger: this.#dependencies.logger,
+      finish: () => this.#finishTurn(session),
+      fail: message => this.#failSession(session, message),
+      retire: () => this.#retireSessionProcessInBackground(session),
+    })) return;
+
     const activeTurn = session.activeTurn;
     if (msg.subtype === 'init') {
       this.#dependencies.logger.info('Claude CLI session initialized', {
@@ -407,18 +417,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       return;
     }
 
-    if (
-      msg.is_error
-      && protocol.abortRequested
-      && msg.terminal_reason === 'aborted_streaming'
-    ) {
-      this.#dependencies.logger.info('Claude CLI turn stopped after an interrupt', resultDetails);
-      this.#finishTurn(session);
-      return;
-    }
-
     const resultText = typeof msg.result === 'string' ? msg.result.trim() : '';
-    if (!msg.is_error && !protocol.assistantContentSeen && resultText) {
+    if (!msg.is_error && !protocol.assistantContentSinceLastResult && resultText) {
       protocol.addOutputMessages(1, true);
       this.emitMessages(
         session.chatId,
@@ -426,21 +426,22 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
         activeTurn.eventMetadata,
       );
     }
-    const completedWithoutResponse = protocol.completedWithoutResponse(msg);
-    if (msg.is_error || completedWithoutResponse) {
-      this.#dependencies.logger.warn('Claude CLI turn completed with an error', resultDetails);
+    protocol.recordAcceptedResult(msg);
+    if (
+      msg.is_error
+      && protocol.abortRequested
+      && msg.terminal_reason === 'aborted_streaming'
+    ) {
+      this.#clearAbortTimer(session);
+    }
+    const resultLog = correlation === 'input'
+      ? 'Claude CLI input result received; awaiting provider idle'
+      : 'Claude CLI continuation result received; awaiting provider idle';
+    if (msg.is_error && !protocol.cleanAbortResultSeen) {
+      this.#dependencies.logger.warn(resultLog, resultDetails);
     } else {
-      this.#dependencies.logger.info('Claude CLI turn completed', resultDetails);
+      this.#dependencies.logger.info(resultLog, resultDetails);
     }
-    if (msg.is_error) {
-      this.#failSession(session, claudeResultFailureMessage(msg));
-      return;
-    }
-    if (completedWithoutResponse) {
-      this.#failSession(session, protocol.emptyCompletionFailureMessage());
-      return;
-    }
-    this.#finishTurn(session);
   }
 
   #handleInputTerminalBeforeStart(
@@ -921,10 +922,18 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       stdin: 'pipe',
       stdout: 'pipe',
       stderr: 'pipe',
-      env: (() => { const { CLAUDECODE, ...env } = process.env; return { ...env, ...options.envOverrides }; })(),
+      env: (() => {
+        const { CLAUDECODE, ...env } = process.env;
+        return {
+          ...env,
+          ...options.envOverrides,
+          CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+        };
+      })(),
     });
 
     session.options = options;
+    session.providerState = 'unknown';
     session.process = proc;
     session.currentThinkingMode = options.thinkingMode || 'none';
     session.currentClaudeThinkingMode = normalizeClaudeThinkingModeForState(options.claudeThinkingMode);
@@ -1033,6 +1042,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       initialization,
       completeInitialization,
       lastActivityAt: Date.now(),
+      providerState: 'unknown',
       activeTurn: null,
       process: null,
       transport: null,
@@ -1149,6 +1159,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
         initialization: null,
         completeInitialization: null,
         lastActivityAt: Date.now(),
+        providerState: 'unknown',
         activeTurn: null,
         process: null,
         transport: null,

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -50,7 +50,7 @@ import {
   type ClaudeProviderSessionState,
   type ClaudeTurnTerminalState,
 } from './cli-protocol.js';
-import { handleClaudeProviderStateMessage } from './cli-session-state.js';
+import { handleClaudeProviderLifecycleMessage } from './cli-session-state.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -69,6 +69,8 @@ interface ClaudeRunningSession {
   completeInitialization: (() => void) | null;
   lastActivityAt: number;
   providerState: ClaudeProviderSessionState;
+  backgroundTaskCount: number;
+  unownedProviderActivity: boolean;
   activeTurn: ClaudeActiveTurn | null;
   process: ReturnType<typeof Bun.spawn> | null;
   transport: ClaudeProcessTransport<ClaudeCLIMessage> | null;
@@ -271,7 +273,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   }
 
   #handleSystemMessage(session: ClaudeRunningSession, msg: ClaudeCLIMessage): void {
-    if (handleClaudeProviderStateMessage(msg, session, {
+    if (handleClaudeProviderLifecycleMessage(msg, session, {
       logger: this.#dependencies.logger,
       finish: () => this.#finishTurn(session),
       fail: message => this.#failSession(session, message),
@@ -427,13 +429,6 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       );
     }
     protocol.recordAcceptedResult(msg);
-    if (
-      msg.is_error
-      && protocol.abortRequested
-      && msg.terminal_reason === 'aborted_streaming'
-    ) {
-      this.#clearAbortTimer(session);
-    }
     const resultLog = correlation === 'input'
       ? 'Claude CLI input result received; awaiting provider idle'
       : 'Claude CLI continuation result received; awaiting provider idle';
@@ -640,6 +635,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   #failSession(session: ClaudeRunningSession, message: string): void {
     const activeTurn = session.activeTurn;
     if (!activeTurn) return;
+    message = activeTurn.protocol.recordedResultFailureMessage ?? message;
     this.#clearAbortTimer(session);
     session.activeTurn = null;
     this.#controlBroker.rejectSession(session.id, 'Claude turn settled', 'interrupt');
@@ -934,6 +930,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
 
     session.options = options;
     session.providerState = 'unknown';
+    session.backgroundTaskCount = 0;
+    session.unownedProviderActivity = false;
     session.process = proc;
     session.currentThinkingMode = options.thinkingMode || 'none';
     session.currentClaudeThinkingMode = normalizeClaudeThinkingModeForState(options.claudeThinkingMode);
@@ -1043,6 +1041,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       completeInitialization,
       lastActivityAt: Date.now(),
       providerState: 'unknown',
+      backgroundTaskCount: 0,
+      unownedProviderActivity: false,
       activeTurn: null,
       process: null,
       transport: null,
@@ -1160,6 +1160,8 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
         completeInitialization: null,
         lastActivityAt: Date.now(),
         providerState: 'unknown',
+        backgroundTaskCount: 0,
+        unownedProviderActivity: false,
         activeTurn: null,
         process: null,
         transport: null,

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -150,13 +150,14 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       resolve = complete;
     });
     const activeTurn: ClaudeActiveTurn = {
-      protocol: new ClaudeTurnState(crypto.randomUUID()),
+      protocol: new ClaudeTurnState(crypto.randomUUID(), session.backgroundTaskCount),
       eventMetadata,
       startedAt: Date.now(),
       completion,
       resolve,
       abortTimer: null,
     };
+    session.unownedProviderActivity = false;
     session.activeTurn = activeTurn;
     session.lastActivityAt = activeTurn.startedAt;
     return activeTurn;

--- a/server-agents/claude/src/agents/claude/cli-protocol.ts
+++ b/server-agents/claude/src/agents/claude/cli-protocol.ts
@@ -77,10 +77,12 @@ export interface ClaudeApiRetryDiagnostics {
 export type ClaudeTurnStartSource = 'lifecycle' | 'replay';
 export type ClaudeTurnTerminalState = 'completed' | 'cancelled' | 'discarded';
 export type ClaudeTurnPhase = 'submitted' | 'started' | 'interrupting';
+export type ClaudeProviderSessionState = 'unknown' | 'running' | 'requires_action' | 'idle';
+export type ClaudeReportedSessionState = Exclude<ClaudeProviderSessionState, 'unknown'>;
 export type ClaudeTurnInputEvent =
   | { type: 'started'; source: ClaudeTurnStartSource }
   | { type: 'terminal-before-start'; state: ClaudeTurnTerminalState };
-export type ClaudeResultCorrelation = 'before-start' | 'matched' | 'mismatched';
+export type ClaudeResultCorrelation = 'before-start' | 'input' | 'continuation' | 'mismatched';
 
 function isClaudeContentPart(value: unknown): value is ClaudeContentPart {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -103,12 +105,36 @@ export function claudeResultFailureMessage(message: ClaudeCLIMessage): string {
   return `Claude CLI turn failed: ${outcome}${apiStatus}`;
 }
 
+export function claudeProviderSessionState(
+  message: ClaudeCLIMessage,
+): ClaudeReportedSessionState | null {
+  if (
+    message.type !== 'system'
+    || message.subtype !== 'session_state_changed'
+  ) {
+    return null;
+  }
+  if (
+    message.state === 'running'
+    || message.state === 'requires_action'
+    || message.state === 'idle'
+  ) {
+    return message.state;
+  }
+  return null;
+}
+
 export class ClaudeTurnState {
   readonly inputUuid: string;
   #phase: ClaudeTurnPhase = 'submitted';
   #inputStarted = false;
   #outputMessageCount = 0;
   #assistantContentSeen = false;
+  #assistantContentVersion = 0;
+  #lastResultAssistantContentVersion = 0;
+  #acceptedResultCount = 0;
+  #resultFailure: string | null = null;
+  #cleanAbortResultSeen = false;
   #lastApiRetry: ClaudeApiRetryDiagnostics | null = null;
   #resultBeforeStart: ClaudeCLIMessage | null = null;
 
@@ -134,6 +160,18 @@ export class ClaudeTurnState {
 
   get assistantContentSeen(): boolean {
     return this.#assistantContentSeen;
+  }
+
+  get assistantContentSinceLastResult(): boolean {
+    return this.#assistantContentVersion > this.#lastResultAssistantContentVersion;
+  }
+
+  get hasAcceptedResult(): boolean {
+    return this.#acceptedResultCount > 0;
+  }
+
+  get cleanAbortResultSeen(): boolean {
+    return this.#cleanAbortResultSeen;
   }
 
   observeInput(message: ClaudeCLIMessage): ClaudeTurnInputEvent | null {
@@ -191,6 +229,7 @@ export class ClaudeTurnState {
   addOutputMessages(count: number, assistantContentSeen = false): void {
     this.#outputMessageCount += count;
     this.#assistantContentSeen ||= assistantContentSeen;
+    if (assistantContentSeen) this.#assistantContentVersion += 1;
   }
 
   recordApiRetry(message: ClaudeCLIMessage): ClaudeApiRetryDiagnostics {
@@ -208,18 +247,34 @@ export class ClaudeTurnState {
   correlateResult(message: ClaudeCLIMessage): ClaudeResultCorrelation {
     if (!this.inputStarted) return 'before-start';
     if (
-      message.user_message_uuid
+      !this.hasAcceptedResult
+      && message.user_message_uuid
       && message.user_message_uuid !== this.inputUuid
     ) {
       return 'mismatched';
     }
-    return 'matched';
+    return this.hasAcceptedResult ? 'continuation' : 'input';
   }
 
-  completedWithoutResponse(message: ClaudeCLIMessage): boolean {
-    return !message.is_error
-      && !this.#assistantContentSeen
-      && (typeof message.result !== 'string' || message.result.trim().length === 0);
+  recordAcceptedResult(message: ClaudeCLIMessage): void {
+    this.#acceptedResultCount += 1;
+    this.#lastResultAssistantContentVersion = this.#assistantContentVersion;
+    if (!message.is_error) return;
+    if (
+      this.abortRequested
+      && message.terminal_reason === 'aborted_streaming'
+    ) {
+      this.#cleanAbortResultSeen = true;
+      return;
+    }
+    this.#resultFailure ??= claudeResultFailureMessage(message);
+  }
+
+  settlementFailureMessage(): string | null {
+    if (this.#resultFailure) return this.#resultFailure;
+    if (this.#cleanAbortResultSeen) return null;
+    if (!this.#assistantContentSeen) return this.emptyCompletionFailureMessage();
+    return null;
   }
 
   emptyCompletionFailureMessage(): string {

--- a/server-agents/claude/src/agents/claude/cli-protocol.ts
+++ b/server-agents/claude/src/agents/claude/cli-protocol.ts
@@ -32,6 +32,7 @@ export interface ClaudeCLIMessage {
   user_message_uuid?: string;
   command_uuid?: string;
   state?: string;
+  tasks?: unknown[];
   permission_denials?: unknown[];
   content?: unknown[];
   message?: { role?: string; content?: unknown };
@@ -124,6 +125,17 @@ export function claudeProviderSessionState(
   return null;
 }
 
+export function claudeBackgroundTaskCount(message: ClaudeCLIMessage): number | null {
+  if (
+    message.type !== 'system'
+    || message.subtype !== 'background_tasks_changed'
+    || !Array.isArray(message.tasks)
+  ) {
+    return null;
+  }
+  return message.tasks.length;
+}
+
 export class ClaudeTurnState {
   readonly inputUuid: string;
   #phase: ClaudeTurnPhase = 'submitted';
@@ -135,6 +147,8 @@ export class ClaudeTurnState {
   #acceptedResultCount = 0;
   #resultFailure: string | null = null;
   #cleanAbortResultSeen = false;
+  #backgroundContinuationPending = false;
+  #backgroundContinuationStarted = false;
   #lastApiRetry: ClaudeApiRetryDiagnostics | null = null;
   #resultBeforeStart: ClaudeCLIMessage | null = null;
 
@@ -172,6 +186,10 @@ export class ClaudeTurnState {
 
   get cleanAbortResultSeen(): boolean {
     return this.#cleanAbortResultSeen;
+  }
+
+  get backgroundContinuationPending(): boolean {
+    return this.#backgroundContinuationPending;
   }
 
   observeInput(message: ClaudeCLIMessage): ClaudeTurnInputEvent | null {
@@ -214,6 +232,28 @@ export class ClaudeTurnState {
 
   markAbortRequested(): void {
     this.#phase = 'interrupting';
+  }
+
+  observeBackgroundTaskCount(count: number): void {
+    if (count <= 0) return;
+    this.#backgroundContinuationPending = true;
+    this.#backgroundContinuationStarted = false;
+  }
+
+  observeProviderSessionState(
+    state: ClaudeReportedSessionState,
+    backgroundTaskCount: number,
+  ): void {
+    // An empty task set precedes the provider-owned completion turn, so the
+    // following running/result pair closes the continuation fence.
+    if (
+      state === 'running'
+      && this.hasAcceptedResult
+      && this.#backgroundContinuationPending
+      && backgroundTaskCount === 0
+    ) {
+      this.#backgroundContinuationStarted = true;
+    }
   }
 
   recordResultBeforeStart(message: ClaudeCLIMessage): void {
@@ -259,6 +299,10 @@ export class ClaudeTurnState {
   recordAcceptedResult(message: ClaudeCLIMessage): void {
     this.#acceptedResultCount += 1;
     this.#lastResultAssistantContentVersion = this.#assistantContentVersion;
+    if (this.#backgroundContinuationStarted) {
+      this.#backgroundContinuationPending = false;
+      this.#backgroundContinuationStarted = false;
+    }
     if (!message.is_error) return;
     if (
       this.abortRequested
@@ -275,6 +319,10 @@ export class ClaudeTurnState {
     if (this.#cleanAbortResultSeen) return null;
     if (!this.#assistantContentSeen) return this.emptyCompletionFailureMessage();
     return null;
+  }
+
+  get recordedResultFailureMessage(): string | null {
+    return this.#resultFailure;
   }
 
   emptyCompletionFailureMessage(): string {

--- a/server-agents/claude/src/agents/claude/cli-protocol.ts
+++ b/server-agents/claude/src/agents/claude/cli-protocol.ts
@@ -148,12 +148,13 @@ export class ClaudeTurnState {
   #resultFailure: string | null = null;
   #cleanAbortResultSeen = false;
   #backgroundContinuationPending = false;
-  #backgroundContinuationStarted = false;
+  #backgroundTaskCount = 0;
   #lastApiRetry: ClaudeApiRetryDiagnostics | null = null;
   #resultBeforeStart: ClaudeCLIMessage | null = null;
 
-  constructor(inputUuid: string) {
+  constructor(inputUuid: string, backgroundTaskCount = 0) {
     this.inputUuid = inputUuid;
+    this.observeBackgroundTaskCount(backgroundTaskCount);
   }
 
   get phase(): ClaudeTurnPhase {
@@ -235,25 +236,8 @@ export class ClaudeTurnState {
   }
 
   observeBackgroundTaskCount(count: number): void {
-    if (count <= 0) return;
-    this.#backgroundContinuationPending = true;
-    this.#backgroundContinuationStarted = false;
-  }
-
-  observeProviderSessionState(
-    state: ClaudeReportedSessionState,
-    backgroundTaskCount: number,
-  ): void {
-    // An empty task set precedes the provider-owned completion turn, so the
-    // following running/result pair closes the continuation fence.
-    if (
-      state === 'running'
-      && this.hasAcceptedResult
-      && this.#backgroundContinuationPending
-      && backgroundTaskCount === 0
-    ) {
-      this.#backgroundContinuationStarted = true;
-    }
+    this.#backgroundTaskCount = count;
+    if (count > 0) this.#backgroundContinuationPending = true;
   }
 
   recordResultBeforeStart(message: ClaudeCLIMessage): void {
@@ -297,11 +281,17 @@ export class ClaudeTurnState {
   }
 
   recordAcceptedResult(message: ClaudeCLIMessage): void {
+    const isContinuation = this.hasAcceptedResult;
     this.#acceptedResultCount += 1;
     this.#lastResultAssistantContentVersion = this.#assistantContentVersion;
-    if (this.#backgroundContinuationStarted) {
+    // The empty snapshot precedes its notification; the accepted continuation
+    // result proves Claude consumed that completion.
+    if (
+      isContinuation
+      && this.#backgroundContinuationPending
+      && this.#backgroundTaskCount === 0
+    ) {
       this.#backgroundContinuationPending = false;
-      this.#backgroundContinuationStarted = false;
     }
     if (!message.is_error) return;
     if (

--- a/server-agents/claude/src/agents/claude/cli-session-state.ts
+++ b/server-agents/claude/src/agents/claude/cli-session-state.ts
@@ -117,7 +117,7 @@ export function handleClaudeProviderLifecycleMessage(
     handlers.retire();
     return true;
   }
-  if (protocol.backgroundContinuationPending) {
+  if (protocol.backgroundContinuationPending && !protocol.abortRequested) {
     handlers.logger.info(
       'Claude CLI became idle while a background continuation remains pending',
       details,

--- a/server-agents/claude/src/agents/claude/cli-session-state.ts
+++ b/server-agents/claude/src/agents/claude/cli-session-state.ts
@@ -61,7 +61,6 @@ export function handleClaudeProviderLifecycleMessage(
   session.providerState = next;
   session.lastActivityAt = Date.now();
   const activeTurn = session.activeTurn;
-  activeTurn?.protocol.observeProviderSessionState(next, session.backgroundTaskCount);
   handlers.logger.debug('Claude CLI session state changed', {
     chatId: session.chatId,
     turnId: activeTurn?.eventMetadata.turnId ?? null,
@@ -87,7 +86,7 @@ export function handleClaudeProviderLifecycleMessage(
         next,
         backgroundTaskCount: session.backgroundTaskCount,
       });
-    } else if (session.unownedProviderActivity) {
+    } else if (next === 'idle' && session.unownedProviderActivity) {
       session.unownedProviderActivity = false;
       handlers.retire();
     }

--- a/server-agents/claude/src/agents/claude/cli-session-state.ts
+++ b/server-agents/claude/src/agents/claude/cli-session-state.ts
@@ -1,0 +1,89 @@
+import type { AgentLogger } from '@garcon/server-agent-interface';
+import {
+  claudeProviderSessionState,
+  type ClaudeCLIMessage,
+  type ClaudeProviderSessionState,
+  type ClaudeTurnState,
+} from './cli-protocol.js';
+
+interface ClaudeProviderStateTurn {
+  readonly protocol: ClaudeTurnState;
+  readonly eventMetadata: { readonly turnId?: string };
+}
+
+export interface ClaudeProviderStateSession {
+  readonly id: string;
+  readonly chatId: string;
+  providerState: ClaudeProviderSessionState;
+  lastActivityAt: number;
+  readonly process: { readonly pid?: number } | null;
+  readonly activeTurn: ClaudeProviderStateTurn | null;
+}
+
+interface ClaudeProviderStateHandlers {
+  readonly logger: AgentLogger;
+  readonly finish: () => void;
+  readonly fail: (message: string) => void;
+  readonly retire: () => void;
+}
+
+export function handleClaudeProviderStateMessage(
+  message: ClaudeCLIMessage,
+  session: ClaudeProviderStateSession,
+  handlers: ClaudeProviderStateHandlers,
+): boolean {
+  const next = claudeProviderSessionState(message);
+  if (!next) return false;
+
+  const previous = session.providerState;
+  session.providerState = next;
+  session.lastActivityAt = Date.now();
+  const activeTurn = session.activeTurn;
+  handlers.logger.debug('Claude CLI session state changed', {
+    chatId: session.chatId,
+    turnId: activeTurn?.eventMetadata.turnId ?? null,
+    sessionId: session.id.slice(0, 8),
+    processId: session.process?.pid ?? null,
+    previous,
+    next,
+    inputStarted: activeTurn?.protocol.inputStarted ?? false,
+    resultSeen: activeTurn?.protocol.hasAcceptedResult ?? false,
+  });
+  if (next !== 'idle' || !activeTurn?.protocol.inputStarted) return true;
+
+  const protocol = activeTurn.protocol;
+  const details = {
+    chatId: session.chatId,
+    turnId: activeTurn.eventMetadata.turnId ?? null,
+    sessionId: session.id.slice(0, 8),
+    processId: session.process?.pid ?? null,
+    inputId: protocol.inputUuid.slice(0, 8),
+    outputMessages: protocol.outputMessageCount,
+    resultSeen: protocol.hasAcceptedResult,
+  };
+  if (!protocol.hasAcceptedResult) {
+    handlers.logger.warn(
+      'Claude CLI became idle before producing a result for the submitted input',
+      details,
+    );
+    handlers.fail(
+      'Claude CLI became idle before the submitted message produced a terminal result.',
+    );
+    handlers.retire();
+    return true;
+  }
+
+  const failure = protocol.settlementFailureMessage();
+  if (failure) {
+    handlers.logger.warn('Claude CLI run settled with an error', details);
+    handlers.fail(failure);
+    return true;
+  }
+  if (protocol.cleanAbortResultSeen) {
+    handlers.logger.info('Claude CLI run stopped after an interrupt', details);
+  } else {
+    handlers.logger.info('Claude CLI run settled at provider idle', details);
+  }
+  handlers.finish();
+  return true;
+}

--- a/server-agents/claude/src/agents/claude/cli-session-state.ts
+++ b/server-agents/claude/src/agents/claude/cli-session-state.ts
@@ -1,5 +1,6 @@
 import type { AgentLogger } from '@garcon/server-agent-interface';
 import {
+  claudeBackgroundTaskCount,
   claudeProviderSessionState,
   type ClaudeCLIMessage,
   type ClaudeProviderSessionState,
@@ -15,6 +16,8 @@ export interface ClaudeProviderStateSession {
   readonly id: string;
   readonly chatId: string;
   providerState: ClaudeProviderSessionState;
+  backgroundTaskCount: number;
+  unownedProviderActivity: boolean;
   lastActivityAt: number;
   readonly process: { readonly pid?: number } | null;
   readonly activeTurn: ClaudeProviderStateTurn | null;
@@ -27,11 +30,30 @@ interface ClaudeProviderStateHandlers {
   readonly retire: () => void;
 }
 
-export function handleClaudeProviderStateMessage(
+export function handleClaudeProviderLifecycleMessage(
   message: ClaudeCLIMessage,
   session: ClaudeProviderStateSession,
   handlers: ClaudeProviderStateHandlers,
 ): boolean {
+  const backgroundTaskCount = claudeBackgroundTaskCount(message);
+  if (backgroundTaskCount !== null) {
+    const previous = session.backgroundTaskCount;
+    session.backgroundTaskCount = backgroundTaskCount;
+    const activeTurn = session.activeTurn;
+    if (activeTurn?.protocol.inputStarted) {
+      activeTurn.protocol.observeBackgroundTaskCount(backgroundTaskCount);
+    }
+    handlers.logger.debug('Claude CLI background tasks changed', {
+      chatId: session.chatId,
+      turnId: activeTurn?.eventMetadata.turnId ?? null,
+      sessionId: session.id.slice(0, 8),
+      processId: session.process?.pid ?? null,
+      previousCount: previous,
+      nextCount: backgroundTaskCount,
+    });
+    return true;
+  }
+
   const next = claudeProviderSessionState(message);
   if (!next) return false;
 
@@ -39,6 +61,7 @@ export function handleClaudeProviderStateMessage(
   session.providerState = next;
   session.lastActivityAt = Date.now();
   const activeTurn = session.activeTurn;
+  activeTurn?.protocol.observeProviderSessionState(next, session.backgroundTaskCount);
   handlers.logger.debug('Claude CLI session state changed', {
     chatId: session.chatId,
     turnId: activeTurn?.eventMetadata.turnId ?? null,
@@ -48,8 +71,29 @@ export function handleClaudeProviderStateMessage(
     next,
     inputStarted: activeTurn?.protocol.inputStarted ?? false,
     resultSeen: activeTurn?.protocol.hasAcceptedResult ?? false,
+    backgroundTaskCount: session.backgroundTaskCount,
   });
-  if (next !== 'idle' || !activeTurn?.protocol.inputStarted) return true;
+  if (!activeTurn) {
+    if (
+      !session.unownedProviderActivity
+      && (next === 'running' || next === 'requires_action')
+    ) {
+      session.unownedProviderActivity = true;
+      handlers.logger.warn('Claude CLI emitted provider activity without an active Garcon turn', {
+        chatId: session.chatId,
+        sessionId: session.id.slice(0, 8),
+        processId: session.process?.pid ?? null,
+        previous,
+        next,
+        backgroundTaskCount: session.backgroundTaskCount,
+      });
+    } else if (session.unownedProviderActivity) {
+      session.unownedProviderActivity = false;
+      handlers.retire();
+    }
+    return true;
+  }
+  if (next !== 'idle' || !activeTurn.protocol.inputStarted) return true;
 
   const protocol = activeTurn.protocol;
   const details = {
@@ -60,6 +104,8 @@ export function handleClaudeProviderStateMessage(
     inputId: protocol.inputUuid.slice(0, 8),
     outputMessages: protocol.outputMessageCount,
     resultSeen: protocol.hasAcceptedResult,
+    backgroundTaskCount: session.backgroundTaskCount,
+    backgroundContinuationPending: protocol.backgroundContinuationPending,
   };
   if (!protocol.hasAcceptedResult) {
     handlers.logger.warn(
@@ -70,6 +116,13 @@ export function handleClaudeProviderStateMessage(
       'Claude CLI became idle before the submitted message produced a terminal result.',
     );
     handlers.retire();
+    return true;
+  }
+  if (protocol.backgroundContinuationPending) {
+    handlers.logger.info(
+      'Claude CLI became idle while a background continuation remains pending',
+      details,
+    );
     return true;
   }
 

--- a/server-agents/claude/src/agents/claude/cli-session-state.ts
+++ b/server-agents/claude/src/agents/claude/cli-session-state.ts
@@ -124,11 +124,15 @@ export function handleClaudeProviderLifecycleMessage(
     );
     return true;
   }
+  const retireAfterSettlement =
+    protocol.backgroundContinuationPending && protocol.abortRequested;
+  if (retireAfterSettlement) session.backgroundTaskCount = 0;
 
   const failure = protocol.settlementFailureMessage();
   if (failure) {
     handlers.logger.warn('Claude CLI run settled with an error', details);
     handlers.fail(failure);
+    if (retireAfterSettlement) handlers.retire();
     return true;
   }
   if (protocol.cleanAbortResultSeen) {
@@ -137,5 +141,6 @@ export function handleClaudeProviderLifecycleMessage(
     handlers.logger.info('Claude CLI run settled at provider idle', details);
   }
   handlers.finish();
+  if (retireAfterSettlement) handlers.retire();
   return true;
 }


### PR DESCRIPTION
Claude can emit an intermediate result and idle state while background shell work may still resume the agent, causing Garcon to mark chats idle, release queue and fork ownership, and discard later output. This change tracks Claude background task snapshots alongside session-state events, keeps the originating turn active through provider-owned continuations, preserves failure and interrupt behavior, and retires interrupted processes before starting the next turn so queued messages and forks cannot race the native session.