### PR TITLE
Add other-view file opening

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1192,6 +1192,7 @@
 	"settings_image_viewer_open_placement": "Image viewers",
 	"settings_markdown_viewer_open_placement": "Markdown viewers",
 	"settings_file_open_placement_source": "Same view",
+	"settings_file_open_placement_other": "Other view",
 	"settings_file_open_placement_dialog": "Dialog",
 	"settings_file_open_placement_main": "Main view",
 	"settings_file_open_placement_sidebar": "Sidebar view",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -839,6 +839,7 @@
 	"file_session_loading": "Loading file...",
 	"file_session_content_request_failed": "The file request failed with status {status}.",
 	"file_session_open_failed": "Unable to open {fileName}: {detail}",
+	"file_session_opened_in_another_view": "Opened {fileName} in another view. Close this dialog to see it.",
 	"file_session_move_main": "Move to main view",
 	"file_session_move_sidebar": "Move to sidebar",
 	"file_session_restore_dialog": "Restore dialog",

--- a/web/src/lib/components/files/MarkdownViewer.svelte
+++ b/web/src/lib/components/files/MarkdownViewer.svelte
@@ -2,13 +2,21 @@
 	import Markdown, { type MarkdownLinkNavigateEvent } from '$lib/components/chat/Markdown.svelte';
 	import { resolveFileLinkFromFile } from '$lib/chat/file-links/file-link-resolver.js';
 	import type { FileSession } from '$lib/files/sessions/file-session.svelte.js';
-	import { getFileSessions, getLocalSettings } from '$lib/context';
-	import type { PresentationHostId } from '$lib/workspace/surface-types.js';
+	import {
+		getFileSessions,
+		getLocalSettings,
+		getNotifications,
+		getWorkspaceLayout,
+	} from '$lib/context';
+	import { fileSurfaceId, type PresentationHostId } from '$lib/workspace/surface-types.js';
+	import * as m from '$lib/paraglide/messages.js';
 
 	let { session, presentation }: { session: FileSession; presentation: PresentationHostId } =
 		$props();
 	const files = getFileSessions();
 	const localSettings = getLocalSettings();
+	const notifications = getNotifications();
+	const workspaceLayout = getWorkspaceLayout();
 	let contentElement: HTMLDivElement;
 	const markdownFontSize = $derived(
 		Number.parseInt(localSettings.markdownViewerFontSize, 10) || 12,
@@ -41,12 +49,21 @@
 			sourceFilePath: session.relativePath,
 		});
 		if (!target) return false;
-		void files.open({
-			...target,
-			mode: 'auto',
-			origin: presentation,
-			reason: 'user-open',
-		});
+		void files
+			.open({
+				...target,
+				mode: 'auto',
+				origin: presentation,
+				reason: 'user-open',
+			})
+			.then((opened) => {
+				if (!opened || presentation !== 'dialog') return;
+				const dialogSurfaceId = workspaceLayout.snapshot.dialogFileSurfaceId;
+				if (!dialogSurfaceId || dialogSurfaceId === fileSurfaceId(opened.id)) return;
+				notifications.info(m.file_session_opened_in_another_view({ fileName: opened.fileName }), {
+					key: 'file-opened-behind-dialog',
+				});
+			});
 		return true;
 	}
 </script>

--- a/web/src/lib/components/files/__tests__/FileSurfaceTestHost.svelte
+++ b/web/src/lib/components/files/__tests__/FileSurfaceTestHost.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { onDestroy, untrack } from 'svelte';
-	import { setFileSessions, setLocalSettings } from '$lib/context';
+	import {
+		setFileSessions,
+		setLocalSettings,
+		setNotifications,
+		setWorkspaceLayout,
+	} from '$lib/context';
 	import { FileSession } from '$lib/files/sessions/file-session.svelte.js';
 	import {
 		FileSessionRegistry,
@@ -8,8 +13,10 @@
 	} from '$lib/files/sessions/file-session-registry.svelte.js';
 	import { CodeEditorController } from '$lib/files/editor/code-editor-controller.svelte.js';
 	import { createLocalSettingsStore } from '$lib/stores/local-settings.svelte.js';
