### PR TITLE
Bound live chat transcript memory and append cost

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build-exe": "bun run check && bun run test && bun run build && bun run build-exe:compile && bun run build-exe:smoke",
     "server": "bun server/main.ts",
     "start": "bun scripts/start.js",
+    "bench:chat-ingestion": "bun run --cwd web profile:chat-ingestion",
     "bench:search": "bun scripts/benchmark-chat-search.js",
     "test": "bun run test:server && bun run --cwd web test",
     "test:server": "bun test common/__tests__/*.test.js && bun test scripts/__tests__/*.test.js && bun scripts/run-test-files.js 'server-agents/**/__tests__/*.{test.js,test.ts}' && bun test server/__tests__/*.test.js && bun test server/chats/search/__tests__/*.test.js && bun scripts/run-test-files.js 'server/**/__tests__/*.test.js'",

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"lint": "svelte-kit sync && eslint . --max-warnings=0",
+		"profile:chat-ingestion": "bun scripts/benchmark-transcript-ingestion.ts",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},

--- a/web/scripts/benchmark-transcript-ingestion.ts
+++ b/web/scripts/benchmark-transcript-ingestion.ts
@@ -1,0 +1,88 @@
+import { AssistantMessage } from '../../common/chat-types.js';
+import { applyChatViewMessages, type ChatViewMessage } from '../../common/chat-view.js';
+
+const MESSAGE_COUNT = Number(process.env.GARCON_PROFILE_MESSAGE_COUNT ?? 20_000);
+const RETENTION_LIMIT = Number(process.env.GARCON_PROFILE_RETENTION_LIMIT ?? 200);
+const RUNS = Number(process.env.GARCON_PROFILE_RUNS ?? 7);
+const TAIL_MESSAGE_COUNT = Math.min(1_000, MESSAGE_COUNT);
+const TIMESTAMP = '2026-07-28T00:00:00.000Z';
+
+interface IngestionSample {
+	durationMs: number;
+	tailDurationMs: number;
+	retainedMessages: number;
+}
+
+function percentile(values: number[], ratio: number): number {
+	const sorted = [...values].sort((left, right) => left - right);
+	return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * ratio))] ?? 0;
+}
+
+function collectGarbage(): void {
+	Bun.gc(true);
+}
+
+function ingest(retentionLimit: number | null): IngestionSample {
+	collectGarbage();
+	let entries: ChatViewMessage[] = [];
+	let lastSeq = 0;
+	const startedAt = performance.now();
+	let tailStartedAt = startedAt;
+	for (let seq = 1; seq <= MESSAGE_COUNT; seq += 1) {
+		if (seq === MESSAGE_COUNT - TAIL_MESSAGE_COUNT + 1) tailStartedAt = performance.now();
+		const incoming = [
+			{
+				seq,
+				message: new AssistantMessage(TIMESTAMP, `message-${seq}-${'x'.repeat(48)}`),
+			},
+		];
+		const applied = applyChatViewMessages(entries, incoming, lastSeq);
+		if (applied.status !== 'applied') throw new Error(`Unexpected gap at ${seq}`);
+		entries =
+			retentionLimit && applied.messages.length > retentionLimit
+				? applied.messages.slice(-retentionLimit)
+				: applied.messages;
+		lastSeq = applied.lastSeq;
+	}
+	const durationMs = performance.now() - startedAt;
+	return {
+		durationMs,
+		tailDurationMs: performance.now() - tailStartedAt,
+		retainedMessages: entries.length,
+	};
+}
+
+function profile(retentionLimit: number | null) {
+	ingest(retentionLimit);
+	const samples = Array.from({ length: RUNS }, () => ingest(retentionLimit));
+	const durations = samples.map((sample) => sample.durationMs);
+	const tailDurations = samples.map((sample) => sample.tailDurationMs);
+	return {
+		retentionLimit,
+		retainedMessages: samples.at(-1)?.retainedMessages ?? 0,
+		durationMs: {
+			samples: durations,
+			p50: percentile(durations, 0.5),
+			p95: percentile(durations, 0.95),
+		},
+		tailDurationMs: {
+			messageCount: TAIL_MESSAGE_COUNT,
+			samples: tailDurations,
+			p50: percentile(tailDurations, 0.5),
+			p95: percentile(tailDurations, 0.95),
+		},
+	};
+}
+
+console.log(
+	JSON.stringify(
+		{
+			messageCount: MESSAGE_COUNT,
+			runs: RUNS,
+			unbounded: profile(null),
+			bounded: profile(RETENTION_LIMIT),
+		},
+		null,
+		2,
+	),
+);

