### PR TITLE
Run real Codex and Claude against scripted models in tests

### DIFF
--- a/integration-tests/support/fake-claude-model.ts
+++ b/integration-tests/support/fake-claude-model.ts
@@ -198,7 +198,7 @@ function errorEvents(message: string): SseEvent[] {
 }
 
 export class FakeClaudeModel {
-  readonly #server: Bun.Server;
+  readonly #server: Bun.Server<undefined>;
   readonly #turns: ClaudeScriptedTurn[] = [];
   readonly #requests: RecordedClaudeModelRequest[] = [];
   readonly #issues: string[] = [];

--- a/integration-tests/support/fake-claude-model.ts
+++ b/integration-tests/support/fake-claude-model.ts
@@ -1,0 +1,299 @@
+// Scripted stand-in for the model behind the real Claude Code CLI. The CLI speaks the Anthropic
+// Messages API to ANTHROPIC_BASE_URL, so pointing that here keeps CLI behavior real -- process
+// lifecycle, local tool execution, JSONL transcript persistence -- while the model's choices
+// become deterministic test script. Parsing is deliberately lenient: the CLI's request shape is
+// its own business, and the scripted turn queue is the correctness mechanism. This is distinct
+// from FakeAnthropicServer, whose strict protocol checks belong to the direct Anthropic agent.
+
+export type ClaudeScriptedBlock =
+  | { readonly kind: 'text'; readonly text: string }
+  | {
+      readonly kind: 'tool_use';
+      readonly id: string;
+      readonly name: string;
+      readonly input: Record<string, unknown>;
+    };
+
+export type ClaudeScriptedTurn =
+  | ClaudeScriptedBlock[]
+  | ((request: RecordedClaudeModelRequest) => ClaudeScriptedBlock[]);
+
+export interface RecordedClaudeModelRequest {
+  readonly id: number;
+  readonly body: Record<string, unknown>;
+  readonly lastUserText: string;
+  readonly toolResults: ReadonlyArray<{ toolUseId: string; content: string }>;
+  readonly receivedAt: number;
+}
+
+export function claudeText(text: string): ClaudeScriptedBlock {
+  return { kind: 'text', text };
+}
+
+export function claudeToolUse(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): ClaudeScriptedBlock {
+  return { kind: 'tool_use', id, name, input };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((block): block is Record<string, unknown> =>
+      isRecord(block) && block.type === 'text' && typeof block.text === 'string')
+    .map((block) => String(block.text))
+    .join('\n');
+}
+
+function lastUserText(body: Record<string, unknown>): string {
+  if (!Array.isArray(body.messages)) return '';
+  for (let index = body.messages.length - 1; index >= 0; index -= 1) {
+    const message = body.messages[index];
+    if (!isRecord(message) || message.role !== 'user') continue;
+    const text = textFromContent(message.content);
+    if (text.length > 0) return text;
+  }
+  return '';
+}
+
+function toolResults(
+  body: Record<string, unknown>,
+): Array<{ toolUseId: string; content: string }> {
+  if (!Array.isArray(body.messages)) return [];
+  const results: Array<{ toolUseId: string; content: string }> = [];
+  for (const message of body.messages) {
+    if (!isRecord(message) || !Array.isArray(message.content)) continue;
+    for (const block of message.content) {
+      if (!isRecord(block) || block.type !== 'tool_result') continue;
+      if (typeof block.tool_use_id !== 'string') continue;
+      results.push({
+        toolUseId: block.tool_use_id,
+        content: textFromContent(block.content),
+      });
+    }
+  }
+  return results;
+}
+
+interface SseEvent {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+function blockEvents(block: ClaudeScriptedBlock, index: number): SseEvent[] {
+  if (block.kind === 'text') {
+    return [
+      {
+        event: 'content_block_start',
+        data: {
+          type: 'content_block_start',
+          index,
+          content_block: { type: 'text', text: '' },
+        },
+      },
+      {
+        event: 'content_block_delta',
+        data: {
+          type: 'content_block_delta',
+          index,
+          delta: { type: 'text_delta', text: block.text },
+        },
+      },
+      { event: 'content_block_stop', data: { type: 'content_block_stop', index } },
+    ];
+  }
+  return [
+    {
+      event: 'content_block_start',
+      data: {
+        type: 'content_block_start',
+        index,
+        content_block: { type: 'tool_use', id: block.id, name: block.name, input: {} },
+      },
+    },
+    {
+      event: 'content_block_delta',
+      data: {
+        type: 'content_block_delta',
+        index,
+        delta: { type: 'input_json_delta', partial_json: JSON.stringify(block.input) },
+      },
+    },
+    { event: 'content_block_stop', data: { type: 'content_block_stop', index } },
+  ];
+}
+
+function turnEvents(
+  blocks: ClaudeScriptedBlock[],
+  request: RecordedClaudeModelRequest,
+): SseEvent[] {
+  const stopReason = blocks.some((block) => block.kind === 'tool_use') ? 'tool_use' : 'end_turn';
+  return [
+    {
+      event: 'message_start',
+      data: {
+        type: 'message_start',
+        message: {
+          id: `msg_scripted_${request.id}`,
+          type: 'message',
+          role: 'assistant',
+          model: String(request.body.model ?? 'scripted'),
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 42,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    },
+    ...blocks.flatMap((block, index) => blockEvents(block, index)),
+    {
+      event: 'message_delta',
+      data: {
+        type: 'message_delta',
+        delta: { stop_reason: stopReason, stop_sequence: null },
+        usage: { output_tokens: 7 },
+      },
+    },
+    { event: 'message_stop', data: { type: 'message_stop' } },
+  ];
+}
+
+function sseResponse(events: SseEvent[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(
+          `event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`,
+        ));
+      }
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: {
+      'cache-control': 'no-cache',
+      'content-type': 'text/event-stream; charset=utf-8',
+    },
+  });
+}
+
+function errorEvents(message: string): SseEvent[] {
+  return [{
+    event: 'error',
+    data: { type: 'error', error: { type: 'api_error', message } },
+  }];
+}
+
+export class FakeClaudeModel {
+  readonly #server: Bun.Server;
+  readonly #turns: ClaudeScriptedTurn[] = [];
+  readonly #requests: RecordedClaudeModelRequest[] = [];
+  readonly #issues: string[] = [];
+  readonly #otherRequests: string[] = [];
+  #requestId = 0;
+  #stopped = false;
+
+  private constructor() {
+    this.#server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      idleTimeout: 0,
+      fetch: (request) => this.#handleRequest(request),
+    });
+  }
+
+  static start(): FakeClaudeModel {
+    return new FakeClaudeModel();
+  }
+
+  get baseUrl(): string {
+    return `http://${this.#server.hostname}:${this.#server.port}`;
+  }
+
+  scriptTurn(turn: ClaudeScriptedTurn): void {
+    this.#turns.push(turn);
+  }
+
+  requests(): readonly RecordedClaudeModelRequest[] {
+    return this.#requests.slice();
+  }
+
+  // Non-messages traffic the CLI generated, kept for inspection rather than failure: telemetry
+  // and auxiliary endpoints are the CLI's business, not the conversation contract.
+  otherRequests(): readonly string[] {
+    return this.#otherRequests.slice();
+  }
+
+  issues(): readonly string[] {
+    return this.#issues.slice();
+  }
+
+  assertSettled(): void {
+    const problems = [
+      ...this.#issues,
+      ...(this.#turns.length > 0
+        ? [`${this.#turns.length} scripted turn(s) were never requested`]
+        : []),
+    ];
+    if (problems.length > 0) {
+      throw new Error(`Fake Claude model was not settled:\n${problems.join('\n')}`);
+    }
+  }
+
+  stop(): void {
+    if (this.#stopped) return;
+    this.#stopped = true;
+    this.#server.stop(true);
+  }
+
+  async #handleRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method !== 'POST' || url.pathname !== '/v1/messages') {
+      this.#otherRequests.push(`${request.method} ${url.pathname}`);
+      return Response.json({ error: { type: 'not_found_error', message: 'unsupported path' } }, {
+        status: 404,
+      });
+    }
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      this.#issues.push('Messages request body was not valid JSON');
+      return sseResponse(errorEvents('invalid request body'));
+    }
+    if (!isRecord(body)) {
+      this.#issues.push('Messages request body was not an object');
+      return sseResponse(errorEvents('invalid request body'));
+    }
+    const recorded: RecordedClaudeModelRequest = {
+      id: ++this.#requestId,
+      body,
+      lastUserText: lastUserText(body),
+      toolResults: toolResults(body),
+      receivedAt: Date.now(),
+    };
+    this.#requests.push(recorded);
+    const turn = this.#turns.shift();
+    if (!turn) {
+      this.#issues.push(
+        `Request ${recorded.id} arrived with no scripted turn (lastUserText: ${JSON.stringify(recorded.lastUserText)})`,
+      );
+      return sseResponse(errorEvents('no scripted turn available'));
+    }
+    const blocks = typeof turn === 'function' ? turn(recorded) : turn;
+    return sseResponse(turnEvents(blocks, recorded));
+  }
+}