+	import { createNotificationsStore } from '$lib/stores/notifications.svelte.js';
 	import type { PresentationHostId } from '$lib/workspace/surface-types.js';
 	import { setSurfaceFrameBridge, SurfaceFrameBridge } from '$lib/workspace/surface-frame-context';
+	import { createWorkspaceLayoutStore } from '$lib/workspace/workspace-layout.svelte.js';
 	import FileSurface from '../FileSurface.svelte';
 
 	let {
@@ -52,6 +59,8 @@
 	}));
 	const frameBridge = new SurfaceFrameBridge();
 	const localSettings = createLocalSettingsStore();
+	const notifications = createNotificationsStore();
+	const workspaceLayout = createWorkspaceLayoutStore();
 
 	const fileSessions = new FileSessionRegistry({
 		getIsMobile: () => presentation === 'mobile',
@@ -135,6 +144,8 @@
 	setSurfaceFrameBridge(() => frameBridge);
 	setFileSessions(fileSessions);
 	setLocalSettings(localSettings);
+	setNotifications(notifications);
+	setWorkspaceLayout(workspaceLayout);
 	onDestroy(() => localSettings.destroy());
 </script>
 

--- a/web/src/lib/components/files/__tests__/MarkdownViewer.test.ts
+++ b/web/src/lib/components/files/__tests__/MarkdownViewer.test.ts
@@ -1,8 +1,15 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileSession } from '$lib/files/sessions/file-session.svelte.js';
 import type { FileOpenRequest } from '$lib/files/sessions/file-session-registry.svelte.js';
+import { NotificationsStore } from '$lib/stores/notifications.svelte.js';
+import { canonicalWorkspaceSnapshot } from '$lib/workspace/canonical-layout.js';
+import { fileSurfaceId, type WorkspaceLayoutMutation } from '$lib/workspace/surface-types.js';
+import {
+	createWorkspaceLayoutStore,
+	reduceWorkspaceLayout,
+} from '$lib/workspace/workspace-layout.svelte.js';
 import MarkdownViewerTestHost from './MarkdownViewerTestHost.svelte';
 
 afterEach(() => {
@@ -10,16 +17,46 @@ afterEach(() => {
 	vi.unstubAllGlobals();
 });
 
-function markdownSession(content: string): FileSession {
+function markdownSession(content: string, relativePath = 'docs/guides/current.md'): FileSession {
 	const session = new FileSession(
 		{
 			canonicalFileRootPath: '/workspace/project',
-			normalizedRelativePath: 'docs/guides/current.md',
+			normalizedRelativePath: relativePath,
 		},
-		'/workspace/project:docs/guides/current.md',
+		`/workspace/project:${relativePath}`,
 	);
 	session.content = content;
 	return session;
+}
+
+function workspaceLayoutWithDialog(dialogSession: FileSession, backgroundSession?: FileSession) {
+	const mutations: WorkspaceLayoutMutation[] = [
+		{
+			type: 'register-surface',
+			surface: {
+				id: fileSurfaceId(dialogSession.id),
+				type: 'file',
+				fileSessionId: dialogSession.id,
+			},
+			host: 'main',
+		},
+		{ type: 'place-in-dialog', surfaceId: fileSurfaceId(dialogSession.id) },
+	];
+	if (backgroundSession) {
+		mutations.push(
+			{
+				type: 'register-surface',
+				surface: {
+					id: fileSurfaceId(backgroundSession.id),
+					type: 'file',
+					fileSessionId: backgroundSession.id,
+				},
+				host: 'main',
+			},
+			{ type: 'focus-host', host: 'main', surfaceId: fileSurfaceId(backgroundSession.id) },
+		);
+	}
+	return createWorkspaceLayoutStore(reduceWorkspaceLayout(canonicalWorkspaceSnapshot(), mutations));
 }
 
 describe('MarkdownViewer', () => {
@@ -158,6 +195,72 @@ describe('MarkdownViewer', () => {
 		expect(onOpen).toHaveBeenCalledWith(
 			expect.objectContaining({ relativePath: 'docs/guides/current.md' }),
 		);
+	});
+
+	it('notifies when a dialog link opens behind the current dialog', async () => {
+		const source = markdownSession('[Sibling](sibling.md)');
+		const opened = markdownSession('', 'docs/guides/sibling.md');
+		const notifications = new NotificationsStore();
+
+		render(MarkdownViewerTestHost, {
+			session: source,
+			presentation: 'dialog',
+			onOpen: vi.fn(() => opened),
+			notifications,
+			workspaceLayout: workspaceLayoutWithDialog(source, opened),
+		});
+
+		await fireEvent.click(screen.getByRole('link', { name: 'Sibling' }));
+
+		await waitFor(() => expect(notifications.items).toHaveLength(1));
+		expect(notifications.items[0]).toMatchObject({
+			key: 'file-opened-behind-dialog',
+			tone: 'info',
+			message: 'Opened sibling.md in another view. Close this dialog to see it.',
+		});
+	});
+
+	it('does not notify when the linked file becomes the dialog occupant', async () => {
+		const source = markdownSession('[Sibling](sibling.md)');
+		const opened = markdownSession('', 'docs/guides/sibling.md');
+		const notifications = new NotificationsStore();
+		const onOpen = vi.fn(() => opened);
+
+		render(MarkdownViewerTestHost, {
+			session: source,
+			presentation: 'dialog',
+			onOpen,
+			notifications,
+			workspaceLayout: workspaceLayoutWithDialog(opened),
+		});
+
+		await fireEvent.click(screen.getByRole('link', { name: 'Sibling' }));
+		await waitFor(() => expect(onOpen).toHaveBeenCalledOnce());
+		await tick();
+		await Promise.resolve();
+
+		expect(notifications.items).toHaveLength(0);
+	});
+
+	it('does not notify when the linked file fails to open', async () => {
+		const source = markdownSession('[Sibling](sibling.md)');
+		const notifications = new NotificationsStore();
+		const onOpen = vi.fn(() => null);
+
+		render(MarkdownViewerTestHost, {
+			session: source,
+			presentation: 'dialog',
+			onOpen,
+			notifications,
+			workspaceLayout: workspaceLayoutWithDialog(source),
+		});
+
+		await fireEvent.click(screen.getByRole('link', { name: 'Sibling' }));
+		await waitFor(() => expect(onOpen).toHaveBeenCalledOnce());
+		await tick();
+		await Promise.resolve();
+
+		expect(notifications.items).toHaveLength(0);
 	});
 
 	it.each(['../../../outside.md', '/tmp/outside.md'])(

--- a/web/src/lib/components/files/__tests__/MarkdownViewerTestHost.svelte
+++ b/web/src/lib/components/files/__tests__/MarkdownViewerTestHost.svelte
@@ -1,23 +1,37 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
-	import { setFileSessions, setLocalSettings } from '$lib/context';
+	import { onDestroy, untrack } from 'svelte';
+	import {
+		setFileSessions,
+		setLocalSettings,
+		setNotifications,
+		setWorkspaceLayout,
+	} from '$lib/context';
 	import type { FileSession } from '$lib/files/sessions/file-session.svelte.js';
 	import {
 		FileSessionRegistry,
 		type FileOpenRequest,
 	} from '$lib/files/sessions/file-session-registry.svelte.js';
 	import { createLocalSettingsStore } from '$lib/stores/local-settings.svelte.js';
-	import type { PresentationHostId } from '$lib/workspace/surface-types.js';
+	import {
+		createNotificationsStore,
+		type NotificationsStore,
+	} from '$lib/stores/notifications.svelte.js';
+	import type { PresentationHostId, WorkspaceLayoutReader } from '$lib/workspace/surface-types.js';
+	import { createWorkspaceLayoutStore } from '$lib/workspace/workspace-layout.svelte.js';
 	import MarkdownViewer from '../MarkdownViewer.svelte';
 
 	let {
 		session,
 		presentation = 'main',
 		onOpen,
+		notifications = createNotificationsStore(),
+		workspaceLayout = createWorkspaceLayoutStore(),
 	}: {
 		session: FileSession;
 		presentation?: PresentationHostId;
-		onOpen: (request: FileOpenRequest) => void;
+		onOpen: (request: FileOpenRequest) => void | FileSession | null | Promise<FileSession | null>;
+		notifications?: NotificationsStore;
+		workspaceLayout?: WorkspaceLayoutReader;
 	} = $props();
 
 	const localSettings = createLocalSettingsStore();
@@ -46,12 +60,13 @@
 		}),
 	});
 	fileSessions.open = async (request) => {
-		onOpen(request);
-		return null;
+		return (await onOpen(request)) ?? null;
 	};
 
 	setFileSessions(fileSessions);
 	setLocalSettings(localSettings);
+	setNotifications(untrack(() => notifications));
+	setWorkspaceLayout(untrack(() => workspaceLayout));
 	onDestroy(() => localSettings.destroy());
 </script>
 

--- a/web/src/lib/components/settings/LocalSettingsSection.svelte
+++ b/web/src/lib/components/settings/LocalSettingsSection.svelte
@@ -43,6 +43,7 @@
 		'textEditorOpenPlacement' | 'imageViewerOpenPlacement' | 'markdownViewerOpenPlacement';
 	const fileOpenPlacementLabels: Record<FileOpenPlacementPreference, () => string> = {
 		source: m.settings_file_open_placement_source,
+		other: m.settings_file_open_placement_other,
 		dialog: m.settings_file_open_placement_dialog,
 		main: m.settings_file_open_placement_main,
 		sidebar: m.settings_file_open_placement_sidebar,

--- a/web/src/lib/components/settings/__tests__/Settings.test.ts
+++ b/web/src/lib/components/settings/__tests__/Settings.test.ts
@@ -217,16 +217,17 @@ describe('Settings', () => {
 				name: 'Markdown viewers',
 			});
 			expect(screen.getAllByRole('option', { name: 'Same view' })).toHaveLength(3);
+			expect(screen.getAllByRole('option', { name: 'Other view' })).toHaveLength(3);
 			expect(screen.getAllByRole('option', { name: 'Dialog' })).toHaveLength(3);
 			expect(screen.getAllByRole('option', { name: 'Main view' })).toHaveLength(3);
 			expect(screen.getAllByRole('option', { name: 'Sidebar view' })).toHaveLength(3);
 			expect((textEditorPlacement as HTMLSelectElement).value).toBe('source');
 			expect((imageViewerPlacement as HTMLSelectElement).value).toBe('source');
 			expect((markdownViewerPlacement as HTMLSelectElement).value).toBe('source');
-			await fireEvent.change(textEditorPlacement, { target: { value: 'main' } });
+			await fireEvent.change(textEditorPlacement, { target: { value: 'other' } });
 			await fireEvent.change(imageViewerPlacement, { target: { value: 'sidebar' } });
 			await fireEvent.change(markdownViewerPlacement, { target: { value: 'dialog' } });
-			expect(onLocalSet).toHaveBeenCalledWith('textEditorOpenPlacement', 'main');
+			expect(onLocalSet).toHaveBeenCalledWith('textEditorOpenPlacement', 'other');
 			expect(onLocalSet).toHaveBeenCalledWith('imageViewerOpenPlacement', 'sidebar');
 			expect(onLocalSet).toHaveBeenCalledWith('markdownViewerOpenPlacement', 'dialog');
 			await fireEvent.change(textEditorPlacement, { target: { value: 'source' } });

--- a/web/src/lib/stores/__tests__/local-settings.test.ts
+++ b/web/src/lib/stores/__tests__/local-settings.test.ts
@@ -194,20 +194,20 @@ describe('LocalSettingsStore', () => {
 
 	it('persists and restores independent file opening preferences', () => {
 		const store = createLocalSettingsStore();
-		store.set('textEditorOpenPlacement', 'source');
+		store.set('textEditorOpenPlacement', 'other');
 		store.set('imageViewerOpenPlacement', 'sidebar');
 		store.set('markdownViewerOpenPlacement', 'dialog');
 
 		expect(
 			JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.localSettings) ?? '{}'),
 		).toMatchObject({
-			textEditorOpenPlacement: 'source',
+			textEditorOpenPlacement: 'other',
 			imageViewerOpenPlacement: 'sidebar',
 			markdownViewerOpenPlacement: 'dialog',
 		});
 
 		const restored = createLocalSettingsStore();
-		expect(restored.textEditorOpenPlacement).toBe('source');
+		expect(restored.textEditorOpenPlacement).toBe('other');
 		expect(restored.imageViewerOpenPlacement).toBe('sidebar');
 		expect(restored.markdownViewerOpenPlacement).toBe('dialog');
 

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -23,9 +23,10 @@ export const CHAT_MAX_WIDTH_VALUES = ['none', 'large', 'medium', 'small'] as con
 export type ChatMaxWidth = (typeof CHAT_MAX_WIDTH_VALUES)[number];
 export const SIDEBAR_SORT_MODE_VALUES = ['manual', 'recent'] as const;
 export type SidebarSortMode = (typeof SIDEBAR_SORT_MODE_VALUES)[number];
-export type FileOpenPlacementPreference = DesktopPlacement | 'source';
+export type FileOpenPlacementPreference = DesktopPlacement | 'source' | 'other';
 export const FILE_OPEN_PLACEMENT_VALUES = [
 	'source',
+	'other',
 	'dialog',
 	'main',
 	'sidebar',

--- a/web/src/lib/workspace/__tests__/workspace-services.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-services.test.ts
@@ -1,25 +1,92 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { tick } from 'svelte';
 import { createAppShellStore } from '$lib/stores/app-shell.svelte.js';
 import { createChatSessionsStore } from '$lib/chat/sessions/chat-sessions.svelte.js';
 import { createGhCapabilityStore } from '$lib/stores/gh-capability.svelte.js';
-import { createLocalSettingsStore } from '$lib/stores/local-settings.svelte.js';
+import {
+	createLocalSettingsStore,
+	type LocalSettingsStore,
+} from '$lib/stores/local-settings.svelte.js';
 import { createModelCatalogStore } from '$lib/agents/model-catalog-store.svelte.js';
 import { createNavigationStore } from '$lib/stores/navigation.svelte.js';
 import { createNotificationsStore } from '$lib/stores/notifications.svelte.js';
 import type { PrimaryWsConnectionPort } from '$lib/ws/connection.svelte.js';
+import { fileSurfaceId } from '$lib/workspace/surface-types.js';
 import {
 	createWorkspaceServices,
 	resolveConfiguredFilePlacement,
 	type WorkspaceServices,
 } from '../workspace-services.js';
 
+vi.mock('$lib/api/files.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/api/files.js')>();
+	return {
+		...actual,
+		resolveFileIdentity: vi.fn(
+			async ({
+				projectPath,
+				relativePath,
+			}: {
+				projectPath: string | null;
+				relativePath: string;
+			}) => ({
+				success: true as const,
+				identity: {
+					canonicalFileRootPath: projectPath ?? '/workspace',
+					normalizedRelativePath: relativePath,
+				},
+			}),
+		),
+		readText: vi.fn(async ({ filePath }: { filePath: string }) => ({
+			content: '',
+			path: `/workspace/${filePath}`,
+			revision: `v1:${filePath}`,
+		})),
+	};
+});
+
+function assembleWorkspaceServices(localSettings: LocalSettingsStore): {
+	services: WorkspaceServices;
+	ghCapability: ReturnType<typeof createGhCapabilityStore>;
+} {
+	const ghCapability = createGhCapabilityStore();
+	ghCapability.hasChecked = true;
+	ghCapability.available = true;
+	const ws = {
+		isConnected: false,
+		sendMessage: () => false,
+		addMessageConsumer: () => () => undefined,
+		onConnectionChange: () => () => undefined,
+	} satisfies PrimaryWsConnectionPort;
+	return {
+		services: createWorkspaceServices({
+			appShell: createAppShellStore(),
+			chatSessions: createChatSessionsStore(),
+			ghCapability,
+			localSettings,
+			modelCatalog: createModelCatalogStore(),
+			navigation: createNavigationStore(),
+			notifications: createNotificationsStore(),
+			terminalIdentity: { clientId: 'test-client' },
+			ws,
+			getRouteIdentity: () => '/',
+			onTerminalLauncherDismissed: () => {},
+			isTerminalLauncherDismissed: () => false,
+			workspaceLayoutRaw: null,
+		}),
+		ghCapability,
+	};
+}
+
 describe('createWorkspaceServices', () => {
 	let services: WorkspaceServices | null = null;
+	let rootLocalSettings: LocalSettingsStore | null = null;
 
 	afterEach(() => {
 		services?.destroy();
 		services = null;
+		rootLocalSettings?.destroy();
+		rootLocalSettings = null;
 	});
 
 	it.each([
@@ -57,6 +124,25 @@ describe('createWorkspaceServices', () => {
 		localSettings.destroy();
 	});
 
+	it('opens each renderer in the other desktop view and falls back to main without one', () => {
+		localStorage.clear();
+		const localSettings = createLocalSettingsStore();
+
+		localSettings.set('textEditorOpenPlacement', 'other');
+		localSettings.set('imageViewerOpenPlacement', 'other');
+		localSettings.set('markdownViewerOpenPlacement', 'other');
+
+		expect(resolveConfiguredFilePlacement(localSettings, 'code', 'main')).toBe('sidebar');
+		expect(resolveConfiguredFilePlacement(localSettings, 'code', 'sidebar')).toBe('main');
+		expect(resolveConfiguredFilePlacement(localSettings, 'image', 'main')).toBe('sidebar');
+		expect(resolveConfiguredFilePlacement(localSettings, 'image', 'sidebar')).toBe('main');
+		expect(resolveConfiguredFilePlacement(localSettings, 'markdown', 'main')).toBe('sidebar');
+		expect(resolveConfiguredFilePlacement(localSettings, 'markdown', 'sidebar')).toBe('main');
+		expect(resolveConfiguredFilePlacement(localSettings, 'markdown', 'dialog')).toBe('main');
+		expect(resolveConfiguredFilePlacement(localSettings, 'markdown', 'mobile')).toBe('main');
+		localSettings.destroy();
+	});
+
 	it('uses main as the desktop fallback for a mobile source origin', () => {
 		localStorage.clear();
 		const localSettings = createLocalSettingsStore();
@@ -65,33 +151,58 @@ describe('createWorkspaceServices', () => {
 		localSettings.destroy();
 	});
 
-	it('assembles the coordinator and keeps root-owned domain bindings reactive', async () => {
-		const ghCapability = createGhCapabilityStore();
-		ghCapability.hasChecked = true;
-		ghCapability.available = true;
-		const localSettings = createLocalSettingsStore();
-		localSettings.showQuickCommitTray = false;
-		const ws = {
-			isConnected: false,
-			sendMessage: () => false,
-			addMessageConsumer: () => () => undefined,
-			onConnectionChange: () => () => undefined,
-		} satisfies PrimaryWsConnectionPort;
-		services = createWorkspaceServices({
-			appShell: createAppShellStore(),
-			chatSessions: createChatSessionsStore(),
-			ghCapability,
-			localSettings,
-			modelCatalog: createModelCatalogStore(),
-			navigation: createNavigationStore(),
-			notifications: createNotificationsStore(),
-			terminalIdentity: { clientId: 'test-client' },
-			ws,
-			getRouteIdentity: () => '/',
-			onTerminalLauncherDismissed: () => {},
-			isTerminalLauncherDismissed: () => false,
-			workspaceLayoutRaw: null,
+	it('routes other-view file opens through the assembled registry and coordinator', async () => {
+		localStorage.clear();
+		rootLocalSettings = createLocalSettingsStore();
+		rootLocalSettings.set('textEditorOpenPlacement', 'other');
+		({ services } = assembleWorkspaceServices(rootLocalSettings));
+
+		const openingFromMain = services.files.open({
+			fileRootPath: '/workspace',
+			relativePath: 'from-main.ts',
+			mode: 'code',
+			origin: 'main',
+			reason: 'user-open',
 		});
+		await vi.waitFor(() => expect(services?.layout.snapshot.sidebar.activeId).toMatch(/^file:/));
+		const sidebarSurfaceId = services.layout.snapshot.sidebar.activeId;
+		if (!sidebarSurfaceId) throw new Error('Expected a sidebar file surface');
+		services.surfaceFrames.register(sidebarSurfaceId, 'sidebar', {
+			element: document.createElement('div'),
+			attachRetainedRenderer: () => {},
+			focusPrimary: () => {},
+		});
+		const fromMain = await openingFromMain;
+		if (!fromMain) throw new Error('Expected main-origin file to open');
+		expect(services.layout.snapshot.sidebar.order).toContain(fileSurfaceId(fromMain.id));
+		expect(services.layout.snapshot.sidebarOpen).toBe(true);
+
+		const openingFromSidebar = services.files.open({
+			fileRootPath: '/workspace',
+			relativePath: 'from-sidebar.ts',
+			mode: 'code',
+			origin: 'sidebar',
+			reason: 'user-open',
+		});
+		await vi.waitFor(() => expect(services?.layout.snapshot.main.activeId).toMatch(/^file:/));
+		const mainSurfaceId = services.layout.snapshot.main.activeId;
+		if (!mainSurfaceId) throw new Error('Expected a main file surface');
+		services.surfaceFrames.register(mainSurfaceId, 'main', {
+			element: document.createElement('div'),
+			attachRetainedRenderer: () => {},
+			focusPrimary: () => {},
+		});
+		const fromSidebar = await openingFromSidebar;
+		if (!fromSidebar) throw new Error('Expected sidebar-origin file to open');
+		expect(services.layout.snapshot.main.order).toContain(fileSurfaceId(fromSidebar.id));
+	});
+
+	it('assembles the coordinator and keeps root-owned domain bindings reactive', async () => {
+		rootLocalSettings = createLocalSettingsStore();
+		rootLocalSettings.showQuickCommitTray = false;
+		const assembled = assembleWorkspaceServices(rootLocalSettings);
+		services = assembled.services;
+		const { ghCapability } = assembled;
 		await tick();
 
 		expect(services.restore.source).toBe('absent');
@@ -103,7 +214,7 @@ describe('createWorkspaceServices', () => {
 		expect(services.gitQuickSummary.isEnabled).toBe(false);
 		expect(services.singletonSurfaces.pullRequests().capabilityState).toBe('available');
 
-		localSettings.showQuickCommitTray = true;
+		rootLocalSettings.showQuickCommitTray = true;
 		ghCapability.available = false;
 		await tick();
 

--- a/web/src/lib/workspace/workspace-services.ts
+++ b/web/src/lib/workspace/workspace-services.ts
@@ -58,8 +58,9 @@ export function resolveConfiguredFilePlacement(
 		}
 	})();
 
-	if (preference !== 'source') return preference;
-	return origin === 'mobile' ? 'main' : origin;
+	if (preference === 'source') return origin === 'mobile' ? 'main' : origin;
+	if (preference === 'other') return origin === 'main' ? 'sidebar' : 'main';
+	return preference;
 }
 
 export interface WorkspaceRootDependencies {


### PR DESCRIPTION
Adds an Other view preference for text, image, and Markdown file opening so files can target the opposite desktop pane without hardcoding Main or Sidebar. Main-origin opens go to Sidebar, other origins resolve to Main, and Markdown dialog links now show the existing info toast when the opened file remains obscured behind the dialog.