### PR TITLE
perf(chat): bound initial-prompt navigation

### DIFF
--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -57,6 +57,18 @@ function page(
 	};
 }
 
+function pendingInput(overrides: Partial<PendingUserInput> = {}): PendingUserInput {
+	return {
+		chatId: 'chat-1',
+		clientRequestId: 'req-1',
+		clientMessageId: 'msg-1',
+		content: 'pending',
+		createdAt: TS,
+		deliveryStatus: 'accepted',
+		...overrides,
+	};
+}
+
 describe('ActiveTranscriptState', () => {
 	beforeEach(() => {
 		localStorage.clear();
@@ -283,6 +295,66 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.chatMessages.map(contentOf)).toEqual(['current']);
 		expect(chat.getCursor()).toEqual({ generationId: 'current-generation', lastSeq: 1 });
 	});
+
+	it.each(['initial', 'latest'] as const)(
+		'preserves snapshot reload ownership when %s navigation races a generation change',
+		async (target) => {
+			const chat = new ActiveTranscriptState();
+			chat.replaceGeneration('chat-1', 'generation-1', [entry(1, assistant('current'))], {
+				lastSeq: 1,
+				pageOldestSeq: 1,
+				hasMore: false,
+			});
+			let resolveOldSnapshot!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+			let resolveNewSnapshot!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+			vi.mocked(getChatMessages)
+				.mockReturnValueOnce(
+					new Promise((resolve) => {
+						resolveOldSnapshot = resolve;
+					}),
+				)
+				.mockReturnValueOnce(
+					new Promise((resolve) => {
+						resolveNewSnapshot = resolve;
+					}),
+				);
+
+			const snapshotLoad = chat.loadMessages('chat-1');
+			expect(getChatMessages).toHaveBeenCalledOnce();
+			expect(chat.applyMessages('chat-1', 'generation-2', [entry(1, assistant('new live'))])).toBe(
+				'applied',
+			);
+
+			await expect(chat.navigateToWindow('chat-1', target)).resolves.toBe('invalidated');
+			expect(getChatMessages).toHaveBeenCalledOnce();
+
+			resolveOldSnapshot({
+				chatId: 'chat-1',
+				limit: 50,
+				...page({
+					generationId: 'generation-1',
+					messages: [entry(1, assistant('old snapshot'))],
+					lastSeq: 1,
+				}),
+			});
+			await vi.waitFor(() => expect(getChatMessages).toHaveBeenCalledTimes(2));
+			resolveNewSnapshot({
+				chatId: 'chat-1',
+				limit: 50,
+				...page({
+					generationId: 'generation-2',
+					messages: [entry(1, assistant('new snapshot'))],
+					lastSeq: 1,
+				}),
+			});
+
+			await expect(snapshotLoad).resolves.toEqual([
+				expect.objectContaining({ content: 'new snapshot' }),
+			]);
+			expect(chat.chatMessages.map(contentOf)).toEqual(['new snapshot']);
+			expect(chat.getCursor()).toEqual({ generationId: 'generation-2', lastSeq: 1 });
+		},
+	);
 
 		it('installs pending inputs from HTTP snapshots and hides them after durable echo', () => {
 		const chat = new ActiveTranscriptState();
@@ -576,7 +648,213 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.hasInitialMessagesToReveal).toBe(true);
 	});
 
