### PR TITLE
Keep singleton open commands available across views

### DIFF
--- a/web/src/lib/components/workspace/WorkspaceTaskBar.svelte
+++ b/web/src/lib/components/workspace/WorkspaceTaskBar.svelte
@@ -111,17 +111,15 @@
 		hostState.order.filter((surfaceId) => !displayedSurfaceIds.includes(surfaceId)),
 	);
 	const gitViewKinds = ['git-history', 'git-compare'] as const;
-	const closedGitViewKinds = $derived(
-		gitViewKinds.filter(
-			(kind) => !workspace.layout.surface(singletonSurfaceId(kind)),
-		),
+	const availableGitViewKinds = $derived(
+		gitViewKinds.filter((kind) => !hostState.order.includes(singletonSurfaceId(kind))),
 	);
-	const otherClosedSingletonKinds = $derived(
+	const otherAvailableSingletonKinds = $derived(
 		PORTABLE_SINGLETON_KINDS.filter(
 			(kind) =>
 				!gitViewKinds.includes(kind as (typeof gitViewKinds)[number]) &&
 				canOffer(kind) &&
-				!workspace.layout.surface(singletonSurfaceId(kind)),
+				!hostState.order.includes(singletonSurfaceId(kind)),
 		),
 	);
 	const activeSurfaceId = $derived(hostState.activeId);
@@ -197,6 +195,15 @@
 		void workspace.moveSurface(surfaceId, host === 'main' ? 'sidebar' : 'main');
 	}
 
+	function openSingletonInHost(kind: PortableSingletonKind): void {
+		const surfaceId = singletonSurfaceId(kind);
+		if (workspace.layout.surface(surfaceId)) {
+			void workspace.moveSurface(surfaceId, host);
+			return;
+		}
+		void workspace.openSingleton(kind, host);
+	}
+
 	function recomputeVisibleTabs(): void {
 		if (!taskbarRoot || !measurementRail || !startControls || !endControls) return;
 		const widths = new Map<string, number>();
@@ -254,8 +261,8 @@
 	}
 </script>
 
-{#snippet icon(surfaceId: string)}
-	{@const kind = iconKind(surfaceId)}
+{#snippet icon(surfaceId: string, singletonKind?: PortableSingletonKind)}
+	{@const kind = singletonKind ?? iconKind(surfaceId)}
 	{#if kind === 'chat'}<MessageSquare class="h-3.5 w-3.5 shrink-0" />
 	{:else if kind === 'git'}<GitBranch class="h-3.5 w-3.5 shrink-0" />
 	{:else if kind === 'git-history'}<History class="h-3.5 w-3.5 shrink-0" />
@@ -416,9 +423,9 @@
 					<SquareTerminal />
 					{terminalLimitReached ? m.terminal_limit_reached() : m.workspace_new_terminal()}
 				</DropdownMenuItem>
-				{#each closedGitViewKinds as kind (kind)}
-					<DropdownMenuItem onclick={() => void workspace.openSingleton(kind, host)}>
-						{@render icon(singletonSurfaceId(kind))}
+				{#each availableGitViewKinds as kind (kind)}
+					<DropdownMenuItem onclick={() => openSingletonInHost(kind)}>
+						{@render icon(singletonSurfaceId(kind), kind)}
 						{kind === 'git-history'
 							? m.workspace_open_git_history()
 							: m.workspace_open_git_compare()}
@@ -437,9 +444,9 @@
 						</DropdownMenuItem>
 					{/each}
 				{/if}
-				{#each otherClosedSingletonKinds as kind (kind)}
-					<DropdownMenuItem onclick={() => void workspace.openSingleton(kind, host)}>
-						{@render icon(singletonSurfaceId(kind))}
+				{#each otherAvailableSingletonKinds as kind (kind)}
+					<DropdownMenuItem onclick={() => openSingletonInHost(kind)}>
+						{@render icon(singletonSurfaceId(kind), kind)}
 						{m.workspace_open_surface({ surface: singletonLabels[kind]() })}
 					</DropdownMenuItem>
 				{/each}

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -454,6 +454,43 @@ describe('PortableSurfaceContent', () => {
 });
 
 describe('WorkspaceRoot', () => {
+	it('moves a singleton through the other host Open command in both directions', async () => {
+		const { workspace } = installContext(withAdditionalSurfaces());
+		const { container } = render(WorkspaceRoot, { isMobile: false, chatActions });
+		const mainMenu = container.querySelector<HTMLButtonElement>(
+			'[data-floating-workspace-toolbar] [data-workspace-taskbar-end] [data-slot="dropdown-menu-trigger"]',
+		);
+		const sidebarMenu = container.querySelector<HTMLButtonElement>(
+			'[data-floating-sidebar-toolbar] [data-workspace-taskbar-end] [data-slot="dropdown-menu-trigger"]',
+		);
+		const openGitWorkbench = m.workspace_open_surface({
+			surface: m.workspace_surface_git_workbench(),
+		});
+		expect(mainMenu).toBeTruthy();
+		expect(sidebarMenu).toBeTruthy();
+		if (!mainMenu || !sidebarMenu) return;
+
+		await fireEvent.click(mainMenu);
+		expect(screen.queryByRole('menuitem', { name: openGitWorkbench })).toBeNull();
+		await fireEvent.keyDown(document, { key: 'Escape' });
+
+		await fireEvent.click(sidebarMenu);
+		await fireEvent.click(screen.getByRole('menuitem', { name: openGitWorkbench }));
+		await waitFor(() => {
+			expect(workspace.layout.snapshot.main.order).not.toContain('singleton:git');
+			expect(workspace.layout.snapshot.sidebar.order).toContain('singleton:git');
+			expect(workspace.layout.snapshot.sidebar.activeId).toBe('singleton:git');
+		});
+
+		await fireEvent.click(mainMenu);
+		await fireEvent.click(screen.getByRole('menuitem', { name: openGitWorkbench }));
+		await waitFor(() => {
+			expect(workspace.layout.snapshot.main.order).toContain('singleton:git');
+			expect(workspace.layout.snapshot.main.activeId).toBe('singleton:git');
+			expect(workspace.layout.snapshot.sidebar.order).not.toContain('singleton:git');
+		});
+	});
+
 	it('opens the user-message navigator from the active Chat taskbar menu', async () => {
 		installContext(canonicalWorkspaceSnapshot());
 		testContext.current!.workspaceContext = {

--- a/web/src/lib/components/workspace/__tests__/WorkspaceTaskBar.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceTaskBar.test.ts
@@ -94,6 +94,11 @@ describe('WorkspaceTaskBar', () => {
 		const moveItem = screen.getByRole('menuitem', { name: m.workspace_move_to_sidebar() });
 		const closeItem = screen.getByRole('menuitem', { name: m.workspace_close_tab() });
 		const newTerminalItem = screen.getByRole('menuitem', { name: m.workspace_new_terminal() });
+		expect(
+			screen.queryByRole('menuitem', {
+				name: m.workspace_open_surface({ surface: m.workspace_surface_git_workbench() }),
+			}),
+		).toBeNull();
 		expect(items.indexOf(moveItem)).toBeLessThan(items.indexOf(newTerminalItem));
 		expect(items.indexOf(closeItem)).toBeLessThan(items.indexOf(newTerminalItem));
 
@@ -150,9 +155,7 @@ describe('WorkspaceTaskBar', () => {
 	it.each(['main', 'sidebar'] as const)(
 		'places standalone Git view commands directly after New Terminal in the %s menu',
 		async (host) => {
-			terminalRegistry.orderedSessions = [
-				{ metadata: { terminalId: 'one', displaySequence: 1 } },
-			];
+			terminalRegistry.orderedSessions = [{ metadata: { terminalId: 'one', displaySequence: 1 } }];
 			render(WorkspaceTaskBar, {
 				host,
 				hostState:
@@ -167,8 +170,7 @@ describe('WorkspaceTaskBar', () => {
 								activeId: 'singleton:files',
 								mru: ['singleton:files'],
 							},
-				labelFor: (surfaceId: string) =>
-					surfaceId === 'singleton:chat' ? 'Chat' : 'Files',
+				labelFor: (surfaceId: string) => (surfaceId === 'singleton:chat' ? 'Chat' : 'Files'),
 				onSelect: vi.fn(),
 			});
 
@@ -183,6 +185,8 @@ describe('WorkspaceTaskBar', () => {
 			});
 			const openTerminal = screen.getByRole('menuitem', { name: 'Terminal 1' });
 
+			expect(history.querySelector('.lucide-history')).toBeTruthy();
+			expect(compare.querySelector('.lucide-git-compare-arrows')).toBeTruthy();
 			expect(items.indexOf(terminal)).toBeLessThan(items.indexOf(history));
 			expect(items.indexOf(history)).toBeLessThan(items.indexOf(compare));
 			expect(items.indexOf(compare)).toBeLessThan(items.indexOf(openTerminal));
@@ -191,6 +195,53 @@ describe('WorkspaceTaskBar', () => {
 			expect(openSingleton).toHaveBeenCalledWith('git-history', host);
 		},
 	);
+
+	it('moves an existing generic singleton from the sidebar into the main view', async () => {
+		render(WorkspaceTaskBar, {
+			host: 'main',
+			hostState: {
+				order: ['singleton:chat'],
+				activeId: 'singleton:chat',
+				mru: ['singleton:chat'],
+			},
+			labelFor: () => 'Chat',
+			onSelect: vi.fn(),
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Workspace actions' }));
+		await fireEvent.click(
+			screen.getByRole('menuitem', {
+				name: m.workspace_open_surface({ surface: m.workspace_surface_git_workbench() }),
+			}),
+		);
+
+		expect(moveSurface).toHaveBeenCalledWith('singleton:git', 'main');
+		expect(openSingleton).not.toHaveBeenCalled();
+	});
+
+	it('moves an existing standalone Git view from main into the sidebar', async () => {
+		surfaces['singleton:git-history'] = {
+			id: 'singleton:git-history',
+			type: 'singleton',
+			kind: 'git-history',
+		};
+		render(WorkspaceTaskBar, {
+			host: 'sidebar',
+			hostState: {
+				order: ['singleton:files'],
+				activeId: 'singleton:files',
+				mru: ['singleton:files'],
+			},
+			labelFor: () => 'Files',
+			onSelect: vi.fn(),
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Workspace actions' }));
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.workspace_open_git_history() }));
+
+		expect(moveSurface).toHaveBeenCalledWith('singleton:git-history', 'sidebar');
+		expect(openSingleton).not.toHaveBeenCalled();
+	});
 
 	it('omits an open Git view command and labels standalone tabs without a Git prefix', async () => {
 		surfaces['singleton:git-history'] = {
@@ -205,20 +256,15 @@ describe('WorkspaceTaskBar', () => {
 				activeId: 'singleton:git-history',
 				mru: ['singleton:git-history', 'singleton:chat'],
 			},
-			labelFor: (surfaceId: string) =>
-				surfaceId === 'singleton:chat' ? 'Chat' : 'History',
+			labelFor: (surfaceId: string) => (surfaceId === 'singleton:chat' ? 'Chat' : 'History'),
 			onSelect: vi.fn(),
 		});
 
 		expect(screen.getByRole('tab', { name: 'History' })).toBeTruthy();
 		expect(screen.queryByRole('tab', { name: 'Git History' })).toBeNull();
 		await fireEvent.click(screen.getByRole('button', { name: 'Workspace actions' }));
-		expect(
-			screen.queryByRole('menuitem', { name: m.workspace_open_git_history() }),
-		).toBeNull();
-		expect(
-			screen.getByRole('menuitem', { name: m.workspace_open_git_compare() }),
-		).toBeTruthy();
+		expect(screen.queryByRole('menuitem', { name: m.workspace_open_git_history() })).toBeNull();
+		expect(screen.getByRole('menuitem', { name: m.workspace_open_git_compare() })).toBeTruthy();
 	});
 
 	it('offers move, pop out, and close for an inactive tab context menu', async () => {


### PR DESCRIPTION
Singleton surfaces can live in only one workspace view, but hiding their Open commands globally made moving them hard to discover. This change keeps each singleton's Open command available in the other view and makes it move an existing surface into that view while preserving creation for unopened surfaces, with coverage for Git and generic singleton flows.