--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
 	ActiveTranscriptState,
 	INITIAL_VISIBLE_MESSAGES,
 } from '../active-transcript-state.svelte.js';
@@ -100,6 +101,58 @@ describe('ActiveTranscriptState', () => {
 
 		expect(chat.chatMessages.map(contentOf)).toEqual(['hello', 'hi', 'next']);
 		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: 3 });
+	});
+
+	it('bounds a bottom-pinned live transcript to the recent message window', () => {
+		const chat = new ActiveTranscriptState();
+		const messageCount = ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 51;
+
+		chat.applyMessages(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: messageCount }, (_, index) =>
+				entry(index + 1, assistant(`message-${index + 1}`)),
+			),
+		);
+
+		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		expect(contentOf(chat.chatMessages[0])).toBe('message-52');
+		expect(chat.getCursor()).toEqual({ generationId: 'generation-1', lastSeq: messageCount });
+		expect(chat.oldestSeq).toBe(52);
+		expect(chat.hasMoreMessages).toBe(true);
+		expect(chat.visibleRows).toHaveLength(INITIAL_VISIBLE_MESSAGES);
+	});
+
+	it('preserves expanded history while scrolled up and compacts it at the live edge', () => {
+		const chat = new ActiveTranscriptState();
+		const initial = Array.from({ length: ACTIVE_TRANSCRIPT_RETENTION_LIMIT }, (_, index) =>
+			entry(index + 1, assistant(`message-${index + 1}`)),
+		);
+		chat.replaceGeneration('chat-1', 'generation-1', initial, {
+			lastSeq: ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+			pageOldestSeq: 1,
+			hasMore: false,
+		});
+		chat.isUserScrolledUp = true;
+
+		chat.applyMessages(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(
+					ACTIVE_TRANSCRIPT_RETENTION_LIMIT + index + 1,
+					assistant(`message-${ACTIVE_TRANSCRIPT_RETENTION_LIMIT + index + 1}`),
+				),
+			),
+		);
+
+		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 50);
+		expect(chat.compactToRecentMessages()).toBe(true);
+		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		expect(contentOf(chat.chatMessages[0])).toBe('message-51');
+		expect(chat.oldestSeq).toBe(51);
+		expect(chat.hasMoreMessages).toBe(true);
+		expect(chat.visibleMessageCount).toBe(INITIAL_VISIBLE_MESSAGES);
 	});
 
 	it('signals generation changes without replacing the current generation', () => {

--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -123,7 +123,7 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.visibleRows).toHaveLength(INITIAL_VISIBLE_MESSAGES);
 	});
 
