### PR TITLE
Keep Git surfaces coherent across chat and repository switches

### DIFF
--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -41,9 +41,13 @@ export class SpaDriver {
     await this.#page.waitForFunction(() => document.querySelector('button') !== null);
   }
 
-  async startOpenAiDirectChat(content: string): Promise<RecordedCompletionRequest> {
+  async startOpenAiDirectChat(
+    content: string,
+    options: { projectPath?: string } = {},
+  ): Promise<RecordedCompletionRequest> {
     return this.#startDirectChat({
       content,
+      projectPath: options.projectPath,
       selectedAgentLabel: 'Direct (Chat Completions)',
       optionAgentLabel: 'Chat Completions',
       modelLabel: 'Integration Echo',
@@ -69,6 +73,7 @@ export class SpaDriver {
 
   async #startDirectChat<TRequest>(input: {
     content: string;
+    projectPath?: string;
     selectedAgentLabel: string;
     optionAgentLabel: string;
     modelLabel: string;
@@ -107,14 +112,15 @@ export class SpaDriver {
       await this.clickButton(input.modelLabel);
     }
 
+    const requestedProjectPath = input.projectPath ?? this.#integration.dirs.project;
     const projectPath = await this.#page.$eval(
       '[role="dialog"] input[aria-label="Project Path"]',
       (element) => (element as HTMLInputElement).value,
     );
-    if (projectPath !== this.#integration.dirs.project) {
+    if (projectPath !== requestedProjectPath) {
       await this.fill(
         '[role="dialog"] input[aria-label="Project Path"]',
-        this.#integration.dirs.project,
+        requestedProjectPath,
       );
     }
     await this.fill('[role="dialog"] textarea[placeholder="How can I help you today?"]', input.content);

--- a/integration-tests/tests/e2e/git-multi-repo-chat-switch.test.ts
+++ b/integration-tests/tests/e2e/git-multi-repo-chat-switch.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from 'bun:test';
+import { appendFile, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { withE2eFixture } from '../../support/e2e-fixture.js';
+import { SpaDriver } from '../../support/spa-driver.js';
+
+const GIT_PANEL = '[role="tabpanel"][data-workspace-surface-id="singleton:git"][aria-hidden="false"]';
+
+async function runGit(projectPath: string, args: string[]): Promise<void> {
+  const process = Bun.spawn(['git', ...args], {
+    cwd: projectPath,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stderr, exitCode] = await Promise.all([new Response(process.stderr).text(), process.exited]);
+  if (exitCode !== 0) throw new Error(`git ${args[0]} failed: ${stderr.trim()}`);
+}
+
+async function createRepo(projectPath: string, prefix: string): Promise<void> {
+  await runGit(projectPath, ['init', '-b', 'main']);
+  await runGit(projectPath, ['config', 'user.email', 'test@example.com']);
+  await runGit(projectPath, ['config', 'user.name', 'E2E Test']);
+  await writeFile(join(projectPath, `${prefix}-notes.txt`), `${prefix} base\n`, 'utf8');
+  await runGit(projectPath, ['add', `${prefix}-notes.txt`]);
+  await runGit(projectPath, ['commit', '-m', `${prefix} base`]);
+  await writeFile(join(projectPath, `${prefix}-notes.txt`), `${prefix} base\n${prefix} change\n`, 'utf8');
+  await writeFile(join(projectPath, `${prefix}-untracked.txt`), `${prefix} untracked\n`, 'utf8');
+}
+
+describe('Lightpanda Git multi-repo chat switching', () => {
+  test('keeps listings, targets, and commenting coherent across repo and chat switches', async () => {
+    await withE2eFixture('git-multi-repo-chat-switch', async (fixture) => {
+      // Both repos live under the fixture's project-base boundary.
+      const repoA = join(fixture.integration.dirs.project, 'repo-a');
+      const repoB = join(fixture.integration.dirs.project, 'repo-b');
+      await mkdir(repoA, { recursive: true });
+      await mkdir(repoB, { recursive: true });
+      await createRepo(repoA, 'alpha');
+      await createRepo(repoB, 'beta');
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.setViewport(1_440, 900);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat('multi-repo-chat-a', { projectPath: repoA });
+      await app.waitForText('echo:multi-repo-chat-a');
+      await app.startOpenAiDirectChat('multi-repo-chat-b', { projectPath: repoB });
+      await app.waitForText('echo:multi-repo-chat-b');
+
+      const chats = (await fixture.integration.client.listChats()).sessions;
+      const chatA = chats.find((chat) => chat.preview.firstMessage === 'multi-repo-chat-a');
+      const chatB = chats.find((chat) => chat.preview.firstMessage === 'multi-repo-chat-b');
+      if (!chatA || !chatB) throw new Error('Both project chats must be listed in the sidebar.');
+      expect(chatA.projectPath).toBe(repoA);
+      expect(chatB.projectPath).toBe(repoB);
+
+      // Chat A: open the Git workbench and confirm repo A listings.
+      await app.clickSidebarChatContaining('multi-repo-chat-a');
+      await app.waitForSelectedChat(chatA.id);
+      await switchToGitSurface(fixture);
+      await waitForPanelFiles(fixture, ['alpha-notes.txt', 'alpha-untracked.txt'], ['beta-notes.txt']);
+
+      // Switch the workbench target to repo B from within chat A.
+      await app.waitForButton(repoA);
+      await app.clickButton(repoA);
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Git target"]');
+      await app.fill('#git-target-path-input', repoB);
+      await fixture.page.waitForFunction(
+        () => {
+          const dialog = document.querySelector('[role="dialog"][aria-label="Git target"]');
+          const button = [...(dialog?.querySelectorAll('button') ?? [])].find(
+            (element) => element.textContent?.trim() === 'OK',
+          );
+          return button instanceof HTMLButtonElement && !button.disabled;
+        },
+        { timeout: 20_000 },
+      );
+      await app.clickButton('OK');
+      await waitForPanelFiles(fixture, ['beta-notes.txt', 'beta-untracked.txt'], ['alpha-notes.txt']);
+
+      // Chat B defaults to its own project, the same physical repo chat A's
+      // workbench just selected; the listing must stay coherent for the new
+      // chat identity. Selecting a chat focuses the Chat surface, so reopen
+      // the Git view the way a user does after every switch.
+      await app.clickSidebarChatContaining('multi-repo-chat-b');
+      await app.waitForSelectedChat(chatB.id);
+      await switchToGitSurface(fixture);
+      await waitForPanelFiles(fixture, ['beta-notes.txt', 'beta-untracked.txt'], ['alpha-notes.txt']);
+
+      // Change repo B's git state on disk while chat B is active, then refresh.
+      await writeFile(join(repoB, 'beta-extra.txt'), 'beta extra untracked\n', 'utf8');
+      await appendFile(join(repoB, 'beta-notes.txt'), 'beta second change\n', 'utf8');
+      await clickPanelButton(fixture, 'Refresh');
+      await waitForPanelFiles(fixture, ['beta-extra.txt'], []);
+
+      // Back to chat A: its remembered target is repo B and must show repo B's
+      // current state, with the target selector reporting repo B.
+      await app.clickSidebarChatContaining('multi-repo-chat-a');
+      await app.waitForSelectedChat(chatA.id);
+      await switchToGitSurface(fixture);
+      await waitForPanelFiles(
+        fixture,
+        ['beta-notes.txt', 'beta-untracked.txt', 'beta-extra.txt'],
+        ['alpha-notes.txt'],
+      );
+      await fixture.page.waitForFunction(
+        ({ panelSelector, expectedPath }) => {
+          const panel = document.querySelector(panelSelector);
+          return [...(panel?.querySelectorAll('button') ?? [])].some(
+            (element) => element.getAttribute('aria-label') === expectedPath,
+          );
+        },
+        { timeout: 20_000 },
+        { panelSelector: GIT_PANEL, expectedPath: repoB },
+      );
+      // A refresh round-trip settles the retained surface's async target
+      // application before user-level review interactions begin.
+      await clickPanelButton(fixture, 'Refresh');
+      await waitForPanelFiles(fixture, ['beta-notes.txt', 'beta-extra.txt'], []);
+
+      // The review comment flow must still work after the switch sequence.
+      // Re-query and click fresh on each attempt: virtual rows re-render while
+      // refreshes settle, which can orphan a previously queried button node.
+      await fixture.page.waitForSelector(
+        '[data-git-virtual-diff-root] button[aria-label="Add to chat"]',
+        { timeout: 20_000 },
+      );
+      let composerOpen = false;
+      for (let attempt = 0; attempt < 5 && !composerOpen; attempt += 1) {
+        await fixture.page.evaluate(() => {
+          const button = document.querySelector<HTMLButtonElement>(
+            '[data-git-virtual-diff-root] button[aria-label="Add to chat"]',
+          );
+          if (!button) throw new Error('Missing Changes comment affordance.');
+          button.click();
+        });
+        composerOpen = await fixture.page
+          .waitForFunction(
+            () => document.querySelector('[data-git-comment-composer] textarea') !== null,
+            { timeout: 4_000 },
+          )
+          .then(() => true)
+          .catch(() => false);
+      }
+      if (!composerOpen) throw new Error('Comment composer did not open after clicking Add to chat.');
+      await app.fill('[data-git-comment-composer] textarea', 'Cross-repo review comment.');
+      await fixture.page.evaluate(() => {
+        const composer = document.querySelector('[data-git-comment-composer]');
+        const button = [...(composer?.querySelectorAll('button') ?? [])].find(
+          (candidate) => candidate.textContent?.trim() === 'Add to chat',
+        );
+        if (!button) throw new Error('Missing Changes Add to chat submit action.');
+        button.click();
+      });
+      await app.waitForText('Added to the Chat composer.');
+      await app.selectMainWorkspaceSurface('Chat');
+      const draft = await fixture.page.$eval(
+        'textarea[placeholder="Reply..."]',
+        (element) => (element as HTMLTextAreaElement).value,
+      );
+      expect(draft).toContain('Git review comment');
+      expect(draft).toContain('Cross-repo review comment.');
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});
+
+async function switchToGitSurface(
+  fixture: Awaited<Parameters<Parameters<typeof withE2eFixture>[1]>[0]>,
+): Promise<void> {
+  const alreadyVisible = await fixture.page.evaluate(
+    (panelSelector) => document.querySelector(panelSelector) !== null,
+    GIT_PANEL,
+  );
+  if (alreadyVisible) return;
+  await fixture.page.evaluate(() => {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'p', ctrlKey: true, bubbles: true }),
+    );
+  });
+  await fixture.page.waitForSelector('[role="dialog"][aria-label="Command palette"]');
+  await fixture.page.evaluate(() => {
+    const option = [...document.querySelectorAll<HTMLButtonElement>('[role="option"]')].find(
+      (button) => button.textContent?.includes('Switch to Git'),
+    );
+    if (!option) throw new Error('Missing Switch to Git command.');
+    option.click();
+  });
+  await fixture.page.waitForFunction(
+    (panelSelector) => document.querySelector(panelSelector) !== null,
+    { timeout: 20_000 },
+    GIT_PANEL,
+  );
+}
+
+async function waitForPanelFiles(
+  fixture: Awaited<Parameters<Parameters<typeof withE2eFixture>[1]>[0]>,
+  presentFiles: string[],
+  absentFiles: string[],
+): Promise<void> {
+  await fixture.page.waitForFunction(
+    ({ panelSelector, present, absent }) => {
+      const panel = document.querySelector(panelSelector);
+      const text = panel?.textContent ?? '';
+      return present.every((name) => text.includes(name))
+        && absent.every((name) => !text.includes(name));
+    },
+    { timeout: 20_000 },
+    { panelSelector: GIT_PANEL, present: presentFiles, absent: absentFiles },
+  );
+}
+
+async function clickPanelButton(
+  fixture: Awaited<Parameters<Parameters<typeof withE2eFixture>[1]>[0]>,
+  name: string,
+): Promise<void> {
+  await fixture.page.waitForFunction(
+    ({ panelSelector, label }) => {
+      const panel = document.querySelector(panelSelector);
+      const button = [...(panel?.querySelectorAll('button') ?? [])].find((element) => {
+        const accessible = element.getAttribute('aria-label') || element.textContent?.trim() || '';
+        return accessible === label;
+      });
+      return button instanceof HTMLButtonElement && !button.disabled;
+    },
+    { timeout: 20_000 },
+    { panelSelector: GIT_PANEL, label: name },
+  );
+  await fixture.page.evaluate(
+    ({ panelSelector, label }) => {
+      const panel = document.querySelector(panelSelector);
+      const button = [...(panel?.querySelectorAll('button') ?? [])].find((element) => {
+        const accessible = element.getAttribute('aria-label') || element.textContent?.trim() || '';
+        return accessible === label;
+      });
+      if (!(button instanceof HTMLButtonElement)) throw new Error(`Missing panel button: ${label}`);
+      button.click();
+    },
+    { panelSelector: GIT_PANEL, label: name },
+  );
+}

--- a/web/src/lib/git/history/__tests__/git-history-surface-chat-switch.test.ts
+++ b/web/src/lib/git/history/__tests__/git-history-surface-chat-switch.test.ts
@@ -1,0 +1,168 @@
+// Regression coverage for chat-switch target retention: selecting another repo
+// in a Git surface, switching to a chat with a different project, and switching
+// back must converge on the remembered target and load listings exactly for it.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitHistorySurfaceController } from '$lib/git/history/git-history-surface.svelte.js';
+import { createGitSurfaceTestDeps } from '$lib/git/__tests__/git-surface-test-deps.js';
+import type { GitTargetCandidate } from '$lib/api/git.js';
+
+vi.mock('$lib/api/git.js', () => ({
+	getGitTargetCandidates: vi.fn(),
+	getGitRefs: vi.fn().mockResolvedValue({ refs: [] }),
+	getGitHistoryCommits: vi.fn(),
+	gitCheckoutRef: vi.fn().mockResolvedValue({ success: true }),
+	gitCreateBranch: vi.fn().mockResolvedValue({ success: true }),
+	gitRevertCommit: vi.fn(),
+}));
+
+const api = vi.mocked(await import('$lib/api/git.js'));
+
+function candidate(
+	projectPath: string,
+	overrides: Partial<GitTargetCandidate> = {},
+): GitTargetCandidate {
+	return {
+		projectPath,
+		repoRoot: projectPath,
+		worktreePath: projectPath,
+		label: projectPath.split('/').pop() ?? projectPath,
+		branch: 'main',
+		source: 'chat-project',
+		isCurrent: true,
+		isMissing: false,
+		...overrides,
+	};
+}
+
+function availableProject(chatId: string, projectPath: string) {
+	return {
+		kind: 'available' as const,
+		project: { chatId, projectPath, effectiveProjectKey: chatId },
+	};
+}
+
+function resolvingProject(chatId: string, projectPath: string) {
+	return {
+		kind: 'resolving' as const,
+		context: { chatId, projectPath, effectiveProjectKey: null },
+	};
+}
+
+function installCandidateRouter(pending?: Map<string, Array<(v: unknown) => void>>) {
+	api.getGitTargetCandidates.mockImplementation((projectPath: string) => {
+		if (pending) {
+			return new Promise((resolve) => {
+				const list = pending.get(projectPath) ?? [];
+				list.push(resolve as (v: unknown) => void);
+				pending.set(projectPath, list);
+			}) as never;
+		}
+		return Promise.resolve({ targets: [candidate(projectPath)] }) as never;
+	});
+}
+
+function historyCalls(): string[] {
+	return api.getGitHistoryCommits.mock.calls.map(([projectPath]) => projectPath as string);
+}
+
+describe('git chat-switch desync repro', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		api.getGitHistoryCommits.mockResolvedValue({
+			project: '/x',
+			ref: 'HEAD',
+			commits: [],
+			nextOffset: null,
+		});
+	});
+
+	it('A: select repo X, switch chat A->B->A, listings follow the remembered target', async () => {
+		installCandidateRouter();
+		const controller = new GitHistorySurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(historyCalls()).toContain('/project-a'));
+
+		// "switch repos in the git screen"
+		await controller.target.selectTarget(candidate('/repo-x', { isCurrent: false }));
+		await vi.waitFor(() => expect(historyCalls()).toContain('/repo-x'));
+
+		// chat A -> B
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		await controller.target.activate();
+		await vi.waitFor(() => expect(historyCalls()).toContain('/project-b'));
+
+		// chat B -> A
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		await controller.target.activate();
+		await vi.waitFor(() =>
+			expect(historyCalls().filter((p) => p === '/repo-x').length).toBeGreaterThanOrEqual(2),
+		);
+
+		expect(controller.target.activeProjectPath).toBe('/repo-x');
+		expect(controller.target.appliedIdentity).toBe(controller.target.identity);
+		// The last listing load must be for the applied target.
+		expect(historyCalls().at(-1)).toBe('/repo-x');
+	});
+
+	it('B: rapid A->B->A with the B candidate fetch still in flight converges on X', async () => {
+		const pending = new Map<string, Array<(v: unknown) => void>>();
+		installCandidateRouter(pending);
+		const controller = new GitHistorySurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		const firstActivation = controller.target.activate();
+		await vi.waitFor(() => expect(pending.get('/project-a')?.length ?? 0).toBeGreaterThan(0));
+		pending.get('/project-a')!.shift()!({ targets: [candidate('/project-a')] });
+		await firstActivation;
+
+		await controller.target.selectTarget(candidate('/repo-x', { isCurrent: false }));
+		// selectTarget kicks a background reconcile fetch for /repo-x; leave it pending.
+
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		// B's candidate fetch is now pending; do NOT resolve it - switch straight back.
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		await vi.waitFor(() => expect(pending.get('/repo-x')?.length ?? 0).toBeGreaterThan(0));
+		for (const resolve of pending.get('/repo-x') ?? []) {
+			resolve({ targets: [candidate('/repo-x')] });
+		}
+		pending.set('/repo-x', []);
+		await controller.target.activate();
+
+		expect(controller.target.activeProjectPath).toBe('/repo-x');
+		expect(controller.target.appliedIdentity).toBe(controller.target.identity);
+		await vi.waitFor(() => expect(historyCalls().at(-1)).toBe('/repo-x'));
+		// No listing load for a project that is not the applied target may come last,
+		// and chat B's aborted context must not have produced an /x load under B.
+		expect(controller.history).toMatchObject({ screen: 'list' });
+	});
+
+	it('C: hidden during the switches, listings load once for X on show', async () => {
+		installCandidateRouter();
+		const controller = new GitHistorySurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await controller.target.selectTarget(candidate('/repo-x', { isCurrent: false }));
+		await vi.waitFor(() => expect(historyCalls()).toContain('/repo-x'));
+
+		controller.setPresentationVisible(false);
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		const callsBeforeShow = historyCalls().length;
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+
+		await vi.waitFor(() => expect(historyCalls().length).toBeGreaterThan(callsBeforeShow));
+		expect(controller.target.activeProjectPath).toBe('/repo-x');
+		expect(controller.target.appliedIdentity).toBe(controller.target.identity);
+		expect(historyCalls().at(-1)).toBe('/repo-x');
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-diff-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-document.test.ts
@@ -73,6 +73,15 @@ function bodyResponse(documentId: string, paths: readonly string[]) {
 	};
 }
 
+function testCommentSource() {
+	return {
+		kind: 'commit' as const,
+		shortHash: 'abc1234',
+		subject: 'Test commit',
+		baseLabel: 'parent abc',
+	};
+}
+
 describe('GitDiffDocumentController', () => {
 	it('reconciles retained viewport demand when the matching document becomes ready', async () => {
 		const controller = new GitDiffDocumentController();
@@ -96,7 +105,13 @@ describe('GitDiffDocumentController', () => {
 				limits,
 				firstBodyCandidates: [],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 
 		await vi.waitFor(() => expect(loadBodies).toHaveBeenCalledOnce());
@@ -120,7 +135,13 @@ describe('GitDiffDocumentController', () => {
 				limits,
 				firstBodyCandidates: [],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 
 		controller.handleBodyDemand({
@@ -156,7 +177,13 @@ describe('GitDiffDocumentController', () => {
 				limits,
 				firstBodyCandidates: [],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 		controller.handleBodyDemand({
 			kind: 'viewport',
@@ -191,7 +218,13 @@ describe('GitDiffDocumentController', () => {
 				limits: constrainedLimits,
 				firstBodyCandidates: ['initial.ts', 'visible.ts'],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 		await vi.waitFor(() => expect(loadBodies).toHaveBeenCalledTimes(2));
 
@@ -232,7 +265,13 @@ describe('GitDiffDocumentController', () => {
 				limits: constrainedLimits,
 				firstBodyCandidates: ['initial.ts', 'blocked.ts', 'visible.ts'],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 		await vi.waitFor(() => expect(controller.fileBodies['initial.ts']?.bodyState).toBe('loaded'));
 
@@ -265,7 +304,13 @@ describe('GitDiffDocumentController', () => {
 				limits: { ...limits, maxLoadedRows: 6 },
 				firstBodyCandidates: [],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 		controller.handleBodyDemand({
 			kind: 'viewport',
@@ -322,7 +367,13 @@ describe('GitDiffDocumentController', () => {
 				limits,
 				firstBodyCandidates: ['initial.ts'],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 
 		controller.focusFile('selected.ts');
@@ -355,7 +406,13 @@ describe('GitDiffDocumentController', () => {
 				limits: { ...limits, maxSummaryFiles: files.length },
 				firstBodyCandidates: [],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 
 		controller.focusFile('file-9999.ts');
@@ -492,6 +549,7 @@ describe('GitDiffDocumentController', () => {
 				diffMode: 'unified',
 				loadBodies,
 				onError: vi.fn(),
+				commentSource: testCommentSource(),
 			},
 		);
 
@@ -543,6 +601,7 @@ describe('GitDiffDocumentController', () => {
 					errors: {},
 				})),
 				onError: vi.fn(),
+				commentSource: testCommentSource(),
 			},
 		);
 
@@ -598,6 +657,7 @@ describe('GitDiffDocumentController', () => {
 				diffMode: 'unified',
 				loadBodies,
 				onError: vi.fn(),
+				commentSource: testCommentSource(),
 			},
 		);
 
@@ -647,6 +707,7 @@ describe('GitDiffDocumentController', () => {
 				diffMode: 'unified',
 				loadBodies,
 				onError: vi.fn(),
+				commentSource: testCommentSource(),
 			},
 		);
 
@@ -702,6 +763,7 @@ describe('GitDiffDocumentController', () => {
 					errors: { 'a.ts': 'Unable to read this path.' },
 				})),
 				onError: vi.fn(),
+				commentSource: testCommentSource(),
 			},
 		);
 
@@ -743,7 +805,13 @@ describe('GitDiffDocumentController', () => {
 				limits,
 				firstBodyCandidates: ['a.ts'],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 		await vi.waitFor(() => expect(controller.fileBodies['a.ts']?.bodyState).toBe('error'));
 
@@ -773,7 +841,13 @@ describe('GitDiffDocumentController', () => {
 					limits: boundedLimits,
 					firstBodyCandidates: [path],
 				},
-				{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+				{
+					contextLines: 5,
+					diffMode: 'unified',
+					loadBodies,
+					onError: vi.fn(),
+					commentSource: testCommentSource(),
+				},
 			);
 
 		open('doc-a', 'a.ts');
@@ -816,7 +890,13 @@ describe('GitDiffDocumentController', () => {
 					limits,
 					firstBodyCandidates: [path],
 				},
-				{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+				{
+					contextLines: 5,
+					diffMode: 'unified',
+					loadBodies,
+					onError: vi.fn(),
+					commentSource: testCommentSource(),
+				},
 			);
 		};
 
@@ -847,7 +927,13 @@ describe('GitDiffDocumentController', () => {
 				limits,
 				firstBodyCandidates: ['a.ts'],
 			},
-			{ contextLines: 5, diffMode: 'unified', loadBodies, onError: vi.fn() },
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
 		);
 		await vi.waitFor(() => expect(controller.isStale).toBe(true));
 
@@ -961,6 +1047,7 @@ describe('GitDiffDocumentController', () => {
 			diffMode: 'unified' as const,
 			loadBodies,
 			onError: vi.fn(),
+			commentSource: testCommentSource(),
 		};
 		controller.open(documentSnapshot, options);
 		await vi.waitFor(() => expect(controller.fileBodies['a.ts']).toBeTruthy());

--- a/web/src/lib/git/review/git-compare-surface.svelte.ts
+++ b/web/src/lib/git/review/git-compare-surface.svelte.ts
@@ -113,7 +113,14 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 			diffMode: this.deps.reviewDisplay.diffMode,
 			contextLines: this.deps.reviewDisplay.contextLines,
 		});
+		// Marked before the await so a concurrent activation for the same
+		// identity does not start a second default load.
 		this.#loadedTargetIdentity = targetIdentity;
-		await this.comparison.compare(projectPath);
+		const loaded = await this.comparison.compare(projectPath);
+		// A failed default load must stay retryable on the next visibility or
+		// activation pass; a superseded identity keeps the newer marker.
+		if (!loaded && this.#loadedTargetIdentity === targetIdentity) {
+			this.#loadedTargetIdentity = null;
+		}
 	}
 }

--- a/web/src/lib/git/review/git-diff-document.svelte.ts
+++ b/web/src/lib/git/review/git-diff-document.svelte.ts
@@ -76,7 +76,10 @@ export interface GitDiffDocumentOpenOptions {
 	onBodyLoadSuccess?: () => void;
 	onStale?: (message: string) => void;
 	onExpired?: (message: string) => void;
-	commentSource?: GitReviewCommentSource;
+	// Every review document is commentable; the source describes the comparison
+	// for the generated chat comment. Read-only diff rendering belongs to the
+	// PR surface's own row source, not to this controller.
+	commentSource: GitReviewCommentSource;
 }
 
 export class GitDiffDocumentController {
@@ -190,9 +193,7 @@ export class GitDiffDocumentController {
 			focusedFilePath: this.focusedFilePath,
 			diffMode: this.diffMode,
 			contextLines: this.contextLines,
-			interaction: this.commentSource
-				? { kind: 'commentable', composerState: this.commentComposer }
-				: { kind: 'read-only' },
+			interaction: { kind: 'commentable', composerState: this.commentComposer },
 			...(placeholderLimit ? { placeholderLimit } : {}),
 		});
 	});
@@ -206,7 +207,7 @@ export class GitDiffDocumentController {
 		this.onBodyLoadSuccess = options.onBodyLoadSuccess ?? null;
 		this.onStale = options.onStale ?? null;
 		this.onExpired = options.onExpired ?? null;
-		this.commentSource = options.commentSource ?? null;
+		this.commentSource = options.commentSource;
 		this.diffMode = options.diffMode;
 		this.contextLines = options.contextLines;
 		this.fileBodies = {};
@@ -288,7 +289,6 @@ export class GitDiffDocumentController {
 	}
 
 	openCommentComposer(filePath: string, side: 'before' | 'after', line: number): void {
-		if (!this.commentSource) return;
 		this.inlineComment.open(filePath, side, line);
 	}
 

--- a/web/src/lib/git/workbench/__tests__/git-workbench-surface-chat-switch.test.ts
+++ b/web/src/lib/git/workbench/__tests__/git-workbench-surface-chat-switch.test.ts
@@ -1,0 +1,330 @@
+// Regression coverage for chat switches over retained Git targets: listings,
+// active tab, and the review document must stay coherent with the applied
+// target, including when two chat identities share one physical repository.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitWorkbenchSurfaceController } from '$lib/git/workbench/git-workbench-surface.svelte.js';
+import { GitCompareSurfaceController } from '$lib/git/review/git-compare-surface.svelte.js';
+import { createGitSurfaceTestDeps } from '$lib/git/__tests__/git-surface-test-deps.js';
+import type {
+	GitReviewDocumentSummary,
+	GitTargetCandidate,
+	GitTreeNode,
+	GitWorkbenchSnapshotResponse,
+} from '$lib/api/git.js';
+
+vi.mock('$lib/api/git.js', () => ({
+	getGitTargetCandidates: vi.fn(),
+	getGitRefs: vi.fn().mockResolvedValue({ refs: [] }),
+	getGitWorkbenchSnapshot: vi.fn(),
+	getGitWorkingTreeFingerprint: vi.fn().mockResolvedValue({
+		status: 'ready',
+		project: '/project',
+		fingerprintVersion: 1,
+		fingerprint: 'v1:baseline',
+		changedPathCount: 0,
+	}),
+	getGitReviewFileBodies: vi.fn().mockResolvedValue({ status: 'ready', files: {} }),
+	getGitStatus: vi.fn().mockResolvedValue({
+		branch: 'main',
+		hasCommits: true,
+		modified: [],
+		added: [],
+		deleted: [],
+		untracked: [],
+	}),
+	getRemoteStatus: vi.fn().mockResolvedValue({ hasRemote: false, branch: 'main' }),
+	getGitRemotes: vi.fn().mockResolvedValue({ remotes: [] }),
+	getGitWorktrees: vi.fn().mockResolvedValue({ worktrees: [] }),
+	gitCheckoutRef: vi.fn().mockResolvedValue({ success: true }),
+	gitCreateBranch: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('$lib/api/git-comparison.js', () => ({
+	getGitComparisonSnapshot: vi.fn(),
+	getGitComparisonFileBodies: vi.fn().mockResolvedValue({ status: 'ready', files: {} }),
+	getGitComparisonFreshness: vi.fn().mockResolvedValue({ status: 'ready', changedEndpoints: [] }),
+}));
+
+vi.stubGlobal('localStorage', {
+	getItem: () => null,
+	setItem: () => {},
+	removeItem: () => {},
+});
+
+const api = vi.mocked(await import('$lib/api/git.js'));
+const comparisonApi = vi.mocked(await import('$lib/api/git-comparison.js'));
+
+const LIMITS = {
+	maxSummaryFiles: 10_000,
+	maxBodyBatchFiles: 24,
+	maxLoadedRows: 100_000,
+	maxLoadedPatchBytes: 10_000_000,
+	maxFileRows: 50_000,
+	maxFilePatchBytes: 5_000_000,
+	maxLineBytes: 20_000,
+	maxContextLines: 50,
+	bodyConcurrency: 4,
+};
+
+function candidate(
+	projectPath: string,
+	overrides: Partial<GitTargetCandidate> = {},
+): GitTargetCandidate {
+	return {
+		projectPath,
+		repoRoot: projectPath,
+		worktreePath: projectPath,
+		label: projectPath.split('/').pop() ?? projectPath,
+		branch: 'main',
+		source: 'chat-project',
+		isCurrent: true,
+		isMissing: false,
+		...overrides,
+	};
+}
+
+function fileNode(path: string): GitTreeNode {
+	return { path, name: path, kind: 'file', staged: false, hasUnstaged: true };
+}
+
+function summaryFor(project: string, paths: string[]): GitReviewDocumentSummary {
+	return {
+		documentId: `doc:${project}`,
+		project,
+		mode: 'working',
+		context: 5,
+		files: paths.map((path) => ({
+			path,
+			indexStatus: ' ' as const,
+			workTreeStatus: 'M' as const,
+			category: 'normal' as const,
+			additions: 1,
+			deletions: 0,
+			estimatedRows: 2,
+			bodyState: 'unloaded' as const,
+			bodyFingerprint: `fp:${path}`,
+			isGenerated: false,
+			isBinary: false,
+			isTooLarge: false,
+		})),
+		limits: LIMITS,
+	};
+}
+
+function snapshotFor(project: string, paths: string[]): GitWorkbenchSnapshotResponse {
+	return {
+		status: 'ready',
+		project,
+		target: {
+			projectPath: project,
+			repoRoot: project,
+			worktreePath: project,
+			label: project.split('/').pop() ?? project,
+			branch: 'main',
+			source: 'chat-project',
+		},
+		tree: { root: paths.map(fileNode), hasCommits: true, statsState: 'loaded' },
+		reviewSummary: summaryFor(project, paths),
+		selectedFile: paths[0] ?? null,
+		firstBodyCandidates: [],
+		snapshotId: `doc:${project}`,
+		workbenchFingerprint: `v1:${project}`,
+	};
+}
+
+function availableProject(chatId: string, projectPath: string) {
+	return {
+		kind: 'available' as const,
+		project: { chatId, projectPath, effectiveProjectKey: chatId },
+	};
+}
+
+function resolvingProject(chatId: string, projectPath: string) {
+	return {
+		kind: 'resolving' as const,
+		context: { chatId, projectPath, effectiveProjectKey: null },
+	};
+}
+
+function installRouters(): void {
+	api.getGitTargetCandidates.mockImplementation((projectPath: string) =>
+		Promise.resolve({ targets: [candidate(projectPath)] }),
+	);
+	api.getGitWorkbenchSnapshot.mockImplementation((projectPath: string) =>
+		Promise.resolve(snapshotFor(projectPath, [`${projectPath.slice(1)}.ts`])),
+	);
+	comparisonApi.getGitComparisonSnapshot.mockImplementation((projectPath: string) =>
+		Promise.resolve({
+			status: 'ready',
+			project: projectPath,
+			repoRoot: projectPath,
+			documentId: `cmp:${projectPath}`,
+			mode: 'direct',
+			from: {
+				kind: 'revision',
+				label: 'HEAD',
+				requestedRevision: 'HEAD',
+				revision: 'HEAD',
+				hash: 'abc123',
+				shortHash: 'abc123',
+			},
+			to: {
+				kind: 'working-tree',
+				label: 'Working tree',
+				fingerprint: 'wt:1',
+				shortFingerprint: 'wt:1',
+			},
+			effectiveFromHash: 'abc123',
+			files: [],
+			limits: LIMITS,
+			firstBodyCandidates: [],
+		} as never),
+	);
+}
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 8; i += 1) {
+		await Promise.resolve();
+	}
+}
+
+describe('workbench surface chat-switch repro', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		installRouters();
+	});
+
+	it('W1: select repo X, A->B->A keeps listings and review doc on X', async () => {
+		const controller = new GitWorkbenchSurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await settle();
+
+		await controller.target.selectTarget(candidate('/repo-x', { isCurrent: false }));
+		await settle();
+		expect(controller.workbench.projectPath).toBe('/repo-x');
+
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		await controller.target.activate();
+		await settle();
+		expect(controller.workbench.projectPath).toBe('/project-b');
+		expect(controller.workbench.review.summary?.project).toBe('/project-b');
+
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		await controller.target.activate();
+		await settle();
+
+		expect(controller.target.activeProjectPath).toBe('/repo-x');
+		expect(controller.target.appliedIdentity).toBe(controller.target.identity);
+		expect(controller.workbench.projectPath).toBe('/repo-x');
+		expect(controller.workbench.review.summary?.project).toBe('/repo-x');
+		expect(controller.workbench.files.filePaths).toContain('repo-x.ts');
+		expect(controller.workbench.files.filePaths).not.toContain('project-b.ts');
+	});
+
+	it('W2: selecting chat B\'s repo in chat A, then visiting B and returning, stays coherent', async () => {
+		const controller = new GitWorkbenchSurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await settle();
+
+		// In chat A, point the workbench at chat B's repo.
+		await controller.target.selectTarget(candidate('/project-b', { isCurrent: false }));
+		await settle();
+		expect(controller.workbench.projectPath).toBe('/project-b');
+
+		// Visit chat B; same physical repo path, different chat identity.
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		await controller.target.activate();
+		await settle();
+		expect(controller.workbench.projectPath).toBe('/project-b');
+		// Work in B on the staged tab with an open comment composer.
+		controller.workbench.setActiveTab('staged');
+		await settle();
+		controller.workbench.drafts.openCommentComposer('project-b.ts', 'after', 1);
+		expect(controller.workbench.drafts.commentComposer.open).toBe(true);
+
+		// Return to chat A (remembered target is /project-b as well).
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		await controller.target.activate();
+		await settle();
+
+		expect(controller.target.appliedIdentity).toBe(controller.target.identity);
+		expect(controller.workbench.projectPath).toBe('/project-b');
+		// The loaded review document must correspond to the active tab: the last
+		// snapshot request's tab must equal the current activeTab.
+		const lastSnapshotCall = api.getGitWorkbenchSnapshot.mock.calls.at(-1);
+		expect(lastSnapshotCall?.[1]).toBe(controller.workbench.files.activeTab);
+		// Chat B's open composer must not leak into chat A's surface identity.
+		expect(controller.workbench.drafts.commentComposer.open).toBe(false);
+		// Comment composer must be functional: open it and confirm the state sticks.
+		controller.workbench.drafts.openCommentComposer('project-b.ts', 'after', 1);
+		expect(controller.workbench.drafts.commentComposer.open).toBe(true);
+	});
+});
+
+describe('compare surface chat-switch repro', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		installRouters();
+	});
+
+	it('C1: A->B->A reloads Compare for the remembered target and keeps comments openable', async () => {
+		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await settle();
+		expect(controller.comparison.snapshot?.repoRoot).toBe('/project-a');
+
+		await controller.target.selectTarget(candidate('/repo-x', { isCurrent: false }));
+		await settle();
+		expect(controller.comparison.snapshot?.repoRoot).toBe('/repo-x');
+
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		await controller.target.activate();
+		await settle();
+		expect(controller.comparison.snapshot?.repoRoot).toBe('/project-b');
+
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		await controller.target.activate();
+		await settle();
+
+		expect(controller.target.appliedIdentity).toBe(controller.target.identity);
+		expect(controller.comparison.snapshot?.repoRoot).toBe('/repo-x');
+		controller.comparison.document.openCommentComposer('any.ts', 'after', 1);
+		expect(controller.comparison.document.commentComposer.open).toBe(true);
+	});
+
+	it('C2: a failed default compare is retried after the next chat switch back', async () => {
+		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await settle();
+
+		comparisonApi.getGitComparisonSnapshot.mockRejectedValueOnce(new Error('boom'));
+		controller.setProjectState(resolvingProject('chat-b', '/project-b'));
+		controller.setProjectState(availableProject('chat-b', '/project-b'));
+		await controller.target.activate();
+		await settle();
+		expect(controller.comparison.error).toContain('boom');
+
+		controller.setProjectState(resolvingProject('chat-a', '/project-a'));
+		controller.setProjectState(availableProject('chat-a', '/project-a'));
+		await controller.target.activate();
+		await settle();
+
+		expect(controller.comparison.snapshot?.repoRoot).toBe('/project-a');
+		controller.comparison.document.openCommentComposer('any.ts', 'after', 1);
+		expect(controller.comparison.document.commentComposer.open).toBe(true);
+	});
+});

--- a/web/src/lib/git/workbench/git-workbench-surface.svelte.ts
+++ b/web/src/lib/git/workbench/git-workbench-surface.svelte.ts
@@ -111,14 +111,16 @@ export class GitWorkbenchSurfaceController implements PortableSingletonControlle
 		if (identityChanged) {
 			this.#saveSelection();
 			const snapshot = identity ? takeMostRecent(this.#selectionByTarget, identity) : null;
-			this.workbench.files.activeTab = snapshot?.diffTab ?? 'unstaged';
 			this.workbench.setDisplayOptions(
 				this.deps.reviewDisplay.diffMode,
 				this.deps.reviewDisplay.contextLines,
 				{ refresh: false },
 			);
 			this.repository.resetForProject(projectPath, { deferMetadata: true });
-			await this.workbench.setTarget(target);
+			// A retained same-path document must not carry the previous surface
+			// identity's open composer or line selection into the new identity.
+			this.workbench.resetReviewInteraction();
+			await this.workbench.setTarget(target, snapshot?.diffTab ?? 'unstaged');
 			this.#loadedIdentity = identity;
 			if (
 				projectPath &&

--- a/web/src/lib/git/workbench/git-workbench.svelte.ts
+++ b/web/src/lib/git/workbench/git-workbench.svelte.ts
@@ -220,10 +220,20 @@ export class GitWorkbenchStore {
 		return this.porcelainController;
 	}
 
-	async setTarget(nextTarget: GitWorkbenchTarget | null): Promise<void> {
+	// Applies the target and owns tab coherence: a retained same-path document
+	// switching tabs runs the full tab transition so the loaded tree and review
+	// document always correspond to the active tab.
+	async setTarget(
+		nextTarget: GitWorkbenchTarget | null,
+		activeTab?: GitDiffTab,
+	): Promise<void> {
 		const nextKey = targetKey(nextTarget);
 		if (nextKey === this.lastTargetKey) {
 			this.target = nextTarget;
+			if (nextTarget && activeTab && activeTab !== this.treeState.activeTab) {
+				await this.applyActiveTab(activeTab);
+				return;
+			}
 			this.virtualReview.markDemandReadinessChanged();
 			if (
 				nextTarget &&
@@ -239,6 +249,7 @@ export class GitWorkbenchStore {
 		this.target = nextTarget;
 		this.lastTargetKey = nextKey;
 		this.resetForTargetChange();
+		if (activeTab) this.treeState.activeTab = activeTab;
 
 		if (nextTarget) {
 			await this.refresh({
@@ -246,6 +257,13 @@ export class GitWorkbenchStore {
 				preserveSelection: false,
 			});
 		}
+	}
+
+	// Clears user interaction state that must not survive a surface identity
+	// change even when the physical target and its loaded data are retained.
+	resetReviewInteraction(): void {
+		this.lineSelection.clearSelection();
+		this.reviewDrafts.closeCommentComposer();
 	}
 
 	dismissError(): void {
@@ -401,6 +419,10 @@ export class GitWorkbenchStore {
 	}
 
 	setActiveTab(tab: GitDiffTab): void {
+		void this.applyActiveTab(tab);
+	}
+
+	private async applyActiveTab(tab: GitDiffTab): Promise<void> {
 		if (tab === this.treeState.activeTab) return;
 		this.treeState.activeTab = tab;
 		this.lineSelection.clearSelection();
@@ -408,7 +430,7 @@ export class GitWorkbenchStore {
 		this.virtualReview.clearForDisplayChange();
 		this.selectFirstVisibleFileForActiveTab();
 		if (this.target)
-			void this.refresh({
+			await this.refresh({
 				reason: 'tab-change',
 				preserveSelection: true,
 				preferSelectedFile: true,


### PR DESCRIPTION
Switching chats while a Git surface targeted another chat's repository could leave the workbench desynchronized: the target session retains a per-chat repository selection, but the workbench store dedupes reloads by project path alone, so returning to a chat whose remembered selection matched the other chat's project restored the per-identity diff tab without reloading the document loaded for the previous tab. The result was listings from the wrong tab, a review document and body pipeline keyed to a stale tab, and an invisible leaked comment composer that blocked review context-line changes everywhere. The workbench store now owns tab application on setTarget and runs the full tab transition when a retained same-path document switches tabs, surface identity changes clear the previous identity's composer and line selection, Compare no longer pins its loaded target identity when the default comparison fails so it retries on the next activation, and review documents now require a comment source since every producer supplies one, removing a silently read-only path. Regression units cover the surface controllers through repo-plus-chat switch sequences, and a new Lightpanda e2e exercises two repositories and two chats end to end, including on-disk git state changes and the review-comment-to-chat-draft flow.