-	it('shares an in-flight earlier-page request with load-all', async () => {
+	it('loads only the first page for initial-prompt navigation', async () => {
+		const chat = new ActiveTranscriptState();
+		chat.replaceGeneration(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(index + 5_995, assistant(`message-${index + 5_995}`)),
+			),
+			{ lastSeq: 6_044, pageOldestSeq: 5_995, hasMore: true },
+		);
+		vi.mocked(getChatMessages).mockResolvedValueOnce({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: Array.from({ length: 50 }, (_, index) =>
+					entry(index + 1, assistant(`message-${index + 1}`)),
+				),
+				lastSeq: 6_044,
+				pageOldestSeq: 1,
+				hasMore: false,
+			}),
+		});
+
+		await expect(chat.navigateToWindow('chat-1', 'initial')).resolves.toBe('loaded');
+
+		expect(getChatMessages).toHaveBeenCalledOnce();
+		expect(getChatMessages).toHaveBeenCalledWith({
+			chatId: 'chat-1',
+			limit: 50,
+			beforeSeq: 51,
+		});
+		expect(chat.visibleRows).toHaveLength(50);
+		expect(chat.visibleRows[0]).toMatchObject({ kind: 'message', seq: 1 });
+		expect(chat.visibleRows.at(-1)).toMatchObject({ kind: 'message', seq: 50 });
+		expect(chat.isViewingInitialMessages).toBe(true);
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: 6_044 });
+		expect(chat.transcriptCache.get('chat-1')?.messages[0]).toMatchObject({ seq: 5_995 });
+	});
+
+	it('keeps the reconnect cursor behind an unseen initial-window server head', async () => {
+		const chat = new ActiveTranscriptState();
+		chat.replaceGeneration(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(index + 51, assistant(`latest-${index + 51}`)),
+			),
+			{ lastSeq: 100, pageOldestSeq: 51, hasMore: true },
+		);
+		let resolveInitial!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+		vi.mocked(getChatMessages).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveInitial = resolve;
+			}),
+		);
+
+		const initial = chat.navigateToWindow('chat-1', 'initial');
+		resolveInitial({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: Array.from({ length: 50 }, (_, index) =>
+					entry(index + 1, assistant(`initial-${index + 1}`)),
+				),
+				lastSeq: 101,
+				pageOldestSeq: 1,
+				hasMore: false,
+			}),
+		});
+
+		await expect(initial).resolves.toBe('loaded');
+		expect(chat.isViewingInitialMessages).toBe(true);
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: 100 });
+		expect(chat.transcriptCache.get('chat-1')?.lastSeq).toBe(100);
+
+		expect(chat.applyMessages('chat-1', 'generation-1', [entry(101, assistant('unseen'))])).toBe(
+			'applied',
+		);
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: 101 });
+	});
+
+	it('keeps the latest window when Bottom supersedes a pending Initial request', async () => {
+		const chat = new ActiveTranscriptState();
+		const latestWindow = Array.from({ length: 50 }, (_, index) =>
+			entry(index + 51, assistant(`latest-${index + 51}`)),
+		);
+		chat.replaceGeneration('chat-1', 'generation-1', latestWindow, {
+			lastSeq: 100,
+			pageOldestSeq: 51,
+			hasMore: true,
+		});
+		let resolveInitial!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+		vi.mocked(getChatMessages).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveInitial = resolve;
+			}),
+		);
+
+		const initial = chat.navigateToWindow('chat-1', 'initial');
+		await expect(chat.navigateToWindow('chat-1', 'latest')).resolves.toBe('loaded');
+		resolveInitial({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: Array.from({ length: 50 }, (_, index) =>
+					entry(index + 1, assistant(`initial-${index + 1}`)),
+				),
+				lastSeq: 100,
+				pageOldestSeq: 1,
+				hasMore: false,
+			}),
+		});
+
+		await expect(initial).resolves.toBe('invalidated');
+		expect(chat.chatMessages.map(contentOf)).toEqual(
+			Array.from({ length: 50 }, (_, index) => `latest-${index + 51}`),
+		);
+		expect(chat.isViewingInitialMessages).toBe(false);
+	});
+
+	it('keeps the initial window when Initial supersedes a pending Bottom request', async () => {
+		const chat = new ActiveTranscriptState();
+		chat.replaceGeneration(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(index + 51, assistant(`latest-${index + 51}`)),
+			),
+			{ lastSeq: 100, pageOldestSeq: 51, hasMore: true },
+		);
+		chat.entries = Array.from({ length: 50 }, (_, index) =>
+			entry(index + 1, assistant(`initial-${index + 1}`)),
+		);
+		chat.oldestSeq = 1;
+		chat.hasMoreMessages = false;
+		chat.visibleMessageCount = 50;
+		chat.isViewingInitialMessages = true;
+		let resolveLatest!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+		vi.mocked(getChatMessages).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveLatest = resolve;
+			}),
+		);
+
+		const latest = chat.navigateToWindow('chat-1', 'latest');
+		await expect(chat.navigateToWindow('chat-1', 'initial')).resolves.toBe('loaded');
+		expect(chat.isLoadingMessages).toBe(false);
+		expect(chat.loadStatus).toBe('loaded');
+		resolveLatest({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: Array.from({ length: 50 }, (_, index) =>
+					entry(index + 51, assistant(`latest-${index + 51}`)),
+				),
+				lastSeq: 100,
+				pageOldestSeq: 51,
+				hasMore: true,
+			}),
+		});
+
+		await expect(latest).resolves.toBe('invalidated');
+		expect(chat.chatMessages.map(contentOf)).toEqual(
+			Array.from({ length: 50 }, (_, index) => `initial-${index + 1}`),
+		);
+		expect(chat.isViewingInitialMessages).toBe(true);
+		expect(chat.isLoadingMessages).toBe(false);
+		expect(chat.loadStatus).toBe('loaded');
+		expect(chat.loadError).toBeNull();
+	});
+
+	it('ignores a stale Bottom rejection after Initial restores the existing initial window', async () => {
+		const chat = new ActiveTranscriptState();
+		chat.replaceGeneration(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(index + 51, assistant(`latest-${index + 51}`)),
+			),
+			{ lastSeq: 100, pageOldestSeq: 51, hasMore: true },
+		);
+		chat.entries = Array.from({ length: 50 }, (_, index) =>
+			entry(index + 1, assistant(`initial-${index + 1}`)),
+		);
+		chat.oldestSeq = 1;
+		chat.hasMoreMessages = false;
+		chat.visibleMessageCount = 50;
+		chat.isViewingInitialMessages = true;
+		let rejectLatest!: (reason: Error) => void;
+		vi.mocked(getChatMessages).mockReturnValueOnce(
+			new Promise((_resolve, reject) => {
+				rejectLatest = reject;
+			}),
+		);
+
+		const latest = chat.navigateToWindow('chat-1', 'latest');
+		await expect(chat.navigateToWindow('chat-1', 'initial')).resolves.toBe('loaded');
+		rejectLatest(new Error('stale latest failure'));
+
+		await expect(latest).resolves.toBe('invalidated');
+		expect(chat.isViewingInitialMessages).toBe(true);
+		expect(chat.isLoadingMessages).toBe(false);
+		expect(chat.loadStatus).toBe('loaded');
+		expect(chat.loadError).toBeNull();
+	});
+
+	it('keeps live messages in the latest cache while viewing the initial page', async () => {
 		const chat = new ActiveTranscriptState();
 		chat.replaceGeneration(
 			'chat-1',
@@ -586,39 +864,196 @@ describe('ActiveTranscriptState', () => {
 			),
 			{ lastSeq: 100, pageOldestSeq: 51, hasMore: true },
 		);
-		let resolvePage!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
-		vi.mocked(getChatMessages).mockReturnValueOnce(
-			new Promise((resolve) => {
-				resolvePage = resolve;
-			}),
-		);
-
-		const firstLoad = chat.loadMoreMessages('chat-1');
-		const loadAll = chat.loadAllMessages('chat-1');
-
-		expect(getChatMessages).toHaveBeenCalledOnce();
-		resolvePage(
-			{
-				chatId: 'chat-1',
-				limit: 50,
-				...page({
+		vi.mocked(getChatMessages).mockResolvedValueOnce({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
 				messages: Array.from({ length: 50 }, (_, index) =>
 					entry(index + 1, assistant(`message-${index + 1}`)),
 				),
 				lastSeq: 100,
 				pageOldestSeq: 1,
 				hasMore: false,
-				}),
+			}),
+		});
+
+		await chat.navigateToWindow('chat-1', 'initial');
+		chat.setPendingUserInputs([
+			{
+				chatId: 'chat-1',
+				clientRequestId: 'req-1',
+				clientMessageId: 'msg-1',
+				content: 'pending-tail',
+				createdAt: '2026-06-01T00:00:01.000Z',
+				deliveryStatus: 'accepted',
 			},
+		]);
+		chat.appendLocalNotice('progress', 'tail-only status');
+		expect(chat.visibleRows).toHaveLength(50);
+		expect(chat.applyMessages('chat-1', 'generation-1', [entry(101, assistant('live-tail'))])).toBe(
+			'applied',
 		);
 
-		await expect(firstLoad).resolves.toBe('loaded');
-		await loadAll;
+		expect(chat.visibleRows).toHaveLength(50);
+		expect(chat.visibleRows.at(-1)).toMatchObject({ kind: 'message', seq: 50 });
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: 101 });
+		expect(chat.transcriptCache.get('chat-1')?.messages.at(-1)).toMatchObject({ seq: 101 });
 
-		expect(getChatMessages).toHaveBeenCalledOnce();
-		expect(chat.visibleRows).toHaveLength(100);
-		expect(chat.hasMoreMessages).toBe(false);
+		vi.mocked(getChatMessages).mockResolvedValueOnce({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: Array.from({ length: 50 }, (_, index) =>
+					entry(index + 52, assistant(`message-${index + 52}`)),
+				),
+				lastSeq: 101,
+				pageOldestSeq: 52,
+				hasMore: true,
+			}),
+		});
+		await chat.navigateToWindow('chat-1', 'latest');
+
+		expect(chat.isViewingInitialMessages).toBe(false);
+		expect(chat.visibleRows.at(-1)).toMatchObject({ kind: 'message', seq: 101 });
 	});
+
+	it('replays live messages that arrive while restoring the latest window', async () => {
+		const chat = new ActiveTranscriptState();
+		chat.replaceGeneration(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(index + 51, assistant(`latest-${index + 51}`)),
+			),
+			{ lastSeq: 100, pageOldestSeq: 51, hasMore: true },
+		);
+		chat.entries = Array.from({ length: 50 }, (_, index) =>
+			entry(index + 1, assistant(`initial-${index + 1}`)),
+		);
+		chat.oldestSeq = 1;
+		chat.hasMoreMessages = false;
+		chat.visibleMessageCount = 50;
+		chat.isViewingInitialMessages = true;
+		let resolveLatest!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+		vi.mocked(getChatMessages).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveLatest = resolve;
+			}),
+		);
+
+		const latest = chat.navigateToWindow('chat-1', 'latest');
+		expect(chat.applyMessages('chat-1', 'generation-1', [entry(101, assistant('live'))])).toBe(
+			'applied',
+		);
+		resolveLatest({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: Array.from({ length: 50 }, (_, index) =>
+					entry(index + 51, assistant(`latest-${index + 51}`)),
+				),
+				lastSeq: 100,
+				pageOldestSeq: 51,
+				hasMore: true,
+			}),
+		});
+
+		await expect(latest).resolves.toBe('loaded');
+		expect(chat.entries.at(-1)).toMatchObject({ seq: 101, message: { content: 'live' } });
+		expect(chat.transcriptCache.get('chat-1')?.messages.at(-1)).toMatchObject({ seq: 101 });
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: 101 });
+	});
+
+	it.each([
+		{
+			name: 'add',
+			mutate: (chat: ActiveTranscriptState) =>
+				chat.upsertPendingUserInput(
+					pendingInput({
+						clientRequestId: 'req-2',
+						clientMessageId: 'msg-2',
+						content: 'added',
+						createdAt: '2026-06-01T00:00:01.000Z',
+					}),
+				),
+			expected: [
+				pendingInput(),
+				pendingInput({
+					clientRequestId: 'req-2',
+					clientMessageId: 'msg-2',
+					content: 'added',
+					createdAt: '2026-06-01T00:00:01.000Z',
+				}),
+			],
+		},
+		{
+			name: 'update',
+			mutate: (chat: ActiveTranscriptState) =>
+				chat.upsertPendingUserInput(pendingInput({ content: 'updated' })),
+			expected: [pendingInput({ content: 'updated' })],
+		},
+		{
+			name: 'clear',
+			mutate: (chat: ActiveTranscriptState) => chat.clearPendingUserInput('req-1'),
+			expected: [],
+		},
+		{
+			name: 'status update',
+			mutate: (chat: ActiveTranscriptState) =>
+				chat.updatePendingUserInputDeliveryStatus('req-1', 'failed'),
+			expected: [pendingInput({ deliveryStatus: 'failed' })],
+		},
+	])(
+		'preserves a pending-input $name while restoring the latest window',
+		async ({ mutate, expected }) => {
+			const chat = new ActiveTranscriptState();
+			chat.replaceGeneration(
+				'chat-1',
+				'generation-1',
+				Array.from({ length: 50 }, (_, index) =>
+					entry(index + 51, assistant(`latest-${index + 51}`)),
+				),
+				{
+					lastSeq: 100,
+					pageOldestSeq: 51,
+					hasMore: true,
+					pendingUserInputs: [pendingInput()],
+				},
+			);
+			chat.entries = Array.from({ length: 50 }, (_, index) =>
+				entry(index + 1, assistant(`initial-${index + 1}`)),
+			);
+			chat.oldestSeq = 1;
+			chat.hasMoreMessages = false;
+			chat.visibleMessageCount = 50;
+			chat.isViewingInitialMessages = true;
+			let resolveLatest!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+			vi.mocked(getChatMessages).mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveLatest = resolve;
+				}),
+			);
+
+			const latest = chat.navigateToWindow('chat-1', 'latest');
+			mutate(chat);
+			resolveLatest({
+				chatId: 'chat-1',
+				limit: 50,
+				...page({
+					messages: Array.from({ length: 50 }, (_, index) =>
+						entry(index + 51, assistant(`latest-${index + 51}`)),
+					),
+					lastSeq: 100,
+					pageOldestSeq: 51,
+					hasMore: true,
+					pendingUserInputs: [pendingInput()],
+				}),
+			});
+
+			await expect(latest).resolves.toBe('loaded');
+			expect(chat.pendingUserInputs).toEqual(expected);
+		},
+	);
 
 	it('discards an earlier page invalidated by explicit navigation', async () => {
 		const chat = new ActiveTranscriptState();
@@ -659,7 +1094,7 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.hasMoreMessages).toBe(true);
 	});
 
