### PR TITLE
Align Git view controls and History comparisons

### DIFF
--- a/integration-tests/tests/e2e/git-view-surfaces.test.ts
+++ b/integration-tests/tests/e2e/git-view-surfaces.test.ts
@@ -52,7 +52,7 @@ describe('Lightpanda standalone Git views', () => {
     });
   });
 
-  test('opens, hands off, and persists History and Compare in independent desktop hosts', async () => {
+  test('compares selected commits inside History while standalone Compare remains independent', async () => {
     await withE2eFixture('git-view-desktop-surfaces', async (fixture) => {
       const project = fixture.integration.dirs.project;
       await createHistoryFixture(project);
@@ -104,14 +104,18 @@ describe('Lightpanda standalone Git views', () => {
       )).not.toBeNull();
 
       await app.selectMainWorkspaceSurface('History');
-      await app.clickButton('Compare revisions');
+      await app.clickButton('Select commits');
+      await app.clickButton('Select first revision as From');
+      await app.clickButton('Select second revision as To');
+      await app.clickButton('Compare');
       await fixture.page.waitForSelector(
-        '[id="sidebar-panel-singleton:git-compare"][aria-hidden="false"]',
+        '[id="main-panel-singleton:git-history"][aria-hidden="false"]'
+          + ' [data-git-diff-document]',
       );
       await fixture.page.waitForFunction(
         () => {
           const panel = document.querySelector(
-            '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+            '[role="tabpanel"][data-workspace-surface-id="singleton:git-history"]'
               + '[aria-hidden="false"]',
           );
           return panel?.textContent?.includes('first revision') === true
@@ -119,6 +123,13 @@ describe('Lightpanda standalone Git views', () => {
         },
         { timeout: 20_000 },
       );
+      expect(await fixture.page.$eval(
+        '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+          + '[aria-hidden="false"]',
+        (element) => element.textContent,
+      )).toContain('Working Tree');
+      await app.clickButton('Back to commit selection');
+      await app.waitForText('second revision');
 
       await fixture.page.waitForFunction(
         () => {
@@ -251,6 +262,16 @@ describe('Lightpanda standalone Git views', () => {
       expect(await fixture.page.$('nav[aria-label="Workspace navigation"]')).toBeNull();
       expect(await app.hasButton('Close view')).toBe(true);
       expect(await app.hasButton('Back')).toBe(false);
+
+      await app.waitForText('second revision');
+      await app.clickButton('Select commits');
+      await app.clickButton('Select first revision as From');
+      await app.clickButton('Select second revision as To');
+      await app.clickButton('Compare');
+      await app.waitForButton('Back to commit selection');
+      expect(await app.hasButton('Close view')).toBe(true);
+      await app.clickButton('Back to commit selection');
+      await app.waitForText('second revision');
 
       await app.clickButton('Close view');
       await fixture.page.waitForSelector(

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -707,6 +707,7 @@
 	"git_history_load_diff_rows_failed": "Failed to load diff rows: {detail}",
 	"git_history_load_more_commits_failed": "Failed to load more commits: {detail}",
 	"git_history_no_commits": "No commits found",
+	"git_history_open_commit": "Open commit {commit}",
 	"git_new_branch_base": "Base",
 	"git_new_branch_branch_name": "Branch Name",
 	"git_new_branch_cancel": "Cancel",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -596,6 +596,7 @@
 	"git_compare_select_commits": "Select commits",
 	"git_compare_select_commit_for": "Select {commit} as {endpoint}",
 	"git_compare_selection_order": "Choose commits in explicit From and To order.",
+	"git_history_back_to_comparison_selection": "Back to commit selection",
 	"git_compare_choose_endpoints": "Choose both comparison endpoints.",
 	"git_compare_load_rows_failed": "Failed to load comparison rows: {detail}",
 	"git_diff_document_changed": "The diff changed while loading.",

--- a/web/src/lib/components/git/CommitSurface.svelte
+++ b/web/src/lib/components/git/CommitSurface.svelte
@@ -30,8 +30,8 @@
 
 	const dialogBodyGridStyle = $derived(
 		isMobile
-			? 'grid-template-rows: minmax(0, 1fr) auto;'
-			: `grid-template-rows: minmax(260px, ${100 - messagePanePercent}fr) auto minmax(150px, ${messagePanePercent}fr);`,
+			? 'grid-template-rows: minmax(0, 1fr) auto auto;'
+			: `grid-template-rows: minmax(260px, ${100 - messagePanePercent}fr) auto auto minmax(150px, ${messagePanePercent}fr);`,
 	);
 	const messagePaneStyle = $derived(
 		isMobile
@@ -142,29 +142,10 @@
 
 <div class="flex h-full min-h-0 min-w-0 overflow-hidden bg-background">
 	<div class="flex min-h-0 min-w-0 flex-1 flex-col">
-		<GitSurfaceToolbar target={controller.target} {presentation} actions={toolbarActions}>
-			{#snippet leading()}
-			<div class="flex min-w-0 max-w-64 shrink items-center gap-2">
-				<GitCommitHorizontal class="h-4 w-4 shrink-0 text-muted-foreground" />
-				<h2 class="min-w-0 truncate text-sm font-medium text-foreground">
-					{controller.selectedFileCount === 0
-						? m.git_quick_commit_select_files()
-						: m.git_changes_commit_files({ count: controller.selectedFileCount })}
-				</h2>
-				<div class="flex shrink-0 gap-1.5 text-xs tabular-nums">
-					{#if controller.totalAdditions > 0}
-						<span class="text-git-added">+{controller.totalAdditions}</span>
-					{/if}
-					{#if controller.totalDeletions > 0}
-						<span class="text-git-deleted">-{controller.totalDeletions}</span>
-					{/if}
-				</div>
-			</div>
-			{/snippet}
-		</GitSurfaceToolbar>
+		<GitSurfaceToolbar target={controller.target} {presentation} actions={toolbarActions} />
 
 		<div bind:this={dialogBodyEl} class="grid min-h-0 min-w-0 flex-1" style={dialogBodyGridStyle}>
-			<section class="min-h-0 min-w-0 overflow-hidden">
+			<section class="min-h-0 min-w-0 overflow-hidden" data-commit-file-tree>
 				<div class="relative flex h-full min-w-0 flex-col overflow-hidden">
 					<div
 						class="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden py-1 {controller.treeErrorMessage
@@ -214,11 +195,33 @@
 				</button>
 			{/if}
 
+			<div
+				class={cn(
+					'flex min-w-0 items-center gap-2 bg-background py-2',
+					isMobile ? 'border-y border-border px-3' : 'border-b border-border px-4',
+				)}
+				data-commit-selection-summary
+			>
+				<GitCommitHorizontal class="h-4 w-4 shrink-0 text-muted-foreground" />
+				<h2 class="min-w-0 truncate text-sm font-medium text-foreground">
+					{controller.selectedFileCount === 0
+						? m.git_quick_commit_select_files()
+						: m.git_changes_commit_files({ count: controller.selectedFileCount })}
+				</h2>
+				<div class="flex shrink-0 gap-1.5 text-xs tabular-nums">
+					{#if controller.totalAdditions > 0}
+						<span class="text-git-added">+{controller.totalAdditions}</span>
+					{/if}
+					{#if controller.totalDeletions > 0}
+						<span class="text-git-deleted">-{controller.totalDeletions}</span>
+					{/if}
+				</div>
+			</div>
+
 			<section
-				class="flex min-h-0 min-w-0 flex-col border-t border-border {isMobile
-					? 'gap-2'
-					: 'gap-3 p-4'}"
+				class="flex min-h-0 min-w-0 flex-col {isMobile ? 'gap-2' : 'gap-3 p-4'}"
 				style={messagePaneStyle}
+				data-commit-message-pane
 			>
 				<textarea
 					data-surface-primary

--- a/web/src/lib/components/git/GitCommitDetailsHeader.svelte
+++ b/web/src/lib/components/git/GitCommitDetailsHeader.svelte
@@ -2,7 +2,6 @@
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import Copy from '@lucide/svelte/icons/copy';
 	import GitBranch from '@lucide/svelte/icons/git-branch';
-	import GitCompareArrows from '@lucide/svelte/icons/git-compare-arrows';
 	import Undo2 from '@lucide/svelte/icons/undo-2';
 	import type { GitCommitSnapshotReady } from '$lib/api/git.js';
 	import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
@@ -15,7 +14,6 @@
 		onBack: () => void;
 		onSelectParent: (parentHash: string | null) => void;
 		onRevertCommit: () => void;
-		onCompare: () => void;
 		diffMode: DiffMode;
 		contextLines: number;
 		diffFontSize: string;
@@ -32,7 +30,6 @@
 		onBack,
 		onSelectParent,
 		onRevertCommit,
-		onCompare,
 		diffMode,
 		contextLines,
 		diffFontSize,
@@ -163,14 +160,6 @@
 				{onSetContextLines}
 				{onSetDiffFontSize}
 			/>
-			<button
-				type="button"
-				class="inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-				onclick={onCompare}
-			>
-				<GitCompareArrows class="h-3.5 w-3.5" />
-				{m.git_compare_action()}
-			</button>
 			<button
 				type="button"
 				class="inline-flex items-center gap-1.5 rounded border border-status-warning-border px-2.5 py-1 text-xs font-medium text-status-warning hover:bg-status-warning/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"

--- a/web/src/lib/components/git/GitCommitDetailsHeader.svelte
+++ b/web/src/lib/components/git/GitCommitDetailsHeader.svelte
@@ -79,7 +79,7 @@
 </script>
 
 <div class="border-b border-border bg-background px-3 py-2">
-	<div class="flex min-w-0 items-start gap-2">
+	<div class="flex min-w-0 items-start gap-2" data-git-commit-details-primary>
 		<button
 			type="button"
 			class="mt-0.5 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
@@ -129,6 +129,9 @@
 				</details>
 			{/if}
 		</div>
+		{#if showFileTreeToggle}
+			<GitFileTreeToggleButton visible={fileTreeVisible} onToggle={onToggleFileTree} />
+		{/if}
 	</div>
 
 	<div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
@@ -152,9 +155,6 @@
 			{/if}
 		</div>
 		<div class="flex items-center gap-2">
-			{#if showFileTreeToggle}
-				<GitFileTreeToggleButton visible={fileTreeVisible} onToggle={onToggleFileTree} />
-			{/if}
 			<GitDiffSettingsMenu
 				{diffMode}
 				{contextLines}

--- a/web/src/lib/components/git/GitCommitDetailsScreen.svelte
+++ b/web/src/lib/components/git/GitCommitDetailsScreen.svelte
@@ -30,7 +30,6 @@
 		onRetry: () => void;
 		onSelectParent: (parent: string | null) => void;
 		onRevertCommit: () => void;
-		onCompare: () => void;
 		onSetDiffMode: (mode: DiffMode) => void;
 		onSetContextLines: (lines: number) => void;
 		onSetDiffFontSize: (size: string) => void;
@@ -70,7 +69,6 @@
 			onBack={props.onBack}
 			onSelectParent={props.onSelectParent}
 			onRevertCommit={props.onRevertCommit}
-			onCompare={props.onCompare}
 			diffMode={props.diffMode}
 			contextLines={props.contextLines}
 			diffFontSize={props.diffFontSize}

--- a/web/src/lib/components/git/GitCommitListScreen.svelte
+++ b/web/src/lib/components/git/GitCommitListScreen.svelte
@@ -181,32 +181,34 @@
 		<div class="divide-y divide-border">
 			{#each commits as commit (commit.hash)}
 				<div
-					class="group px-3 py-2 hover:bg-muted/40 {comparisonFrom === commit.hash ||
-					comparisonTo === commit.hash
+					class="group relative cursor-pointer select-none px-3 py-2 hover:bg-muted/40 {comparisonFrom ===
+						commit.hash || comparisonTo === commit.hash
 						? 'bg-interactive-accent/10'
 						: ''}"
 				>
-					<div class="flex items-stretch gap-2">
-						<button
-							type="button"
-							class="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-							aria-pressed={comparisonSelectionActive
-								? comparisonFrom === commit.hash || comparisonTo === commit.hash
-								: undefined}
-							aria-label={comparisonSelectionActive
-								? m.git_compare_select_commit_for({
-										commit: commit.subject || commit.shortHash,
-										endpoint:
-											comparisonSelectionSlot === 'from'
-												? m.git_compare_from()
-												: m.git_compare_to(),
-									})
-								: undefined}
-							onclick={() =>
-								comparisonSelectionActive
-									? onSelectComparisonCommit(commit.hash)
-									: onOpenCommit(commit.hash)}
-						>
+					<button
+						type="button"
+						class="absolute inset-0 z-0 cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent"
+						aria-pressed={comparisonSelectionActive
+							? comparisonFrom === commit.hash || comparisonTo === commit.hash
+							: undefined}
+						aria-label={comparisonSelectionActive
+							? m.git_compare_select_commit_for({
+									commit: commit.subject || commit.shortHash,
+									endpoint:
+										comparisonSelectionSlot === 'from' ? m.git_compare_from() : m.git_compare_to(),
+								})
+							: m.git_history_open_commit({
+									commit: commit.subject || commit.shortHash,
+								})}
+						data-git-history-commit-row
+						onclick={() =>
+							comparisonSelectionActive
+								? onSelectComparisonCommit(commit.hash)
+								: onOpenCommit(commit.hash)}
+					></button>
+					<div class="pointer-events-none relative z-[1] flex items-stretch gap-2">
+						<div class="min-w-0 flex-1 text-left">
 							<div class="flex min-w-0 items-center gap-2">
 								<span class="min-w-0 truncate text-sm font-medium text-foreground">
 									{commit.subject || commit.shortHash}
@@ -232,10 +234,10 @@
 									</span>
 								{/if}
 							</div>
-						</button>
+						</div>
 						<button
 							type="button"
-							class="self-center rounded p-1 text-muted-foreground opacity-70 hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+							class="pointer-events-auto self-center rounded p-1 text-muted-foreground opacity-70 hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
 							title={copiedHash === commit.hash ? 'Copied commit hash' : 'Copy commit hash'}
 							aria-label={copiedHash === commit.hash ? 'Copied commit hash' : 'Copy commit hash'}
 							onclick={(event) => copyCommitHash(event, commit.hash)}
@@ -244,10 +246,12 @@
 						</button>
 						<ChevronRight class="self-center h-4 w-4 shrink-0 text-muted-foreground" />
 					</div>
-					{#if !comparisonSelectionActive}<div class="mt-2 flex justify-end">
+					{#if !comparisonSelectionActive}<div
+							class="pointer-events-none relative z-[1] mt-2 flex justify-end"
+						>
 							<button
 								type="button"
-								class="inline-flex items-center gap-1.5 rounded border border-status-warning-border px-2.5 py-1 text-xs font-medium text-status-warning hover:bg-status-warning/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+								class="pointer-events-auto inline-flex items-center gap-1.5 rounded border border-status-warning-border px-2.5 py-1 text-xs font-medium text-status-warning hover:bg-status-warning/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
 								onclick={() => onRevertCommit(commit)}
 							>
 								<Undo2 class="h-3.5 w-3.5" />

--- a/web/src/lib/components/git/GitCommitListScreen.svelte
+++ b/web/src/lib/components/git/GitCommitListScreen.svelte
@@ -3,7 +3,6 @@
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
 	import Copy from '@lucide/svelte/icons/copy';
 	import GitBranch from '@lucide/svelte/icons/git-branch';
-	import GitCompareArrows from '@lucide/svelte/icons/git-compare-arrows';
 	import History from '@lucide/svelte/icons/history';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
@@ -30,7 +29,6 @@
 		onCancelComparison: () => void;
 		onSelectComparisonCommit: (hash: string) => void;
 		onSelectComparisonSlot: (slot: 'from' | 'to') => void;
-		onOpenComparison: () => void;
 		onOpenSelectedComparison: () => void;
 	}
 
@@ -53,7 +51,6 @@
 		onCancelComparison,
 		onSelectComparisonCommit,
 		onSelectComparisonSlot,
-		onOpenComparison,
 		onOpenSelectedComparison,
 	}: GitCommitListScreenProps = $props();
 
@@ -144,15 +141,7 @@
 			<div class="flex flex-wrap items-center gap-2">
 				<button
 					type="button"
-					class="inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-					onclick={onOpenComparison}
-				>
-					<GitCompareArrows class="h-3.5 w-3.5" />
-					{m.git_compare_title()}
-				</button>
-				<button
-					type="button"
-					class="rounded px-2.5 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+					class="rounded border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
 					onclick={onBeginComparison}
 				>
 					{m.git_compare_select_commits()}

--- a/web/src/lib/components/git/GitComparisonHeader.svelte
+++ b/web/src/lib/components/git/GitComparisonHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
 	import type { GitComparisonSnapshotReady } from '$lib/api/git-comparison.js';
 	import GitFileTreeToggleButton from './GitFileTreeToggleButton.svelte';
@@ -9,6 +10,7 @@
 		showFileTreeToggle: boolean;
 		fileTreeVisible: boolean;
 		onToggleFileTree: () => void;
+		onBack?: () => void;
 	}
 
 	let {
@@ -16,6 +18,7 @@
 		showFileTreeToggle,
 		fileTreeVisible,
 		onToggleFileTree,
+		onBack,
 	}: GitComparisonHeaderProps = $props();
 	let additions = $derived(snapshot.files.reduce((sum, file) => sum + file.additions, 0));
 	let additionsKnown = $derived(snapshot.files.every((file) => file.statsKnown !== false));
@@ -30,6 +33,17 @@
 
 <header class="border-b border-border bg-background px-3 py-2">
 	<div class="flex min-w-0 items-center gap-2">
+		{#if onBack}
+			<button
+				type="button"
+				class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+				aria-label={m.git_history_back_to_comparison_selection()}
+				title={m.git_history_back_to_comparison_selection()}
+				onclick={onBack}
+			>
+				<ArrowLeft class="h-4 w-4" />
+			</button>
+		{/if}
 		<div class="min-w-0 flex-1">
 			<h3 class="text-sm font-semibold text-foreground">{m.git_compare_title()}</h3>
 			<div class="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">

--- a/web/src/lib/components/git/GitComparisonScreen.svelte
+++ b/web/src/lib/components/git/GitComparisonScreen.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import AlertTriangle from '@lucide/svelte/icons/triangle-alert';
 	import type { GitComparisonController } from '$lib/git/review/git-comparison.svelte.js';
 	import type { ChatDraftAppend } from '$lib/chat/composer/chat-draft-append.js';
@@ -12,7 +13,8 @@
 		isMobile: boolean;
 		active?: boolean;
 		fontSize: number;
-		onEdit: () => void;
+		onBack?: () => void;
+		onEdit?: () => void;
 		onRefresh: () => void;
 		onOpenInEditor?: (relativePath: string, line: number) => void;
 		onAppendToChatDraft?: ChatDraftAppend;
@@ -25,6 +27,7 @@
 		isMobile,
 		active = true,
 		fontSize,
+		onBack,
 		onEdit,
 		onRefresh,
 		onOpenInEditor,
@@ -44,6 +47,7 @@
 			{showFileTreeToggle}
 			{fileTreeVisible}
 			{onToggleFileTree}
+			{onBack}
 		/>
 		{#if comparison.staleMessage}
 			<div
@@ -64,14 +68,31 @@
 {/snippet}
 
 {#snippet fallbackActions()}
-	<button
-		type="button"
-		class="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
-		onclick={onEdit}
-	>
-		{m.git_compare_edit()}
-	</button>
+	{#if onEdit}
+		<button
+			type="button"
+			class="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+			onclick={onEdit}
+		>
+			{m.git_compare_edit()}
+		</button>
+	{/if}
 {/snippet}
+
+{#if onBack && !comparison.snapshot}
+	<header class="flex items-center gap-2 border-b border-border bg-background px-3 py-2">
+		<button
+			type="button"
+			class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+			aria-label={m.git_history_back_to_comparison_selection()}
+			title={m.git_history_back_to_comparison_selection()}
+			onclick={onBack}
+		>
+			<ArrowLeft class="h-4 w-4" />
+		</button>
+		<h3 class="text-sm font-semibold text-foreground">{m.git_compare_title()}</h3>
+	</header>
+{/if}
 
 <GitDiffDocumentScreen
 	{header}

--- a/web/src/lib/components/git/GitHistoryPanel.svelte
+++ b/web/src/lib/components/git/GitHistoryPanel.svelte
@@ -3,14 +3,12 @@
 	import AlertTriangle from '@lucide/svelte/icons/triangle-alert';
 	import X from '@lucide/svelte/icons/x';
 	import type { GitHistorySurfaceController } from '$lib/git/history/git-history-surface.svelte.js';
-	import type { GitComparisonDialogDefaults } from '$lib/git/review/git-comparison.svelte.js';
 	import type { ChatDraftAppend } from '$lib/chat/composer/chat-draft-append.js';
 	import { gitProjectInvalidations } from '$lib/git/surface/git-project-invalidation.svelte.js';
 	import { resolveGitEditorRoot } from '$lib/git/surface/git-editor-root.js';
 	import {
 		getFileSessions,
 		getGitReviewDisplay,
-		getGitViewLauncher,
 		getLocalSettings,
 		getTransientLayers,
 		getWorkspaceCoordinator,
@@ -36,7 +34,6 @@
 
 	const workspace = getWorkspaceCoordinator();
 	const shortcuts = getWorkspaceShortcuts();
-	const gitViews = getGitViewLauncher();
 	const reviewDisplay = getGitReviewDisplay();
 	const localSettings = getLocalSettings();
 	const fileSessions = getFileSessions();
@@ -59,7 +56,13 @@
 
 	$effect(() =>
 		shortcuts.registerSurface(singletonSurfaceId('git-history'), (event) => {
-			if (!controller.comparisonSelection.active || event.key !== 'Escape') return false;
+			if (
+				controller.history.screen !== 'list' ||
+				!controller.comparisonSelection.active ||
+				event.key !== 'Escape'
+			) {
+				return false;
+			}
 			event.preventDefault();
 			controller.comparisonSelection.cancel();
 			return true;
@@ -74,25 +77,20 @@
 		untrack(() => void controller.refreshForInvalidation(key, version));
 	});
 
-	function openComparison(comparison: GitComparisonDialogDefaults): void {
-		const effectiveProjectKey = controller.target.effectiveProjectKey;
-		const target = activeTarget;
-		if (!effectiveProjectKey || !target) return;
-		void gitViews.openCompare(
-			{
-				presentation,
-				source: { effectiveProjectKey, target: { ...target } },
-			},
-			comparison,
-		);
-	}
-
 	function requestRevert(
 		commit: NonNullable<GitHistorySurfaceController['pendingRevertCommit']>,
 	): void {
 		transientLayers.open('main-inert', () => {
 			controller.pendingRevertCommit = commit;
 		});
+	}
+
+	function refreshHistory(): void {
+		if (controller.history.screen === 'comparison' && projectPath) {
+			void controller.history.comparison.refresh(projectPath);
+			return;
+		}
+		void controller.target.refreshTargets();
 	}
 
 	function openInEditor(relativePath: string, line: number): void {
@@ -115,7 +113,7 @@
 	<GitHistoryToolbar
 		{controller}
 		{presentation}
-		onRefresh={() => void controller.target.refreshTargets()}
+		onRefresh={refreshHistory}
 		onClose={() => void workspace.closeSurface(singletonSurfaceId('git-history'))}
 		{closeDisabled}
 	/>
@@ -153,7 +151,7 @@
 		{diffFontSize}
 		onRevertCommit={requestRevert}
 		onOpenInEditor={openInEditor}
-		onOpenComparison={openComparison}
+		onOpenSelectedComparison={() => controller.openSelectedComparison()}
 		{onAppendToChatDraft}
 		onOpenChat={() => void workspace.focusChat()}
 		onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}

--- a/web/src/lib/components/git/GitHistoryToolbar.svelte
+++ b/web/src/lib/components/git/GitHistoryToolbar.svelte
@@ -32,14 +32,8 @@
 			label: m.git_header_refresh(),
 			icon: RefreshCw,
 			onclick: onRefresh,
-			disabled:
-				controller.history.listLoading ||
-				controller.history.commitLoading ||
-				controller.history.comparison.isLoading,
-			busy:
-				controller.history.listLoading ||
-				controller.history.commitLoading ||
-				controller.history.comparison.isLoading,
+			disabled: controller.history.activeScreenLoading,
+			busy: controller.history.activeScreenLoading,
 			priority: 0,
 		},
 	]);

--- a/web/src/lib/components/git/GitHistoryToolbar.svelte
+++ b/web/src/lib/components/git/GitHistoryToolbar.svelte
@@ -32,8 +32,14 @@
 			label: m.git_header_refresh(),
 			icon: RefreshCw,
 			onclick: onRefresh,
-			disabled: controller.history.listLoading || controller.history.commitLoading,
-			busy: controller.history.listLoading || controller.history.commitLoading,
+			disabled:
+				controller.history.listLoading ||
+				controller.history.commitLoading ||
+				controller.history.comparison.isLoading,
+			busy:
+				controller.history.listLoading ||
+				controller.history.commitLoading ||
+				controller.history.comparison.isLoading,
 			priority: 0,
 		},
 	]);

--- a/web/src/lib/components/git/GitHistoryView.svelte
+++ b/web/src/lib/components/git/GitHistoryView.svelte
@@ -6,14 +6,10 @@
 		type GitHistoryRevertTarget,
 		type GitHistoryController,
 	} from '$lib/git/history/git-history.svelte.js';
-	import {
-		GIT_EMPTY_TREE_REVISION,
-		recentCommitComparisonDefaults,
-		type GitComparisonDialogDefaults,
-	} from '$lib/git/review/git-comparison.svelte.js';
 	import type { GitHistoryComparisonSelectionState } from '$lib/git/history/git-history-comparison-selection.svelte.js';
 	import GitCommitDetailsScreen from './GitCommitDetailsScreen.svelte';
 	import GitCommitListScreen from './GitCommitListScreen.svelte';
+	import GitComparisonScreen from './GitComparisonScreen.svelte';
 
 	interface GitHistoryViewProps {
 		history: GitHistoryController;
@@ -26,7 +22,7 @@
 		diffFontSize: number;
 		onRevertCommit: (commit: GitHistoryRevertTarget) => void;
 		onOpenInEditor?: (relativePath: string, line: number) => void;
-		onOpenComparison: (defaults: GitComparisonDialogDefaults) => void;
+		onOpenSelectedComparison: () => void;
 		onAppendToChatDraft?: ChatDraftAppend;
 		onOpenChat: () => void;
 		onSetDiffMode?: (mode: DiffMode) => void;
@@ -45,7 +41,7 @@
 		diffFontSize,
 		onRevertCommit,
 		onOpenInEditor,
-		onOpenComparison,
+		onOpenSelectedComparison,
 		onAppendToChatDraft,
 		onOpenChat,
 		onSetDiffMode = () => undefined,
@@ -59,15 +55,6 @@
 			shortHash: commit.shortHash,
 			subject: commit.subject,
 		});
-	}
-
-	function openSelectedHistoryRange(): void {
-		const defaults = comparisonSelection.take();
-		if (defaults) onOpenComparison(defaults);
-	}
-
-	function openHistoryComparison(): void {
-		onOpenComparison(recentCommitComparisonDefaults(history.commits));
 	}
 </script>
 
@@ -96,10 +83,9 @@
 		onCancelComparison={() => comparisonSelection.cancel()}
 		onSelectComparisonCommit={(hash) => comparisonSelection.select(hash)}
 		onSelectComparisonSlot={(slot) => comparisonSelection.setSlot(slot)}
-		onOpenComparison={openHistoryComparison}
-		onOpenSelectedComparison={openSelectedHistoryRange}
+		{onOpenSelectedComparison}
 	/>
-{:else}
+{:else if history.screen === 'commit'}
 	<GitCommitDetailsScreen
 		snapshot={history.commitSnapshot}
 		files={history.visibleFiles}
@@ -121,15 +107,6 @@
 		onRevertCommit={() => {
 			if (history.commitSnapshot) revertListCommit(history.commitSnapshot.commit);
 		}}
-		onCompare={() => {
-			const snapshot = history.commitSnapshot;
-			if (!snapshot) return;
-			onOpenComparison({
-				fromRevision: snapshot.selectedParent ?? GIT_EMPTY_TREE_REVISION,
-				toKind: 'revision',
-				toRevision: snapshot.commit.hash,
-			});
-		}}
 		{onSetDiffMode}
 		{onSetContextLines}
 		{onSetDiffFontSize}
@@ -148,6 +125,21 @@
 		onComposerSubmit={() => history.document.submitComment(onAppendToChatDraft)}
 		onComposerClose={() => history.document.closeCommentComposer()}
 		onComposerFocusHandled={() => history.document.markCommentComposerFocused()}
+		{onOpenChat}
+	/>
+{:else}
+	<GitComparisonScreen
+		comparison={history.comparison}
+		isLoading={history.comparison.isLoading}
+		{isMobile}
+		{active}
+		fontSize={Number(diffFontSize) || 12}
+		onBack={() => history.backToList()}
+		onRefresh={() => {
+			if (projectPath) void history.comparison.refresh(projectPath);
+		}}
+		{onOpenInEditor}
+		{onAppendToChatDraft}
 		{onOpenChat}
 	/>
 {/if}

--- a/web/src/lib/components/git/GitSurfaceToolbar.svelte
+++ b/web/src/lib/components/git/GitSurfaceToolbar.svelte
@@ -11,7 +11,6 @@
 	let {
 		target,
 		presentation,
-		leading,
 		actions,
 		fixed,
 		onClose,
@@ -19,7 +18,6 @@
 	}: {
 		target: GitTargetSessionController;
 		presentation: 'main' | 'sidebar' | 'mobile';
-		leading?: Snippet;
 		actions: readonly ResponsiveSurfaceAction[];
 		fixed?: Snippet;
 		onClose?: () => void;
@@ -35,17 +33,12 @@
 	class="flex min-h-10 min-w-0 items-center gap-2 border-b border-border bg-background px-2"
 	data-git-surface-toolbar
 >
-	{@render leading?.()}
 	<GitTargetSelector
 		{target}
 		isMobile={presentation === 'mobile'}
 		disabled={!target.canChangeTarget}
 	/>
-	<ResponsiveSurfaceActions
-		{actions}
-		menuLabel={m.git_more_actions()}
-		fixed={fixedControls}
-	/>
+	<ResponsiveSurfaceActions {actions} menuLabel={m.git_more_actions()} fixed={fixedControls} />
 	{#if presentation === 'mobile' && onClose}
 		<button
 			type="button"

--- a/web/src/lib/components/git/GitWorkbench.svelte
+++ b/web/src/lib/components/git/GitWorkbench.svelte
@@ -14,6 +14,7 @@
 	import GitBranchIcon from '@lucide/svelte/icons/git-branch';
 	import GitFileTree from './GitFileTree.svelte';
 	import GitFileTreeResizeHandle from './GitFileTreeResizeHandle.svelte';
+	import GitFileTreeToggleButton from './GitFileTreeToggleButton.svelte';
 	import GitVirtualDiffSurface from './GitVirtualDiffSurface.svelte';
 	import GitPorcelainPanel from './GitPorcelainPanel.svelte';
 	import GitCommentModal from './GitCommentModal.svelte';
@@ -38,6 +39,10 @@
 		observeContainerWidth,
 	} from '$lib/components/shared/container-presentation.js';
 	import { gitContainerBreakpoints } from './git-container-presentation.js';
+	import {
+		persistGitDiffDocumentFileTreeVisible,
+		readGitDiffDocumentFileTreeVisible,
+	} from '$lib/git/surface/git-file-tree-preferences.js';
 
 	interface GitWorkbenchProps {
 		projectPath?: string | null;
@@ -103,6 +108,7 @@
 	type SinglePane = 'files' | 'diff';
 	let containerWidth = $state(0);
 	let singlePane = $state<SinglePane>('files');
+	let fileTreeVisible = $state(readGitDiffDocumentFileTreeVisible());
 	const observeWorkbenchWidth = observeContainerWidth((width) => {
 		containerWidth = width;
 	});
@@ -111,9 +117,17 @@
 			? 'narrow'
 			: 'wide',
 	);
+	let filePaneHidden = $derived(
+		containerPresentation === 'wide' ? !fileTreeVisible : singlePane !== 'files',
+	);
 	let diffViewportActive = $derived(
 		active && (containerPresentation === 'wide' || singlePane === 'diff'),
 	);
+
+	function toggleFileTree(): void {
+		fileTreeVisible = !fileTreeVisible;
+		persistGitDiffDocumentFileTreeVisible(fileTreeVisible);
+	}
 
 	function handleBodyDemand(demand: GitReviewBodyDemand): void {
 		wb.handleReviewBodyDemand(demand);
@@ -397,6 +411,7 @@
 			<div class="flex items-center gap-1">
 				{@render diffNavigation()}
 				{@render inspectorButtons()}
+				<GitFileTreeToggleButton visible={fileTreeVisible} onToggle={toggleFileTree} />
 			</div>
 		</div>
 	{/if}
@@ -571,28 +586,26 @@
 					containerPresentation === 'wide' ? 'grid' : 'flex',
 				)}
 				style={containerPresentation === 'wide'
-					? `grid-template-columns: ${files.treePaneWidthPx}px 6px minmax(0,1fr); grid-template-rows: minmax(0,1fr);`
+					? `grid-template-columns: ${fileTreeVisible ? `${files.treePaneWidthPx}px 6px minmax(0,1fr)` : '0px minmax(0,1fr)'}; grid-template-rows: minmax(0,1fr);`
 					: undefined}
 				data-git-wide-layout={containerPresentation === 'wide' ? '' : undefined}
 			>
 				<div
 					class={cn(
 						'flex min-h-0 flex-col overflow-hidden bg-background',
-						containerPresentation === 'wide' && 'border-r border-border',
+						containerPresentation === 'wide' && fileTreeVisible && 'border-r border-border',
 						containerPresentation === 'narrow' && 'absolute inset-0',
-						containerPresentation === 'narrow' &&
-							singlePane !== 'files' &&
-							'invisible pointer-events-none',
+						filePaneHidden && 'invisible pointer-events-none',
 					)}
-					aria-hidden={containerPresentation === 'narrow' && singlePane !== 'files'}
-					inert={containerPresentation === 'narrow' && singlePane !== 'files'}
+					aria-hidden={filePaneHidden}
+					inert={filePaneHidden}
 					data-git-files-pane
 				>
 					<div class="min-h-0 flex-1 overflow-hidden">
 						{@render fileTree(containerPresentation !== 'wide')}
 					</div>
 				</div>
-				{#if containerPresentation === 'wide'}
+				{#if containerPresentation === 'wide' && fileTreeVisible}
 					<GitFileTreeResizeHandle
 						width={files.treePaneWidthPx}
 						onResize={(width) => files.previewTreePaneWidth(width)}

--- a/web/src/lib/components/git/__tests__/CommitSurface.test.ts
+++ b/web/src/lib/components/git/__tests__/CommitSurface.test.ts
@@ -42,13 +42,36 @@ describe('CommitSurface', () => {
 	});
 
 	it('uses the shared folder and branch target controls', () => {
-		render(CommitSurfaceTestHost, {
+		const { container } = render(CommitSurfaceTestHost, {
 			controller: makeController(),
 			presentation: 'main',
 		});
 
-		expect(screen.getByRole('button', { name: '/project' })).toBeTruthy();
+		const folder = screen.getByRole('button', { name: '/project' });
+		const toolbar = container.querySelector('[data-git-surface-toolbar]');
+		expect(toolbar?.querySelector('button')).toBe(folder);
 		expect(screen.getByRole('button', { name: /current ref HEAD/i })).toBeTruthy();
+	});
+
+	it('places the selected-file summary between the file tree and commit message', () => {
+		const { container } = render(CommitSurfaceTestHost, {
+			controller: makeController(),
+			presentation: 'main',
+		});
+
+		const toolbar = container.querySelector('[data-git-surface-toolbar]');
+		const tree = container.querySelector('[data-commit-file-tree]');
+		const summary = container.querySelector('[data-commit-selection-summary]');
+		const message = screen.getByRole('textbox');
+		expect(summary?.textContent).toContain(m.git_quick_commit_select_files());
+		expect(toolbar?.contains(summary)).toBe(false);
+		expect(tree).toBeTruthy();
+		expect(summary).toBeTruthy();
+		if (!tree || !summary) return;
+		expect(tree.compareDocumentPosition(summary) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(
+			summary.compareDocumentPosition(message) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
 	});
 
 	it('owns branch state independently from another Commit controller', () => {

--- a/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
+++ b/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GitComparisonController } from '$lib/git/review/git-comparison.svelte.js';
 import GitComparisonScreen from '../GitComparisonScreen.svelte';
@@ -33,5 +33,27 @@ describe('GitComparisonScreen', () => {
 
 		expect(screen.getByText('Revision HEAD was not found.')).toBeTruthy();
 		expect(screen.queryByText('Loading comparison')).toBeNull();
+	});
+
+	it('offers local back navigation without exposing the standalone Edit action', async () => {
+		const comparison = new GitComparisonController();
+		comparison.error = 'Revision older was not found.';
+		const onBack = vi.fn();
+
+		render(GitComparisonScreen, {
+			comparison,
+			isLoading: false,
+			isMobile: false,
+			fontSize: 12,
+			onBack,
+			onRefresh: vi.fn(),
+			onOpenChat: vi.fn(),
+		});
+
+		expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+		await fireEvent.click(
+			screen.getByRole('button', { name: 'Back to commit selection' }),
+		);
+		expect(onBack).toHaveBeenCalledOnce();
 	});
 });

--- a/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
+++ b/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
@@ -7,6 +7,10 @@ import {
 	type GitDiffFileRequest,
 } from '$lib/api/git.js';
 import {
+	getGitComparisonSnapshot,
+	type GitComparisonSnapshotReady,
+} from '$lib/api/git-comparison.js';
+import {
 	installResizeObserverHarness,
 	ResizeObserverHarness,
 } from '$lib/components/shared/__tests__/resize-observer-harness';
@@ -14,7 +18,6 @@ import {
 	GitHistoryController,
 	type GitHistoryRevertTarget,
 } from '$lib/git/history/git-history.svelte.js';
-import { GIT_EMPTY_TREE_REVISION } from '$lib/git/review/git-comparison.svelte.js';
 import { GitHistoryComparisonSelectionState } from '$lib/git/history/git-history-comparison-selection.svelte.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
 import { LOCAL_STORAGE_KEYS } from '$lib/utils/local-persistence';
@@ -25,6 +28,16 @@ vi.mock('$lib/api/git.js', () => ({
 	getGitCommitSnapshot: vi.fn(),
 	getGitCommitFileBodies: vi.fn(),
 }));
+
+vi.mock('$lib/api/git-comparison.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/api/git-comparison.js')>();
+	return {
+		...actual,
+		getGitComparisonFreshness: vi.fn(),
+		getGitComparisonSnapshot: vi.fn(),
+		getGitComparisonFileBodies: vi.fn(),
+	};
+});
 
 const limits = {
 	maxSummaryFiles: 1000,
@@ -96,6 +109,34 @@ function snapshot() {
 		files: commitFiles(),
 		limits,
 		firstBodyCandidates: ['a.ts'],
+	};
+}
+
+function comparisonSnapshot(): GitComparisonSnapshotReady {
+	return {
+		status: 'ready',
+		project: '/project',
+		repoRoot: '/repo',
+		documentId: 'comparison-doc',
+		mode: 'direct',
+		from: {
+			kind: 'revision',
+			requestedRevision: 'older',
+			label: 'older',
+			hash: 'a'.repeat(40),
+			shortHash: 'aaaaaaa',
+		},
+		to: {
+			kind: 'revision',
+			requestedRevision: 'newer',
+			label: 'newer',
+			hash: 'b'.repeat(40),
+			shortHash: 'bbbbbbb',
+		},
+		effectiveFromHash: 'a'.repeat(40),
+		files: [],
+		limits,
+		firstBodyCandidates: [],
 	};
 }
 
@@ -174,6 +215,7 @@ describe('GitHistoryView', () => {
 		vi.mocked(getGitCommitFileBodies).mockImplementation(
 			async (_project, _documentId, _commit, files) => bodiesForPaths(requestedPaths(files)),
 		);
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(comparisonSnapshot());
 	});
 
 	afterEach(() => {
@@ -188,7 +230,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history,
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -233,7 +275,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -282,7 +324,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: true,
@@ -339,7 +381,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -412,7 +454,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -462,7 +504,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -522,7 +564,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history,
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -576,7 +618,7 @@ describe('GitHistoryView', () => {
 			props: {
 				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison: vi.fn(),
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -598,17 +640,13 @@ describe('GitHistoryView', () => {
 		expect(getGitCommitSnapshot).not.toHaveBeenCalled();
 	});
 
-	it('routes History and commit comparison intents through the parent opener', async () => {
+	it('removes generic comparison launchers from the list and commit details', async () => {
 		const history = createHistory();
-		const onOpenComparison = vi.fn();
-		comparisonSelection.begin();
-		comparisonSelection.select('older');
-		comparisonSelection.select('newer');
 		render(GitHistoryView, {
 			props: {
 				history,
 				comparisonSelection,
-				onOpenComparison,
+				onOpenSelectedComparison: vi.fn(),
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -620,31 +658,21 @@ describe('GitHistoryView', () => {
 		});
 
 		await screen.findByText('List commit');
-		await fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
-		expect(onOpenComparison).toHaveBeenLastCalledWith({
-			fromRevision: 'older',
-			toKind: 'revision',
-			toRevision: 'newer',
-		});
+		expect(screen.queryByRole('button', { name: 'Compare revisions' })).toBeNull();
+		expect(screen.getByRole('button', { name: 'Select commits' })).toBeTruthy();
 
 		await fireEvent.click(screen.getByRole('button', { name: /List commit/ }));
 		await screen.findByText('Commit detail');
-		await fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
-		expect(onOpenComparison).toHaveBeenLastCalledWith({
-			fromRevision: 'parent',
-			toKind: 'revision',
-			toRevision: 'abcdef1234567890',
-		});
+		expect(screen.queryByRole('button', { name: 'Compare' })).toBeNull();
 	});
 
-	it('opens editable revision endpoints or explicit commit selection from History', async () => {
-		const history = createHistory();
-		const onOpenComparison = vi.fn();
+	it('collects explicit commit endpoints before enabling the local comparison', async () => {
+		const onOpenSelectedComparison = vi.fn();
 		render(GitHistoryView, {
 			props: {
-				history,
+				history: createHistory(),
 				comparisonSelection,
-				onOpenComparison,
+				onOpenSelectedComparison,
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -656,36 +684,44 @@ describe('GitHistoryView', () => {
 		});
 
 		await screen.findByText('List commit');
-		await fireEvent.click(screen.getByRole('button', { name: 'Compare revisions' }));
-		expect(onOpenComparison).toHaveBeenCalledWith({
-			fromRevision: 'parent',
-			toKind: 'revision',
-			toRevision: 'abcdef1234567890',
-		});
-
 		await fireEvent.click(screen.getByRole('button', { name: 'Select commits' }));
 		expect(comparisonSelection.active).toBe(true);
+		expect((screen.getByRole('button', { name: 'Compare' }) as HTMLButtonElement).disabled).toBe(
+			true,
+		);
 		const commitButton = screen.getByRole('button', { name: 'Select List commit as From' });
 		expect(commitButton.getAttribute('aria-pressed')).toBe('false');
 		await fireEvent.click(commitButton);
 		expect(
 			screen.getByRole('button', { name: 'Select List commit as To', pressed: true }),
 		).toBeTruthy();
+		await fireEvent.click(
+			screen.getByRole('button', { name: 'Select List commit as To', pressed: true }),
+		);
+		await fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+		expect(onOpenSelectedComparison).toHaveBeenCalledOnce();
 	});
 
-	it('defaults an empty History comparison to the empty tree', async () => {
-		vi.mocked(getGitHistoryCommits).mockResolvedValue({
-			project: '/project',
-			ref: 'HEAD',
-			commits: [],
-			nextOffset: null,
+	it('renders selected revisions inside History and returns to the preserved selection', async () => {
+		const history = createHistory();
+		history.listScrollTop = 240;
+		comparisonSelection.begin();
+		comparisonSelection.select('older');
+		comparisonSelection.select('newer');
+		const onOpenSelectedComparison = vi.fn(() => {
+			const comparison = comparisonSelection.comparison();
+			if (comparison) {
+				history.openComparison('/project', comparison, {
+					diffMode: 'unified',
+					contextLines: 5,
+				});
+			}
 		});
-		const onOpenComparison = vi.fn();
 		render(GitHistoryView, {
 			props: {
-				history: createHistory(),
+				history,
 				comparisonSelection,
-				onOpenComparison,
+				onOpenSelectedComparison,
 				onOpenChat: vi.fn(),
 				projectPath: '/project',
 				isMobile: false,
@@ -696,13 +732,28 @@ describe('GitHistoryView', () => {
 			},
 		});
 
-		await screen.findByText('No commits found');
-		await fireEvent.click(screen.getByRole('button', { name: 'Compare revisions' }));
+		await screen.findByText('List commit');
+		await fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
 
-		expect(onOpenComparison).toHaveBeenCalledWith({
-			fromRevision: GIT_EMPTY_TREE_REVISION,
-			toKind: 'revision',
-			toRevision: 'HEAD',
+		expect(onOpenSelectedComparison).toHaveBeenCalledOnce();
+		expect(await screen.findByText('Compare revisions')).toBeTruthy();
+		expect(getGitComparisonSnapshot).toHaveBeenCalledWith(
+			'/project',
+			{ kind: 'revision', revision: 'older' },
+			{ kind: 'revision', revision: 'newer' },
+			'direct',
+			expect.objectContaining({ context: 5 }),
+		);
+		expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Back to commit selection' }));
+
+		expect(await screen.findByText('List commit')).toBeTruthy();
+		expect(history.listScrollTop).toBe(240);
+		expect(comparisonSelection).toMatchObject({
+			active: true,
+			from: 'older',
+			to: 'newer',
 		});
 	});
 });

--- a/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
+++ b/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
@@ -200,7 +200,10 @@ describe('GitHistoryView', () => {
 		});
 
 		await screen.findByText('List commit');
-		await fireEvent.click(screen.getByRole('button', { name: /List commit/ }));
+		const commitRow = screen.getByRole('button', { name: 'Open commit List commit' });
+		expect(commitRow.hasAttribute('data-git-history-commit-row')).toBe(true);
+		expect(commitRow.parentElement?.classList.contains('select-none')).toBe(true);
+		await fireEvent.click(commitRow);
 
 		await screen.findByText('Commit detail');
 		await waitFor(() => {
@@ -252,6 +255,7 @@ describe('GitHistoryView', () => {
 
 		const panes = container.querySelector<HTMLElement>('[data-git-diff-document-panes]');
 		const filesPane = container.querySelector<HTMLElement>('[data-git-history-files-pane]');
+		const fileTreeToggle = screen.getByRole('button', { name: 'Hide file tree' });
 		const resizer = screen.getByRole('slider', { name: 'Resize file tree, 300 pixels' });
 		expect(panes?.style.gridTemplateColumns).toContain('300px 6px');
 
@@ -259,7 +263,7 @@ describe('GitHistoryView', () => {
 		expect(panes?.style.gridTemplateColumns).toContain('316px 6px');
 		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.gitTreePaneWidthPx)).toBe('316');
 
-		await fireEvent.click(screen.getByRole('button', { name: 'Hide file tree' }));
+		await fireEvent.click(fileTreeToggle);
 		expect(filesPane?.getAttribute('aria-hidden')).toBe('true');
 		expect(filesPane?.hasAttribute('inert')).toBe(true);
 		expect(panes?.style.gridTemplateColumns).toBe('0px minmax(0,1fr)');

--- a/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
+++ b/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
@@ -255,8 +255,10 @@ describe('GitHistoryView', () => {
 
 		const panes = container.querySelector<HTMLElement>('[data-git-diff-document-panes]');
 		const filesPane = container.querySelector<HTMLElement>('[data-git-history-files-pane]');
+		const primaryHeader = container.querySelector('[data-git-commit-details-primary]');
 		const fileTreeToggle = screen.getByRole('button', { name: 'Hide file tree' });
 		const resizer = screen.getByRole('slider', { name: 'Resize file tree, 300 pixels' });
+		expect(primaryHeader?.contains(fileTreeToggle)).toBe(true);
 		expect(panes?.style.gridTemplateColumns).toContain('300px 6px');
 
 		await fireEvent.keyDown(resizer, { key: 'ArrowRight' });

--- a/web/src/lib/components/git/__tests__/GitWorkbench.test.ts
+++ b/web/src/lib/components/git/__tests__/GitWorkbench.test.ts
@@ -8,6 +8,7 @@ import {
 	installResizeObserverHarness,
 	ResizeObserverHarness,
 } from '$lib/components/shared/__tests__/resize-observer-harness';
+import { LOCAL_STORAGE_KEYS } from '$lib/utils/local-persistence';
 
 function makeTarget(): GitWorkbenchTarget {
 	return {
@@ -136,10 +137,12 @@ describe('GitWorkbench', () => {
 
 	beforeEach(() => {
 		restoreResizeObserver = installResizeObserverHarness();
+		localStorage.removeItem(LOCAL_STORAGE_KEYS.gitDiffDocumentFileTreeVisible);
 	});
 
 	afterEach(() => {
 		restoreResizeObserver();
+		localStorage.removeItem(LOCAL_STORAGE_KEYS.gitDiffDocumentFileTreeVisible);
 	});
 
 	it('shows an initial loading state before the store adopts the rendered target', () => {
@@ -203,5 +206,42 @@ describe('GitWorkbench', () => {
 		expect(filesPane?.getAttribute('aria-hidden')).toBe('false');
 		expect(diffPane?.getAttribute('aria-hidden')).toBe('true');
 		expect(container.querySelector('[data-git-virtual-diff-root]')).toBe(diffSurface);
+	});
+
+	it('hides and restores the file tree in the wide layout', async () => {
+		const target = makeTarget();
+		const { container } = render(GitWorkbenchTestHost, {
+			props: {
+				target,
+				isMobile: false,
+				wb: makeWorkbenchStub(target),
+				diffFontSize: 12,
+			},
+		});
+		const workbench = container.querySelector<HTMLElement>('[data-git-workbench]');
+		expect(workbench).toBeTruthy();
+		if (!workbench) return;
+
+		ResizeObserverHarness.emit(workbench, 1_100);
+		await waitFor(() => expect(workbench.dataset.gitLayout).toBe('wide'));
+
+		const panes = container.querySelector<HTMLElement>('[data-git-wide-layout]');
+		const filesPane = container.querySelector<HTMLElement>('[data-git-files-pane]');
+		expect(panes?.style.gridTemplateColumns).toContain('300px 6px');
+		expect(container.querySelector('[data-git-tree-resizer]')).toBeTruthy();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Hide file tree' }));
+
+		expect(filesPane?.getAttribute('aria-hidden')).toBe('true');
+		expect(filesPane?.hasAttribute('inert')).toBe(true);
+		expect(panes?.style.gridTemplateColumns).toBe('0px minmax(0,1fr)');
+		expect(container.querySelector('[data-git-tree-resizer]')).toBeNull();
+		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.gitDiffDocumentFileTreeVisible)).toBe('false');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Show file tree' }));
+
+		expect(filesPane?.getAttribute('aria-hidden')).toBe('false');
+		expect(panes?.style.gridTemplateColumns).toContain('300px 6px');
+		expect(container.querySelector('[data-git-tree-resizer]')).toBeTruthy();
 	});
 });

--- a/web/src/lib/git/commit/__tests__/commit-controller.test.ts
+++ b/web/src/lib/git/commit/__tests__/commit-controller.test.ts
@@ -627,27 +627,35 @@ describe('CommitController', () => {
 		expect(controller.retainedDraftCount).toBe(2);
 	});
 
-	it('does not publish a generated message after a programmatic same-chat target change', async () => {
+	it('does not publish a generated message after invalidation retargets the same chat', async () => {
 		const generation = deferred<{ message: string }>();
 		mockedApi.generateCommitMessage.mockReturnValueOnce(generation.promise);
+		const project = targetCandidate('/project');
+		const worktree = targetCandidate('/repo/worktree', {
+			branch: 'feature',
+			isCurrent: false,
+		});
+		mockedApi.getGitTargetCandidates.mockResolvedValue({
+			targets: [project, worktree],
+		});
 		const controller = makeController();
 		await controller.setContext('chat', '/project');
 		await controller.setPresentationVisible(true);
+		await controller.target.selectTarget(worktree);
+		await vi.waitFor(() => expect(controller.target.isLoadingTargets).toBe(false));
 
 		const pending = controller.generateMessage();
 		await vi.waitFor(() =>
-			expect(mockedApi.generateCommitMessage).toHaveBeenCalledWith('/project', ['staged.ts']),
+			expect(mockedApi.generateCommitMessage).toHaveBeenCalledWith('/repo/worktree', ['staged.ts']),
 		);
-		await controller.target.selectTarget(
-			targetCandidate('/repo/worktree', {
-				branch: 'feature',
-				isCurrent: false,
-			}),
-		);
+		mockedApi.getGitTargetCandidates.mockResolvedValueOnce({
+			targets: [project],
+		});
+		await controller.target.refreshForInvalidation('chat', 1);
 		generation.resolve({ message: 'Stale project message' });
 		await pending;
 
-		expect(controller.projectPath).toBe('/repo/worktree');
+		expect(controller.projectPath).toBe('/project');
 		expect(controller.message).toBe('');
 	});
 });

--- a/web/src/lib/git/commit/__tests__/commit-controller.test.ts
+++ b/web/src/lib/git/commit/__tests__/commit-controller.test.ts
@@ -638,14 +638,12 @@ describe('CommitController', () => {
 		await vi.waitFor(() =>
 			expect(mockedApi.generateCommitMessage).toHaveBeenCalledWith('/project', ['staged.ts']),
 		);
-		await controller.target.applyExternalTarget('chat', {
-			projectPath: '/repo/worktree',
-			repoRoot: '/repo',
-			worktreePath: '/repo/worktree',
-			label: 'worktree',
-			branch: 'feature',
-			source: 'worktree',
-		});
+		await controller.target.selectTarget(
+			targetCandidate('/repo/worktree', {
+				branch: 'feature',
+				isCurrent: false,
+			}),
+		);
 		generation.resolve({ message: 'Stale project message' });
 		await pending;
 

--- a/web/src/lib/git/history/__tests__/git-history-comparison-selection.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history-comparison-selection.test.ts
@@ -2,20 +2,20 @@ import { describe, expect, it } from 'vitest';
 import { GitHistoryComparisonSelectionState } from '$lib/git/history/git-history-comparison-selection.svelte.js';
 
 describe('GitHistoryComparisonSelectionState', () => {
-	it('collects a from/to pair and clears it after consumption', () => {
+	it('collects a from/to pair without discarding the editable selection', () => {
 		const selection = new GitHistoryComparisonSelectionState();
 		selection.begin();
 		selection.select('older');
 		selection.select('newer');
 
-		expect(selection.take()).toEqual({
+		expect(selection.comparison()).toEqual({
 			fromRevision: 'older',
 			toKind: 'revision',
 			toRevision: 'newer',
 		});
-		expect(selection.active).toBe(false);
-		expect(selection.from).toBeNull();
-		expect(selection.to).toBeNull();
+		expect(selection.active).toBe(true);
+		expect(selection.from).toBe('older');
+		expect(selection.to).toBe('newer');
 	});
 
 	it('supports slot replacement and rejects incomplete selections', () => {
@@ -25,10 +25,10 @@ describe('GitHistoryComparisonSelectionState', () => {
 		selection.setSlot('from');
 		selection.select('older');
 
-		expect(selection.take()).toBeNull();
+		expect(selection.comparison()).toBeNull();
 		expect(selection.active).toBe(true);
 		selection.select('new');
-		expect(selection.take()?.fromRevision).toBe('older');
+		expect(selection.comparison()?.fromRevision).toBe('older');
 	});
 
 	it('cancel clears all range state', () => {

--- a/web/src/lib/git/history/__tests__/git-history-surface.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history-surface.test.ts
@@ -73,6 +73,66 @@ describe('GitHistorySurfaceController', () => {
 		);
 	});
 
+	it('opens a complete commit selection inside History with shared review settings', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.reviewDisplay.setDiffMode('split');
+		deps.reviewDisplay.setContextLines(9);
+		const controller = new GitHistorySurfaceController(deps);
+		const openComparison = vi
+			.spyOn(controller.history, 'openComparison')
+			.mockImplementation(() => undefined);
+		setProject(controller);
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		controller.comparisonSelection.begin();
+		controller.comparisonSelection.select('older');
+		controller.comparisonSelection.select('newer');
+
+		expect(controller.openSelectedComparison()).toBe(true);
+		expect(openComparison).toHaveBeenCalledWith(
+			'/project',
+			{
+				fromRevision: 'older',
+				toKind: 'revision',
+				toRevision: 'newer',
+			},
+			{ diffMode: 'split', contextLines: 9 },
+		);
+		expect(controller.comparisonSelection).toMatchObject({
+			active: true,
+			from: 'older',
+			to: 'newer',
+		});
+	});
+
+	it('rejects incomplete local comparison selections', async () => {
+		const controller = new GitHistorySurfaceController(createGitSurfaceTestDeps());
+		const openComparison = vi.spyOn(controller.history, 'openComparison');
+		setProject(controller);
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		controller.comparisonSelection.begin();
+		controller.comparisonSelection.select('older');
+
+		expect(controller.openSelectedComparison()).toBe(false);
+		expect(openComparison).not.toHaveBeenCalled();
+	});
+
+	it('uses the active local comparison document for context-change guards', () => {
+		const deps = createGitSurfaceTestDeps();
+		const controller = new GitHistorySurfaceController(deps);
+		controller.setPresentationVisible(true);
+		controller.history.screen = 'comparison';
+		controller.history.comparison.document.openCommentComposer('src/a.ts', 'after', 12);
+		controller.history.comparison.document.setCommentBody('Keep this comment');
+
+		expect(deps.reviewDisplay.setContextLines(12)).toBe(false);
+		expect(controller.history.comparison.document.commentComposer.body).toBe('Keep this comment');
+		expect(controller.history.comparison.document.commentError).toBe(
+			'Add or close this comment before changing context lines.',
+		);
+	});
+
 	it('reloads once for an invalidation and does not consume it twice', async () => {
 		const controller = new GitHistorySurfaceController(createGitSurfaceTestDeps());
 		setProject(controller);
@@ -123,21 +183,14 @@ describe('GitHistorySurfaceController', () => {
 		await controller.target.activate();
 		await vi.waitFor(() => expect(api.getGitHistoryCommits).toHaveBeenCalledOnce());
 
-		await expect(
-			controller.target.switchBranch('feature', 'local-branch'),
-		).resolves.toBe(true);
+		await expect(controller.target.switchBranch('feature', 'local-branch')).resolves.toBe(true);
 		await vi.waitFor(() => expect(api.getGitHistoryCommits).toHaveBeenCalledTimes(2));
 
 		expect(api.getGitHistoryCommits).toHaveBeenCalledTimes(2);
 	});
 
 	it('pauses an initial list request while hidden and resumes it once', async () => {
-		let resolve!: (value: {
-			project: string;
-			ref: string;
-			commits: [];
-			nextOffset: null;
-		}) => void;
+		let resolve!: (value: { project: string; ref: string; commits: []; nextOffset: null }) => void;
 		const pending = new Promise<{
 			project: string;
 			ref: string;
@@ -219,5 +272,27 @@ describe('GitHistorySurfaceController', () => {
 		controller.dispose();
 		expect(controller.comparisonSelection.active).toBe(false);
 		expect(controller.pendingRevertCommit).toBeNull();
+	});
+
+	it('clears a local comparison and its selection when the target changes', async () => {
+		const controller = new GitHistorySurfaceController(createGitSurfaceTestDeps());
+		setProject(controller);
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		controller.comparisonSelection.begin();
+		controller.comparisonSelection.select('older');
+		controller.comparisonSelection.select('newer');
+		controller.history.screen = 'comparison';
+
+		await controller.target.selectTarget(
+			candidate('/other', {
+				worktreePath: '/other',
+				label: 'other',
+				isCurrent: false,
+			}),
+		);
+
+		expect(controller.history.screen).toBe('list');
+		expect(controller.comparisonSelection.active).toBe(false);
 	});
 });

--- a/web/src/lib/git/history/__tests__/git-history-surface.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history-surface.test.ts
@@ -123,9 +123,43 @@ describe('GitHistorySurfaceController', () => {
 		const controller = new GitHistorySurfaceController(deps);
 		controller.setPresentationVisible(true);
 		controller.history.screen = 'comparison';
+		controller.history.comparison.document.open(
+			{
+				project: '/project',
+				documentId: 'comparison',
+				files: [],
+				limits: {
+					maxSummaryFiles: 100,
+					maxBodyBatchFiles: 24,
+					maxLoadedRows: 10_000,
+					maxLoadedPatchBytes: 1_000_000,
+					maxFileRows: 5_000,
+					maxFilePatchBytes: 500_000,
+					maxLineBytes: 20_000,
+					maxContextLines: 50,
+					bodyConcurrency: 4,
+				},
+				firstBodyCandidates: [],
+			},
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies: vi.fn(),
+				onError: vi.fn(),
+				commentSource: {
+					kind: 'comparison',
+					fromLabel: 'older',
+					fromIdentity: 'abc1234',
+					toLabel: 'newer',
+					toIdentity: 'def5678',
+					mode: 'direct',
+				},
+			},
+		);
 		controller.history.comparison.document.openCommentComposer('src/a.ts', 'after', 12);
 		controller.history.comparison.document.setCommentBody('Keep this comment');
 
+		expect(controller.history.comparison.document.commentComposer.open).toBe(true);
 		expect(deps.reviewDisplay.setContextLines(12)).toBe(false);
 		expect(controller.history.comparison.document.commentComposer.body).toBe('Keep this comment');
 		expect(controller.history.comparison.document.commentError).toBe(

--- a/web/src/lib/git/history/__tests__/git-history.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history.test.ts
@@ -404,6 +404,28 @@ describe('GitHistoryController', () => {
 		expect(history.activeDocument).toBe(history.document);
 	});
 
+	it('reports loading only for the active History screen', () => {
+		const history = new GitHistoryController();
+
+		history.screen = 'list';
+		history.listLoading = true;
+		history.commitLoading = false;
+		history.comparison.isLoading = false;
+		expect(history.activeScreenLoading).toBe(true);
+
+		history.screen = 'commit';
+		history.listLoading = true;
+		expect(history.activeScreenLoading).toBe(false);
+		history.commitLoading = true;
+		expect(history.activeScreenLoading).toBe(true);
+
+		history.screen = 'comparison';
+		history.commitLoading = true;
+		expect(history.activeScreenLoading).toBe(false);
+		history.comparison.isLoading = true;
+		expect(history.activeScreenLoading).toBe(true);
+	});
+
 	it('aborts a local comparison when returning to the commit list', async () => {
 		const pending = deferred<GitComparisonSnapshotReady>();
 		vi.mocked(getGitComparisonSnapshot).mockReturnValueOnce(pending.promise);

--- a/web/src/lib/git/history/__tests__/git-history.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history.test.ts
@@ -5,6 +5,11 @@ import {
 	getGitHistoryCommits,
 	type GitCommitFileSummary,
 } from '$lib/api/git.js';
+import {
+	getGitComparisonFileBodies,
+	getGitComparisonSnapshot,
+	type GitComparisonSnapshotReady,
+} from '$lib/api/git-comparison.js';
 import { GitHistoryController } from '$lib/git/history/git-history.svelte.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
 
@@ -13,6 +18,16 @@ vi.mock('$lib/api/git.js', () => ({
 	getGitCommitSnapshot: vi.fn(),
 	getGitCommitFileBodies: vi.fn(),
 }));
+
+vi.mock('$lib/api/git-comparison.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/api/git-comparison.js')>();
+	return {
+		...actual,
+		getGitComparisonFreshness: vi.fn(),
+		getGitComparisonSnapshot: vi.fn(),
+		getGitComparisonFileBodies: vi.fn(),
+	};
+});
 
 function deferred<T>() {
 	let resolve!: (value: T) => void;
@@ -129,10 +144,54 @@ function body(fingerprint = 'fp-a') {
 	return bodiesForPaths(['a.ts'], () => fingerprint);
 }
 
+function comparisonSnapshot(): GitComparisonSnapshotReady {
+	return {
+		status: 'ready',
+		project: '/project',
+		repoRoot: '/repo',
+		documentId: 'comparison-doc',
+		mode: 'direct',
+		from: {
+			kind: 'revision',
+			requestedRevision: 'older',
+			label: 'older',
+			hash: 'a'.repeat(40),
+			shortHash: 'aaaaaaa',
+		},
+		to: {
+			kind: 'revision',
+			requestedRevision: 'newer',
+			label: 'newer',
+			hash: 'b'.repeat(40),
+			shortHash: 'bbbbbbb',
+		},
+		effectiveFromHash: 'a'.repeat(40),
+		files: [],
+		limits: {
+			maxSummaryFiles: 1000,
+			maxBodyBatchFiles: 24,
+			maxLoadedRows: 10_000,
+			maxLoadedPatchBytes: 1024 * 1024,
+			maxFileRows: 10_000,
+			maxFilePatchBytes: 1024 * 1024,
+			maxLineBytes: 20_000,
+			maxContextLines: 50,
+			bodyConcurrency: 4,
+		},
+		firstBodyCandidates: [],
+	};
+}
+
 describe('GitHistoryController', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.mocked(getGitCommitFileBodies).mockResolvedValue(body());
+		vi.mocked(getGitComparisonFileBodies).mockResolvedValue({
+			status: 'ready',
+			documentId: 'comparison-doc',
+			files: {},
+			errors: {},
+		});
 	});
 
 	it('loads the initial commit list', async () => {
@@ -307,6 +366,67 @@ describe('GitHistoryController', () => {
 		pendingBody.resolve(body());
 		await flushPromises();
 		expect(history.fileBodies).toEqual({});
+	});
+
+	it('opens a selected revision comparison locally and preserves list state on back', async () => {
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(comparisonSnapshot());
+		const history = new GitHistoryController();
+		history.resetForProject('/project');
+		history.listScrollTop = 320;
+
+		history.openComparison(
+			'/project',
+			{
+				fromRevision: 'older',
+				toKind: 'revision',
+				toRevision: 'newer',
+			},
+			{ diffMode: 'split', contextLines: 8 },
+		);
+
+		expect(history.screen).toBe('comparison');
+		await vi.waitFor(() => expect(history.comparison.snapshot).not.toBeNull());
+		expect(getGitComparisonSnapshot).toHaveBeenCalledWith(
+			'/project',
+			{ kind: 'revision', revision: 'older' },
+			{ kind: 'revision', revision: 'newer' },
+			'direct',
+			expect.objectContaining({ context: 8 }),
+		);
+		expect(history.activeDocument).toBe(history.comparison.document);
+		expect(history.comparison.document.diffMode).toBe('split');
+
+		history.backToList();
+
+		expect(history.screen).toBe('list');
+		expect(history.listScrollTop).toBe(320);
+		expect(history.comparison.snapshot).toBeNull();
+		expect(history.activeDocument).toBe(history.document);
+	});
+
+	it('aborts a local comparison when returning to the commit list', async () => {
+		const pending = deferred<GitComparisonSnapshotReady>();
+		vi.mocked(getGitComparisonSnapshot).mockReturnValueOnce(pending.promise);
+		const history = new GitHistoryController();
+		history.resetForProject('/project');
+		history.openComparison(
+			'/project',
+			{
+				fromRevision: 'older',
+				toKind: 'revision',
+				toRevision: 'newer',
+			},
+			{ diffMode: 'unified', contextLines: 5 },
+		);
+		const signal = vi.mocked(getGitComparisonSnapshot).mock.calls[0]?.[4]?.signal;
+
+		history.backToList();
+		pending.resolve(comparisonSnapshot());
+		await flushPromises();
+
+		expect(signal?.aborted).toBe(true);
+		expect(history.screen).toBe('list');
+		expect(history.comparison.snapshot).toBeNull();
 	});
 
 	it('ignores stale commit snapshots after selecting another commit', async () => {

--- a/web/src/lib/git/history/git-history-comparison-selection.svelte.ts
+++ b/web/src/lib/git/history/git-history-comparison-selection.svelte.ts
@@ -36,14 +36,12 @@ export class GitHistoryComparisonSelectionState {
 		if (this.active) this.slot = slot;
 	}
 
-	take(): GitComparisonDialogDefaults | null {
+	comparison(): GitComparisonDialogDefaults | null {
 		if (!this.from || !this.to) return null;
-		const comparison: GitComparisonDialogDefaults = {
+		return {
 			fromRevision: this.from,
 			toKind: 'revision',
 			toRevision: this.to,
 		};
-		this.cancel();
-		return comparison;
 	}
 }

--- a/web/src/lib/git/history/git-history-surface.svelte.ts
+++ b/web/src/lib/git/history/git-history-surface.svelte.ts
@@ -51,9 +51,9 @@ export class GitHistorySurfaceController implements PortableSingletonController 
 			singletonSurfaceId('git-history'),
 			{
 				isVisible: () => this.presentationVisible,
-				hasOpenCommentComposer: () => this.history.document.commentComposer.open,
+				hasOpenCommentComposer: () => this.history.activeDocument.commentComposer.open,
 				markContextChangeBlocked: () =>
-					this.history.document.markContextChangeBlocked(),
+					this.history.activeDocument.markContextChangeBlocked(),
 				apply: (diffMode, contextLines) =>
 					this.history.setDisplayOptions(
 						this.target.activeProjectPath,
@@ -62,6 +62,17 @@ export class GitHistorySurfaceController implements PortableSingletonController 
 					),
 			},
 		);
+	}
+
+	openSelectedComparison(): boolean {
+		const projectPath = this.target.activeProjectPath;
+		const comparison = this.comparisonSelection.comparison();
+		if (!projectPath || !comparison) return false;
+		this.history.openComparison(projectPath, comparison, {
+			diffMode: this.deps.reviewDisplay.diffMode,
+			contextLines: this.deps.reviewDisplay.contextLines,
+		});
+		return true;
 	}
 
 	setProjectState(projectState: WorkspaceProjectState): void {

--- a/web/src/lib/git/history/git-history.svelte.ts
+++ b/web/src/lib/git/history/git-history.svelte.ts
@@ -9,11 +9,16 @@ import {
 } from '$lib/api/git.js';
 import { GitDiffDocumentController } from '$lib/git/review/git-diff-document.svelte.js';
 import type { GitReviewBodyDemand } from '$lib/git/review/git-review-body-demand.js';
+import {
+	GitComparisonController,
+	type GitComparisonDialogDefaults,
+	type GitComparisonDisplayOptions,
+} from '$lib/git/review/git-comparison.svelte.js';
 import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
 import * as m from '$lib/paraglide/messages.js';
 import { isAbortError } from '$lib/utils/is-abort-error.js';
 
-export type GitHistoryScreen = 'list' | 'commit';
+export type GitHistoryScreen = 'list' | 'commit' | 'comparison';
 
 export interface GitHistoryRevertTarget {
 	hash: string;
@@ -35,6 +40,7 @@ const BODY_CANDIDATE_COUNT = 8;
 
 export class GitHistoryController {
 	readonly document = new GitDiffDocumentController();
+	readonly comparison = new GitComparisonController();
 	screen = $state<GitHistoryScreen>('list');
 	commits = $state<GitHistoryCommitListItem[]>([]);
 	nextOffset = $state<number | null>(0);
@@ -57,6 +63,10 @@ export class GitHistoryController {
 
 	get visibleFiles(): GitCommitFileSummary[] {
 		return this.document.visibleFiles;
+	}
+
+	get activeDocument(): GitDiffDocumentController {
+		return this.screen === 'comparison' ? this.comparison.document : this.document;
 	}
 
 	get rowSource() {
@@ -91,12 +101,17 @@ export class GitHistoryController {
 		const normalizedContext = Number.isFinite(contextLines)
 			? Math.max(0, Math.round(contextLines))
 			: DEFAULT_CONTEXT_LINES;
-		const contextChanged = this.document.contextLines !== normalizedContext;
-		if (contextChanged && this.document.commentComposer.open) {
-			this.document.markContextChangeBlocked();
+		const activeDocument = this.activeDocument;
+		const contextChanged = activeDocument.contextLines !== normalizedContext;
+		if (contextChanged && activeDocument.commentComposer.open) {
+			activeDocument.markContextChangeBlocked();
 			return;
 		}
 		this.document.setDisplayOptions(diffMode, normalizedContext);
+		if (projectPath && this.screen === 'comparison') {
+			this.comparison.setDisplayOptions(projectPath, diffMode, normalizedContext);
+			return;
+		}
 		if (contextChanged && projectPath && this.screen === 'commit' && this.selectedCommitHash) {
 			this.loadCommitSnapshot(projectPath, this.selectedCommitHash, this.selectedParentHash);
 		}
@@ -203,16 +218,34 @@ export class GitHistoryController {
 	}
 
 	openCommit(projectPath: string, commitHash: string): void {
+		this.comparison.reset();
 		this.screen = 'commit';
 		this.selectedCommitHash = commitHash;
 		this.selectedParentHash = null;
 		this.loadCommitSnapshot(projectPath, commitHash, null);
 	}
 
+	openComparison(
+		projectPath: string,
+		defaults: GitComparisonDialogDefaults,
+		displayOptions: GitComparisonDisplayOptions,
+	): void {
+		this.commitAbort?.abort();
+		this.commitAbort = null;
+		this.commitGeneration += 1;
+		this.document.clear({ preserveCache: true });
+		this.commitLoading = false;
+		this.screen = 'comparison';
+		this.comparison.setSpecification(defaults, displayOptions);
+		void this.comparison.compare(projectPath);
+	}
+
 	backToList(): void {
 		this.screen = 'list';
 		this.commitAbort?.abort();
+		this.commitAbort = null;
 		this.document.clear({ preserveCache: true });
+		this.comparison.reset();
 		this.commitLoading = false;
 		this.documentRecoveryAttempted = false;
 	}
@@ -250,6 +283,7 @@ export class GitHistoryController {
 		this.listAbort = null;
 		this.commitAbort = null;
 		this.document.clear();
+		this.comparison.reset();
 		this.listGeneration += 1;
 		this.commitGeneration += 1;
 		this.loadedProjectPath = projectPath;

--- a/web/src/lib/git/history/git-history.svelte.ts
+++ b/web/src/lib/git/history/git-history.svelte.ts
@@ -69,6 +69,12 @@ export class GitHistoryController {
 		return this.screen === 'comparison' ? this.comparison.document : this.document;
 	}
 
+	get activeScreenLoading(): boolean {
+		if (this.screen === 'comparison') return this.comparison.isLoading;
+		if (this.screen === 'commit') return this.commitLoading;
+		return this.listLoading;
+	}
+
 	get rowSource() {
 		return this.document.rowSource;
 	}

--- a/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
+++ b/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
@@ -114,65 +114,6 @@ describe('GitCompareSurfaceController', () => {
 		expect(controller.comparison.toRevision).toBe('feature');
 	});
 
-	it('applies a History launch target and endpoints without an intermediate default request', async () => {
-		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
-		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
-		setProject(controller);
-		controller.prepareLaunch({
-			source: {
-				effectiveProjectKey: 'chat',
-				target: {
-					projectPath: '/repo/worktree',
-					repoRoot: '/repo',
-					worktreePath: '/repo/worktree',
-					label: 'worktree',
-					branch: 'feature',
-					source: 'worktree',
-				},
-			},
-			comparison: {
-				fromRevision: 'parent',
-				toKind: 'revision',
-				toRevision: 'commit',
-			},
-		});
-
-		controller.setPresentationVisible(true);
-		await controller.target.activate();
-		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
-
-		expect(compare).toHaveBeenCalledWith('/repo/worktree');
-		expect(controller.comparison.fromRevision).toBe('parent');
-		expect(controller.comparison.toRevision).toBe('commit');
-	});
-
-	it('keeps the latest explicit launch during rapid requests', async () => {
-		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
-		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
-		setProject(controller);
-		controller.prepareLaunch({
-			comparison: {
-				fromRevision: 'old',
-				toKind: 'revision',
-				toRevision: 'older',
-			},
-		});
-		controller.prepareLaunch({
-			comparison: {
-				fromRevision: 'new',
-				toKind: 'revision',
-				toRevision: 'newer',
-			},
-		});
-
-		controller.setPresentationVisible(true);
-		await controller.target.activate();
-		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
-
-		expect(controller.comparison.fromRevision).toBe('new');
-		expect(controller.comparison.toRevision).toBe('newer');
-	});
-
 	it('checks freshness once for a same-target invalidation and preserves the specification', async () => {
 		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
 		vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);

--- a/web/src/lib/git/review/__tests__/git-comparison.test.ts
+++ b/web/src/lib/git/review/__tests__/git-comparison.test.ts
@@ -5,11 +5,7 @@ import {
 	getGitComparisonSnapshot,
 	type GitComparisonSnapshotReady,
 } from '$lib/api/git-comparison.js';
-import {
-	GIT_EMPTY_TREE_REVISION,
-	GitComparisonController,
-	recentCommitComparisonDefaults,
-} from '../git-comparison.svelte.js';
+import { GitComparisonController } from '../git-comparison.svelte.js';
 
 vi.mock('$lib/api/git-comparison.js', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api/git-comparison.js')>();
@@ -408,6 +404,35 @@ describe('GitComparisonController', () => {
 		expect(vi.mocked(getGitComparisonSnapshot).mock.calls[0]?.[4]).toMatchObject({ context: 12 });
 	});
 
+	it('restarts an in-flight snapshot when the context setting changes', async () => {
+		const first = deferred<GitComparisonSnapshotReady>();
+		const second = {
+			...workingTreeSnapshot(),
+			documentId: 'comparison-doc-new-context',
+		};
+		vi.mocked(getGitComparisonSnapshot)
+			.mockReturnValueOnce(first.promise)
+			.mockResolvedValueOnce(second);
+		const comparison = new GitComparisonController();
+		comparison.openDialog({ fromRevision: 'main', toKind: 'working-tree' });
+		const firstRequest = comparison.compare('/project');
+		const firstSignal = vi.mocked(getGitComparisonSnapshot).mock.calls[0]?.[4]?.signal;
+
+		comparison.setDisplayOptions('/project', 'unified', 12);
+
+		await vi.waitFor(() => expect(getGitComparisonSnapshot).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() =>
+			expect(comparison.snapshot?.documentId).toBe('comparison-doc-new-context'),
+		);
+		expect(firstSignal?.aborted).toBe(true);
+		expect(vi.mocked(getGitComparisonSnapshot).mock.calls[1]?.[4]).toMatchObject({
+			context: 12,
+		});
+		first.resolve(workingTreeSnapshot());
+		expect(await firstRequest).toBe(false);
+		expect(comparison.snapshot?.documentId).toBe('comparison-doc-new-context');
+	});
+
 	it('refreshes an expired comparison document once without retrying indefinitely', async () => {
 		const first = {
 			...workingTreeSnapshotWithFile(),
@@ -417,9 +442,7 @@ describe('GitComparisonController', () => {
 			...first,
 			documentId: 'comparison-doc-recovered',
 		};
-		vi.mocked(getGitComparisonSnapshot)
-			.mockResolvedValueOnce(first)
-			.mockResolvedValueOnce(second);
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValueOnce(first).mockResolvedValueOnce(second);
 		vi.mocked(getGitComparisonFileBodies).mockResolvedValue({
 			status: 'document-expired',
 			documentId: 'expired-doc',
@@ -534,24 +557,5 @@ describe('GitComparisonController', () => {
 
 		expect(comparison.document.isStale).toBe(true);
 		expect(comparison.staleMessage).toContain('Working Tree changed');
-	});
-});
-
-describe('recentCommitComparisonDefaults', () => {
-	it('compares adjacent commits when both are available', () => {
-		expect(
-			recentCommitComparisonDefaults([
-				{ hash: 'new', parents: ['parent'] },
-				{ hash: 'old', parents: ['older'] },
-			]),
-		).toEqual({ fromRevision: 'old', toKind: 'revision', toRevision: 'new' });
-	});
-
-	it('compares a root commit to the empty tree', () => {
-		expect(recentCommitComparisonDefaults([{ hash: 'root', parents: [] }])).toEqual({
-			fromRevision: GIT_EMPTY_TREE_REVISION,
-			toKind: 'revision',
-			toRevision: 'root',
-		});
 	});
 });

--- a/web/src/lib/git/review/git-compare-surface.svelte.ts
+++ b/web/src/lib/git/review/git-compare-surface.svelte.ts
@@ -2,7 +2,6 @@ import type { PortableSingletonController } from '$lib/workspace/portable-single
 import type { WorkspaceProjectState } from '$lib/workspace/workspace-context.svelte.js';
 import { singletonSurfaceId } from '$lib/workspace/surface-types.js';
 import type { GitSurfaceControllerDeps } from '$lib/git/surface/git-surface-controller-deps.js';
-import type { GitTarget } from '$lib/git/targets/git-target.js';
 import { GitTargetSessionController } from '$lib/git/targets/git-target-session.svelte.js';
 import {
 	GitComparisonController,
@@ -14,24 +13,12 @@ export const DEFAULT_GIT_COMPARISON: GitComparisonDialogDefaults = {
 	toKind: 'working-tree',
 };
 
-export interface GitCompareLaunchIntent {
-	source?: {
-		effectiveProjectKey: string;
-		target: GitTarget;
-	};
-	comparison?: GitComparisonDialogDefaults;
-}
-
 export class GitCompareSurfaceController implements PortableSingletonController {
 	readonly comparison = new GitComparisonController();
 	readonly target: GitTargetSessionController;
 	presentationVisible = $state(false);
 
-	#pendingLaunch: { token: number; intent: GitCompareLaunchIntent } | null = null;
-	#nextLaunchToken = 0;
-	#activationGeneration = 0;
 	#loadedTargetIdentity: string | null = null;
-	#externalTargetApplications = 0;
 	#unregisterReviewDisplay: () => void;
 
 	get isLoading(): boolean {
@@ -50,11 +37,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 			canChangeTarget: () =>
 				deps.gitMutations.pendingCount(singletonSurfaceId('git-compare')) === 0,
 			onTargetChanged: (_target, _identity, reason, identityChanged) => {
-				if (
-					reason === 'invalidation' &&
-					!identityChanged &&
-					!this.#pendingLaunch
-				) {
+				if (reason === 'invalidation' && !identityChanged) {
 					const projectPath = this.target.activeProjectPath;
 					if (projectPath && this.presentationVisible) {
 						void this.comparison.checkFreshness(projectPath);
@@ -63,7 +46,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 				}
 				this.comparison.reset();
 				this.#loadedTargetIdentity = null;
-				if (this.presentationVisible && this.#externalTargetApplications === 0) {
+				if (this.presentationVisible) {
 					void this.#activateComparison();
 				}
 			},
@@ -104,29 +87,14 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		return this.target.refreshForInvalidation(effectiveProjectKey, version);
 	}
 
-	prepareLaunch(intent: GitCompareLaunchIntent): number {
-		const token = ++this.#nextLaunchToken;
-		this.#pendingLaunch = { token, intent };
-		if (this.presentationVisible) void this.#activateComparison();
-		return token;
-	}
-
-	cancelPreparedLaunch(token: number): void {
-		if (this.#pendingLaunch?.token === token) this.#pendingLaunch = null;
-	}
-
 	dispose(): void {
 		this.#unregisterReviewDisplay();
 		this.target.dispose();
 		this.comparison.reset();
-		this.#pendingLaunch = null;
-		this.#activationGeneration += 1;
 		this.#loadedTargetIdentity = null;
 	}
 
 	async #activateComparison(): Promise<void> {
-		const generation = ++this.#activationGeneration;
-		let pending = this.#pendingLaunch;
 		if (
 			!this.presentationVisible ||
 			this.target.projectIdentityPending ||
@@ -137,51 +105,14 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 			return;
 		}
 
-		if (pending?.intent.source) {
-			const source = pending.intent.source;
-			if (source.effectiveProjectKey !== this.target.effectiveProjectKey) {
-				if (this.#pendingLaunch?.token === pending.token) {
-					this.#pendingLaunch = null;
-				}
-				pending = null;
-				this.comparison.reset();
-				this.#loadedTargetIdentity = null;
-			} else {
-				this.#externalTargetApplications += 1;
-				try {
-					const applied = await this.target.applyExternalTarget(
-						source.effectiveProjectKey,
-						source.target,
-					);
-					if (!applied) return;
-				} finally {
-					this.#externalTargetApplications -= 1;
-				}
-			}
-		}
-
 		const projectPath = this.target.activeProjectPath;
 		const targetIdentity = this.target.appliedIdentity;
-		if (
-			!this.presentationVisible ||
-			!projectPath ||
-			!targetIdentity ||
-			generation !== this.#activationGeneration
-		) {
-			return;
-		}
-		if (!pending && this.#loadedTargetIdentity === targetIdentity) return;
-
-		if (pending && this.#pendingLaunch?.token === pending.token) {
-			this.#pendingLaunch = null;
-		}
-		this.comparison.setSpecification(
-			pending?.intent.comparison ?? DEFAULT_GIT_COMPARISON,
-			{
-				diffMode: this.deps.reviewDisplay.diffMode,
-				contextLines: this.deps.reviewDisplay.contextLines,
-			},
-		);
+		if (!projectPath || !targetIdentity) return;
+		if (this.#loadedTargetIdentity === targetIdentity) return;
+		this.comparison.setSpecification(DEFAULT_GIT_COMPARISON, {
+			diffMode: this.deps.reviewDisplay.diffMode,
+			contextLines: this.deps.reviewDisplay.contextLines,
+		});
 		this.#loadedTargetIdentity = targetIdentity;
 		await this.comparison.compare(projectPath);
 	}

--- a/web/src/lib/git/review/git-comparison.svelte.ts
+++ b/web/src/lib/git/review/git-comparison.svelte.ts
@@ -12,29 +12,12 @@ import * as m from '$lib/paraglide/messages.js';
 import { isAbortError } from '$lib/utils/is-abort-error.js';
 
 export type GitComparisonToKind = 'revision' | 'working-tree';
-export const GIT_EMPTY_TREE_REVISION = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
 export interface GitComparisonDialogDefaults {
 	fromRevision: string;
 	toKind: GitComparisonToKind;
 	toRevision?: string;
 	mode?: GitComparisonMode;
-}
-
-interface GitComparisonCommitCandidate {
-	hash: string;
-	parents: string[];
-}
-
-export function recentCommitComparisonDefaults(
-	commits: GitComparisonCommitCandidate[],
-): GitComparisonDialogDefaults {
-	const toCommit = commits[0];
-	return {
-		fromRevision: commits[1]?.hash ?? toCommit?.parents[0] ?? GIT_EMPTY_TREE_REVISION,
-		toKind: 'revision',
-		toRevision: toCommit?.hash ?? 'HEAD',
-	};
 }
 
 export interface GitComparisonDisplayOptions {
@@ -147,7 +130,12 @@ export class GitComparisonController {
 			diffMode,
 			this.snapshot ? this.loadedContextLines : contextLines,
 		);
-		if (!contextChanged || !this.snapshot) return;
+		if (!contextChanged) return;
+		if (this.isLoading) {
+			void this.compare(projectPath);
+			return;
+		}
+		if (!this.snapshot) return;
 		if (this.snapshot.to.kind === 'working-tree') {
 			if (contextLines !== this.loadedContextLines) {
 				if (!this.document.isStale) {

--- a/web/src/lib/git/surface/__tests__/git-view-launcher.test.ts
+++ b/web/src/lib/git/surface/__tests__/git-view-launcher.test.ts
@@ -4,19 +4,6 @@ import {
 	type GitViewSurfacePort,
 	type GitViewWorkspacePort,
 } from '$lib/git/surface/git-view-launcher.svelte.js';
-import type { GitCompareLaunchIntent } from '$lib/git/review/git-compare-surface.svelte.js';
-import type { GitTarget } from '$lib/git/targets/git-target.js';
-
-function target(): GitTarget {
-	return {
-		projectPath: '/repo/worktree',
-		repoRoot: '/repo',
-		worktreePath: '/repo/worktree',
-		label: 'worktree',
-		branch: 'feature',
-		source: 'worktree',
-	};
-}
 
 function harness(options: {
 	existing?: readonly string[];
@@ -24,42 +11,24 @@ function harness(options: {
 	mobile?: (kind: 'git-history' | 'git-compare') => Promise<void>;
 }) {
 	const existing = new Set(options.existing ?? []);
-	const events: string[] = [];
-	const prepareLaunch = vi.fn((intent: GitCompareLaunchIntent) => {
-		events.push(
-			`compare:prepare:${intent.source?.target.projectPath ?? 'none'}:${
-				intent.comparison?.fromRevision ?? 'default'
-			}`,
-		);
-		return 7;
-	});
-	const cancelPreparedLaunch = vi.fn();
-	const compare = { prepareLaunch, cancelPreparedLaunch };
 	const workspace = {
 		layout: {
-			surface: (surfaceId: string) =>
-				existing.has(surfaceId) ? { id: surfaceId } : null,
+			surface: (surfaceId: string) => (existing.has(surfaceId) ? { id: surfaceId } : null),
 		},
 		openSingleton: vi.fn(async (kind, host) => {
-			events.push(`workspace:open:${kind}:${host}`);
 			await options.open?.(kind as 'git-history' | 'git-compare', host);
 		}),
 		focusMobileSingleton: vi.fn(async (kind) => {
-			events.push(`workspace:mobile:${kind}`);
 			await options.mobile?.(kind as 'git-history' | 'git-compare');
 		}),
 	} satisfies GitViewWorkspacePort;
 	const surfaces = {
-		gitCompare: vi.fn(() => compare),
 		disposeSurface: vi.fn(),
 	} satisfies GitViewSurfacePort;
 	return {
 		launcher: new GitViewLauncher(workspace, surfaces),
 		workspace,
 		surfaces,
-		events,
-		prepareLaunch,
-		cancelPreparedLaunch,
 	};
 }
 
@@ -70,36 +39,10 @@ describe('GitViewLauncher', () => {
 		expect(workspace.openSingleton).toHaveBeenCalledWith('git-history', 'sidebar');
 	});
 
-	it('opens mobile Compare without preparing an empty launch', async () => {
-		const { launcher, workspace, prepareLaunch } = harness({});
+	it('opens mobile Compare without constructing contextual launch state', async () => {
+		const { launcher, workspace } = harness({});
 		await launcher.openCompare({ presentation: 'mobile' });
 		expect(workspace.focusMobileSingleton).toHaveBeenCalledWith('git-compare');
-		expect(prepareLaunch).not.toHaveBeenCalled();
-	});
-
-	it('prepares contextual Compare before workspace focus', async () => {
-		const { launcher, events } = harness({
-			existing: ['singleton:git-compare'],
-		});
-		await launcher.openCompare(
-			{
-				presentation: 'sidebar',
-				source: {
-					effectiveProjectKey: 'chat',
-					target: target(),
-				},
-			},
-			{
-				fromRevision: 'parent',
-				toKind: 'revision',
-				toRevision: 'commit',
-			},
-		);
-
-		expect(events).toEqual([
-			'compare:prepare:/repo/worktree:parent',
-			'workspace:open:git-compare:sidebar',
-		]);
 	});
 
 	it('disposes a new controller only when registration leaves no descriptor', async () => {
@@ -117,14 +60,9 @@ describe('GitViewLauncher', () => {
 
 	it('retains a controller when registration published before focus settling failed', async () => {
 		const existing = new Set<string>();
-		const compare = {
-			prepareLaunch: vi.fn(() => 3),
-			cancelPreparedLaunch: vi.fn(),
-		};
 		const workspace = {
 			layout: {
-				surface: (surfaceId: string) =>
-					existing.has(surfaceId) ? { id: surfaceId } : null,
+				surface: (surfaceId: string) => (existing.has(surfaceId) ? { id: surfaceId } : null),
 			},
 			openSingleton: vi.fn(async () => {
 				existing.add('singleton:git-compare');
@@ -133,36 +71,23 @@ describe('GitViewLauncher', () => {
 			focusMobileSingleton: vi.fn(async () => undefined),
 		} satisfies GitViewWorkspacePort;
 		const surfaces = {
-			gitCompare: vi.fn(() => compare),
 			disposeSurface: vi.fn(),
 		} satisfies GitViewSurfacePort;
 		const launcher = new GitViewLauncher(workspace, surfaces);
 
-		await expect(
-			launcher.openCompare(
-				{ presentation: 'main' },
-				{ fromRevision: 'HEAD', toKind: 'working-tree' },
-			),
-		).rejects.toThrow('frame failed');
-		expect(compare.cancelPreparedLaunch).toHaveBeenCalledWith(3);
+		await expect(launcher.openCompare({ presentation: 'main' })).rejects.toThrow('frame failed');
 		expect(surfaces.disposeSurface).not.toHaveBeenCalled();
 	});
 
 	it('does not dispose an existing surface after focus failure', async () => {
-		const { launcher, surfaces, cancelPreparedLaunch } = harness({
+		const { launcher, surfaces } = harness({
 			existing: ['singleton:git-compare'],
 			open: async () => {
 				throw new Error('focus failed');
 			},
 		});
 
-		await expect(
-			launcher.openCompare(
-				{ presentation: 'main' },
-				{ fromRevision: 'HEAD', toKind: 'working-tree' },
-			),
-		).rejects.toThrow('focus failed');
-		expect(cancelPreparedLaunch).toHaveBeenCalledWith(7);
+		await expect(launcher.openCompare({ presentation: 'main' })).rejects.toThrow('focus failed');
 		expect(surfaces.disposeSurface).not.toHaveBeenCalled();
 	});
 });

--- a/web/src/lib/git/surface/git-view-launcher.svelte.ts
+++ b/web/src/lib/git/surface/git-view-launcher.svelte.ts
@@ -1,6 +1,3 @@
-import type { GitComparisonDialogDefaults } from '$lib/git/review/git-comparison.svelte.js';
-import type { GitTarget } from '$lib/git/targets/git-target.js';
-import type { GitCompareLaunchIntent } from '$lib/git/review/git-compare-surface.svelte.js';
 import {
 	singletonSurfaceId,
 	type HostId,
@@ -8,10 +5,6 @@ import {
 
 export interface GitViewLaunchOrigin {
 	presentation: HostId | 'mobile';
-	source?: {
-		effectiveProjectKey: string;
-		target: GitTarget;
-	};
 }
 
 export interface GitViewWorkspacePort {
@@ -26,10 +19,6 @@ export interface GitViewWorkspacePort {
 }
 
 export interface GitViewSurfacePort {
-	gitCompare(): {
-		prepareLaunch(intent: GitCompareLaunchIntent): number;
-		cancelPreparedLaunch(token: number): void;
-	};
 	disposeSurface(kind: 'git-history' | 'git-compare'): void;
 }
 
@@ -56,17 +45,9 @@ export class GitViewLauncher {
 		}
 	}
 
-	async openCompare(
-		origin: GitViewLaunchOrigin,
-		comparison?: GitComparisonDialogDefaults,
-	): Promise<void> {
+	async openCompare(origin: GitViewLaunchOrigin): Promise<void> {
 		const surfaceId = singletonSurfaceId('git-compare');
 		const existed = Boolean(this.workspace.layout.surface(surfaceId));
-		const controller = this.surfaces.gitCompare();
-		const launchToken =
-			origin.source || comparison
-				? controller.prepareLaunch({ source: origin.source, comparison })
-				: null;
 		try {
 			if (origin.presentation === 'mobile') {
 				await this.workspace.focusMobileSingleton('git-compare');
@@ -74,7 +55,6 @@ export class GitViewLauncher {
 				await this.workspace.openSingleton('git-compare', origin.presentation);
 			}
 		} catch (error) {
-			if (launchToken !== null) controller.cancelPreparedLaunch(launchToken);
 			if (!existed && !this.workspace.layout.surface(surfaceId)) {
 				this.surfaces.disposeSurface('git-compare');
 			}

--- a/web/src/lib/git/targets/git-target-session.svelte.ts
+++ b/web/src/lib/git/targets/git-target-session.svelte.ts
@@ -183,22 +183,6 @@ export class GitTargetSessionController implements PortableSingletonController {
 		return true;
 	}
 
-	async applyExternalTarget(
-		effectiveProjectKey: string,
-		target: GitTarget,
-	): Promise<boolean> {
-		if (
-			this.projectIdentityPending ||
-			effectiveProjectKey !== this.effectiveProjectKey
-		) {
-			return false;
-		}
-		this.activeTarget = { ...target };
-		this.#rememberTarget();
-		await this.#applyTarget('selection');
-		return true;
-	}
-
 	async switchBranch(
 		branch: string,
 		refKind: GitRefKind | undefined,


### PR DESCRIPTION
Git views currently place related controls and comparison flows inconsistently, making common actions harder to find and use. This aligns file-tree toggles across large Git layouts, moves Commit selection details into the commit workflow while preserving shared target controls, makes History rows reliably clickable, removes redundant Compare launchers, and keeps selected-commit comparisons inside History with screen-aware navigation, loading, refresh, and comment behavior.