### PR TITLE
Expand Claude and Codex live conformance coverage

### DIFF
--- a/integration-tests/support/live-agent.ts
+++ b/integration-tests/support/live-agent.ts
@@ -24,7 +24,7 @@ function expectVisibleResponseBeforeSettlement(input: {
   events: readonly ServerWsMessage[];
   chatId: string;
   turnId: string | undefined;
-  marker: string;
+  marker?: string;
 }): void {
   const processingStarted = input.events.findIndex((event) =>
     event.type === 'chat-processing-updated'
@@ -33,9 +33,13 @@ function expectVisibleResponseBeforeSettlement(input: {
   const assistantResponse = input.events.findIndex((event) =>
     event.type === 'chat-messages'
     && event.chatId === input.chatId
+    && event.turnId === input.turnId
     && event.messages.some((entry) =>
       entry.message.type === 'assistant-message'
-      && entry.message.content.includes(input.marker)));
+      && (
+        input.marker === undefined
+        || entry.message.content.includes(input.marker)
+      )));
   const processingStopped = input.events.findIndex((event) =>
     event.type === 'chat-processing-updated'
     && event.chatId === input.chatId
@@ -55,7 +59,7 @@ export async function waitForVisibleResponse(input: {
   fixture: IntegrationFixture;
   chatId: string;
   turnId: string | undefined;
-  marker: string;
+  marker?: string;
   afterIndex: number;
 }): Promise<void> {
   expectFinished((await input.fixture.client.waitForTurnTerminal(

--- a/integration-tests/support/live-claude-protocol-forwarder.ts
+++ b/integration-tests/support/live-claude-protocol-forwarder.ts
@@ -3,6 +3,7 @@ import { appendFileSync } from 'node:fs';
 const realBinary = requiredEnvironment('GARCON_LIVE_CLAUDE_REAL_BINARY');
 const startedPath = requiredEnvironment('GARCON_LIVE_CLAUDE_STARTED_PATH');
 const terminalReasonPath = requiredEnvironment('GARCON_LIVE_CLAUDE_TERMINAL_REASON_PATH');
+const interruptReceiptPath = requiredEnvironment('GARCON_LIVE_CLAUDE_INTERRUPT_RECEIPT_PATH');
 const child = Bun.spawn([realBinary, ...process.argv.slice(2)], {
   env: process.env,
   stdin: 'inherit',
@@ -16,6 +17,10 @@ function requiredEnvironment(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`Live Claude protocol forwarder requires ${name}.`);
   return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function observe(line: string): void {
@@ -48,6 +53,24 @@ function observe(line: string): void {
         reason: message.terminal_reason,
         userMessageUuid:
           typeof message.user_message_uuid === 'string' ? message.user_message_uuid : null,
+      })}\n`,
+    );
+  }
+  const control = isRecord(message.response) ? message.response : null;
+  const receipt = control?.subtype === 'success' && isRecord(control.response)
+    ? control.response
+    : null;
+  if (
+    message.type === 'control_response'
+    && receipt
+    && (Array.isArray(receipt.cancelled) || Array.isArray(receipt.still_queued))
+  ) {
+    appendFileSync(
+      interruptReceiptPath,
+      `${JSON.stringify({
+        type: 'interrupt-receipt',
+        cancelledCount: Array.isArray(receipt.cancelled) ? receipt.cancelled.length : 0,
+        stillQueuedCount: Array.isArray(receipt.still_queued) ? receipt.still_queued.length : 0,
       })}\n`,
     );
   }

--- a/integration-tests/support/live-claude-protocol-probe.ts
+++ b/integration-tests/support/live-claude-protocol-probe.ts
@@ -10,7 +10,9 @@ const PROTOCOL_PROBE_TIMEOUT_MS = 90_000;
 
 export interface LiveClaudeProtocolProbe {
   prepareWorkspace(directories: IntegrationDirectories): Promise<void>;
+  readInterruptReceipts(): Promise<LiveClaudeInterruptReceipt[]>;
   waitForInputStarted(count?: number): Promise<string>;
+  waitForInterruptReceipt(count?: number): Promise<LiveClaudeInterruptReceipt>;
   waitForTerminal(
     count?: number,
   ): Promise<{
@@ -19,11 +21,18 @@ export interface LiveClaudeProtocolProbe {
   }>;
 }
 
+export interface LiveClaudeInterruptReceipt {
+  cancelledCount: number;
+  stillQueuedCount: number;
+}
+
 interface LiveClaudeProbeEntry {
-  type: 'started' | 'terminal';
+  type: 'started' | 'terminal' | 'interrupt-receipt';
   commandUuid?: string;
   reason?: 'aborted_streaming' | 'aborted_tools';
   userMessageUuid?: string | null;
+  cancelledCount?: number;
+  stillQueuedCount?: number;
 }
 
 async function readProbeEntries(path: string): Promise<LiveClaudeProbeEntry[]> {
@@ -66,12 +75,14 @@ export function createLiveClaudeProtocolProbe(
   if (!realBinary) throw new Error('Live Claude protocol probe requires the Claude binary.');
   let startedPath = '';
   let terminalReasonPath = '';
+  let interruptReceiptPath = '';
 
   return {
     async prepareWorkspace(directories) {
       const wrapperPath = join(directories.root, 'claude-protocol-probe');
       startedPath = join(directories.root, 'claude-started-inputs');
       terminalReasonPath = join(directories.root, 'claude-terminal-results');
+      interruptReceiptPath = join(directories.root, 'claude-interrupt-receipts');
       await writeFile(wrapperPath, `#!/usr/bin/env bash
 exec "$GARCON_LIVE_CLAUDE_BUN_BINARY" "$GARCON_LIVE_CLAUDE_FORWARDER" "$@"
 `, { mode: 0o700 });
@@ -80,7 +91,24 @@ exec "$GARCON_LIVE_CLAUDE_BUN_BINARY" "$GARCON_LIVE_CLAUDE_FORWARDER" "$@"
       serverEnvironment.GARCON_LIVE_CLAUDE_REAL_BINARY = realBinary;
       serverEnvironment.GARCON_LIVE_CLAUDE_STARTED_PATH = startedPath;
       serverEnvironment.GARCON_LIVE_CLAUDE_TERMINAL_REASON_PATH = terminalReasonPath;
+      serverEnvironment.GARCON_LIVE_CLAUDE_INTERRUPT_RECEIPT_PATH = interruptReceiptPath;
       serverEnvironment.CLAUDE_BINARY = wrapperPath;
+    },
+    async readInterruptReceipts() {
+      return (await readProbeEntries(interruptReceiptPath))
+        .filter((
+          entry,
+        ): entry is LiveClaudeProbeEntry & {
+          cancelledCount: number;
+          stillQueuedCount: number;
+        } =>
+          entry.type === 'interrupt-receipt'
+          && typeof entry.cancelledCount === 'number'
+          && typeof entry.stillQueuedCount === 'number')
+        .map((entry) => ({
+          cancelledCount: entry.cancelledCount,
+          stillQueuedCount: entry.stillQueuedCount,
+        }));
     },
     waitForInputStarted(count = 1) {
       return waitForProbeEntry(
@@ -90,6 +118,25 @@ exec "$GARCON_LIVE_CLAUDE_BUN_BINARY" "$GARCON_LIVE_CLAUDE_FORWARDER" "$@"
         count,
         'input start',
       ).then((entry) => entry.commandUuid);
+    },
+    waitForInterruptReceipt(count = 1) {
+      return waitForProbeEntry(
+        () => interruptReceiptPath,
+        (
+          entry,
+        ): entry is LiveClaudeProbeEntry & {
+          cancelledCount: number;
+          stillQueuedCount: number;
+        } =>
+          entry.type === 'interrupt-receipt'
+          && typeof entry.cancelledCount === 'number'
+          && typeof entry.stillQueuedCount === 'number',
+        count,
+        'interrupt receipt',
+      ).then((entry) => ({
+        cancelledCount: entry.cancelledCount,
+        stillQueuedCount: entry.stillQueuedCount,
+      }));
     },
     waitForTerminal(count = 1) {
       return waitForProbeEntry(

--- a/integration-tests/support/live-claude.ts
+++ b/integration-tests/support/live-claude.ts
@@ -77,6 +77,7 @@ export function liveClaudeForkRunRequest(input: {
   sourceChatId: string;
   chatId: string;
   command: string;
+  permissionMode?: ForkRunCommandRequest['permissionMode'];
 }): ForkRunCommandRequest {
   return {
     clientRequestId: crypto.randomUUID(),
@@ -84,7 +85,7 @@ export function liveClaudeForkRunRequest(input: {
     sourceChatId: input.sourceChatId,
     chatId: input.chatId,
     command: input.command,
-    permissionMode: 'default',
+    permissionMode: input.permissionMode ?? 'default',
     thinkingMode: LIVE_CLAUDE_THINKING_MODE,
     agentSettings: CLAUDE_AGENT_SETTINGS,
     model: LIVE_CLAUDE_MODEL,

--- a/integration-tests/support/live-codex-protocol-forwarder.ts
+++ b/integration-tests/support/live-codex-protocol-forwarder.ts
@@ -1,0 +1,57 @@
+import { appendFileSync } from 'node:fs';
+
+const realBinary = requiredEnvironment('GARCON_LIVE_CODEX_REAL_BINARY');
+const approvalPath = requiredEnvironment('GARCON_LIVE_CODEX_APPROVAL_PATH');
+const child = Bun.spawn([realBinary, ...process.argv.slice(2)], {
+  env: process.env,
+  stdin: 'inherit',
+  stdout: 'pipe',
+  stderr: 'inherit',
+});
+const decoder = new TextDecoder();
+let pending = '';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Live Codex protocol forwarder requires ${name}.`);
+  return value;
+}
+
+function isApprovalMethod(value: unknown): value is string {
+  return typeof value === 'string' && [
+    'item/commandExecution/requestApproval',
+    'item/fileChange/requestApproval',
+    'item/permissions/requestApproval',
+    'execCommandApproval',
+    'applyPatchApproval',
+  ].includes(value);
+}
+
+function observe(line: string): void {
+  let message: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+    message = parsed as Record<string, unknown>;
+  } catch {
+    return;
+  }
+  if (!isApprovalMethod(message.method) || !['number', 'string'].includes(typeof message.id)) {
+    return;
+  }
+  appendFileSync(
+    approvalPath,
+    `${JSON.stringify({ type: 'approval-request', method: message.method })}\n`,
+  );
+}
+
+for await (const chunk of child.stdout) {
+  process.stdout.write(chunk);
+  pending += decoder.decode(chunk, { stream: true });
+  const lines = pending.split('\n');
+  pending = lines.pop() ?? '';
+  for (const line of lines) observe(line);
+}
+pending += decoder.decode();
+if (pending) observe(pending);
+process.exitCode = await child.exited;

--- a/integration-tests/support/live-codex-protocol-probe.ts
+++ b/integration-tests/support/live-codex-protocol-probe.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { IntegrationDirectories } from './integration-fixture.js';
+
+const FORWARDER_PATH = fileURLToPath(
+  new URL('./live-codex-protocol-forwarder.ts', import.meta.url),
+);
+const PROTOCOL_PROBE_TIMEOUT_MS = 90_000;
+
+export interface LiveCodexProtocolProbe {
+  prepareWorkspace(directories: IntegrationDirectories): Promise<void>;
+  readApprovalRequests(): Promise<string[]>;
+  waitForApprovalRequest(count?: number): Promise<string>;
+}
+
+interface LiveCodexProbeEntry {
+  type: 'approval-request';
+  method?: string;
+}
+
+async function readProbeEntries(path: string): Promise<LiveCodexProbeEntry[]> {
+  try {
+    return (await readFile(path, 'utf8'))
+      .split('\n')
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line) as LiveCodexProbeEntry];
+        } catch {
+          return [];
+        }
+      });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+export function createLiveCodexProtocolProbe(
+  serverEnvironment: Record<string, string>,
+): LiveCodexProtocolProbe {
+  const realBinary = serverEnvironment.GARCON_CODEX_CLI;
+  if (!realBinary) throw new Error('Live Codex protocol probe requires the Codex binary.');
+  let approvalPath = '';
+
+  async function readApprovalRequests(): Promise<string[]> {
+    return (await readProbeEntries(approvalPath)).flatMap((entry) =>
+      entry.type === 'approval-request' && typeof entry.method === 'string'
+        ? [entry.method]
+        : []);
+  }
+
+  return {
+    async prepareWorkspace(directories) {
+      const wrapperPath = join(directories.root, 'codex-protocol-probe');
+      approvalPath = join(directories.root, 'codex-approval-requests');
+      await writeFile(wrapperPath, `#!/usr/bin/env bash
+exec "$GARCON_LIVE_CODEX_BUN_BINARY" "$GARCON_LIVE_CODEX_FORWARDER" "$@"
+`, { mode: 0o700 });
+      serverEnvironment.GARCON_LIVE_CODEX_BUN_BINARY = process.execPath;
+      serverEnvironment.GARCON_LIVE_CODEX_FORWARDER = FORWARDER_PATH;
+      serverEnvironment.GARCON_LIVE_CODEX_REAL_BINARY = realBinary;
+      serverEnvironment.GARCON_LIVE_CODEX_APPROVAL_PATH = approvalPath;
+      serverEnvironment.GARCON_CODEX_CLI = wrapperPath;
+    },
+    readApprovalRequests,
+    async waitForApprovalRequest(count = 1) {
+      const deadline = Date.now() + PROTOCOL_PROBE_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        const requests = await readApprovalRequests();
+        if (requests.length >= count) return requests[count - 1]!;
+        await Bun.sleep(25);
+      }
+      throw new Error('Timed out waiting for a live Codex approval request.');
+    },
+  };
+}

--- a/integration-tests/support/live-codex.ts
+++ b/integration-tests/support/live-codex.ts
@@ -298,6 +298,7 @@ export function liveCodexForkRunRequest(input: {
   sourceChatId: string;
   chatId: string;
   command: string;
+  permissionMode?: ForkRunCommandRequest['permissionMode'];
 }): ForkRunCommandRequest {
   return {
     clientRequestId: crypto.randomUUID(),
@@ -305,7 +306,7 @@ export function liveCodexForkRunRequest(input: {
     sourceChatId: input.sourceChatId,
     chatId: input.chatId,
     command: input.command,
-    permissionMode: 'default',
+    permissionMode: input.permissionMode ?? 'default',
     thinkingMode: LIVE_CODEX_THINKING_MODE,
     agentSettings: CODEX_AGENT_SETTINGS,
     model: LIVE_CODEX_MODEL,

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -762,7 +762,10 @@ describe('live Claude lifecycle', () => {
       if (!stoppedBash) throw new Error('Live Claude stopped Bash tool use was not rendered.');
       const stoppedResult = messagesOfType(stoppedTranscript.messages, 'tool-result')
         .find((message) => message.toolId === stoppedBash.toolId);
-      expect(stoppedResult?.isError).toBe(true);
+      expect(stoppedResult).toBeDefined();
+      if (stoppedTerminal.reason === 'aborted_tools') {
+        expect(stoppedResult?.isError).toBe(true);
+      }
 
       const recoveryMarker = marker('POST_INTERRUPT');
       const recoveryPrompt = exactReplyPrompt(recoveryMarker);

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
   type IntegrationFixture,
   withIntegrationFixture,
 } from '../../../support/integration-fixture.js';
+import { GarconApiError } from '../../../support/garcon-client.js';
 import {
   exactReplyPrompt,
   expectAssistantMarker,
@@ -128,18 +129,38 @@ describe('live Claude lifecycle', () => {
       const parentChatId = fixture.newChatId();
       const firstMarker = marker('PARENT_FIRST');
       const secondMarker = marker('PARENT_SECOND');
-      const firstPrompt = exactReplyPrompt(firstMarker);
+      const firstPrompt = [
+        'Use the Bash tool now to run exactly `sleep 2`.',
+        `After it succeeds, reply with exactly ${firstMarker}.`,
+        'Do not run any other command.',
+      ].join(' ');
       const secondPrompt = exactReplyPrompt(secondMarker);
       const firstCursor = fixture.client.markEvents();
       const first = await fixture.client.startChat(liveClaudeStartRequest({
         chatId: parentChatId,
         projectPath: fixture.dirs.project,
         command: firstPrompt,
+        permissionMode: 'bypassPermissions',
       }));
 
       const queueCursor = fixture.client.markEvents();
       const queued = await fixture.client.enqueueNew(parentChatId, secondPrompt);
       expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([secondPrompt]);
+      const childChatId = fixture.newChatId();
+      const childMarker = marker('CHILD');
+      const childPrompt = [
+        'Use the Bash tool now to run exactly `sleep 2`.',
+        `After it succeeds, reply with exactly ${childMarker}.`,
+        'Do not run any other command.',
+      ].join(' ');
+      const childCursor = fixture.client.markEvents();
+      const childRequest = liveClaudeForkRunRequest({
+        sourceChatId: parentChatId,
+        chatId: childChatId,
+        command: childPrompt,
+        permissionMode: 'bypassPermissions',
+      });
+      await expectBusyFork(fixture.client.forkRunChat(childRequest));
 
       expectFinished((await fixture.client.waitForTurnTerminal(parentChatId, first.turnId, {
         afterIndex: firstCursor,
@@ -166,6 +187,33 @@ describe('live Claude lifecycle', () => {
         && entry.message.content.includes(firstMarker));
       if (!firstAssistant) throw new Error('Live Claude first response was not persisted.');
 
+      const child = await fixture.client.forkRunChat(childRequest);
+      const grandchildChatId = fixture.newChatId();
+      const grandchildMarker = marker('GRANDCHILD');
+      const grandchildPrompt = exactReplyPrompt(grandchildMarker);
+      const grandchildCursor = fixture.client.markEvents();
+      const grandchildRequest = liveClaudeForkRunRequest({
+        sourceChatId: childChatId,
+        chatId: grandchildChatId,
+        command: grandchildPrompt,
+      });
+      await expectBusyFork(fixture.client.forkRunChat(grandchildRequest));
+      await waitForVisibleClaudeResponse({
+        fixture,
+        chatId: childChatId,
+        turnId: child.turnId,
+        marker: childMarker,
+        afterIndex: childCursor,
+      });
+      const grandchild = await fixture.client.forkRunChat(grandchildRequest);
+      await waitForVisibleClaudeResponse({
+        fixture,
+        chatId: grandchildChatId,
+        turnId: grandchild.turnId,
+        marker: grandchildMarker,
+        afterIndex: grandchildCursor,
+      });
+
       const pointChatId = fixture.newChatId();
       await fixture.client.forkChat({
         sourceChatId: parentChatId,
@@ -185,40 +233,6 @@ describe('live Claude lifecycle', () => {
         turnId: pointTurn.turnId,
         marker: pointMarker,
         afterIndex: pointCursor,
-      });
-
-      const childChatId = fixture.newChatId();
-      const childMarker = marker('CHILD');
-      const childPrompt = exactReplyPrompt(childMarker);
-      const childCursor = fixture.client.markEvents();
-      const child = await fixture.client.forkRunChat(liveClaudeForkRunRequest({
-        sourceChatId: parentChatId,
-        chatId: childChatId,
-        command: childPrompt,
-      }));
-      await waitForVisibleClaudeResponse({
-        fixture,
-        chatId: childChatId,
-        turnId: child.turnId,
-        marker: childMarker,
-        afterIndex: childCursor,
-      });
-
-      const grandchildChatId = fixture.newChatId();
-      const grandchildMarker = marker('GRANDCHILD');
-      const grandchildPrompt = exactReplyPrompt(grandchildMarker);
-      const grandchildCursor = fixture.client.markEvents();
-      const grandchild = await fixture.client.forkRunChat(liveClaudeForkRunRequest({
-        sourceChatId: childChatId,
-        chatId: grandchildChatId,
-        command: grandchildPrompt,
-      }));
-      await waitForVisibleClaudeResponse({
-        fixture,
-        chatId: grandchildChatId,
-        turnId: grandchild.turnId,
-        marker: grandchildMarker,
-        afterIndex: grandchildCursor,
       });
 
       const parentContinuationMarker = marker('PARENT_CONTINUATION');
@@ -302,7 +316,9 @@ describe('live Claude lifecycle', () => {
     const toolMarker = marker('TOOL_OUTPUT');
     const fixtureName = 'live-tool-input.txt';
     const copyName = 'live-tool-copy.txt';
+    const deniedCopyName = 'live-tool-denied-copy.txt';
     const toolCommand = `cp ${fixtureName} ${copyName} && cat ${copyName}`;
+    const deniedToolCommand = `cp ${fixtureName} ${deniedCopyName} && cat ${deniedCopyName}`;
     await withIntegrationFixture('live-claude-permission-and-restart', async (fixture) => {
       const chatId = fixture.newChatId();
       const prompt = [
@@ -396,6 +412,62 @@ describe('live Claude lifecycle', () => {
       expect(restoredResult?.content).toEqual(result?.content);
       expect(countUserContent(restored.messages, prompt)).toBe(1);
 
+      const deniedPrompt = [
+        'This is the denial half of the Garcon permission integration check.',
+        `Use the Bash tool exactly once to run \`${deniedToolCommand}\`.`,
+        'If permission is denied, do not retry the command.',
+      ].join(' ');
+      const deniedCursor = fixture.client.markEvents();
+      const deniedTurn = await fixture.client.runChat(liveClaudeRunRequest({
+        chatId,
+        command: deniedPrompt,
+      }));
+      const deniedPermissionEvent = await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'permission-request'
+            && entry.message.requestedTool.type === 'bash-tool-use'
+            && entry.message.requestedTool.command.includes(deniedToolCommand)),
+        'live Claude denied Bash permission request',
+        { afterIndex: deniedCursor, timeoutMs: TURN_TIMEOUT_MS },
+      );
+      const deniedPermission = deniedPermissionEvent.messages.find((entry) =>
+        entry.message.type === 'permission-request'
+        && entry.message.requestedTool.type === 'bash-tool-use'
+        && entry.message.requestedTool.command.includes(deniedToolCommand));
+      if (deniedPermission?.message.type !== 'permission-request') {
+        throw new Error('Live Claude denied permission request was not found.');
+      }
+      const deniedPermissionId = deniedPermission.message.permissionRequestId;
+      expect((await fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionRequestId: deniedPermissionId,
+        allow: false,
+        alwaysAllow: false,
+      })).status).toBe('accepted');
+      expectFinished((await fixture.client.waitForTurnTerminal(chatId, deniedTurn.turnId, {
+        afterIndex: deniedCursor,
+        timeoutMs: TURN_TIMEOUT_MS,
+      })).type);
+
+      const afterDenial = await fixture.client.getMessages(chatId);
+      const deniedResolution = messagesOfType(afterDenial.messages, 'permission-resolved').find(
+        (message) => message.permissionRequestId === deniedPermissionId,
+      );
+      const deniedBash = messagesOfType(afterDenial.messages, 'bash-tool-use').find(
+        (message) => message.command.includes(deniedToolCommand),
+      );
+      const deniedResult = messagesOfType(afterDenial.messages, 'tool-result').find(
+        (message) => message.toolId === deniedBash?.toolId,
+      );
+      expect(deniedResolution?.allowed).toBe(false);
+      expect(deniedResult?.isError).toBe(true);
+      expect(await Bun.file(join(fixture.dirs.project, deniedCopyName)).exists()).toBe(false);
+      expect(countUserContent(afterDenial.messages, deniedPrompt)).toBe(1);
+
       const resumedMarker = marker('TOOL_CHAT_RESUMED');
       const resumedPrompt = exactReplyPrompt(resumedMarker);
       const resumedCursor = fixture.client.markEvents();
@@ -411,7 +483,11 @@ describe('live Claude lifecycle', () => {
         afterIndex: resumedCursor,
       });
       const finalTranscript = await fixture.client.getMessages(chatId);
-      expect(userContents(finalTranscript.messages)).toEqual([prompt, resumedPrompt]);
+      expect(userContents(finalTranscript.messages)).toEqual([
+        prompt,
+        deniedPrompt,
+        resumedPrompt,
+      ]);
       expectAssistantMarker(assistantContents(finalTranscript.messages), resumedMarker);
     }, {
       redactSensitiveDiagnostics: true,
@@ -458,6 +534,11 @@ describe('live Claude lifecycle', () => {
       const terminal = await protocolProbe.waitForTerminal();
       expect(['aborted_streaming', 'aborted_tools']).toContain(terminal.reason);
       expect(terminal.userMessageUuid === null || terminal.userMessageUuid === inputUuid).toBe(true);
+      expect(await protocolProbe.waitForInterruptReceipt()).toEqual({
+        cancelledCount: 0,
+        stillQueuedCount: 0,
+      });
+      expect(await protocolProbe.readInterruptReceipts()).toHaveLength(1);
 
       const stopEvents = fixture.client.eventsSince(stopCursor);
       const stoppingIndex = stopEvents.findIndex((event) =>
@@ -552,6 +633,10 @@ describe('live Claude lifecycle', () => {
         interruptedTerminal.userMessageUuid === null
         || interruptedTerminal.userMessageUuid === interruptedInputUuid,
       ).toBe(true);
+      expect(await protocolProbe.waitForInterruptReceipt()).toEqual({
+        cancelledCount: 0,
+        stillQueuedCount: 0,
+      });
       const successorInput = await fixture.client.waitForEvent(
         (event): event is PendingUserInputUpdatedMessage =>
           event.type === 'pending-user-input-updated'
@@ -624,6 +709,11 @@ describe('live Claude lifecycle', () => {
         stoppedTerminal.userMessageUuid === null
         || stoppedTerminal.userMessageUuid === stoppedInputUuid,
       ).toBe(true);
+      expect(await protocolProbe.waitForInterruptReceipt(2)).toEqual({
+        cancelledCount: 0,
+        stillQueuedCount: 0,
+      });
+      expect(await protocolProbe.readInterruptReceipts()).toHaveLength(2);
 
       const stopEvents = fixture.client.eventsSince(stopCommandCursor);
       expect(stopEvents.filter((event) =>
@@ -689,6 +779,20 @@ describe('live Claude lifecycle', () => {
     });
   });
 });
+
+async function expectBusyFork(promise: Promise<unknown>): Promise<void> {
+  let error: unknown;
+  try {
+    await promise;
+  } catch (cause) {
+    error = cause;
+  }
+  expect(error).toBeInstanceOf(GarconApiError);
+  expect(error).toMatchObject({
+    status: 409,
+    body: { errorCode: 'SESSION_BUSY', retryable: true },
+  });
+}
 
 interface PersistedClaudeChat {
   agentSessionId: string;

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -668,12 +668,23 @@ describe('live Claude lifecycle', () => {
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
+      const stoppedCursor = fixture.client.markEvents();
       const stoppedTurn = await fixture.client.runChat(liveClaudeRunRequest({
         chatId,
         command: stoppedPrompt,
         permissionMode: 'bypassPermissions',
       }));
       await waitForFile(stoppedStarted);
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'bash-tool-use'
+            && entry.message.command.includes(stoppedCommand)),
+        'live Claude stopped Bash tool use',
+        { afterIndex: stoppedCursor, timeoutMs: TURN_TIMEOUT_MS },
+      );
       const stoppedInputUuid = await protocolProbe.waitForInputStarted(3);
       const stopCommandCursor = fixture.client.markEvents();
       const stopRequestId = crypto.randomUUID();

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -573,9 +573,12 @@ describe('live Claude lifecycle', () => {
         fixture,
         chatId,
         turnId: recovery.turnId,
-        marker: recoveryMarker,
         afterIndex: recoveryCursor,
       });
+      expect(countUserContent(
+        (await fixture.client.getMessages(chatId)).messages,
+        recoveryPrompt,
+      )).toBe(1);
     }, {
       prepareWorkspace: protocolProbe.prepareWorkspace,
       redactSensitiveDiagnostics: true,
@@ -658,36 +661,29 @@ describe('live Claude lifecycle', () => {
       expect(assistantContents(transcript.messages).join('\n')).not.toContain('SHOULD_NOT_COMPLETE');
       expect((await fixture.client.getExecutionControl(chatId)).queue.entries).toEqual([]);
 
+      const stoppedStarted = join(fixture.dirs.project, '.claude-stop-started');
+      const stoppedCommand = 'touch .claude-stop-started && sleep 30';
       const stoppedPrompt = [
-        'Use the Bash tool now to run exactly `sleep 30`.',
+        `Use the Bash tool now to run exactly \`${stoppedCommand}\`.`,
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
-      const stopCursor = fixture.client.markEvents();
       const stoppedTurn = await fixture.client.runChat(liveClaudeRunRequest({
         chatId,
         command: stoppedPrompt,
         permissionMode: 'bypassPermissions',
       }));
-      await fixture.client.waitForEvent(
-        (event): event is ChatMessagesMessage =>
-          event.type === 'chat-messages'
-          && event.chatId === chatId
-          && event.messages.some((entry) =>
-            entry.message.type === 'bash-tool-use'
-            && entry.message.command.includes('sleep 30')),
-        'live Claude stopped sleep tool use',
-        { afterIndex: stopCursor, timeoutMs: TURN_TIMEOUT_MS },
-      );
+      await waitForFile(stoppedStarted);
       const stoppedInputUuid = await protocolProbe.waitForInputStarted(3);
       const stopCommandCursor = fixture.client.markEvents();
+      const stopRequestId = crypto.randomUUID();
       const stopped = await Promise.all([
         fixture.client.stopChat({
-          clientRequestId: crypto.randomUUID(),
+          clientRequestId: stopRequestId,
           chatId,
         }),
         fixture.client.stopChat({
-          clientRequestId: crypto.randomUUID(),
+          clientRequestId: stopRequestId,
           chatId,
         }),
       ]);
@@ -751,7 +747,7 @@ describe('live Claude lifecycle', () => {
       expect(assistantContents(stoppedTranscript.messages).join('\n'))
         .not.toContain('STOPPED_TURN_SHOULD_NOT_COMPLETE');
       const stoppedBash = messagesOfType(stoppedTranscript.messages, 'bash-tool-use')
-        .findLast((message) => message.command.includes('sleep 30'));
+        .findLast((message) => message.command.includes(stoppedCommand));
       if (!stoppedBash) throw new Error('Live Claude stopped Bash tool use was not rendered.');
       const stoppedResult = messagesOfType(stoppedTranscript.messages, 'tool-result')
         .find((message) => message.toolId === stoppedBash.toolId);
@@ -792,6 +788,15 @@ async function expectBusyFork(promise: Promise<unknown>): Promise<void> {
     status: 409,
     body: { errorCode: 'SESSION_BUSY', retryable: true },
   });
+}
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (await Bun.file(path).exists()) return;
+    await Bun.sleep(25);
+  }
+  throw new Error('Timed out waiting for the live Claude command marker.');
 }
 
 interface PersistedClaudeChat {

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -380,13 +380,14 @@ describe('live Codex lifecycle', () => {
       }));
       await waitForFile(stoppedStarted);
       const stopCommandCursor = fixture.client.markEvents();
+      const stopRequestId = crypto.randomUUID();
       const stopped = await Promise.all([
         fixture.client.stopChat({
-          clientRequestId: crypto.randomUUID(),
+          clientRequestId: stopRequestId,
           chatId,
         }),
         fixture.client.stopChat({
-          clientRequestId: crypto.randomUUID(),
+          clientRequestId: stopRequestId,
           chatId,
         }),
       ]);

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type {
-  ChatMessagesMessage,
+  PendingUserInputClearedMessage,
   PendingUserInputUpdatedMessage,
 } from '../../../../common/ws-events.js';
 import {
@@ -377,23 +377,12 @@ describe('live Codex lifecycle', () => {
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
-      const stoppedCursor = fixture.client.markEvents();
       const stoppedTurn = await fixture.client.runChat(liveCodexRunRequest({
         chatId,
         command: stoppedPrompt,
         permissionMode: 'bypassPermissions',
       }));
       await waitForFile(stoppedStarted);
-      await fixture.client.waitForEvent(
-        (event): event is ChatMessagesMessage =>
-          event.type === 'chat-messages'
-          && event.chatId === chatId
-          && event.messages.some((entry) =>
-            entry.message.type === 'bash-tool-use'
-            && entry.message.command.includes(stoppedCommand)),
-        'live Codex stopped shell tool use',
-        { afterIndex: stoppedCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
-      );
       const stopCommandCursor = fixture.client.markEvents();
       const stopRequestId = crypto.randomUUID();
       const stopped = await Promise.all([
@@ -414,6 +403,14 @@ describe('live Codex lifecycle', () => {
         afterIndex: stopCommandCursor,
         timeoutMs: LIVE_TURN_TIMEOUT_MS,
       });
+      await fixture.client.waitForEvent(
+        (event): event is PendingUserInputClearedMessage =>
+          event.type === 'pending-user-input-cleared'
+          && event.chatId === chatId
+          && event.clientRequestId === stoppedTurn.clientRequestId,
+        'live Codex stopped input settlement',
+        { afterIndex: stopCommandCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
       const stopEvents = fixture.client.eventsSince(stopCommandCursor);
       expect(stopEvents.filter((event) =>
         event.type === 'chat-session-stopped'
@@ -451,20 +448,19 @@ describe('live Codex lifecycle', () => {
         .not.toContain('CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE');
       const stoppedBash = messagesOfType(stoppedTranscript.messages, 'bash-tool-use')
         .findLast((message) => message.command.includes(stoppedCommand));
-      if (!stoppedBash) throw new Error('Live Codex stopped shell tool use was not rendered.');
       const stoppedResult = messagesOfType(stoppedTranscript.messages, 'tool-result')
-        .find((message) => message.toolId === stoppedBash.toolId);
-      expect(stoppedResult?.isError).toBe(true);
+        .find((message) => message.toolId === stoppedBash?.toolId);
+      expect(countUserContent(stoppedTranscript.messages, stoppedPrompt)).toBe(1);
 
       await fixture.restartGarcon();
       const restoredTranscript = await fixture.client.getMessages(chatId);
       const restoredBash = messagesOfType(restoredTranscript.messages, 'bash-tool-use')
-        .findLast((message) => message.command.includes('sleep 30'));
+        .findLast((message) => message.command.includes(stoppedCommand));
       const restoredResult = messagesOfType(restoredTranscript.messages, 'tool-result')
         .find((message) => message.toolId === restoredBash?.toolId);
-      expect(restoredBash).toBeDefined();
-      expect(restoredResult?.isError).toBe(true);
-      expect(restoredResult?.content).toEqual(stoppedResult?.content);
+      expect(restoredBash).toEqual(stoppedBash);
+      expect(restoredResult).toEqual(stoppedResult);
+      expect(countUserContent(restoredTranscript.messages, stoppedPrompt)).toBe(1);
 
       const recoveryMarker = liveMarker('CODEX_POST_INTERRUPT');
       const recoveryPrompt = exactReplyPrompt(recoveryMarker);

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -474,6 +474,7 @@ describe('live Codex lifecycle', () => {
         && event.turnId === stoppedTurn.turnId
           ? event.messages
           : []);
+      // Codex may omit an interrupted command item entirely, so only cross-source parity is stable.
       const liveStoppedExecutions = toolExecutionProjections(liveStoppedMessages);
       expect(toolExecutionProjections(stoppedTranscript.messages, priorBashToolIds))
         .toEqual(liveStoppedExecutions);

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -1,7 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { PendingUserInputUpdatedMessage } from '../../../../common/ws-events.js';
+import type {
+  ChatMessagesMessage,
+  PendingUserInputUpdatedMessage,
+} from '../../../../common/ws-events.js';
 import {
   assistantContents,
   countUserContent,
@@ -368,17 +371,29 @@ describe('live Codex lifecycle', () => {
       expect((await fixture.client.getExecutionControl(chatId)).queue.entries).toEqual([]);
 
       const stoppedStarted = join(fixture.dirs.project, '.codex-stop-started');
+      const stoppedCommand = 'touch .codex-stop-started && sleep 30';
       const stoppedPrompt = [
-        'Use the shell tool now to run exactly `touch .codex-stop-started && sleep 30`.',
+        `Use the shell tool now to run exactly \`${stoppedCommand}\`.`,
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
+      const stoppedCursor = fixture.client.markEvents();
       const stoppedTurn = await fixture.client.runChat(liveCodexRunRequest({
         chatId,
         command: stoppedPrompt,
         permissionMode: 'bypassPermissions',
       }));
       await waitForFile(stoppedStarted);
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'bash-tool-use'
+            && entry.message.command.includes(stoppedCommand)),
+        'live Codex stopped shell tool use',
+        { afterIndex: stoppedCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
       const stopCommandCursor = fixture.client.markEvents();
       const stopRequestId = crypto.randomUUID();
       const stopped = await Promise.all([
@@ -435,7 +450,7 @@ describe('live Codex lifecycle', () => {
       expect(assistantContents(stoppedTranscript.messages).join('\n'))
         .not.toContain('CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE');
       const stoppedBash = messagesOfType(stoppedTranscript.messages, 'bash-tool-use')
-        .findLast((message) => message.command.includes('sleep 30'));
+        .findLast((message) => message.command.includes(stoppedCommand));
       if (!stoppedBash) throw new Error('Live Codex stopped shell tool use was not rendered.');
       const stoppedResult = messagesOfType(stoppedTranscript.messages, 'tool-result')
         .find((message) => message.toolId === stoppedBash.toolId);

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { PendingUserInputUpdatedMessage } from '../../../../common/ws-events.js';
 import {
@@ -12,6 +12,7 @@ import {
   type IntegrationFixture,
   withIntegrationFixture,
 } from '../../../support/integration-fixture.js';
+import { GarconApiError } from '../../../support/garcon-client.js';
 import {
   exactReplyPrompt,
   expectAssistantMarker,
@@ -27,6 +28,7 @@ import {
   startLiveCodexTestEnvironment,
   type LiveCodexTestEnvironment,
 } from '../../../support/live-codex.js';
+import { createLiveCodexProtocolProbe } from '../../../support/live-codex-protocol-probe.js';
 
 describe('live Codex lifecycle', () => {
   let liveEnvironment: LiveCodexTestEnvironment | undefined;
@@ -68,6 +70,21 @@ describe('live Codex lifecycle', () => {
       const queueCursor = fixture.client.markEvents();
       const queued = await fixture.client.enqueueNew(parentChatId, secondPrompt);
       expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([secondPrompt]);
+      const childChatId = fixture.newChatId();
+      const childMarker = liveMarker('CODEX_CHILD');
+      const childPrompt = [
+        'Use the shell tool now to run exactly `sleep 2`.',
+        `After it succeeds, reply with exactly ${childMarker}.`,
+        'Do not run any other command.',
+      ].join(' ');
+      const childCursor = fixture.client.markEvents();
+      const childRequest = liveCodexForkRunRequest({
+        sourceChatId: parentChatId,
+        chatId: childChatId,
+        command: childPrompt,
+        permissionMode: 'bypassPermissions',
+      });
+      await expectBusyFork(fixture.client.forkRunChat(childRequest));
 
       expectFinished((await fixture.client.waitForTurnTerminal(parentChatId, first.turnId, {
         afterIndex: firstCursor,
@@ -88,21 +105,31 @@ describe('live Codex lifecycle', () => {
         { afterIndex: queueCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
       )).type);
 
-      const childChatId = fixture.newChatId();
-      const childMarker = liveMarker('CODEX_CHILD');
-      const childPrompt = exactReplyPrompt(childMarker);
-      const childCursor = fixture.client.markEvents();
-      const child = await fixture.client.forkRunChat(liveCodexForkRunRequest({
-        sourceChatId: parentChatId,
-        chatId: childChatId,
-        command: childPrompt,
-      }));
+      const child = await fixture.client.forkRunChat(childRequest);
+      const grandchildChatId = fixture.newChatId();
+      const grandchildMarker = liveMarker('CODEX_GRANDCHILD');
+      const grandchildPrompt = exactReplyPrompt(grandchildMarker);
+      const grandchildCursor = fixture.client.markEvents();
+      const grandchildRequest = liveCodexForkRunRequest({
+        sourceChatId: childChatId,
+        chatId: grandchildChatId,
+        command: grandchildPrompt,
+      });
+      await expectBusyFork(fixture.client.forkRunChat(grandchildRequest));
       await waitForVisibleResponse({
         fixture,
         chatId: childChatId,
         turnId: child.turnId,
         marker: childMarker,
         afterIndex: childCursor,
+      });
+      const grandchild = await fixture.client.forkRunChat(grandchildRequest);
+      await waitForVisibleResponse({
+        fixture,
+        chatId: grandchildChatId,
+        turnId: grandchild.turnId,
+        marker: grandchildMarker,
+        afterIndex: grandchildCursor,
       });
 
       const parentAfterQueue = await fixture.client.getMessages(parentChatId);
@@ -131,23 +158,6 @@ describe('live Codex lifecycle', () => {
         turnId: pointTurn.turnId,
         marker: pointMarker,
         afterIndex: pointCursor,
-      });
-
-      const grandchildChatId = fixture.newChatId();
-      const grandchildMarker = liveMarker('CODEX_GRANDCHILD');
-      const grandchildPrompt = exactReplyPrompt(grandchildMarker);
-      const grandchildCursor = fixture.client.markEvents();
-      const grandchild = await fixture.client.forkRunChat(liveCodexForkRunRequest({
-        sourceChatId: childChatId,
-        chatId: grandchildChatId,
-        command: grandchildPrompt,
-      }));
-      await waitForVisibleResponse({
-        fixture,
-        chatId: grandchildChatId,
-        turnId: grandchild.turnId,
-        marker: grandchildMarker,
-        afterIndex: grandchildCursor,
       });
 
       const parentContinuationMarker = liveMarker('CODEX_PARENT_CONTINUATION');
@@ -233,6 +243,70 @@ describe('live Codex lifecycle', () => {
     });
   });
 
+  test('auto-approves an escalated app-server command in manual bypass', async () => {
+    if (!liveEnvironment) throw new Error('Live Codex test environment was not initialized.');
+    const testEnvironment = liveEnvironment;
+    const serverEnvironment = { ...testEnvironment.serverEnvironment };
+    const protocolProbe = createLiveCodexProtocolProbe(serverEnvironment);
+    const output = liveMarker('CODEX_MANUAL_BYPASS');
+    const outsidePath = join(
+      process.cwd(),
+      `.live-codex-manual-bypass-${crypto.randomUUID()}`,
+    );
+    const command = `printf %s ${output} > ${outsidePath} && cat ${outsidePath}`;
+
+    try {
+      await withIntegrationFixture('live-codex-manual-bypass', async (fixture) => {
+        const chatId = fixture.newChatId();
+        const prompt = [
+          `Use the shell tool to run exactly \`${command}\`.`,
+          `After it succeeds, reply with exactly ${output}.`,
+          'Do not run any other command.',
+        ].join(' ');
+        const cursor = fixture.client.markEvents();
+        const turn = await fixture.client.startChat(liveCodexStartRequest({
+          chatId,
+          projectPath: fixture.dirs.project,
+          command: prompt,
+          permissionMode: 'manualBypass',
+        }));
+        await waitForVisibleResponse({
+          fixture,
+          chatId,
+          turnId: turn.turnId,
+          marker: output,
+          afterIndex: cursor,
+        });
+
+        expect((await readFile(outsidePath, 'utf8')).trim()).toBe(output);
+        expect(await protocolProbe.waitForApprovalRequest()).toBe(
+          'item/commandExecution/requestApproval',
+        );
+        expect(await protocolProbe.readApprovalRequests()).toEqual([
+          'item/commandExecution/requestApproval',
+        ]);
+        const transcript = await fixture.client.getMessages(chatId);
+        expectPersistedCommand(transcript, command, output);
+        expect(messagesOfType(transcript.messages, 'permission-request')).toEqual([]);
+
+        await fixture.restartGarcon();
+        const restored = await fixture.client.getMessages(chatId);
+        expectPersistedCommand(restored, command, output);
+        expect(countUserContent(restored.messages, prompt)).toBe(1);
+      }, {
+        forbiddenPersistedValues: testEnvironment.forbiddenPersistedValues,
+        redactSensitiveDiagnostics: true,
+        serverEnvironment,
+        prepareWorkspace: async (directories) => {
+          await testEnvironment.prepareWorkspace(directories);
+          await protocolProbe.prepareWorkspace(directories);
+        },
+      });
+    } finally {
+      await rm(outsidePath, { force: true });
+    }
+  });
+
   test('interrupts and stops active tools while preserving later delivery', async () => {
     if (!liveEnvironment) throw new Error('Live Codex test environment was not initialized.');
     const testEnvironment = liveEnvironment;
@@ -247,7 +321,7 @@ describe('live Codex lifecycle', () => {
       ].join(' ');
       const successorMarker = liveMarker('CODEX_INTERRUPT_SUCCESSOR');
       const successorPrompt = exactReplyPrompt(successorMarker);
-      await fixture.client.startChat(liveCodexStartRequest({
+      const active = await fixture.client.startChat(liveCodexStartRequest({
         chatId,
         projectPath: fixture.dirs.project,
         command: interruptedPrompt,
@@ -284,6 +358,13 @@ describe('live Codex lifecycle', () => {
       expectAssistantMarker(assistantContents(transcript.messages), successorMarker);
       expect(assistantContents(transcript.messages).join('\n'))
         .not.toContain('CODEX_SHOULD_NOT_COMPLETE');
+      expect(fixture.client.eventsSince(interruptCursor)).not.toContainEqual(
+        expect.objectContaining({
+          type: 'agent-run-failed',
+          chatId,
+          turnId: active.turnId,
+        }),
+      );
       expect((await fixture.client.getExecutionControl(chatId)).queue.entries).toEqual([]);
 
       const stoppedStarted = join(fixture.dirs.project, '.codex-stop-started');
@@ -292,25 +373,82 @@ describe('live Codex lifecycle', () => {
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
-      const stopCursor = fixture.client.markEvents();
-      await fixture.client.runChat(liveCodexRunRequest({
+      const stoppedTurn = await fixture.client.runChat(liveCodexRunRequest({
         chatId,
         command: stoppedPrompt,
         permissionMode: 'bypassPermissions',
       }));
       await waitForFile(stoppedStarted);
-      const stopped = await fixture.client.stopChat({
-        clientRequestId: crypto.randomUUID(),
-        chatId,
-      });
-      expect(stopped.outcome).toBe('interrupt-requested');
+      const stopCommandCursor = fixture.client.markEvents();
+      const stopped = await Promise.all([
+        fixture.client.stopChat({
+          clientRequestId: crypto.randomUUID(),
+          chatId,
+        }),
+        fixture.client.stopChat({
+          clientRequestId: crypto.randomUUID(),
+          chatId,
+        }),
+      ]);
+      expect(stopped.map((response) => response.outcome)).toEqual([
+        'interrupt-requested',
+        'interrupt-requested',
+      ]);
       await fixture.client.waitForProcessing(chatId, false, {
-        afterIndex: stopCursor,
+        afterIndex: stopCommandCursor,
         timeoutMs: LIVE_TURN_TIMEOUT_MS,
       });
-      expect(assistantContents(
-        (await fixture.client.getMessages(chatId)).messages,
-      ).join('\n')).not.toContain('CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE');
+      const stopEvents = fixture.client.eventsSince(stopCommandCursor);
+      expect(stopEvents.filter((event) =>
+        event.type === 'chat-session-stopped'
+        && event.chatId === chatId
+        && event.outcome === 'interrupt-requested'
+        && event.intent === 'stop')).toHaveLength(1);
+      const stoppingIndex = stopEvents.findIndex((event) =>
+        event.type === 'chat-processing-updated'
+        && event.chatId === chatId
+        && event.phase === 'stopping');
+      const outcomeIndex = stopEvents.findIndex((event) =>
+        event.type === 'chat-session-stopped'
+        && event.chatId === chatId
+        && event.outcome === 'interrupt-requested'
+        && event.intent === 'stop');
+      const idleIndex = stopEvents.findIndex((event) =>
+        event.type === 'chat-processing-updated'
+        && event.chatId === chatId
+        && event.phase === null);
+      expect(stoppingIndex).toBeGreaterThanOrEqual(0);
+      expect(outcomeIndex).toBeGreaterThan(stoppingIndex);
+      expect(idleIndex).toBeGreaterThan(stoppingIndex);
+      expect(stopEvents).not.toContainEqual(expect.objectContaining({
+        type: 'agent-run-failed',
+        chatId,
+        turnId: stoppedTurn.turnId,
+      }));
+      expect((await fixture.client.ping()).processing).toEqual({
+        outcome: 'snapshot',
+        chats: [],
+      });
+
+      const stoppedTranscript = await fixture.client.getMessages(chatId);
+      expect(assistantContents(stoppedTranscript.messages).join('\n'))
+        .not.toContain('CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE');
+      const stoppedBash = messagesOfType(stoppedTranscript.messages, 'bash-tool-use')
+        .findLast((message) => message.command.includes('sleep 30'));
+      if (!stoppedBash) throw new Error('Live Codex stopped shell tool use was not rendered.');
+      const stoppedResult = messagesOfType(stoppedTranscript.messages, 'tool-result')
+        .find((message) => message.toolId === stoppedBash.toolId);
+      expect(stoppedResult?.isError).toBe(true);
+
+      await fixture.restartGarcon();
+      const restoredTranscript = await fixture.client.getMessages(chatId);
+      const restoredBash = messagesOfType(restoredTranscript.messages, 'bash-tool-use')
+        .findLast((message) => message.command.includes('sleep 30'));
+      const restoredResult = messagesOfType(restoredTranscript.messages, 'tool-result')
+        .find((message) => message.toolId === restoredBash?.toolId);
+      expect(restoredBash).toBeDefined();
+      expect(restoredResult?.isError).toBe(true);
+      expect(restoredResult?.content).toEqual(stoppedResult?.content);
 
       const recoveryMarker = liveMarker('CODEX_POST_INTERRUPT');
       const recoveryPrompt = exactReplyPrompt(recoveryMarker);
@@ -334,6 +472,20 @@ describe('live Codex lifecycle', () => {
     });
   });
 });
+
+async function expectBusyFork(promise: Promise<unknown>): Promise<void> {
+  let error: unknown;
+  try {
+    await promise;
+  } catch (cause) {
+    error = cause;
+  }
+  expect(error).toBeInstanceOf(GarconApiError);
+  expect(error).toMatchObject({
+    status: 409,
+    body: { errorCode: 'SESSION_BUSY', retryable: true },
+  });
+}
 
 function expectPersistedCommand(
   transcript: Awaited<ReturnType<IntegrationFixture['client']['getMessages']>>,

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -475,7 +475,6 @@ describe('live Codex lifecycle', () => {
           ? event.messages
           : []);
       const liveStoppedExecutions = toolExecutionProjections(liveStoppedMessages);
-      expect(liveStoppedExecutions.length).toBeGreaterThan(0);
       expect(toolExecutionProjections(stoppedTranscript.messages, priorBashToolIds))
         .toEqual(liveStoppedExecutions);
       expect(countUserContent(stoppedTranscript.messages, stoppedPrompt)).toBe(1);

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { ChatViewMessage } from '../../../../common/chat-view.js';
 import type {
   PendingUserInputClearedMessage,
   PendingUserInputStatusUpdatedMessage,
@@ -377,6 +378,12 @@ describe('live Codex lifecycle', () => {
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
+      const beforeStoppedTranscript = await fixture.client.getMessages(chatId);
+      const priorBashToolIds = new Set(
+        messagesOfType(beforeStoppedTranscript.messages, 'bash-tool-use')
+          .map((message) => message.toolId),
+      );
+      const stoppedCursor = fixture.client.markEvents();
       const stoppedTurn = await fixture.client.runChat(liveCodexRunRequest({
         chatId,
         command: stoppedPrompt,
@@ -461,20 +468,22 @@ describe('live Codex lifecycle', () => {
       const stoppedTranscript = await fixture.client.getMessages(chatId);
       expect(assistantContents(stoppedTranscript.messages).join('\n'))
         .not.toContain('CODEX_STOPPED_TURN_SHOULD_NOT_COMPLETE');
-      const stoppedBash = messagesOfType(stoppedTranscript.messages, 'bash-tool-use')
-        .findLast((message) => message.command.includes(stoppedCommand));
-      const stoppedResult = messagesOfType(stoppedTranscript.messages, 'tool-result')
-        .find((message) => message.toolId === stoppedBash?.toolId);
+      const liveStoppedMessages = fixture.client.eventsSince(stoppedCursor).flatMap((event) =>
+        event.type === 'chat-messages'
+        && event.chatId === chatId
+        && event.turnId === stoppedTurn.turnId
+          ? event.messages
+          : []);
+      const liveStoppedExecutions = toolExecutionProjections(liveStoppedMessages);
+      expect(liveStoppedExecutions.length).toBeGreaterThan(0);
+      expect(toolExecutionProjections(stoppedTranscript.messages, priorBashToolIds))
+        .toEqual(liveStoppedExecutions);
       expect(countUserContent(stoppedTranscript.messages, stoppedPrompt)).toBe(1);
 
       await fixture.restartGarcon();
       const restoredTranscript = await fixture.client.getMessages(chatId);
-      const restoredBash = messagesOfType(restoredTranscript.messages, 'bash-tool-use')
-        .findLast((message) => message.command.includes(stoppedCommand));
-      const restoredResult = messagesOfType(restoredTranscript.messages, 'tool-result')
-        .find((message) => message.toolId === restoredBash?.toolId);
-      expect(restoredBash).toEqual(stoppedBash);
-      expect(restoredResult).toEqual(stoppedResult);
+      expect(toolExecutionProjections(restoredTranscript.messages, priorBashToolIds))
+        .toEqual(liveStoppedExecutions);
       expect(countUserContent(restoredTranscript.messages, stoppedPrompt)).toBe(1);
 
       const recoveryMarker = liveMarker('CODEX_POST_INTERRUPT');
@@ -533,6 +542,32 @@ function expectPersistedCommand(
   const resultSeq = transcript.messages.find((entry) =>
     entry.message.type === 'tool-result' && entry.message.toolId === bash.toolId)?.seq;
   expect(resultSeq).toBeGreaterThan(bashSeq ?? Number.MAX_SAFE_INTEGER);
+}
+
+function toolExecutionProjections(
+  messages: readonly ChatViewMessage[],
+  excludedToolIds: ReadonlySet<string> = new Set(),
+): Array<{
+  bash: { toolId: string; command: string; description?: string };
+  result: { toolId: string; content: Record<string, unknown>; isError: boolean } | null;
+}> {
+  const results = messagesOfType(messages, 'tool-result');
+  return messagesOfType(messages, 'bash-tool-use')
+    .filter((bash) => !excludedToolIds.has(bash.toolId))
+    .map((bash) => {
+      const result = results.find((message) => message.toolId === bash.toolId);
+      return {
+        bash: {
+          toolId: bash.toolId,
+          command: bash.command,
+          description: bash.description,
+        },
+        result: result
+          ? { toolId: result.toolId, content: result.content, isError: result.isError }
+          : null,
+      };
+    })
+    .sort((left, right) => left.bash.toolId.localeCompare(right.bash.toolId));
 }
 
 async function waitForFile(path: string): Promise<void> {

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -3,6 +3,7 @@ import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type {
   PendingUserInputClearedMessage,
+  PendingUserInputStatusUpdatedMessage,
   PendingUserInputUpdatedMessage,
 } from '../../../../common/ws-events.js';
 import {
@@ -277,7 +278,6 @@ describe('live Codex lifecycle', () => {
           fixture,
           chatId,
           turnId: turn.turnId,
-          marker: output,
           afterIndex: cursor,
         });
 
@@ -403,14 +403,29 @@ describe('live Codex lifecycle', () => {
         afterIndex: stopCommandCursor,
         timeoutMs: LIVE_TURN_TIMEOUT_MS,
       });
-      await fixture.client.waitForEvent(
-        (event): event is PendingUserInputClearedMessage =>
-          event.type === 'pending-user-input-cleared'
-          && event.chatId === chatId
-          && event.clientRequestId === stoppedTurn.clientRequestId,
+      const stoppedInputSettlement = await fixture.client.waitForEvent(
+        (
+          event,
+        ): event is PendingUserInputClearedMessage | PendingUserInputStatusUpdatedMessage =>
+          (
+            event.type === 'pending-user-input-cleared'
+            && event.chatId === chatId
+            && event.clientRequestId === stoppedTurn.clientRequestId
+            && event.reason === 'persisted'
+          )
+          || (
+            event.type === 'pending-user-input-status-updated'
+            && event.chatId === chatId
+            && event.clientRequestId === stoppedTurn.clientRequestId
+            && event.deliveryStatus === 'unconfirmed'
+          ),
         'live Codex stopped input settlement',
         { afterIndex: stopCommandCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
       );
+      expect(
+        stoppedInputSettlement.type === 'pending-user-input-cleared'
+        || stoppedInputSettlement.deliveryStatus === 'unconfirmed',
+      ).toBe(true);
       const stopEvents = fixture.client.eventsSince(stopCommandCursor);
       expect(stopEvents.filter((event) =>
         event.type === 'chat-session-stopped'

--- a/integration-tests/tests/server/live-claude-protocol-probe.test.ts
+++ b/integration-tests/tests/server/live-claude-protocol-probe.test.ts
@@ -26,6 +26,13 @@ console.log(JSON.stringify({
   type: 'result',
   terminal_reason: 'aborted_streaming',
 }));
+console.log(JSON.stringify({
+  type: 'control_response',
+  response: {
+    subtype: 'success',
+    response: { cancelled: ['private-uuid'], still_queued: [] },
+  },
+}));
 `, { mode: 0o700 });
       const environment = { CLAUDE_BINARY: fakeBinary };
       const probe = createLiveClaudeProtocolProbe(environment);
@@ -55,11 +62,21 @@ console.log(JSON.stringify({
         reason: 'aborted_streaming',
         userMessageUuid: null,
       });
+      expect(await probe.waitForInterruptReceipt()).toEqual({
+        cancelledCount: 1,
+        stillQueuedCount: 0,
+      });
+      expect(await probe.readInterruptReceipts()).toEqual([{
+        cancelledCount: 1,
+        stillQueuedCount: 0,
+      }]);
       const persistedProbeData = [
         await readFile(join(root, 'claude-started-inputs'), 'utf8'),
         await readFile(join(root, 'claude-terminal-results'), 'utf8'),
+        await readFile(join(root, 'claude-interrupt-receipts'), 'utf8'),
       ].join('\n');
       expect(persistedProbeData).not.toContain('private output');
+      expect(persistedProbeData).not.toContain('private-uuid');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/integration-tests/tests/server/live-codex-protocol-probe.test.ts
+++ b/integration-tests/tests/server/live-codex-protocol-probe.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createLiveCodexProtocolProbe } from '../../support/live-codex-protocol-probe.js';
+
+describe('live Codex protocol probe', () => {
+  test('observes approval methods without persisting request details', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'garcon-codex-probe-'));
+    try {
+      const fakeBinary = join(root, 'fake-codex');
+      await writeFile(fakeBinary, `#!/usr/bin/env bun
+console.log(JSON.stringify({
+  id: 'private-request-id',
+  method: 'item/commandExecution/requestApproval',
+  params: {
+    command: 'private command',
+    cwd: '/private/path',
+  },
+}));
+console.log(JSON.stringify({ method: 'unrelated', params: { content: 'private output' } }));
+`, { mode: 0o700 });
+      const environment = { GARCON_CODEX_CLI: fakeBinary };
+      const probe = createLiveCodexProtocolProbe(environment);
+      await probe.prepareWorkspace({
+        root,
+        config: join(root, 'config'),
+        workspace: join(root, 'workspace'),
+        project: join(root, 'project'),
+        home: join(root, 'home'),
+      });
+
+      const child = Bun.spawn([environment.GARCON_CODEX_CLI], {
+        env: { ...process.env, ...environment },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const output = await new Response(child.stdout).text();
+      expect(await child.exited).toBe(0);
+      expect(output).toContain('private command');
+
+      expect(await probe.waitForApprovalRequest()).toBe(
+        'item/commandExecution/requestApproval',
+      );
+      expect(await probe.readApprovalRequests()).toEqual([
+        'item/commandExecution/requestApproval',
+      ]);
+      const persistedProbeData = await readFile(join(root, 'codex-approval-requests'), 'utf8');
+      expect(persistedProbeData).not.toContain('private-request-id');
+      expect(persistedProbeData).not.toContain('private command');
+      expect(persistedProbeData).not.toContain('/private/path');
+      expect(persistedProbeData).not.toContain('private output');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -1417,6 +1417,105 @@ describe('CodexAppServerRuntime', () => {
     expect(fake.interruptTurn).toHaveBeenCalledWith('thread-1', 'turn-1');
   });
 
+  it('keeps an interrupted turn attached until the provider terminal notification', async () => {
+    const fake = new FakeClient();
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    const processing = [];
+    const finished = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+    provider.onProcessing((_chatId, value) => processing.push(value));
+    provider.onFinished((chatId, exitCode) => finished.push({ chatId, exitCode }));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      nativePath: null,
+    }));
+    await expect(provider.abort('thread-1')).resolves.toBe(true);
+
+    expect(provider.isRunning('thread-1')).toBe(true);
+    expect(provider.getRunningSessions()).toMatchObject([{ id: 'thread-1', status: 'interrupting' }]);
+    expect(fake.shutdown).not.toHaveBeenCalled();
+    expect(processing).toEqual([true]);
+
+    fake.emit('notification', {
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'commandExecution',
+          id: 'command-after-interrupt',
+          command: 'printf persisted',
+          cwd: '/repo',
+          processId: null,
+          source: 'agent',
+          status: 'completed',
+          commandActions: [],
+          aggregatedOutput: 'persisted',
+          exitCode: 0,
+          durationMs: 12,
+        },
+      },
+    });
+
+    expect(emitted).toHaveLength(2);
+    expect(emitted[0]).toBeInstanceOf(BashToolUseMessage);
+    expect(emitted[1]).toBeInstanceOf(ToolResultMessage);
+    expect(emitted[1]).toMatchObject({
+      toolId: 'command-after-interrupt',
+      content: { raw: 'persisted' },
+      isError: false,
+    });
+
+    const terminal = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: makeTurn({ status: 'interrupted' }),
+      },
+    });
+    await terminal;
+
+    expect(finished).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
+    expect(processing).toEqual([true, false]);
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles once when the interrupted terminal notification wins the response race', async () => {
+    let fake;
+    fake = new FakeClient({
+      interruptTurn: async () => {
+        fake.emit('notification', {
+          method: 'turn/completed',
+          params: {
+            threadId: 'thread-1',
+            turn: makeTurn({ status: 'interrupted' }),
+          },
+        });
+        return {};
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const processing = [];
+    const finished = [];
+    provider.onProcessing((_chatId, value) => processing.push(value));
+    provider.onFinished((chatId, exitCode) => finished.push({ chatId, exitCode }));
+
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      nativePath: null,
+    }));
+    await expect(provider.abort('thread-1')).resolves.toBe(true);
+
+    expect(finished).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
+    expect(processing).toEqual([true, false]);
+    expect(provider.isRunning('thread-1')).toBe(false);
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
   it('does not restore a managed goal turn that completes before its start response', async () => {
     const nativePath = path.join(tmpDir, 'completed-before-start-response-goal-thread.jsonl');
     let fake;

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -1418,7 +1418,26 @@ describe('CodexAppServerRuntime', () => {
   });
 
   it('keeps an interrupted turn attached until the provider terminal notification', async () => {
-    const fake = new FakeClient();
+    const commandItem = {
+      type: 'commandExecution',
+      id: 'command-after-interrupt',
+      command: 'printf persisted',
+      cwd: '/repo',
+      processId: null,
+      source: 'agent',
+      status: 'completed',
+      commandActions: [],
+      aggregatedOutput: 'persisted',
+      exitCode: 0,
+      durationMs: 12,
+    };
+    const fake = new FakeClient({
+      listThreadTurns: async () => ({
+        data: [makeTurn({ items: [commandItem], status: 'interrupted' })],
+        nextCursor: null,
+        backwardsCursor: null,
+      }),
+    });
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
     const emitted = [];
     const processing = [];
@@ -1443,19 +1462,7 @@ describe('CodexAppServerRuntime', () => {
       params: {
         threadId: 'thread-1',
         turnId: 'turn-1',
-        item: {
-          type: 'commandExecution',
-          id: 'command-after-interrupt',
-          command: 'printf persisted',
-          cwd: '/repo',
-          processId: null,
-          source: 'agent',
-          status: 'completed',
-          commandActions: [],
-          aggregatedOutput: 'persisted',
-          exitCode: 0,
-          durationMs: 12,
-        },
+        item: commandItem,
       },
     });
 
@@ -1482,6 +1489,57 @@ describe('CodexAppServerRuntime', () => {
     expect(processing).toEqual([true, false]);
     expect(provider.isRunning('thread-1')).toBe(false);
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers interrupted items persisted without an item completion notification', async () => {
+    const commandItem = {
+      type: 'commandExecution',
+      id: 'persisted-command',
+      command: 'printf recovered',
+      cwd: '/repo',
+      processId: null,
+      source: 'agent',
+      status: 'completed',
+      commandActions: [],
+      aggregatedOutput: 'recovered',
+      exitCode: 0,
+      durationMs: 8,
+    };
+    const fake = new FakeClient({
+      listThreadTurns: async () => ({
+        data: [makeTurn({ items: [commandItem], status: 'interrupted' })],
+        nextCursor: null,
+        backwardsCursor: null,
+      }),
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+
+    await provider.runTurn(makeRequest({ agentSessionId: 'thread-1', nativePath: null }));
+    await expect(provider.abort('thread-1')).resolves.toBe(true);
+    const terminal = new Promise((resolve) => provider.onFinished(resolve));
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ status: 'interrupted' }) },
+    });
+    await terminal;
+
+    expect(fake.listThreadTurns).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      cursor: null,
+      limit: 10,
+      sortDirection: 'desc',
+      itemsView: 'full',
+    });
+    expect(emitted).toHaveLength(2);
+    expect(emitted[0]).toMatchObject({ type: 'bash-tool-use', toolId: 'persisted-command' });
+    expect(emitted[1]).toMatchObject({
+      type: 'tool-result',
+      toolId: 'persisted-command',
+      content: { raw: 'recovered' },
+      isError: false,
+    });
   });
 
   it('settles once when the interrupted terminal notification wins the response race', async () => {
@@ -5473,11 +5531,41 @@ describe('CodexAppServerRuntime', () => {
     });
     fake.emit('notification', {
       method: 'turn/completed',
-      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-1' }) },
+      params: {
+        threadId: 'thread-1',
+        turn: makeTurn({ id: 'turn-1', items: [liveItem], itemsView: 'summary' }),
+      },
     });
     await finished;
 
     expect(emitted.map((message) => message.content)).toEqual(['Already emitted']);
+  });
+
+  it('uses the terminal agent summary when its item completion notification is absent', async () => {
+    const terminalItem = {
+      type: 'agentMessage',
+      id: 'terminal-agent-message',
+      text: 'Recovered final line',
+      phase: null,
+      memoryCitation: null,
+    };
+    const fake = new FakeClient();
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
+    const finished = new Promise((resolve) => provider.onFinished(resolve));
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
+
+    await provider.runTurn(makeRequest());
+    fake.emit('notification', {
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: makeTurn({ id: 'turn-1', items: [terminalItem], itemsView: 'summary' }),
+      },
+    });
+    await finished;
+
+    expect(emitted.map((message) => message.content)).toEqual(['Recovered final line']);
   });
 
   it('retries retryable utility app-server overload responses while resolving native paths', async () => {

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -1542,7 +1542,14 @@ describe('CodexAppServerRuntime', () => {
     });
   });
 
-  it('settles once when the interrupted terminal notification wins the response race', async () => {
+  it('reconciles once when a completed terminal notification wins the interrupt response race', async () => {
+    const terminalItem = {
+      type: 'agentMessage',
+      id: 'race-terminal-item',
+      text: 'Recovered at the interrupt boundary',
+      phase: null,
+      memoryCitation: null,
+    };
     let fake;
     fake = new FakeClient({
       interruptTurn: async () => {
@@ -1550,15 +1557,22 @@ describe('CodexAppServerRuntime', () => {
           method: 'turn/completed',
           params: {
             threadId: 'thread-1',
-            turn: makeTurn({ status: 'interrupted' }),
+            turn: makeTurn({ status: 'completed' }),
           },
         });
         return {};
       },
+      listThreadTurns: async () => ({
+        data: [makeTurn({ items: [terminalItem], status: 'completed' })],
+        nextCursor: null,
+        backwardsCursor: null,
+      }),
     });
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
+    const emitted = [];
     const processing = [];
     const finished = [];
+    provider.onMessages((_chatId, messages) => emitted.push(...messages));
     provider.onProcessing((_chatId, value) => processing.push(value));
     provider.onFinished((chatId, exitCode) => finished.push({ chatId, exitCode }));
 
@@ -1568,10 +1582,26 @@ describe('CodexAppServerRuntime', () => {
     }));
     await expect(provider.abort('thread-1')).resolves.toBe(true);
 
+    expect(emitted.map((message) => message.content)).toEqual(['Recovered at the interrupt boundary']);
     expect(finished).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
     expect(processing).toEqual([true, false]);
     expect(provider.isRunning('thread-1')).toBe(false);
     expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores running status when the interrupt request is rejected', async () => {
+    const fake = new FakeClient({
+      interruptTurn: async () => {
+        throw new Error('interrupt rejected');
+      },
+    });
+    const provider = new CodexAppServerRuntime({ createClient: () => fake });
+
+    await provider.runTurn(makeRequest({ agentSessionId: 'thread-1', nativePath: null }));
+
+    await expect(provider.abort('thread-1')).resolves.toBe(false);
+    expect(provider.getRunningSessions()).toMatchObject([{ id: 'thread-1', status: 'running' }]);
+    expect(fake.shutdown).not.toHaveBeenCalled();
   });
 
   it('does not restore a managed goal turn that completes before its start response', async () => {

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -130,6 +130,36 @@ async function writeJsonl(filePath, entries) {
   await fs.writeFile(filePath, `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`, 'utf8');
 }
 
+function commandHistoryEntries(callId, command, output) {
+  return [
+    {
+      type: 'session_meta',
+      timestamp: '2026-07-28T00:00:00.000Z',
+      payload: { id: 'thread-1', history_mode: 'legacy' },
+    },
+    {
+      type: 'event_msg',
+      timestamp: '2026-07-28T00:00:01.000Z',
+      payload: { type: 'user_message', message: 'Run the command' },
+    },
+    {
+      type: 'response_item',
+      timestamp: '2026-07-28T00:00:02.000Z',
+      payload: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: command, workdir: '/repo' }),
+        call_id: callId,
+      },
+    },
+    {
+      type: 'response_item',
+      timestamp: '2026-07-28T00:00:03.000Z',
+      payload: { type: 'function_call_output', call_id: callId, output },
+    },
+  ];
+}
+
 class FakeClient extends EventEmitter {
   constructor(script = {}) {
     super();
@@ -1431,13 +1461,7 @@ describe('CodexAppServerRuntime', () => {
       exitCode: 0,
       durationMs: 12,
     };
-    const fake = new FakeClient({
-      listThreadTurns: async () => ({
-        data: [makeTurn({ items: [commandItem], status: 'interrupted' })],
-        nextCursor: null,
-        backwardsCursor: null,
-      }),
-    });
+    const fake = new FakeClient();
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
     const emitted = [];
     const processing = [];
@@ -1492,32 +1516,19 @@ describe('CodexAppServerRuntime', () => {
   });
 
   it('recovers interrupted items persisted without an item completion notification', async () => {
-    const commandItem = {
-      type: 'commandExecution',
-      id: 'persisted-command',
-      command: 'printf recovered',
-      cwd: '/repo',
-      processId: null,
-      source: 'agent',
-      status: 'completed',
-      commandActions: [],
-      aggregatedOutput: 'recovered',
-      exitCode: 0,
-      durationMs: 8,
-    };
-    const fake = new FakeClient({
-      listThreadTurns: async () => ({
-        data: [makeTurn({ items: [commandItem], status: 'interrupted' })],
-        nextCursor: null,
-        backwardsCursor: null,
-      }),
-    });
+    const nativePath = path.join(tmpDir, 'interrupted-recovery.jsonl');
+    await writeJsonl(nativePath, commandHistoryEntries('prior-command', 'printf prior', 'prior'));
+    const fake = new FakeClient();
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
     const emitted = [];
     provider.onMessages((_chatId, messages) => emitted.push(...messages));
 
-    await provider.runTurn(makeRequest({ agentSessionId: 'thread-1', nativePath: null }));
+    await provider.runTurn(makeRequest({ agentSessionId: 'thread-1', nativePath }));
     await expect(provider.abort('thread-1')).resolves.toBe(true);
+    await writeJsonl(nativePath, [
+      ...commandHistoryEntries('prior-command', 'printf prior', 'prior'),
+      ...commandHistoryEntries('persisted-command', 'printf recovered', 'recovered').slice(2),
+    ]);
     const terminal = new Promise((resolve) => provider.onFinished(resolve));
     fake.emit('notification', {
       method: 'turn/completed',
@@ -1525,13 +1536,6 @@ describe('CodexAppServerRuntime', () => {
     });
     await terminal;
 
-    expect(fake.listThreadTurns).toHaveBeenCalledWith({
-      threadId: 'thread-1',
-      cursor: null,
-      limit: 10,
-      sortDirection: 'desc',
-      itemsView: 'full',
-    });
     expect(emitted).toHaveLength(2);
     expect(emitted[0]).toMatchObject({ type: 'bash-tool-use', toolId: 'persisted-command' });
     expect(emitted[1]).toMatchObject({
@@ -1543,16 +1547,15 @@ describe('CodexAppServerRuntime', () => {
   });
 
   it('reconciles once when a completed terminal notification wins the interrupt response race', async () => {
-    const terminalItem = {
-      type: 'agentMessage',
-      id: 'race-terminal-item',
-      text: 'Recovered at the interrupt boundary',
-      phase: null,
-      memoryCitation: null,
-    };
+    const nativePath = path.join(tmpDir, 'interrupt-response-race.jsonl');
+    await writeJsonl(nativePath, commandHistoryEntries('prior-command', 'printf prior', 'prior'));
     let fake;
     fake = new FakeClient({
       interruptTurn: async () => {
+        await writeJsonl(nativePath, [
+          ...commandHistoryEntries('prior-command', 'printf prior', 'prior'),
+          ...commandHistoryEntries('race-command', 'printf raced', 'raced').slice(2),
+        ]);
         fake.emit('notification', {
           method: 'turn/completed',
           params: {
@@ -1562,11 +1565,6 @@ describe('CodexAppServerRuntime', () => {
         });
         return {};
       },
-      listThreadTurns: async () => ({
-        data: [makeTurn({ items: [terminalItem], status: 'completed' })],
-        nextCursor: null,
-        backwardsCursor: null,
-      }),
     });
     const provider = new CodexAppServerRuntime({ createClient: () => fake });
     const emitted = [];
@@ -1578,11 +1576,15 @@ describe('CodexAppServerRuntime', () => {
 
     await provider.runTurn(makeRequest({
       agentSessionId: 'thread-1',
-      nativePath: null,
+      nativePath,
     }));
+    const terminal = new Promise((resolve) => provider.onFinished(resolve));
     await expect(provider.abort('thread-1')).resolves.toBe(true);
+    await terminal;
 
-    expect(emitted.map((message) => message.content)).toEqual(['Recovered at the interrupt boundary']);
+    expect(emitted).toHaveLength(2);
+    expect(emitted[0]).toMatchObject({ type: 'bash-tool-use', toolId: 'race-command' });
+    expect(emitted[1]).toMatchObject({ type: 'tool-result', toolId: 'race-command' });
     expect(finished).toEqual([{ chatId: 'chat-1', exitCode: 0 }]);
     expect(processing).toEqual([true, false]);
     expect(provider.isRunning('thread-1')).toBe(false);

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -637,6 +637,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         eventMetadata: codexEventMetadata(request),
       });
       activeSession = session;
+      await session.turnItems.seedHistory(session.nativePath);
       session.onAbortable = request.onAbortable;
       session.activeDeliveryReservations += 1;
       try {
@@ -726,8 +727,9 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         permissionMode: request.permissionMode,
         eventMetadata: codexEventMetadata(request),
       });
-      session.turnItems.markManualCompaction();
       activeSession = session;
+      await session.turnItems.seedHistory(session.nativePath);
+      session.turnItems.markManualCompaction();
       session.onAbortable = request.onAbortable;
       this.#releaseBufferedClientEvents(client);
       markCodexExecutionStarted(request);
@@ -1132,7 +1134,6 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #handleTurnStarted(client: CodexAppServerClient, params: TurnStartedNotification): void {
     const session = this.#sessionForClientThread(client, params.threadId);
     if (!session) return;
-    session.turnItems.beginTurn();
     session.activeTurnId = params.turn.id;
     if (session.status !== 'interrupting') session.status = 'running';
     this.#notifyAbortable(session);
@@ -1268,6 +1269,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       new Date().toISOString(),
       session.liveCodeModeResultToolIds,
     );
+    session.turnItems.recordMessages(messages);
     if (messages.length) this.emitMessages(session.chatId, messages);
   }
 
@@ -1310,10 +1312,8 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       return;
     }
     const aborted = params.turn.status === 'interrupted' || session.status === 'interrupting';
-    const completionItems = aborted
-      ? await session.turnItems.interruptedItems(session.client, session.threadId, params.turn)
-      : params.turn.items;
-    for (const item of completionItems) session.turnItems.emit(item);
+    for (const item of params.turn.items) session.turnItems.emit(item);
+    if (aborted) await session.turnItems.reconcileInterrupted(session.nativePath);
     session.capacityRetryCount = 0;
     session.pendingCapacityFailure = null;
     session.status = 'completing';

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -760,9 +760,13 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       this.#finishSession(session, { aborted: true });
       return true;
     }
+    if (session.status === 'interrupting') return true;
+    // Set before awaiting because the RPC response and turn/completed can arrive in one stdout read.
+    session.status = 'interrupting';
     try {
       await session.client.interruptTurn(session.threadId, turnId);
     } catch (error) {
+      if (this.#sessions.get(agentSessionId) === session && session.status === 'interrupting') session.status = 'running';
       this.#logger.warn('Codex turn interruption failed', {
         turnId,
         error: error instanceof Error ? error.message : String(error),
@@ -770,8 +774,6 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       return false;
     }
     if (this.#sessions.get(agentSessionId) !== session) return true;
-    // Codex replies immediately before turn/completed, so the runtime remains attached until that event.
-    session.status = 'interrupting';
     return true;
   }
 

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -92,8 +92,7 @@ interface RunningCodexSession {
   status: RunningStatus;
   permissionMode: PermissionMode;
   startedAt: string;
-  // Set when this session was started by an explicit /compact, so the resulting
-  // contextCompaction item is labeled 'manual' rather than 'auto'.
+  // Labels contextCompaction from an explicit /compact as manual rather than auto.
   manualCompactionPending?: boolean;
   cleanupAttachments?: () => Promise<void>;
   turnStartWaiters: Set<TurnStartWaiter>;
@@ -771,6 +770,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       return false;
     }
     if (this.#sessions.get(agentSessionId) !== session) return true;
+    // Codex replies immediately before turn/completed, so the runtime remains attached until that event.
     session.status = 'interrupting';
     return true;
   }

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -53,8 +53,8 @@ import { CodexSkillDiscovery, type CodexSkillRef } from '../slash-command-discov
 import type { CodexGoalCommand } from '../goal-command.js';
 import { cleanupMaterializedGoalDraft, materializeGoalDraft } from './goal-files.js';
 
-type RunningStatus = 'running' | 'completing' | 'completed' | 'failed' | 'aborted';
-type FinishSessionOptions = { failedMessage?: string; aborted?: boolean };
+type RunningStatus = 'running' | 'interrupting' | 'completing' | 'completed' | 'failed' | 'aborted';
+type FinishSessionOptions = { failedMessage?: string; aborted?: boolean; emitFinishedOnAbort?: boolean };
 type GoalCommandOptions = {
   keepSession: boolean;
   goalSynchronized?: boolean;
@@ -141,7 +141,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #history: CodexHistoryService;
   #idlePurger = new IdleSessionPurger<RunningCodexSession>({
     sessions: () => this.#sessions.entries(),
-    isRunning: (session) => session.status === 'running' || session.status === 'completing',
+    isRunning: (session) => isActiveSessionStatus(session.status),
     lastActivityAt: () => 0,
     purge: (threadId, session) => {
       this.#sessions.delete(threadId);
@@ -771,20 +771,18 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       return false;
     }
     if (this.#sessions.get(agentSessionId) !== session) return true;
-    session.status = 'aborted';
-    this.#cancelTurnStartWaiters(session, 'Codex session aborted');
-    this.#finishSession(session, { aborted: true });
+    session.status = 'interrupting';
     return true;
   }
 
   isRunning(agentSessionId: string): boolean {
     const status = this.#sessions.get(agentSessionId)?.status;
-    return status === 'running' || status === 'completing';
+    return status !== undefined && isActiveSessionStatus(status);
   }
 
   getRunningSessions(): Array<{ id: string; status: string; startedAt: string }> {
     return Array.from(this.#sessions.values())
-      .filter((session) => session.status === 'running' || session.status === 'completing')
+      .filter((session) => isActiveSessionStatus(session.status))
       .map((session) => ({ id: session.threadId, status: session.status, startedAt: session.startedAt }));
   }
 
@@ -1132,7 +1130,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
     const session = this.#sessionForClientThread(client, params.threadId);
     if (!session) return;
     session.activeTurnId = params.turn.id;
-    session.status = 'running';
+    if (session.status !== 'interrupting') session.status = 'running';
     this.#notifyAbortable(session);
     for (const waiter of session.turnStartWaiters) waiter.resolve(params.turn.id);
   }
@@ -1315,7 +1313,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       this.#finishSession(session, { failedMessage });
       return;
     }
-    const aborted = params.turn.status === 'interrupted' || session.status === 'aborted';
+    const aborted = params.turn.status === 'interrupted' || session.status === 'interrupting';
     session.capacityRetryCount = 0;
     session.pendingCapacityFailure = null;
     session.status = 'completing';
@@ -1328,7 +1326,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         return;
       }
     }
-    this.#finishSession(session, { aborted });
+    this.#finishSession(session, { aborted, emitFinishedOnAbort: aborted });
   }
 
   #handleErrorNotification(client: CodexAppServerClient, params: ErrorNotification): void {
@@ -1452,7 +1450,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
 
   #handleClientExit(client: CodexAppServerClient, code: number): void {
     const session = this.#sessionForClient(client);
-    if (!session || (session.status !== 'running' && session.status !== 'completing')) return;
+    if (!session || !isActiveSessionStatus(session.status)) return;
     this.#finishSession(session, { failedMessage: `Codex app-server exited with code ${code}` });
   }
 
@@ -1473,7 +1471,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
 
     if (opts.failedMessage) {
       this.emitFailed(session.chatId, opts.failedMessage, session.eventMetadata);
-    } else if (!opts.aborted) {
+    } else if (!opts.aborted || opts.emitFinishedOnAbort) {
       this.emitFinished(session.chatId, 0, session.eventMetadata);
     }
 
@@ -1729,6 +1727,7 @@ function mergeFinishOptions(
   return {
     failedMessage: next.failedMessage ?? current?.failedMessage,
     aborted: Boolean(next.aborted || current?.aborted),
+    emitFinishedOnAbort: Boolean(next.emitFinishedOnAbort || current?.emitFinishedOnAbort),
   };
 }
 
@@ -1740,6 +1739,7 @@ function isTerminalSessionStatus(status: RunningStatus): boolean {
   return status === 'completed' || status === 'failed' || status === 'aborted';
 }
 
+function isActiveSessionStatus(status: RunningStatus): boolean { return status === 'running' || status === 'interrupting' || status === 'completing'; }
 function hasActiveGoalContinuation(session: RunningCodexSession): boolean {
   return session.managesGoalLifecycle
     && Boolean(session.activeTurnId || session.goal?.status === 'active');

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -1,4 +1,4 @@
-import { AssistantMessage, ErrorMessage, PermissionCancelledMessage, PermissionResolvedMessage, type ChatMessage, type CompactionTrigger } from '@garcon/common/chat-types';
+import { AssistantMessage, ErrorMessage, PermissionCancelledMessage, PermissionResolvedMessage, type ChatMessage } from '@garcon/common/chat-types';
 import { AgentEventEmitterRuntime } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import type { AgentActiveInputHandoff, AgentLogger } from '@garcon/server-agent-interface';
@@ -17,7 +17,7 @@ import {
 import type { PermissionMode } from '@garcon/common/chat-modes';
 import { buildApprovalMessage, buildApprovalResponse, createPendingApproval, isApprovalRequest, type CodexPendingApproval } from './approvals.js';
 import { CodexAppServerClient, CodexAppServerRpcError, type CodexAppServerClientOptions, type CodexAppServerMetric } from './client.js';
-import { convertCodexAppServerLiveItem, convertCodexRawCodeModeItem } from './converter.js';
+import { convertCodexRawCodeModeItem } from './converter.js';
 import { accessibleThreadPath, waitForMaterializedThread } from './durability.js';
 import { NativePathDiscoveryRefreshLimiter, type NativePathDiscoveryRefreshLimiterOptions } from './native-path-discovery-refresh.js';
 import { IdleSessionPurger } from '@garcon/server-agent-common/shared/idle-session-purger';
@@ -52,6 +52,7 @@ import {
 import { CodexSkillDiscovery, type CodexSkillRef } from '../slash-command-discovery.js';
 import type { CodexGoalCommand } from '../goal-command.js';
 import { cleanupMaterializedGoalDraft, materializeGoalDraft } from './goal-files.js';
+import { CodexTurnItemLedger } from './turn-item-ledger.js';
 
 type RunningStatus = 'running' | 'interrupting' | 'completing' | 'completed' | 'failed' | 'aborted';
 type FinishSessionOptions = { failedMessage?: string; aborted?: boolean; emitFinishedOnAbort?: boolean };
@@ -92,8 +93,6 @@ interface RunningCodexSession {
   status: RunningStatus;
   permissionMode: PermissionMode;
   startedAt: string;
-  // Labels contextCompaction from an explicit /compact as manual rather than auto.
-  manualCompactionPending?: boolean;
   cleanupAttachments?: () => Promise<void>;
   turnStartWaiters: Set<TurnStartWaiter>;
   goal: CodexThreadGoal | null;
@@ -104,6 +103,7 @@ interface RunningCodexSession {
   activeDeliveryReservations: number;
   pendingFinish: FinishSessionOptions | null;
   liveCodeModeResultToolIds: Map<string, string>;
+  turnItems: CodexTurnItemLedger;
   capacityRetryCount: number;
   turnAttemptGeneration: number;
   pendingCapacityFailure: { turnId: string; message: string } | null;
@@ -726,7 +726,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
         permissionMode: request.permissionMode,
         eventMetadata: codexEventMetadata(request),
       });
-      session.manualCompactionPending = true;
+      session.turnItems.markManualCompaction();
       activeSession = session;
       session.onAbortable = request.onAbortable;
       this.#releaseBufferedClientEvents(client);
@@ -1030,6 +1030,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       activeDeliveryReservations: 0,
       pendingFinish: null,
       liveCodeModeResultToolIds: new Map(),
+      turnItems: new CodexTurnItemLedger(this.#logger, (messages) => this.emitMessages(args.chatId, messages)),
       capacityRetryCount: 0,
       turnAttemptGeneration: 0,
       pendingCapacityFailure: null,
@@ -1129,6 +1130,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #handleTurnStarted(client: CodexAppServerClient, params: TurnStartedNotification): void {
     const session = this.#sessionForClientThread(client, params.threadId);
     if (!session) return;
+    session.turnItems.beginTurn();
     session.activeTurnId = params.turn.id;
     if (session.status !== 'interrupting') session.status = 'running';
     this.#notifyAbortable(session);
@@ -1253,15 +1255,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #handleItemCompleted(client: CodexAppServerClient, params: ItemCompletedNotification): void {
     const session = this.#sessionForClientTurn(client, params.threadId, params.turnId);
     if (!session) return;
-    // A contextCompaction item is 'manual' only when this session was started by
-    // /compact; otherwise the app-server auto-compacted to free context.
-    let compactionTrigger: CompactionTrigger | undefined;
-    if (params.item.type === 'contextCompaction') {
-      compactionTrigger = session.manualCompactionPending ? 'manual' : 'auto';
-      session.manualCompactionPending = false;
-    }
-    const messages = convertCodexAppServerLiveItem(params.item, undefined, compactionTrigger);
-    if (messages.length) this.emitMessages(session.chatId, messages);
+    session.turnItems.emit(params.item);
   }
 
   #handleRawResponseItemCompleted(client: CodexAppServerClient, params: RawResponseItemCompletedNotification): void {
@@ -1314,6 +1308,10 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       return;
     }
     const aborted = params.turn.status === 'interrupted' || session.status === 'interrupting';
+    const completionItems = aborted
+      ? await session.turnItems.interruptedItems(session.client, session.threadId, params.turn)
+      : params.turn.items;
+    for (const item of completionItems) session.turnItems.emit(item);
     session.capacityRetryCount = 0;
     session.pendingCapacityFailure = null;
     session.status = 'completing';

--- a/server-agents/codex/src/agents/codex/app-server/turn-item-ledger.ts
+++ b/server-agents/codex/src/agents/codex/app-server/turn-item-ledger.ts
@@ -1,7 +1,8 @@
+import type { ChatMessage } from '@garcon/common/chat-types';
 import type { AgentLogger } from '@garcon/server-agent-interface';
-import type { CodexAppServerClient } from './client.js';
+import { loadCodexChatMessages } from '../history-loader.js';
 import { convertCodexAppServerLiveItem } from './converter.js';
-import type { CodexThreadItem, CodexTurn } from './protocol.js';
+import type { CodexThreadItem } from './protocol.js';
 
 export class CodexTurnItemLedger {
   readonly #seenIds = new Set<string>();
@@ -17,8 +18,10 @@ export class CodexTurnItemLedger {
     this.#emit = emit;
   }
 
-  beginTurn(): void {
-    this.#seenIds.clear();
+  async seedHistory(nativePath: string | null): Promise<void> {
+    if (!nativePath) return;
+    const messages = await loadCodexChatMessages(nativePath, this.#logger, { throwOnError: true });
+    this.recordMessages(messages);
   }
 
   markManualCompaction(): void {
@@ -36,32 +39,40 @@ export class CodexTurnItemLedger {
     if (messages.length) this.#emit(messages);
   }
 
-  async interruptedItems(
-    client: CodexAppServerClient,
-    threadId: string,
-    turn: CodexTurn,
-  ): Promise<CodexThreadItem[]> {
-    try {
-      // App-server may persist an interrupted command without item/completed, so reload that turn before teardown.
-      const response = await client.listThreadTurns({
-        threadId,
-        cursor: null,
-        limit: 10,
-        sortDirection: 'desc',
-        itemsView: 'full',
-      });
-      const storedTurn = response.data.find((candidate) => candidate.id === turn.id);
-      if (!storedTurn || storedTurn.itemsView !== 'full') {
-        throw new Error(`Interrupted Codex turn ${turn.id} was not available with full items`);
-      }
-      return storedTurn.items;
-    } catch (error) {
-      this.#logger.warn('Codex interrupted turn item reconciliation failed', {
-        threadId,
-        turnId: turn.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return turn.items;
+  recordMessages(messages: ChatMessage[]): void {
+    for (const message of messages) {
+      const toolId = messageToolId(message);
+      if (toolId) this.#seenIds.add(toolId);
     }
   }
+
+  async reconcileInterrupted(nativePath: string | null): Promise<void> {
+    if (!nativePath) return;
+    try {
+      // Loaded turn views omit interrupted commands, while the JSONL is complete before turn/completed.
+      const messages = await loadCodexChatMessages(nativePath, this.#logger, { throwOnError: true });
+      const missingIds = new Set<string>();
+      for (const message of messages) {
+        const toolId = messageToolId(message);
+        if (toolId && !this.#seenIds.has(toolId)) missingIds.add(toolId);
+      }
+      if (!missingIds.size) return;
+      for (const id of missingIds) this.#seenIds.add(id);
+      this.#emit(
+        messages.filter((message) => {
+          const toolId = messageToolId(message);
+          return toolId ? missingIds.has(toolId) : false;
+        }),
+      );
+    } catch (error) {
+      this.#logger.warn('Codex interrupted turn item reconciliation failed', {
+        nativePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+function messageToolId(message: ChatMessage): string | null {
+  return 'toolId' in message && typeof message.toolId === 'string' ? message.toolId : null;
 }

--- a/server-agents/codex/src/agents/codex/app-server/turn-item-ledger.ts
+++ b/server-agents/codex/src/agents/codex/app-server/turn-item-ledger.ts
@@ -1,0 +1,67 @@
+import type { AgentLogger } from '@garcon/server-agent-interface';
+import type { CodexAppServerClient } from './client.js';
+import { convertCodexAppServerLiveItem } from './converter.js';
+import type { CodexThreadItem, CodexTurn } from './protocol.js';
+
+export class CodexTurnItemLedger {
+  readonly #seenIds = new Set<string>();
+  readonly #logger: AgentLogger;
+  readonly #emit: (messages: ReturnType<typeof convertCodexAppServerLiveItem>) => void;
+  #manualCompactionPending = false;
+
+  constructor(
+    logger: AgentLogger,
+    emit: (messages: ReturnType<typeof convertCodexAppServerLiveItem>) => void,
+  ) {
+    this.#logger = logger;
+    this.#emit = emit;
+  }
+
+  beginTurn(): void {
+    this.#seenIds.clear();
+  }
+
+  markManualCompaction(): void {
+    this.#manualCompactionPending = true;
+  }
+
+  emit(item: CodexThreadItem): void {
+    if (this.#seenIds.has(item.id)) return;
+    this.#seenIds.add(item.id);
+    const compactionTrigger = item.type === 'contextCompaction'
+      ? this.#manualCompactionPending ? 'manual' : 'auto'
+      : undefined;
+    if (item.type === 'contextCompaction') this.#manualCompactionPending = false;
+    const messages = convertCodexAppServerLiveItem(item, undefined, compactionTrigger);
+    if (messages.length) this.#emit(messages);
+  }
+
+  async interruptedItems(
+    client: CodexAppServerClient,
+    threadId: string,
+    turn: CodexTurn,
+  ): Promise<CodexThreadItem[]> {
+    try {
+      // App-server may persist an interrupted command without item/completed, so reload that turn before teardown.
+      const response = await client.listThreadTurns({
+        threadId,
+        cursor: null,
+        limit: 10,
+        sortDirection: 'desc',
+        itemsView: 'full',
+      });
+      const storedTurn = response.data.find((candidate) => candidate.id === turn.id);
+      if (!storedTurn || storedTurn.itemsView !== 'full') {
+        throw new Error(`Interrupted Codex turn ${turn.id} was not available with full items`);
+      }
+      return storedTurn.items;
+    } catch (error) {
+      this.#logger.warn('Codex interrupted turn item reconciliation failed', {
+        threadId,
+        turnId: turn.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return turn.items;
+    }
+  }
+}


### PR DESCRIPTION
Extends the credential-backed provider gates to cover retryable active fork and refork admission, permission denial and manual-bypass approval behavior, correlated Claude interrupt receipts, duplicate Stop coalescing, processing-state reconciliation, interrupted tool persistence across restart, and post-interruption recovery so the real Claude and Codex CLIs continuously verify Garcon's lifecycle contracts.