-	it('preserves expanded history while scrolled up and compacts it at the live edge', () => {
+	it('preserves expanded history until it is explicitly compacted at the live edge', () => {
 		const chat = new ActiveTranscriptState();
 		const initial = Array.from({ length: ACTIVE_TRANSCRIPT_RETENTION_LIMIT }, (_, index) =>
 			entry(index + 1, assistant(`message-${index + 1}`)),
@@ -133,7 +133,8 @@ describe('ActiveTranscriptState', () => {
 			pageOldestSeq: 1,
 			hasMore: false,
 		});
-		chat.isUserScrolledUp = true;
+		chat.visibleMessageCount = INITIAL_VISIBLE_MESSAGES + 50;
+		chat.isUserScrolledUp = false;
 
 		chat.applyMessages(
 			'chat-1',
@@ -147,6 +148,7 @@ describe('ActiveTranscriptState', () => {
 		);
 
 		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 50);
+		expect(chat.visibleMessageCount).toBe(INITIAL_VISIBLE_MESSAGES + 50);
 		expect(chat.compactToRecentMessages()).toBe(true);
 		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
 		expect(contentOf(chat.chatMessages[0])).toBe('message-51');

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -124,7 +124,7 @@ describe('ConversationScrollController', () => {
 		cleanup?.();
 	});
 
-	it('releases expanded transcript history when returning to the live edge', () => {
+	it('releases expanded transcript history when returning to the live edge', async () => {
 		const scroller = { scrollTop: 120, scrollHeight: 900, clientHeight: 400 } as HTMLDivElement;
 		const chatState = scrollState({
 			isUserScrolledUp: true,
@@ -138,6 +138,10 @@ describe('ConversationScrollController', () => {
 		});
 
 		controller.scrollToBottom();
+		expect(chatState.compactToRecentMessages).not.toHaveBeenCalled();
+
+		chatState.isUserScrolledUp = true;
+		await controller.scrollToLatest();
 
 		expect(scroller.scrollTop).toBe(900);
 		expect(chatState.isUserScrolledUp).toBe(false);

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -8,6 +8,7 @@ function scrollState<T extends Partial<ConversationScrollState>>(
 	overrides: T,
 ): T & ConversationScrollState {
 	const complete = {
+		compactToRecentMessages: vi.fn(() => false),
 		completeInitialMessagesReveal: vi.fn(),
 		displayMessageCount: 0,
 		generationId: 'generation-1',
@@ -121,6 +122,27 @@ describe('ConversationScrollController', () => {
 
 		expect(scroller.scrollTop).toBe(180);
 		cleanup?.();
+	});
+
+	it('releases expanded transcript history when returning to the live edge', () => {
+		const scroller = { scrollTop: 120, scrollHeight: 900, clientHeight: 400 } as HTMLDivElement;
+		const chatState = scrollState({
+			isUserScrolledUp: true,
+			compactToRecentMessages: vi.fn(() => true),
+		});
+		const controller = new ConversationScrollController({
+			getScrollContainer: () => scroller,
+			getQueueContainer: () => undefined,
+			chatState,
+			sessions: { selectedChatId: 'chat-1' },
+		});
+
+		controller.scrollToBottom();
+
+		expect(scroller.scrollTop).toBe(900);
+		expect(chatState.isUserScrolledUp).toBe(false);
+		expect(controller.isPinnedToBottom).toBe(true);
+		expect(chatState.compactToRecentMessages).toHaveBeenCalledOnce();
 	});
 
 	it('preserves the viewport anchor after older messages render', async () => {

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -13,6 +13,7 @@ import { createRandomId } from '$lib/utils/random-id';
 const MESSAGES_PER_PAGE = 50;
 export const INITIAL_VISIBLE_MESSAGES = 100;
 export const INITIAL_SWITCH_VISIBLE_MESSAGES = 20;
+export const ACTIVE_TRANSCRIPT_RETENTION_LIMIT = 200;
 const SWITCH_REVEAL_BATCH_SIZE = 20;
 type ChatPage = Awaited<ReturnType<typeof getChatMessages>>;
 export type MessageApplyResult = 'applied' | 'generation-changed' | 'gap-detected';
@@ -272,10 +273,19 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		}
 		const applied = applyChatViewMessages(this.entries, messages, this.lastSeq);
 		if (applied.status === 'applied') {
+			const shouldCompact = !this.isUserScrolledUp;
+			const nextEntries =
+				shouldCompact && applied.messages.length > ACTIVE_TRANSCRIPT_RETENTION_LIMIT
+					? applied.messages.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
+					: applied.messages;
 			this.generationId = generationId;
-			this.entries = applied.messages;
+			this.entries = nextEntries;
 			this.lastSeq = applied.lastSeq;
 			this.oldestSeq = this.entries[0]?.seq ?? 0;
+			if (nextEntries.length < applied.messages.length) {
+				this.hasMoreMessages = true;
+				this.visibleMessageCount = Math.min(this.visibleMessageCount, INITIAL_VISIBLE_MESSAGES);
+			}
 		} else {
 			const restored = this.transcriptCache.get(chatId);
 			if (!restored || restored.generationId !== generationId) return 'gap-detected';
@@ -587,6 +597,16 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		this.#snapshotBuffer = null;
 		this.#initialRevealPhase = 'complete';
 		this.isViewingInitialMessages = false;
+	}
+
+	compactToRecentMessages(): boolean {
+		if (this.entries.length <= ACTIVE_TRANSCRIPT_RETENTION_LIMIT) return false;
+		this.entries = this.entries.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		this.oldestSeq = this.entries[0]?.seq ?? 0;
+		this.totalMessages = this.entries.length;
+		this.hasMoreMessages = true;
+		this.visibleMessageCount = Math.min(this.visibleMessageCount, INITIAL_VISIBLE_MESSAGES);
+		return true;
 	}
 
 	loadEarlierMessages(): void {

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -273,7 +273,8 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		}
 		const applied = applyChatViewMessages(this.entries, messages, this.lastSeq);
 		if (applied.status === 'applied') {
-			const shouldCompact = !this.isUserScrolledUp;
+			const shouldCompact =
+				!this.isUserScrolledUp && this.visibleMessageCount <= INITIAL_VISIBLE_MESSAGES;
 			const nextEntries =
 				shouldCompact && applied.messages.length > ACTIVE_TRANSCRIPT_RETENTION_LIMIT
 					? applied.messages.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT)

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -73,7 +73,6 @@ export class ConversationScrollController {
 		node.scrollTop = node.scrollHeight;
 		this.deps.chatState.isUserScrolledUp = false;
 		this.setPinnedToBottom(true);
-		this.deps.chatState.compactToRecentMessages();
 	}
 
 	async scrollToLatest(): Promise<void> {
@@ -81,10 +80,12 @@ export class ConversationScrollController {
 		if (!chatId) return;
 		if (!this.deps.chatState.isViewingInitialMessages && !this.isScrollingToTop) {
 			this.scrollToBottom();
+			this.deps.chatState.compactToRecentMessages();
 			return;
 		}
 		if (!(await this.#navigateToWindow(chatId, 'latest'))) return;
 		this.scrollToBottom();
+		this.deps.chatState.compactToRecentMessages();
 	}
 
 	async restoreLatestWindow(chatId: string): Promise<boolean> {

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -15,6 +15,7 @@ const USER_SCROLL_INTENT_WINDOW_MS = 2_000;
 
 export type ConversationScrollState = Pick<
 	ActiveTranscriptState,
+	| 'compactToRecentMessages'
 	| 'displayMessageCount'
 	| 'completeInitialMessagesReveal'
 	| 'generationId'
@@ -72,6 +73,7 @@ export class ConversationScrollController {
 		node.scrollTop = node.scrollHeight;
 		this.deps.chatState.isUserScrolledUp = false;
 		this.setPinnedToBottom(true);
+		this.deps.chatState.compactToRecentMessages();
 	}
 
 	async scrollToLatest(): Promise<void> {


### PR DESCRIPTION
## Summary

- bound a live-edge active transcript to the latest 200 messages while keeping older history pageable
- preserve expanded history while the user is reading or navigating it, then release it through the existing `scrollToLatest()` path
- compose with the bounded initial/latest navigation introduced by #420
- add a reproducible transcript-ingestion benchmark and regression coverage for both retention modes

## Root cause and current-base scope

The shared transcript cache, persisted snapshot cache, WebSocket log, object URLs, and Mermaid cache are already bounded or cleaned up.

The selected live chat was different: every streamed or paged message remained in `ActiveTranscriptState.entries` for the lifetime of the active conversation. Each incoming message copied and re-indexed that growing array, and manually expanded history remained resident after returning to the live edge. This made later messages progressively more expensive and retained their rendered rows and tool payloads.

PR #420 landed while this PR was under review and independently fixed the most extreme navigation case: “scroll to initial prompt” no longer loads every history page. Current main now swaps between bounded 50-message initial/latest windows for that action.

This PR retains that design and fixes the remaining long-running-chat path:

- live-edge appends retain at most 200 message envelopes;
- explicitly expanded pages are preserved while visible, including navigator pagination that temporarily remains bottom-pinned;
- generic resize and initial-scroll restoration never compact transcript state;
- explicit `scrollToLatest()` releases expanded history and keeps it pageable.

## Browser incident profile

These measurements reproduced the original report before #420 landed. They compare the same production build/API snapshot against the initial combined prototype, so they document the incident and the target behavior; they are not an isolated #421-vs-current-main attribution now that #420 is part of the base.

Measured in headless Chromium 149 with a real 3,002-event, tool-heavy Garcon transcript after a forced V8 GC:

| After expanding history, then returning to live edge | Incident baseline | Bounded prototype | Change |
| --- | ---: | ---: | ---: |
| JS heap used | 159.3 MB | 39.7 MB | -75.1% |
| DOM nodes | 158,979 | 23,692 | -85.1% |
| Event listeners | 1,146 | 203 | -82.3% |
| DOM elements | 25,297 | 2,958 | -88.3% |
| Rendered chat rows | 760 | 26 | -96.6% |

The initial latest-page view stayed effectively unchanged at 24.4 MB heap, and ordinary chat-switch p50 stayed flat (198.3 ms before, 199.9 ms after). The win is specifically the long-chat degradation path.

For context, #420’s current-main profile reports 31–32 MiB heap, 2,070 DOM nodes, and 26 rendered rows for the now-bounded initial-prompt navigation path.

## Live transcript ingestion latency

`bun run bench:chat-ingestion` applies 20,000 sequential messages through the production transcript merge primitive for seven measured runs. Two runs on the contended Garcon host produced:

| Metric | Unbounded | 200-message window | Relative improvement |
| --- | ---: | ---: | ---: |
| Full-run p50 | 696.7–1,174.8 ms | 33.3–36.3 ms | 20.6–32.4x |
| Final 1,000 messages p50 | 61.8–86.3 ms | 1.33–1.64 ms | 46.5–52.4x |
| Retained message envelopes | 20,000 | 200 | 99.0% fewer |

The absolute unbounded timing varies with host contention, but the bounded path remains stable. The tail measurement captures the reported symptom: appends became slower as an active chat accumulated messages.

## Review fix

The first implementation compacted inside generic `scrollToBottom()`. Review found that resize restoration or user-message navigator pagination could then discard a page that had just loaded. The final implementation keeps generic scroll restoration state-preserving and compacts only through `scrollToLatest()`. A regression test covers the distinction.

## Validation

- combined transcript/navigation suite: 108 tests passed
- full frontend suite passed with `TZ=UTC`
- `bun run check` passed lint, Svelte diagnostics, and type checks
- `bun run build` passed
- `bun run bench:chat-ingestion` reproduced the bounded append profile

The full repository run exposed one unrelated timing-sensitive Codex retry test on current main; the isolated test passed 3/3 on immediate rerun. GitHub Actions are the final merge gate.

## Scope

This fixes browser retention and per-message frontend work. It does not address the separate provider/server latency observed during host CPU, swap, and temporary-filesystem contention.