--- a/integration-tests/support/fake-codex-model.ts
+++ b/integration-tests/support/fake-codex-model.ts
@@ -126,7 +126,7 @@ function failedEvents(message: string): Array<Record<string, unknown>> {
 }
 
 export class FakeCodexModel {
-  readonly #server: Bun.Server;
+  readonly #server: Bun.Server<undefined>;
   readonly #turns: CodexScriptedTurn[] = [];
   readonly #requests: RecordedCodexModelRequest[] = [];
   readonly #issues: string[] = [];

--- a/integration-tests/support/fake-codex-model.ts
+++ b/integration-tests/support/fake-codex-model.ts
@@ -1,0 +1,224 @@
+// Scripted stand-in for the model behind a real Codex binary. Codex talks the OpenAI Responses
+// SSE protocol to whatever base_url its provider config names; pointing that at this server (via
+// the credential proxy's --upstream-url) keeps every provider-side behavior real -- process
+// lifecycle, sandboxing, rollout persistence, app-server protocol -- while the model's choices
+// become deterministic test script. Codex parses only the SSE data JSON and keys on its `type`
+// field, tolerates unknown event types, and accepts complete items via response.output_item.done,
+// so the emitted stream is the minimal created/item.done*/completed sequence.
+
+export type CodexScriptedItem = Record<string, unknown>;
+
+export type CodexScriptedTurn =
+  | CodexScriptedItem[]
+  | ((request: RecordedCodexModelRequest) => CodexScriptedItem[]);
+
+export interface RecordedCodexModelRequest {
+  readonly id: number;
+  readonly body: Record<string, unknown>;
+  readonly lastUserText: string;
+  readonly functionCallOutputs: ReadonlyArray<{ callId: string; output: string }>;
+  readonly receivedAt: number;
+}
+
+export function codexAssistantMessage(text: string): CodexScriptedItem {
+  return {
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text }],
+  };
+}
+
+// The pinned Codex exposes the unified exec tool as `exec_command` with a string `cmd`.
+export function codexExecCommandCall(
+  callId: string,
+  cmd: string,
+  extraArguments: Record<string, unknown> = {},
+): CodexScriptedItem {
+  return {
+    type: 'function_call',
+    name: 'exec_command',
+    arguments: JSON.stringify({ cmd, ...extraArguments }),
+    call_id: callId,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function lastUserText(body: Record<string, unknown>): string {
+  if (!Array.isArray(body.input)) return '';
+  for (let index = body.input.length - 1; index >= 0; index -= 1) {
+    const item = body.input[index];
+    if (!isRecord(item) || item.type !== 'message' || item.role !== 'user') continue;
+    if (typeof item.content === 'string') return item.content;
+    if (!Array.isArray(item.content)) continue;
+    return item.content
+      .filter((part): part is Record<string, unknown> =>
+        isRecord(part) && part.type === 'input_text' && typeof part.text === 'string')
+      .map((part) => String(part.text))
+      .join('\n');
+  }
+  return '';
+}
+
+function functionCallOutputs(
+  body: Record<string, unknown>,
+): Array<{ callId: string; output: string }> {
+  if (!Array.isArray(body.input)) return [];
+  return body.input
+    .filter((item): item is Record<string, unknown> =>
+      isRecord(item) && item.type === 'function_call_output' && typeof item.call_id === 'string')
+    .map((item) => ({
+      callId: String(item.call_id),
+      output: typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? null),
+    }));
+}
+
+function sseResponse(events: Array<Record<string, unknown>>): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: {
+      'cache-control': 'no-cache',
+      'content-type': 'text/event-stream; charset=utf-8',
+    },
+  });
+}
+
+function turnEvents(items: CodexScriptedItem[], responseId: string): Array<Record<string, unknown>> {
+  // Codex keeps sampling until the model signals it is done: tool outputs queue pending input,
+  // and end_turn tells the loop whether the model expects another round.
+  const expectsFollowUp = items.some((item) =>
+    item.type === 'function_call' || item.type === 'custom_tool_call' || item.type === 'local_shell_call');
+  return [
+    { type: 'response.created', response: {} },
+    ...items.map((item) => ({ type: 'response.output_item.done', item })),
+    {
+      type: 'response.completed',
+      response: {
+        id: responseId,
+        end_turn: !expectsFollowUp,
+        usage: {
+          input_tokens: 42,
+          input_tokens_details: null,
+          output_tokens: 7,
+          output_tokens_details: null,
+          total_tokens: 49,
+        },
+      },
+    },
+  ];
+}
+
+function failedEvents(message: string): Array<Record<string, unknown>> {
+  return [
+    { type: 'response.created', response: {} },
+    { type: 'response.failed', response: { error: { code: 'fake_model_unscripted', message } } },
+  ];
+}
+
+export class FakeCodexModel {
+  readonly #server: Bun.Server;
+  readonly #turns: CodexScriptedTurn[] = [];
+  readonly #requests: RecordedCodexModelRequest[] = [];
+  readonly #issues: string[] = [];
+  #requestId = 0;
+  #stopped = false;
+
+  private constructor() {
+    this.#server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      idleTimeout: 0,
+      fetch: (request) => this.#handleRequest(request),
+    });
+  }
+
+  static start(): FakeCodexModel {
+    return new FakeCodexModel();
+  }
+
+  get baseUrl(): string {
+    return `http://${this.#server.hostname}:${this.#server.port}`;
+  }
+
+  get responsesUrl(): string {
+    return `${this.baseUrl}/v1/responses`;
+  }
+
+  scriptTurn(turn: CodexScriptedTurn): void {
+    this.#turns.push(turn);
+  }
+
+  requests(): readonly RecordedCodexModelRequest[] {
+    return this.#requests.slice();
+  }
+
+  issues(): readonly string[] {
+    return this.#issues.slice();
+  }
+
+  // Every scripted turn must have been consumed and every request must have been scripted;
+  // anything else means the test and the binary disagreed about the conversation shape.
+  assertSettled(): void {
+    const problems = [
+      ...this.#issues,
+      ...(this.#turns.length > 0
+        ? [`${this.#turns.length} scripted turn(s) were never requested`]
+        : []),
+    ];
+    if (problems.length > 0) {
+      throw new Error(`Fake Codex model was not settled:\n${problems.join('\n')}`);
+    }
+  }
+
+  stop(): void {
+    if (this.#stopped) return;
+    this.#stopped = true;
+    this.#server.stop(true);
+  }
+
+  async #handleRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method !== 'POST' || url.pathname !== '/v1/responses') {
+      this.#issues.push(`Unexpected request: ${request.method} ${url.pathname}`);
+      return Response.json({ error: { message: 'unsupported path' } }, { status: 404 });
+    }
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      this.#issues.push('Responses request body was not valid JSON');
+      return sseResponse(failedEvents('invalid request body'));
+    }
+    if (!isRecord(body)) {
+      this.#issues.push('Responses request body was not an object');
+      return sseResponse(failedEvents('invalid request body'));
+    }
+    const recorded: RecordedCodexModelRequest = {
+      id: ++this.#requestId,
+      body,
+      lastUserText: lastUserText(body),
+      functionCallOutputs: functionCallOutputs(body),
+      receivedAt: Date.now(),
+    };
+    this.#requests.push(recorded);
+    const turn = this.#turns.shift();
+    if (!turn) {
+      this.#issues.push(
+        `Request ${recorded.id} arrived with no scripted turn (lastUserText: ${JSON.stringify(recorded.lastUserText)})`,
+      );
+      return sseResponse(failedEvents('no scripted turn available'));
+    }
+    const items = typeof turn === 'function' ? turn(recorded) : turn;
+    return sseResponse(turnEvents(items, `resp_fake_${recorded.id}`));
+  }
+}