-	it('does not complete another chat reveal when an old load-all request settles', async () => {
+	it('does not replace another chat when an initial-page request settles', async () => {
 		const transcriptCache = new ChatTranscriptCache({ limit: 100 });
 		transcriptCache.replaceFromPage('chat-2', {
 			generationId: 'generation-2',
@@ -686,7 +1121,7 @@ describe('ActiveTranscriptState', () => {
 			}),
 		);
 
-		const loadAll = chat.loadAllMessages('chat-1');
+		const initialLoad = chat.navigateToWindow('chat-1', 'initial');
 		expect(getChatMessages).toHaveBeenCalledOnce();
 		chat.activateChat('chat-2');
 		expect(chat.visibleRows).toHaveLength(20);
@@ -704,7 +1139,7 @@ describe('ActiveTranscriptState', () => {
 				hasMore: false,
 			}),
 		});
-		await loadAll;
+		await expect(initialLoad).resolves.toBe('invalidated');
 
 		expect(chat.activeChatId).toBe('chat-2');
 		expect(chat.visibleRows).toHaveLength(20);
@@ -793,7 +1228,7 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.isLoadingMoreMessages).toBe(false);
 	});
 
-	it('loads a new chat to its true top while the previous chat page request is pending', async () => {
+	it('loads a new chat initial page while the previous chat page request is pending', async () => {
 		const chat = new ActiveTranscriptState();
 		chat.replaceGeneration(
 			'chat-1',
@@ -835,12 +1270,14 @@ describe('ActiveTranscriptState', () => {
 			{ lastSeq: 100, pageOldestSeq: 51, hasMore: true },
 		);
 
-		await chat.loadAllMessages('chat-2');
+		await expect(chat.navigateToWindow('chat-2', 'initial')).resolves.toBe('loaded');
 
 		expect(getChatMessages).toHaveBeenCalledTimes(2);
 		expect(chat.hasMoreMessages).toBe(false);
-		expect(chat.visibleRows).toHaveLength(100);
+		expect(chat.visibleRows).toHaveLength(50);
 		expect(chat.visibleRows[0]).toMatchObject({ kind: 'message', seq: 1 });
+		expect(chat.visibleRows.at(-1)).toMatchObject({ kind: 'message', seq: 50 });
+		expect(chat.isViewingInitialMessages).toBe(true);
 		expect(chat.isLoadingMoreMessages).toBe(false);
 
 		resolveOldPage({

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -3,8 +3,6 @@ import {
 	ConversationScrollController,
 	type ConversationScrollState,
 } from '../conversation-scroll-controller.svelte';
-import { ActiveTranscriptState } from '../active-transcript-state.svelte';
-import { AssistantMessage } from '$shared/chat-types';
 
 function scrollState<T extends Partial<ConversationScrollState>>(
 	overrides: T,
@@ -17,10 +15,11 @@ function scrollState<T extends Partial<ConversationScrollState>>(
 		hasMoreMessages: false,
 		isLoadingMessages: false,
 		isUserScrolledUp: false,
+		isViewingInitialMessages: false,
 		invalidatePendingHistoryLoad: vi.fn(),
-		loadAllMessages: vi.fn(async () => undefined),
 		loadMoreMessages: vi.fn(async () => 'exhausted' as const),
 		loadStatus: 'loaded' as const,
+		navigateToWindow: vi.fn(async () => 'loaded' as const),
 		...overrides,
 	} satisfies ConversationScrollState;
 	return Object.assign(overrides, complete);
@@ -335,6 +334,44 @@ describe('ConversationScrollController', () => {
 		expect(controller.isPinnedToBottom).toBe(false);
 	});
 
+	it('does not cancel a message jump when bottom sync runs on the latest window', async () => {
+		const scroller = {
+			scrollTop: 200,
+			scrollHeight: 1_200,
+			clientHeight: 400,
+			getBoundingClientRect: () => ({ top: 100 }),
+		} as HTMLDivElement;
+		const content = document.createElement('div');
+		const row = document.createElement('div');
+		row.dataset.chatRowId = 'generation-1:7';
+		row.getBoundingClientRect = vi.fn(() => ({ top: 350, height: 100 }) as DOMRect);
+		content.append(row);
+		const chatState = {
+			generationId: 'generation-1',
+			isUserScrolledUp: false,
+			isViewingInitialMessages: false,
+			navigateToWindow: vi.fn(async () => 'loaded' as const),
+		};
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getScrollContentContainer: () => content,
+			getQueueContainer: () => undefined,
+			chatState: scrollState(chatState),
+			sessions: { selectedChatId: 'chat-1' },
+		});
+
+		const jump = controller.jumpToMessageRow({
+			chatId: 'chat-1',
+			generationId: 'generation-1',
+			rowId: 'generation-1:7',
+		});
+		const bottomSync = controller.scrollToLatest();
+
+		expect(await jump).toBe(true);
+		await bottomSync;
+		expect(chatState.navigateToWindow).not.toHaveBeenCalled();
+	});
+
 	it('jumps to a pending row before the first transcript generation exists', async () => {
 		const scroller = {
 			scrollTop: 0,
@@ -405,7 +442,7 @@ describe('ConversationScrollController', () => {
 		const chatState = {
 			hasMoreMessages: false,
 			isUserScrolledUp: false,
-			loadAllMessages: vi.fn(),
+			navigateToWindow: vi.fn(async () => 'loaded' as const),
 		};
 
 		const controller = new ConversationScrollController({
@@ -422,18 +459,49 @@ describe('ConversationScrollController', () => {
 		expect(chatState.isUserScrolledUp).toBe(true);
 		expect(controller.isPinnedToBottom).toBe(false);
 		expect(controller.isScrollingToTop).toBe(false);
+		expect(chatState.navigateToWindow).toHaveBeenCalledWith('chat-1', 'initial');
 	});
 
-	it('completes the retained reveal before scrolling to top without pagination', async () => {
+	it('reloads the latest window before scrolling down from the initial page', async () => {
+		let scrollHeight = 1_200;
+		const scroller = { scrollTop: 0, clientHeight: 400 } as HTMLDivElement;
+		Object.defineProperty(scroller, 'scrollHeight', {
+			get: () => scrollHeight,
+			configurable: true,
+		});
+		const chatState = {
+			isUserScrolledUp: true,
+			isViewingInitialMessages: true,
+			navigateToWindow: vi.fn(async (_chatId: string, target: 'initial' | 'latest') => {
+				expect(target).toBe('latest');
+				chatState.isViewingInitialMessages = false;
+				scrollHeight = 1_600;
+				return 'loaded' as const;
+			}),
+		};
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: scrollState(chatState),
+			sessions: { selectedChatId: 'chat-1' },
+		});
+		controller.setPinnedToBottom(false);
+
+		await controller.scrollToLatest();
+
+		expect(chatState.navigateToWindow).toHaveBeenCalledWith('chat-1', 'latest');
+		expect(scroller.scrollTop).toBe(1_600);
+		expect(chatState.isUserScrolledUp).toBe(false);
+		expect(controller.isPinnedToBottom).toBe(true);
+	});
+
+	it('replaces the retained reveal with the bounded initial window before scrolling', async () => {
 		const scroller = { scrollTop: 800, scrollHeight: 1200, clientHeight: 400 } as HTMLDivElement;
 		const chatState = {
 			hasInitialMessagesToReveal: true,
 			hasMoreMessages: false,
 			isUserScrolledUp: true,
-			completeInitialMessagesReveal: vi.fn(() => {
-				chatState.hasInitialMessagesToReveal = false;
-			}),
-			loadAllMessages: vi.fn(async () => undefined),
+			navigateToWindow: vi.fn(async () => 'loaded' as const),
 		};
 		const controller = new ConversationScrollController({
 			getScrollContainer: () => scroller,
@@ -444,43 +512,103 @@ describe('ConversationScrollController', () => {
 
 		await controller.scrollToTop();
 
-		expect(chatState.completeInitialMessagesReveal).toHaveBeenCalledOnce();
-		expect(chatState.loadAllMessages).not.toHaveBeenCalled();
+		expect(chatState.navigateToWindow).toHaveBeenCalledWith('chat-1', 'initial');
 		expect(scroller.scrollTop).toBe(0);
 		expect(chatState.isUserScrolledUp).toBe(true);
 		expect(controller.isPinnedToBottom).toBe(false);
 	});
 
-	it('keeps all previously exposed history when scrolling to the true transcript top', async () => {
-		const chatState = new ActiveTranscriptState();
-		chatState.replaceGeneration(
-			'chat-1',
-			'generation-1',
-			Array.from({ length: 175 }, (_, index) => ({
-				seq: index + 1,
-				message: new AssistantMessage(
-					'2026-07-01T00:00:00.000Z',
-					`message-${index + 1}`,
-				),
-			})),
-			{ lastSeq: 175, pageOldestSeq: 1, hasMore: false },
-		);
-		chatState.loadEarlierMessages();
+	it('waits for the bounded initial window before scrolling to its first row', async () => {
+		let resolveInitial!: () => void;
+		const initialLoad = new Promise<'loaded'>((resolve) => {
+			resolveInitial = () => resolve('loaded');
+		});
+		const chatState = {
+			isUserScrolledUp: true,
+			navigateToWindow: vi.fn(() => initialLoad),
+		};
 		const scroller = { scrollTop: 800, scrollHeight: 1600, clientHeight: 400 } as HTMLDivElement;
 		const controller = new ConversationScrollController({
 			getScrollContainer: () => scroller,
 			getQueueContainer: () => undefined,
-			chatState,
+			chatState: scrollState(chatState),
 			sessions: { selectedChatId: 'chat-1' },
 		});
 
-		expect(chatState.visibleRows[0]).toMatchObject({ kind: 'message', seq: 1 });
+		const scrollToTop = controller.scrollToTop();
+		expect(scroller.scrollTop).toBe(800);
 
-		await controller.scrollToTop();
+		resolveInitial();
+		await scrollToTop;
 
 		expect(scroller.scrollTop).toBe(0);
-		expect(chatState.visibleRows).toHaveLength(175);
-		expect(chatState.visibleRows[0]).toMatchObject({ kind: 'message', seq: 1 });
+	});
+
+	it('honors Bottom when it supersedes a pending Initial navigation', async () => {
+		let resolveInitial!: () => void;
+		const initial = new Promise<'loaded'>((resolve) => {
+			resolveInitial = () => resolve('loaded');
+		});
+		const chatState = {
+			isUserScrolledUp: false,
+			navigateToWindow: vi.fn((_chatId: string, target: 'initial' | 'latest') =>
+				target === 'initial' ? initial : Promise.resolve('loaded' as const),
+			),
+		};
+		const scroller = { scrollTop: 600, scrollHeight: 1_200, clientHeight: 400 } as HTMLDivElement;
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: scrollState(chatState),
+			sessions: { selectedChatId: 'chat-1' },
+		});
+
+		const toInitial = controller.scrollToTop();
+		await controller.scrollToLatest();
+		resolveInitial();
+		await toInitial;
+
+		expect(chatState.navigateToWindow.mock.calls).toEqual([
+			['chat-1', 'initial'],
+			['chat-1', 'latest'],
+		]);
+		expect(scroller.scrollTop).toBe(1_200);
+		expect(chatState.isUserScrolledUp).toBe(false);
+		expect(controller.isPinnedToBottom).toBe(true);
+	});
+
+	it('honors Initial when it supersedes a pending Bottom navigation', async () => {
+		let resolveLatest!: () => void;
+		const latest = new Promise<'loaded'>((resolve) => {
+			resolveLatest = () => resolve('loaded');
+		});
+		const chatState = {
+			isUserScrolledUp: true,
+			isViewingInitialMessages: true,
+			navigateToWindow: vi.fn((_chatId: string, target: 'initial' | 'latest') =>
+				target === 'latest' ? latest : Promise.resolve('loaded' as const),
+			),
+		};
+		const scroller = { scrollTop: 0, scrollHeight: 1_200, clientHeight: 400 } as HTMLDivElement;
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: scrollState(chatState),
+			sessions: { selectedChatId: 'chat-1' },
+		});
+
+		const toLatest = controller.scrollToLatest();
+		await controller.scrollToTop();
+		resolveLatest();
+		await toLatest;
+
+		expect(chatState.navigateToWindow.mock.calls).toEqual([
+			['chat-1', 'latest'],
+			['chat-1', 'initial'],
+		]);
+		expect(scroller.scrollTop).toBe(0);
+		expect(chatState.isUserScrolledUp).toBe(true);
+		expect(controller.isPinnedToBottom).toBe(false);
 	});
 
 	it('does not snap to bottom from an untagged scroll event', () => {
@@ -504,6 +632,50 @@ describe('ConversationScrollController', () => {
 		expect(scroller.scrollTop).toBe(500);
 		expect(chatState.isUserScrolledUp).toBe(false);
 		expect(controller.isPinnedToBottom).toBe(true);
+	});
+
+	it('keeps the detached initial window unpinned at its geometric bottom', () => {
+		const scroller = { scrollTop: 800, scrollHeight: 1_200, clientHeight: 400 } as HTMLDivElement;
+		const chatState = {
+			isUserScrolledUp: false,
+			isViewingInitialMessages: true,
+		};
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: scrollState(chatState),
+			sessions: { selectedChatId: 'chat-1' },
+		});
+		controller.setPinnedToBottom(true);
+
+		controller.handleScroll();
+
+		expect(chatState.isUserScrolledUp).toBe(true);
+		expect(controller.isPinnedToBottom).toBe(false);
+	});
+
+	it('does not auto-fill or pin an underfilled detached initial window', async () => {
+		const scroller = { scrollTop: 0, scrollHeight: 300, clientHeight: 500 } as HTMLDivElement;
+		const chatState = {
+			hasMoreMessages: true,
+			isUserScrolledUp: false,
+			isViewingInitialMessages: true,
+			loadMoreMessages: vi.fn(async () => 'loaded' as const),
+		};
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState: scrollState(chatState),
+			sessions: { selectedChatId: 'chat-1' },
+		});
+		controller.setPinnedToBottom(true);
+
+		await controller.fillUnderfilledViewport();
+
+		expect(chatState.loadMoreMessages).not.toHaveBeenCalled();
+		expect(scroller.scrollTop).toBe(0);
+		expect(chatState.isUserScrolledUp).toBe(true);
+		expect(controller.isPinnedToBottom).toBe(false);
 	});
 
 	it('tracks initial bottom restoration only for the selected chat with rendered rows', () => {
@@ -661,9 +833,10 @@ describe('ConversationScrollController', () => {
 				scrollHeight = 1200;
 			}),
 			loadMoreMessages: vi.fn(() => pageLoad),
-			loadAllMessages: vi.fn(async () => {
+			navigateToWindow: vi.fn(async () => {
 				await pageLoad;
 				chatState.hasMoreMessages = false;
+				return 'loaded' as const;
 			}),
 		};
 		const controller = new ConversationScrollController({
@@ -677,7 +850,7 @@ describe('ConversationScrollController', () => {
 		controller.handleScroll();
 		await vi.waitFor(() => expect(chatState.loadMoreMessages).toHaveBeenCalledOnce());
 		const scrollToTop = controller.scrollToTop();
-		await vi.waitFor(() => expect(chatState.loadAllMessages).toHaveBeenCalledOnce());
+		await vi.waitFor(() => expect(chatState.navigateToWindow).toHaveBeenCalledOnce());
 
 		scrollHeight = 1500;
 		resolveLoad('loaded');

--- a/web/src/lib/chat/transcript/__tests__/user-message-navigator-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/user-message-navigator-controller.test.ts
@@ -43,6 +43,7 @@ function setup(messages: ChatViewMessage[] = [entry(1, user('first'))]) {
 	});
 	let selectedChatId: string | null = 'chat-1';
 	const reloadTranscript = vi.fn(async () => undefined);
+	const restoreLatestTranscript = vi.fn(async () => true);
 	const loadOlderMessages = vi.fn<UserMessageNavigatorOptions['loadOlderMessages']>(
 		async () => 'loaded',
 	);
@@ -51,6 +52,7 @@ function setup(messages: ChatViewMessage[] = [entry(1, user('first'))]) {
 		transcript,
 		getSelectedChatId: () => selectedChatId,
 		reloadTranscript,
+		restoreLatestTranscript,
 		loadOlderMessages,
 		jumpToRow,
 	});
@@ -58,6 +60,7 @@ function setup(messages: ChatViewMessage[] = [entry(1, user('first'))]) {
 		controller,
 		transcript,
 		reloadTranscript,
+		restoreLatestTranscript,
 		loadOlderMessages,
 		jumpToRow,
 		selectChat(chatId: string | null) {
@@ -84,6 +87,37 @@ describe('UserMessageNavigatorController', () => {
 			expect.objectContaining({ id: 'generation-1:3', seq: 3, content: 'second' }),
 			expect.objectContaining({ id: 'generation-1:1', seq: 1, content: 'first' }),
 		]);
+	});
+
+	it('restores the latest bounded suffix before opening from the detached initial window', async () => {
+		const pendingRestore = deferred<boolean>();
+		const { controller, transcript, restoreLatestTranscript } = setup([
+			entry(1, user('early prompt')),
+		]);
+		transcript.lastSeq = 100;
+		transcript.isViewingInitialMessages = true;
+		restoreLatestTranscript.mockImplementationOnce(async () => {
+			const restored = await pendingRestore.promise;
+			if (restored) {
+				transcript.entries = [
+					entry(99, user('recent prompt')),
+					entry(100, assistant('recent response')),
+				];
+				transcript.oldestSeq = 99;
+				transcript.hasMoreMessages = true;
+				transcript.isViewingInitialMessages = false;
+			}
+			return restored;
+		});
+
+		const open = controller.openForActiveChat();
+		expect(controller.open).toBe(false);
+		pendingRestore.resolve(true);
+		await open;
+
+		expect(restoreLatestTranscript).toHaveBeenCalledWith('chat-1');
+		expect(controller.open).toBe(true);
+		expect(controller.items.map((item) => item.content)).toEqual(['recent prompt']);
 	});
 
 	it('includes pending and failed user rows with attachment metadata', () => {
@@ -181,6 +215,7 @@ describe('UserMessageNavigatorController', () => {
 			transcript,
 			getSelectedChatId: () => 'chat-1',
 			reloadTranscript: vi.fn(async () => undefined),
+			restoreLatestTranscript: vi.fn(async () => true),
 			loadOlderMessages: vi.fn(async () => 'exhausted' as const),
 			jumpToRow: vi.fn(async () => false),
 		});
@@ -205,6 +240,7 @@ describe('UserMessageNavigatorController', () => {
 			transcript,
 			getSelectedChatId: () => 'chat-1',
 			reloadTranscript: vi.fn(async () => undefined),
+			restoreLatestTranscript: vi.fn(async () => true),
 			loadOlderMessages: vi.fn(async () => 'exhausted' as const),
 			jumpToRow: vi.fn(async () => false),
 		});
@@ -232,6 +268,7 @@ describe('UserMessageNavigatorController', () => {
 			transcript,
 			getSelectedChatId: () => 'chat-1',
 			reloadTranscript: vi.fn(async () => undefined),
+			restoreLatestTranscript: vi.fn(async () => true),
 			loadOlderMessages: vi.fn(async () => 'exhausted' as const),
 			jumpToRow,
 		});
@@ -256,6 +293,7 @@ describe('UserMessageNavigatorController', () => {
 			transcript,
 			getSelectedChatId: () => 'chat-1',
 			reloadTranscript,
+			restoreLatestTranscript: vi.fn(async () => true),
 			loadOlderMessages: vi.fn(async () => 'exhausted' as const),
 			jumpToRow: vi.fn(async () => false),
 		});

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -21,6 +21,8 @@ type InitialRevealPhase = 'pending' | 'revealing' | 'complete';
 
 export type ChatLoadStatus = 'idle' | 'loading' | 'loaded' | 'empty' | 'error';
 export type OlderMessagesLoadResult = 'loaded' | 'exhausted' | 'invalidated' | 'failed';
+export type TranscriptWindowLoadResult = 'loaded' | 'invalidated' | 'failed';
+export type TranscriptWindowTarget = 'initial' | 'latest';
 
 export interface ChatLoadMessagesOptions {
 	minimumLimit?: number;
@@ -98,11 +100,15 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 	isUserScrolledUp = $state(false);
 	loadStatus = $state<ChatLoadStatus>('idle');
 	loadError = $state<string | null>(null);
+	isViewingInitialMessages = $state(false);
 	#snapshotBuffer: Array<{ generationId: string; messages: ChatViewMessage[] }> | null = null;
 	#loadEpoch = 0;
+	#pendingUserInputsRevision = 0;
+	#pendingUserInputsRevisionAtLoadStart = 0;
 	#loadMorePromise: Promise<OlderMessagesLoadResult> | null = null;
 	#loadingMoreChatId: string | null = null;
 	#loadMoreOperationEpoch = 0;
+	#windowNavigationEpoch = 0;
 	#initialRevealPhase = $state<InitialRevealPhase>('complete');
 
 	constructor(transcriptCache = new ChatTranscriptCache({ limit: INITIAL_VISIBLE_MESSAGES })) {
@@ -127,6 +133,10 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		return ids;
 	});
 
+	#displayLocalNotices = $derived(
+		this.isViewingInitialMessages ? ([] as LocalNoticeRow[]) : this.localNotices,
+	);
+
 	#displayRows = $derived.by(() => {
 		const durableRows = this.#renderEntries.map((entry) => ({
 			kind: 'message' as const,
@@ -138,8 +148,8 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 			this.visiblePendingInputs.length === 0
 				? durableRows
 				: mergeRowsWithPendingInputs(durableRows, this.visiblePendingInputs);
-		if (this.localNotices.length === 0) return merged;
-		return [...merged, ...this.localNotices];
+		if (this.#displayLocalNotices.length === 0) return merged;
+		return [...merged, ...this.#displayLocalNotices];
 	});
 
 	#displayMessages = $derived.by(() =>
@@ -147,12 +157,15 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 	);
 
 	#displayMessageCount = $derived.by(
-		() => this.#renderEntries.length + this.visiblePendingInputs.length + this.localNotices.length,
+		() =>
+			this.#renderEntries.length +
+			this.visiblePendingInputs.length +
+			this.#displayLocalNotices.length,
 	);
 
 	#visibleRows = $derived.by(() => {
-		const noticeCount = Math.min(this.localNotices.length, this.visibleMessageCount);
-		const visibleNotices = this.localNotices.slice(-noticeCount);
+		const noticeCount = Math.min(this.#displayLocalNotices.length, this.visibleMessageCount);
+		const visibleNotices = this.#displayLocalNotices.slice(-noticeCount);
 		const messageLimit = this.visibleMessageCount - noticeCount;
 		if (messageLimit === 0) return visibleNotices;
 
@@ -205,6 +218,7 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 	}
 
 	get visiblePendingInputs(): PendingUserInput[] {
+		if (this.isViewingInitialMessages) return [];
 		return this.pendingUserInputs.filter(
 			(input) => !this.#echoedClientRequestIds.has(input.clientRequestId),
 		);
@@ -245,6 +259,17 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 			);
 			return 'gap-detected';
 		}
+		if (this.isViewingInitialMessages) {
+			this.generationId = generationId;
+			this.lastSeq = result.lastSeq;
+			if (result.changed) {
+				this.localNotices = [];
+			}
+			if (this.entries.length > 0 && this.loadStatus !== 'error') {
+				this.loadStatus = 'loaded';
+			}
+			return 'applied';
+		}
 		const applied = applyChatViewMessages(this.entries, messages, this.lastSeq);
 		if (applied.status === 'applied') {
 			this.generationId = generationId;
@@ -270,7 +295,7 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 	}
 
 	beginSnapshotLoad(): number {
-		const epoch = ++this.#loadEpoch;
+		const epoch = this.#beginLoadEpoch();
 		this.#snapshotBuffer = [];
 		this.isLoadingMessages = true;
 		this.loadStatus = 'loading';
@@ -309,11 +334,10 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		this.oldestSeq = options.pageOldestSeq;
 		this.hasMoreMessages = options.hasMore;
 		this.totalMessages = messages.length;
-		this.pendingUserInputs = options.pendingUserInputs
-			? sortPendingInputs(options.pendingUserInputs)
-			: [];
+		this.#replacePendingUserInputs(options.pendingUserInputs ?? []);
 		this.visibleMessageCount = INITIAL_VISIBLE_MESSAGES;
 		this.#initialRevealPhase = 'complete';
+		this.isViewingInitialMessages = false;
 		this.localNotices = [];
 		this.loadStatus = messages.length === 0 ? 'empty' : 'loaded';
 		this.loadError = null;
@@ -354,11 +378,14 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		this.oldestSeq = page.pageOldestSeq;
 		this.hasMoreMessages = page.hasMore;
 		this.totalMessages = page.messages.length;
-		this.pendingUserInputs = pendingInputsFromPage(page);
+		if (this.#pendingUserInputsRevision === this.#pendingUserInputsRevisionAtLoadStart) {
+			this.#replacePendingUserInputs(pendingInputsFromPage(page));
+		}
 		this.localNotices = [];
 		this.loadStatus = page.messages.length === 0 ? 'empty' : 'loaded';
 		this.loadError = null;
 		this.isLoadingMessages = false;
+		this.isViewingInitialMessages = false;
 		for (const batch of buffered) {
 			const result = this.applyMessages(chatId, batch.generationId, batch.messages);
 			if (result !== 'applied') return result;
@@ -504,7 +531,7 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 	}
 
 	setPendingUserInputs(inputs: PendingUserInput[]): void {
-		this.pendingUserInputs = sortPendingInputs(inputs);
+		this.#replacePendingUserInputs(inputs);
 	}
 
 	upsertPendingUserInput(input: PendingUserInput): void {
@@ -513,31 +540,45 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		const index = next.findIndex((entry) => entry.clientRequestId === input.clientRequestId);
 		if (index >= 0) next[index] = input;
 		else next.push(input);
-		this.pendingUserInputs = sortPendingInputs(next);
+		this.#replacePendingUserInputs(next);
 	}
 
 	clearPendingUserInput(clientRequestId: string): void {
-		this.pendingUserInputs = this.pendingUserInputs.filter(
+		const next = this.pendingUserInputs.filter(
 			(input) => input.clientRequestId !== clientRequestId,
 		);
+		if (next.length === this.pendingUserInputs.length) return;
+		this.#replacePendingUserInputs(next);
 	}
 
 	updatePendingUserInputDeliveryStatus(
 		clientRequestId: string,
 		deliveryStatus: UserMessageDeliveryStatus,
 	): void {
-		this.pendingUserInputs = this.pendingUserInputs.map((input) =>
-			input.clientRequestId === clientRequestId ? { ...input, deliveryStatus } : input,
+		const current = this.pendingUserInputs.find(
+			(input) => input.clientRequestId === clientRequestId,
 		);
+		if (!current || current.deliveryStatus === deliveryStatus) return;
+		this.#replacePendingUserInputs(
+			this.pendingUserInputs.map((input) =>
+				input.clientRequestId === clientRequestId ? { ...input, deliveryStatus } : input,
+			),
+		);
+	}
+
+	#replacePendingUserInputs(inputs: PendingUserInput[]): void {
+		this.#pendingUserInputsRevision += 1;
+		this.pendingUserInputs = sortPendingInputs(inputs);
 	}
 
 	clearMessages(): void {
 		this.#invalidateLoadMoreOperation();
+		this.#loadEpoch += 1;
 		this.entries = [];
 		this.generationId = '';
 		this.lastSeq = 0;
 		this.oldestSeq = 0;
-		this.pendingUserInputs = [];
+		this.#replacePendingUserInputs([]);
 		this.localNotices = [];
 		this.hasMoreMessages = false;
 		this.totalMessages = 0;
@@ -545,6 +586,7 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		this.loadError = null;
 		this.#snapshotBuffer = null;
 		this.#initialRevealPhase = 'complete';
+		this.isViewingInitialMessages = false;
 	}
 
 	loadEarlierMessages(): void {
@@ -578,21 +620,100 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		this.#initialRevealPhase = 'complete';
 	}
 
-	async loadAllMessages(chatId: string): Promise<void> {
-		const generationId = this.generationId;
-		const operationEpoch = this.#loadMoreOperationEpoch;
-		const isCurrentTranscript = () =>
-			this.#isCurrentLoadMoreOperation(chatId, generationId, operationEpoch);
-		if (!isCurrentTranscript()) return;
+	async navigateToWindow(
+		chatId: string,
+		target: TranscriptWindowTarget,
+	): Promise<TranscriptWindowLoadResult> {
+		if (!chatId || this.activeChatId !== chatId) return 'invalidated';
+		if (this.#snapshotBuffer) return 'invalidated';
+		const alreadyAtTarget =
+			target === 'latest'
+				? !this.isViewingInitialMessages
+				: this.isViewingInitialMessages ||
+					(this.oldestSeq === 1 &&
+						this.entries.length <= MESSAGES_PER_PAGE &&
+						this.entries.at(-1)?.seq === this.lastSeq);
 
-		while (isCurrentTranscript() && this.hasMoreMessages) {
-			const result = await this.loadMoreMessages(chatId);
-			if (!isCurrentTranscript()) return;
-			if (result !== 'loaded') break;
+		const windowNavigationEpoch = ++this.#windowNavigationEpoch;
+		const loadEpoch = this.#beginLoadEpoch();
+		this.#invalidateLoadMoreOperation();
+		this.isLoadingMessages = false;
+		if (alreadyAtTarget) return 'loaded';
+
+		const generationId = this.generationId;
+		const latestLastSeq = this.lastSeq;
+
+		try {
+			const page = await getChatMessages(
+				target === 'initial'
+					? {
+							chatId,
+							limit: MESSAGES_PER_PAGE,
+							beforeSeq: Math.min(latestLastSeq + 1, MESSAGES_PER_PAGE + 1),
+						}
+					: { chatId, limit: MESSAGES_PER_PAGE },
+			);
+			if (
+				windowNavigationEpoch !== this.#windowNavigationEpoch ||
+				loadEpoch !== this.#loadEpoch ||
+				this.activeChatId !== chatId ||
+				this.generationId !== generationId
+			) {
+				return 'invalidated';
+			}
+			if (page.generationId !== generationId) {
+				this.transcriptCache.markStale(chatId);
+				return 'invalidated';
+			}
+
+			if (target === 'latest') {
+				const cached = this.transcriptCache.get(chatId);
+				const latestPage =
+					cached &&
+					!cached.stale &&
+					cached.generationId === page.generationId &&
+					cached.lastSeq > page.lastSeq
+						? {
+								...page,
+								messages: cached.messages,
+								lastSeq: cached.lastSeq,
+								pageOldestSeq: cached.oldestSeq,
+							}
+						: page;
+				return this.setFromPage(chatId, latestPage, loadEpoch) === 'applied'
+					? 'loaded'
+					: 'invalidated';
+			}
+
+			this.entries = page.messages;
+			this.oldestSeq = page.pageOldestSeq;
+			this.hasMoreMessages = false;
+			this.totalMessages = page.messages.length;
+			this.visibleMessageCount = page.messages.length;
+			this.#initialRevealPhase = 'complete';
+			const initialWindowServerLastSeq = Math.max(this.lastSeq, page.lastSeq);
+			this.isViewingInitialMessages = (page.messages.at(-1)?.seq ?? 0) < initialWindowServerLastSeq;
+			if (this.isViewingInitialMessages) this.isUserScrolledUp = true;
+			this.loadStatus = page.messages.length === 0 ? 'empty' : 'loaded';
+			this.loadError = null;
+			return 'loaded';
+		} catch (error) {
+			if (
+				windowNavigationEpoch !== this.#windowNavigationEpoch ||
+				loadEpoch !== this.#loadEpoch ||
+				this.activeChatId !== chatId ||
+				this.generationId !== generationId
+			) {
+				return 'invalidated';
+			}
+			console.error(`Error loading ${target} messages:`, error);
+			return 'failed';
 		}
-		if (!isCurrentTranscript()) return;
-		this.visibleMessageCount = Math.max(this.visibleMessageCount, this.displayMessageCount);
-		this.#initialRevealPhase = 'complete';
+	}
+
+	#beginLoadEpoch(): number {
+		this.#pendingUserInputsRevisionAtLoadStart = this.#pendingUserInputsRevision;
+		return ++this.#loadEpoch;
 	}
 
 	resetForNewChat(): void {

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -7,6 +7,7 @@ import { reconcileScrollAfterHeightDelta } from '$lib/chat/transcript/scroll-anc
 import type {
 	ActiveTranscriptState,
 	OlderMessagesLoadResult,
+	TranscriptWindowTarget,
 } from '$lib/chat/transcript/active-transcript-state.svelte.js';
 import type { UserMessageNavigatorTarget } from '$lib/chat/transcript/user-message-navigator-controller.svelte.js';
 
@@ -21,10 +22,11 @@ export type ConversationScrollState = Pick<
 	| 'hasMoreMessages'
 	| 'isLoadingMessages'
 	| 'isUserScrolledUp'
+	| 'isViewingInitialMessages'
 	| 'invalidatePendingHistoryLoad'
-	| 'loadAllMessages'
 	| 'loadMoreMessages'
 	| 'loadStatus'
+	| 'navigateToWindow'
 >;
 
 export interface ScrollControllerDeps {
@@ -72,6 +74,23 @@ export class ConversationScrollController {
 		this.setPinnedToBottom(true);
 	}
 
+	async scrollToLatest(): Promise<void> {
+		const chatId = this.deps.sessions.selectedChatId;
+		if (!chatId) return;
+		if (!this.deps.chatState.isViewingInitialMessages && !this.isScrollingToTop) {
+			this.scrollToBottom();
+			return;
+		}
+		if (!(await this.#navigateToWindow(chatId, 'latest'))) return;
+		this.scrollToBottom();
+	}
+
+	async restoreLatestWindow(chatId: string): Promise<boolean> {
+		if (!(await this.#navigateToWindow(chatId, 'latest'))) return false;
+		this.#preserveDetachedWindowSemantics();
+		return true;
+	}
+
 	setPinnedToBottom(isPinned: boolean): void {
 		this.isPinnedToBottom = isPinned;
 		if (isPinned) this.#lastUserScrollIntentAt = 0;
@@ -107,27 +126,19 @@ export class ConversationScrollController {
 		}
 	}
 
-	/** Loads all paginated messages and scrolls to the very top instantly. */
+	/** Loads the bounded initial transcript window and scrolls to its first row. */
 	async scrollToTop(): Promise<void> {
 		const chatId = this.deps.sessions.selectedChatId;
 		if (!chatId) return;
 
-		const operationEpoch = ++this.#anchorOperationEpoch;
 		this.isScrollingToTop = true;
 		try {
-			this.deps.chatState.completeInitialMessagesReveal();
-			await tick();
-			if (!this.#isCurrentAnchorOperation(chatId, operationEpoch)) return;
-			if (this.deps.chatState.hasMoreMessages) {
-				await this.deps.chatState.loadAllMessages(chatId);
-			}
-			if (!this.#isCurrentAnchorOperation(chatId, operationEpoch)) return;
+			if (!(await this.#navigateToWindow(chatId, 'initial'))) return;
+			this.#preserveDetachedWindowSemantics();
 			const node = this.deps.getScrollContainer();
 			if (node) {
 				this.noteUserScrollIntent();
 				node.scrollTop = 0;
-				this.deps.chatState.isUserScrolledUp = true;
-				this.setPinnedToBottom(false);
 			}
 		} finally {
 			this.isScrollingToTop = false;
@@ -137,6 +148,10 @@ export class ConversationScrollController {
 	handleScroll(): void {
 		const node = this.deps.getScrollContainer();
 		if (!node || !this.#isViewportVisible || node.clientHeight <= 0) return;
+		if (this.deps.chatState.isViewingInitialMessages) {
+			this.#preserveDetachedWindowSemantics();
+			return;
+		}
 		const nearBottom = this.isNearBottom();
 		const shouldRemainPinned =
 			!nearBottom &&
@@ -297,6 +312,10 @@ export class ConversationScrollController {
 
 	async fillUnderfilledViewport(): Promise<void> {
 		const chatId = this.deps.sessions.selectedChatId;
+		if (this.deps.chatState.isViewingInitialMessages) {
+			this.#preserveDetachedWindowSemantics();
+			return;
+		}
 		if (
 			!chatId ||
 			!this.#isViewportVisible ||
@@ -432,6 +451,10 @@ export class ConversationScrollController {
 
 	#restoreBottomNow(): void {
 		this.#cancelBottomRestoreFrame();
+		if (this.deps.chatState.isViewingInitialMessages) {
+			this.#preserveDetachedWindowSemantics();
+			return;
+		}
 		if (!this.#isViewportVisible || this.deps.chatState.isUserScrolledUp) return;
 		const node = this.deps.getScrollContainer();
 		if (!node || node.clientHeight <= 0) return;
@@ -450,6 +473,25 @@ export class ConversationScrollController {
 			this.#lastUserScrollIntentAt > 0 &&
 			performance.now() - this.#lastUserScrollIntentAt <= USER_SCROLL_INTENT_WINDOW_MS
 		);
+	}
+
+	async #navigateToWindow(
+		chatId: string,
+		target: TranscriptWindowTarget,
+	): Promise<boolean> {
+		if (this.deps.sessions.selectedChatId !== chatId) return false;
+		const operationEpoch = ++this.#anchorOperationEpoch;
+		const result = await this.deps.chatState.navigateToWindow(chatId, target);
+		if (result !== 'loaded' || !this.#isCurrentAnchorOperation(chatId, operationEpoch)) {
+			return false;
+		}
+		await tick();
+		return this.#isCurrentAnchorOperation(chatId, operationEpoch);
+	}
+
+	#preserveDetachedWindowSemantics(): void {
+		this.deps.chatState.isUserScrolledUp = true;
+		this.setPinnedToBottom(false);
 	}
 
 	handleHalfPageScroll(event: KeyboardEvent): void {

--- a/web/src/lib/chat/transcript/user-message-navigator-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/user-message-navigator-controller.svelte.ts
@@ -31,6 +31,7 @@ export interface UserMessageNavigatorTranscriptPort {
 	readonly displayRows: readonly ChatDisplayRow[];
 	readonly hasMoreMessages: boolean;
 	readonly isLoadingMessages: boolean;
+	readonly isViewingInitialMessages: boolean;
 	readonly loadStatus: ChatLoadStatus;
 	revealAllLoadedMessages(): void;
 }
@@ -39,6 +40,7 @@ export interface UserMessageNavigatorOptions {
 	transcript: UserMessageNavigatorTranscriptPort;
 	getSelectedChatId: () => string | null;
 	reloadTranscript: (chatId: string) => Promise<void>;
+	restoreLatestTranscript: (chatId: string) => Promise<boolean>;
 	loadOlderMessages: (chatId: string) => Promise<OlderMessagesLoadResult>;
 	jumpToRow: (target: UserMessageNavigatorTarget) => Promise<boolean>;
 }
@@ -110,12 +112,24 @@ export class UserMessageNavigatorController implements UserMessageNavigatorDialo
 			: null;
 	}
 
-	openForActiveChat(): void {
+	async openForActiveChat(): Promise<void> {
 		const chatId = this.options.getSelectedChatId();
-		const generationId = this.options.transcript.generationId;
 		if (!chatId || this.options.transcript.activeChatId !== chatId) return;
 
-		this.#lifecycleEpoch += 1;
+		const lifecycleEpoch = ++this.#lifecycleEpoch;
+		if (this.options.transcript.isViewingInitialMessages) {
+			const restored = await this.options.restoreLatestTranscript(chatId);
+			if (
+				!restored ||
+				lifecycleEpoch !== this.#lifecycleEpoch ||
+				this.options.getSelectedChatId() !== chatId ||
+				this.options.transcript.activeChatId !== chatId
+			) {
+				return;
+			}
+		}
+
+		const generationId = this.options.transcript.generationId;
 		this.openedChatId = chatId;
 		this.openedGenerationId = generationId || null;
 		this.isLoadingOlder = false;

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -329,6 +329,9 @@
 		sessions,
 	});
 	function scrollToBottomAndFill(): void {
+		void scroll.scrollToLatest().then(() => scroll.fillUnderfilledViewport());
+	}
+	function reconcilePinnedBottom(): void {
 		scroll.scrollToBottom();
 		void scroll.fillUnderfilledViewport();
 	}
@@ -363,6 +366,7 @@
 		transcript: chatState,
 		getSelectedChatId: () => sessions.selectedChatId,
 		reloadTranscript: (chatId) => controller.loadChat(chatId),
+		restoreLatestTranscript: (chatId) => scroll.restoreLatestWindow(chatId),
 		loadOlderMessages: (chatId) => scroll.loadMoreMessagesForNavigator(chatId),
 		jumpToRow: (target) => scroll.jumpToMessageRow(target),
 	});
@@ -372,7 +376,7 @@
 		onRegisterSubmit?.(submitToActiveChat);
 		onRegisterAppendToDraft?.(appendToActiveDraft);
 		onRegisterReload?.(reloadSelectedChat);
-		onRegisterUserMessageNavigator?.(() => userMessageNavigator.openForActiveChat());
+		onRegisterUserMessageNavigator?.(() => void userMessageNavigator.openForActiveChat());
 		const unregisterSubagentToolbar = subagentToolbar.register({
 			get model() {
 				return subagentModel;
@@ -425,7 +429,7 @@
 		const _bottomRowId = chatState.bottomVisibleRowId;
 		const _reserveComposerTraySpace = reserveComposerTraySpace;
 		if (_isVisible && !chatState.isUserScrolledUp && localSettings.autoScrollToBottom) {
-			scrollToBottomAndFill();
+			reconcilePinnedBottom();
 			scroll.completeInitialBottomRestore();
 		}
 	});
@@ -669,7 +673,7 @@
 				variant="outline"
 				size="icon"
 				class="absolute bottom-14 right-5 sm:right-6 z-20 w-11 h-11 rounded-full shadow-md hover:shadow-lg"
-				onclick={() => scroll.scrollToBottom()}
+				onclick={scrollToBottomAndFill}
 				title={m.workspace_scroll_to_bottom()}
 			>
 				<ArrowDown class="w-5 h-5" />


### PR DESCRIPTION
Metric | Before | After
-- | -- | --
Navigation latency | 35.5 s | 305 ms median
Requests | 120 | 1
JS heap | 698.5 MiB | 31–32 MiB
DOM nodes | 76,889 | 2,070
Main-thread long tasks | 119 / 8.6 s | 0–1 / ≤53 ms

The profiled slowdown was unbounded transcript loading and rendering, not evidence of a persistent memory leak or server CPU bottleneck. “Scroll to initial prompt” loaded all 6,044 messages and rendered the entire transcript.

## Before

- “Scroll to initial prompt” loaded every 50-message page sequentially for a 6,044-message transcript.
- The measured path took 35.5 s, issued 120 message requests, grew JS heap from 36.6 MiB to 698.5 MiB, and expanded the DOM from 1,155 to 76,889 nodes.
- Rendering all 2,268 chat rows produced 119 long tasks totaling 8.6 s.

```mermaid
flowchart LR
  Click[Scroll to initial prompt] --> All[Load every history page]
  All --> Requests[120 sequential requests]
  Requests --> Render[Render entire transcript]
  Render --> Pressure[699 MiB heap and 77k DOM nodes]
```

## After

```mermaid
flowchart LR
  Click[Scroll to initial prompt] --> First[Fetch first 50-message window]
  First --> Render[Render bounded initial window]
  Live[Live messages] --> Cache[Update latest cache and cursor]
  Bottom[Scroll to bottom] --> Latest[Fetch latest 50-message window]
  Cache --> Latest
```

Initial-prompt navigation now replaces only the active rendered window and leaves the latest transcript cache intact. Live events continue updating the latest cache while the initial window is visible, returning to the bottom restores the latest bounded page, and opposite navigation requests obey the most recent user intent.

On the same 6,044-message production-build profile, three runs completed in a 305 ms median with one request, 31–32 MiB JS heap, 2,070 DOM nodes, and 26 rendered chat rows. Two runs had no long task; the remaining run had one 53 ms task.

## Files

- `active-transcript-state.svelte.ts` owns bounded initial/latest window state and navigation invalidation.
- `conversation-scroll-controller.svelte.ts` preserves detached-window and scroll-anchor semantics.
- `user-message-navigator-controller.svelte.ts` restores the latest bounded suffix before opening.
- `ConversationWorkspace.svelte` wires bounded window restoration into the chat UI.
- Transcript controller tests cover bounds, live updates, chat switches, navigation races, and detached-window geometry.

## Tests

- `bun run check`
- Three affected test files: 104 tests
- Full web suite: 352 files, 3,220 tests
- GitHub Actions: server tests, web tests, protocol integration, Lightpanda E2E, live conformance, and executable build
- `bun run build`
- `bun run start --port 0` isolated startup smoke
- Browser profile against a 6,044-message transcript

Prompted by: yk (@chiayong)