--- a/integration-tests/support/live-claude.ts
+++ b/integration-tests/support/live-claude.ts
@@ -11,7 +11,7 @@ import type {
 export const LIVE_CLAUDE_MODEL = 'haiku';
 export const LIVE_CLAUDE_THINKING_MODE = 'low';
 
-const CLAUDE_BINARY = fileURLToPath(
+export const CLAUDE_BINARY = fileURLToPath(
   new URL('../node_modules/.bin/claude', import.meta.url),
 );
 const CLAUDE_AGENT_SETTINGS: AgentSettingsEnvelope = {

--- a/integration-tests/support/live-codex.ts
+++ b/integration-tests/support/live-codex.ts
@@ -86,6 +86,9 @@ export interface LiveCodexTestEnvironment {
 
 interface LiveCodexTestEnvironmentOptions {
   upstreamUrl?: string;
+  // Scripted-model environments proxy to a local fake, so any placeholder key works and no
+  // credential needs to exist in the environment.
+  testingKey?: string;
 }
 
 type CodexProxyProcess = Bun.Subprocess<'pipe', 'ignore', 'ignore'>;
@@ -164,7 +167,7 @@ async function removeProxyRoot(root: string, testingKey: string): Promise<void> 
 export async function startLiveCodexTestEnvironment(
   options: LiveCodexTestEnvironmentOptions = {},
 ): Promise<LiveCodexTestEnvironment> {
-  const testingKey = process.env.OPENAI_TESTING_KEY?.trim();
+  const testingKey = options.testingKey ?? process.env.OPENAI_TESTING_KEY?.trim();
   if (!testingKey) {
     throw new Error('OPENAI_TESTING_KEY is required for live Codex integration tests.');
   }

--- a/integration-tests/support/scripted-claude.ts
+++ b/integration-tests/support/scripted-claude.ts
@@ -1,0 +1,32 @@
+// Runs the real pinned Claude Code CLI with its model swapped for a script. ANTHROPIC_BASE_URL
+// points the CLI at FakeClaudeModel, so CLI behavior stays real while every model choice is
+// deterministic and no credential is required.
+
+import { constants } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { FakeClaudeModel } from './fake-claude-model.js';
+import { CLAUDE_BINARY } from './live-claude.js';
+
+export interface ScriptedClaudeTestEnvironment {
+  readonly model: FakeClaudeModel;
+  readonly serverEnvironment: Record<string, string>;
+  dispose(): void;
+}
+
+export async function startScriptedClaudeTestEnvironment(): Promise<ScriptedClaudeTestEnvironment> {
+  await access(CLAUDE_BINARY, constants.X_OK);
+  const model = FakeClaudeModel.start();
+  return {
+    model,
+    serverEnvironment: {
+      ANTHROPIC_API_KEY: 'garcon-scripted-claude-key',
+      ANTHROPIC_AUTH_TOKEN: '',
+      ANTHROPIC_BASE_URL: model.baseUrl,
+      CLAUDE_BINARY,
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+    },
+    dispose() {
+      model.stop();
+    },
+  };
+}

--- a/integration-tests/support/scripted-codex.ts
+++ b/integration-tests/support/scripted-codex.ts
@@ -1,0 +1,39 @@
+// Runs the real pinned Codex binary with its model swapped for a script. The topology is the
+// live one -- Codex talks to the credential proxy, the proxy forwards upstream -- with the
+// upstream pointed at FakeCodexModel instead of OpenAI, so provider behavior stays real while
+// every model choice is deterministic and no credential is required.
+
+import { FakeCodexModel } from './fake-codex-model.js';
+import {
+  startLiveCodexTestEnvironment,
+  type LiveCodexTestEnvironment,
+} from './live-codex.js';
+
+export interface ScriptedCodexTestEnvironment extends LiveCodexTestEnvironment {
+  readonly model: FakeCodexModel;
+}
+
+export async function startScriptedCodexTestEnvironment(): Promise<ScriptedCodexTestEnvironment> {
+  const model = FakeCodexModel.start();
+  let environment: LiveCodexTestEnvironment;
+  try {
+    environment = await startLiveCodexTestEnvironment({
+      upstreamUrl: model.responsesUrl,
+      testingKey: `garcon-scripted-codex-${crypto.randomUUID()}`,
+    });
+  } catch (error) {
+    model.stop();
+    throw error;
+  }
+  return {
+    ...environment,
+    model,
+    async dispose() {
+      try {
+        await environment.dispose();
+      } finally {
+        model.stop();
+      }
+    },
+  };
+}

--- a/integration-tests/tests/server/claude-scripted-model.test.ts
+++ b/integration-tests/tests/server/claude-scripted-model.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { messagesOfType } from '../../support/chat-assertions.js';
+import {
+  claudeText,
+  claudeToolUse,
+} from '../../support/fake-claude-model.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+import { waitForVisibleResponse } from '../../support/live-agent.js';
+import { liveClaudeStartRequest } from '../../support/live-claude.js';
+import {
+  startScriptedClaudeTestEnvironment,
+  type ScriptedClaudeTestEnvironment,
+} from '../../support/scripted-claude.js';
+
+// The real pinned Claude CLI runs the whole turn -- spawn, local tool execution, JSONL
+// transcript persistence -- while the model behind it is a deterministic script.
+describe('Claude against a scripted model', () => {
+  let environment: ScriptedClaudeTestEnvironment | undefined;
+
+  beforeAll(async () => {
+    environment = await startScriptedClaudeTestEnvironment();
+  });
+
+  afterAll(() => {
+    environment?.dispose();
+  });
+
+  test('completes a scripted tool turn end to end', async () => {
+    if (!environment) throw new Error('Scripted Claude environment was not initialized.');
+    const testEnvironment = environment;
+    const marker = `GARCON_SCRIPTED_CLAUDE_${crypto.randomUUID().replaceAll('-', '')}`;
+    const reply = `SCRIPTED_DONE_${crypto.randomUUID().replaceAll('-', '')}`;
+    testEnvironment.model.scriptTurn([
+      claudeToolUse('toolu_scripted_1', 'Bash', { command: `echo ${marker}` }),
+    ]);
+    testEnvironment.model.scriptTurn([claudeText(reply)]);
+
+    await withIntegrationFixture('claude-scripted-model', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(liveClaudeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'Run the scripted command.',
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+
+      const transcript = await fixture.client.getMessages(chatId);
+      const bash = messagesOfType(transcript.messages, 'bash-tool-use').find(
+        (message) => message.command.includes(`echo ${marker}`),
+      );
+      if (!bash) throw new Error('Scripted Claude shell tool use was not rendered.');
+      const result = messagesOfType(transcript.messages, 'tool-result').find(
+        (message) => message.toolId === bash.toolId,
+      );
+      expect(result?.isError).toBe(false);
+      expect(JSON.stringify(result?.content)).toContain(marker);
+
+      const requests = testEnvironment.model.requests();
+      expect(requests.length).toBeGreaterThanOrEqual(2);
+      expect(requests[0].lastUserText).toContain('Run the scripted command.');
+      const followUp = requests.find((request) =>
+        request.toolResults.some((toolResult) =>
+          toolResult.toolUseId === 'toolu_scripted_1' && toolResult.content.includes(marker)));
+      if (!followUp) throw new Error('Tool result never reached the scripted model.');
+      testEnvironment.model.assertSettled();
+    }, {
+      serverEnvironment: testEnvironment.serverEnvironment,
+    });
+  });
+});

--- a/integration-tests/tests/server/codex-scripted-model.test.ts
+++ b/integration-tests/tests/server/codex-scripted-model.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { messagesOfType } from '../../support/chat-assertions.js';
+import {
+  codexAssistantMessage,
+  codexExecCommandCall,
+} from '../../support/fake-codex-model.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+import { waitForVisibleResponse } from '../../support/live-agent.js';
+import { liveCodexStartRequest } from '../../support/live-codex.js';
+import {
+  startScriptedCodexTestEnvironment,
+  type ScriptedCodexTestEnvironment,
+} from '../../support/scripted-codex.js';
+
+// The real pinned Codex binary runs the whole turn -- spawn, tool execution, rollout
+// persistence, app-server protocol -- while the model behind it is a deterministic script.
+describe('Codex against a scripted model', () => {
+  let environment: ScriptedCodexTestEnvironment | undefined;
+
+  beforeAll(async () => {
+    environment = await startScriptedCodexTestEnvironment();
+  });
+
+  afterAll(async () => {
+    await environment?.dispose();
+  });
+
+  test('completes a scripted tool turn end to end', async () => {
+    if (!environment) throw new Error('Scripted Codex environment was not initialized.');
+    const testEnvironment = environment;
+    const marker = `GARCON_SCRIPTED_CODEX_${crypto.randomUUID().replaceAll('-', '')}`;
+    const reply = `SCRIPTED_DONE_${crypto.randomUUID().replaceAll('-', '')}`;
+    testEnvironment.model.scriptTurn([codexExecCommandCall('call_1', `echo ${marker}`)]);
+    testEnvironment.model.scriptTurn([codexAssistantMessage(reply)]);
+
+    await withIntegrationFixture('codex-scripted-model', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(liveCodexStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'Run the scripted command.',
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+
+      const transcript = await fixture.client.getMessages(chatId);
+      const bash = messagesOfType(transcript.messages, 'bash-tool-use').find(
+        (message) => message.command.includes(`echo ${marker}`),
+      );
+      if (!bash) throw new Error('Scripted Codex shell tool use was not rendered.');
+      const result = messagesOfType(transcript.messages, 'tool-result').find(
+        (message) => message.toolId === bash.toolId,
+      );
+      expect(result?.isError).toBe(false);
+      expect(JSON.stringify(result?.content)).toContain(marker);
+
+      const requests = testEnvironment.model.requests();
+      expect(requests).toHaveLength(2);
+      expect(requests[0].lastUserText).toContain('Run the scripted command.');
+      expect(requests[1].functionCallOutputs).toHaveLength(1);
+      expect(requests[1].functionCallOutputs[0].callId).toBe('call_1');
+      expect(requests[1].functionCallOutputs[0].output).toContain(marker);
+      testEnvironment.model.assertSettled();
+    }, {
+      serverEnvironment: testEnvironment.serverEnvironment,
+      prepareWorkspace: testEnvironment.prepareWorkspace,
+    });
+  });
+});


### PR DESCRIPTION
Live provider tests roll dice on every PR because the model decides the conversation shape, while the protocol-level fakes drift from real provider behavior in exactly the timing and persistence edges where regressions live. This adds a deterministic tier that keeps the provider real and scripts only the model: the pinned Codex binary talks through its credential proxy to a scripted OpenAI Responses server, and the pinned Claude CLI talks to a scripted Anthropic Messages server, so process lifecycle, sandboxing, tool execution, and native transcript persistence are exercised as shipped while every model choice is deterministic test script. The tier needs no credentials, runs in the standard test:server suite on every PR, and fails loudly on any unscripted request or unconsumed script; two end-to-end tests prove a scripted tool turn against each real binary.