### PR TITLE
Polish Files view settings

### DIFF
--- a/FILES_RESPONSIVE_DETAILS_POLICY_DESIGN.md
+++ b/FILES_RESPONSIVE_DETAILS_POLICY_DESIGN.md
@@ -249,7 +249,7 @@ This biases the unmeasured first frame toward the safe narrow presentation and a
 </script>
 
 <div
-	class="flex h-full min-h-0 min-w-0 flex-col bg-card"
+	class="flex h-full min-h-0 min-w-0 flex-col bg-background"
 	data-file-tree-root
 	data-file-tree-layout={viewMode}
 	{@attach observeFileTreeWidth}
@@ -291,7 +291,6 @@ The checkbox reflects only the override:
 ```svelte
 <DropdownMenuCheckboxItem
 	checked={store.viewPreference === 'always-details'}
-	closeOnSelect={false}
 	onCheckedChange={(checked) => store.setAlwaysUseDetailedRows(Boolean(checked))}
 >
 	{m.filetree_always_use_detailed_rows()}
@@ -619,7 +618,7 @@ Work:
 - Replace the old message with `Always use detailed rows`.
 - Bind checkbox state to preference.
 - Bind section labels, reset action, and sort groups to resolved mode.
-- Keep `closeOnSelect={false}`.
+- Use the dropdown primitive's default close behavior for this top-level preference.
 
 Validation:
 
@@ -845,6 +844,26 @@ Both original reviewer sessions were resumed once more against `6e91a7e`. Kimi K
 independently verified the flex shrink/truncation behavior, stable component identity, details grid
 placement, and directory path, and reported no remaining admissible finding.
 
+### Post-merge Files polish
+
+The Files tree root, toolbar, breadcrumbs, and sticky column header use `background` rather than
+`card`, matching the workspace frame, floating tab bar, Git surfaces, and Commit surface. Popup
+surfaces continue to use `card` as intended.
+
+The persistent Files popup trigger uses the standard Settings icon while retaining its existing
+accessible `File browser actions` name and responsive overflow behavior. `ResponsiveSurfaceActions`
+accepts a typed optional menu icon so this presentation choice does not fork its measurement or menu
+implementation.
+
+`Show icons` is a persisted, default-on binary preference immediately below `Show breadcrumbs`. It
+removes file, folder, and parent-directory glyphs and their spacing without changing disclosure rails,
+status glyphs, row heights, virtual geometry, or accessible names. The binary preference is an
+ordinary boolean; the responsive view policy remains the separate exhaustive discriminator.
+
+`Always use detailed rows` now uses the dropdown primitive's default select behavior and closes after
+selection, consistent with the other top-level Files preferences. The detail sort key and direction
+radio items deliberately remain open for multi-step sorting changes.
+
 ## Acceptance Criteria
 
 - The popup label is `Always use detailed rows`.
@@ -860,8 +879,11 @@ placement, and directory path, and reported no remaining admissible finding.
 - Responsive transitions preserve selection, expansion, focus, visible anchor, and physical end.
 - A later user scroll cancels deferred restoration.
 - Responsive width changes do not sort or rebuild the logical tree.
-- Details-mode file and folder icons are 32 px and span the two-line text block.
-- Column-mode icons remain 16 px.
+- When icons are enabled, details-mode file and folder icons are 32 px and span the two-line text block.
+- When icons are enabled, column-mode icons remain 16 px.
+- `Show icons` defaults on, persists locally, and removes entry and parent glyphs without changing row geometry.
+- The Files surface uses the same `background` token as its workspace frame and sibling Git views.
+- The Files view popup uses a Settings trigger and closes after toggling `Always use detailed rows`.
 - Title and subtitle share one structurally aligned text stack without compensating subtitle padding.
 - A focused copy-path action preserves its DOM identity, focus, and transient state across responsive transitions.
 - All focused tests, `bun run check`, `bun run test`, and fresh startup validation pass.

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -452,6 +452,7 @@
 	"filetree_settings_folders_first": "Folders first",
 	"filetree_settings_show_hidden_files": "Show hidden files",
 	"filetree_show_breadcrumbs": "Show breadcrumbs",
+	"filetree_show_icons": "Show icons",
 	"filetree_always_use_detailed_rows": "Always use detailed rows",
 	"filetree_size": "Size",
 	"filetree_sort_ascending": "Ascending",

--- a/web/src/lib/components/files/FileTree.svelte
+++ b/web/src/lib/components/files/FileTree.svelte
@@ -45,7 +45,7 @@
 </script>
 
 <div
-	class="flex h-full min-h-0 min-w-0 flex-col bg-card"
+	class="flex h-full min-h-0 min-w-0 flex-col bg-background"
 	data-file-tree-root
 	data-file-tree-layout={viewMode}
 	{@attach observeFileTreeWidth}

--- a/web/src/lib/components/files/FileTreeBreadcrumbs.svelte
+++ b/web/src/lib/components/files/FileTreeBreadcrumbs.svelte
@@ -87,7 +87,7 @@
 
 <nav
 	aria-label={m.filetree_location()}
-	class="relative flex h-8 min-w-0 shrink-0 items-center overflow-hidden border-b border-border bg-card px-2 text-xs"
+	class="relative flex h-8 min-w-0 shrink-0 items-center overflow-hidden border-b border-border bg-background px-2 text-xs"
 	data-file-tree-breadcrumbs
 >
 	<Folder class="mr-1.5 h-3.5 w-3.5 shrink-0 text-file-icon-folder" aria-hidden="true" />

--- a/web/src/lib/components/files/FileTreeColumnHeader.svelte
+++ b/web/src/lib/components/files/FileTreeColumnHeader.svelte
@@ -118,7 +118,7 @@
 	role="row"
 	aria-rowindex={ariaRowIndex}
 	data-file-tree-column-grid
-	class="sticky top-0 z-20 grid h-8 min-h-8 gap-2 border-b border-border bg-card px-2 text-xs font-medium text-muted-foreground"
+	class="sticky top-0 z-20 grid h-8 min-h-8 gap-2 border-b border-border bg-background px-2 text-xs font-medium text-muted-foreground"
 	style={`grid-template-columns: ${store.columnGridTemplate}`}
 >
 	{#each visibleColumns as column, columnIndex (column)}

--- a/web/src/lib/components/files/FileTreeMenuContent.svelte
+++ b/web/src/lib/components/files/FileTreeMenuContent.svelte
@@ -62,8 +62,13 @@
 	{m.filetree_show_breadcrumbs()}
 </DropdownMenuCheckboxItem>
 <DropdownMenuCheckboxItem
+	checked={store.showIcons}
+	onCheckedChange={(checked) => store.setShowIcons(Boolean(checked))}
+>
+	{m.filetree_show_icons()}
+</DropdownMenuCheckboxItem>
+<DropdownMenuCheckboxItem
 	checked={store.viewPreference === 'always-details'}
-	closeOnSelect={false}
 	onCheckedChange={(checked) => store.setAlwaysUseDetailedRows(Boolean(checked))}
 >
 	{m.filetree_always_use_detailed_rows()}

--- a/web/src/lib/components/files/FileTreeParentRow.svelte
+++ b/web/src/lib/components/files/FileTreeParentRow.svelte
@@ -8,6 +8,7 @@
 		path,
 		gridTemplate,
 		fillerColumnKeys,
+		showIcons,
 		ariaRowIndex,
 		focused,
 		onActivate,
@@ -18,6 +19,7 @@
 		path: string;
 		gridTemplate: string;
 		fillerColumnKeys: readonly FileTreeColumnKey[];
+		showIcons: boolean;
 		ariaRowIndex: number;
 		focused: boolean;
 		onActivate: () => void;
@@ -42,7 +44,9 @@
 >
 	<div role="rowheader" class="flex min-w-0 items-center" title={path}>
 		<span class="file-tree-disclosure-slot shrink-0" aria-hidden="true"></span>
-		<FolderUp class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-folder" />
+		{#if showIcons}
+			<FolderUp class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-folder" />
+		{/if}
 		<span class="truncate">..</span>
 		<span class="sr-only">{m.filetree_parent_directory()}</span>
 	</div>

--- a/web/src/lib/components/files/FileTreeRenderRow.svelte
+++ b/web/src/lib/components/files/FileTreeRenderRow.svelte
@@ -35,6 +35,7 @@
 		path={row.path}
 		gridTemplate={profile.gridTemplate}
 		fillerColumnKeys={profile.fillerColumnKeys}
+		showIcons={store.showIcons}
 		{ariaRowIndex}
 		{focused}
 		{onActivate}

--- a/web/src/lib/components/files/FileTreeRow.svelte
+++ b/web/src/lib/components/files/FileTreeRow.svelte
@@ -114,22 +114,26 @@
 						<ChevronRight class="h-3.5 w-3.5" />
 					{/if}
 				</button>
-				{#if expanded}
-					<FolderOpen class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-folder" />
-				{:else}
-					<Folder class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-folder" />
+				{#if store.showIcons}
+					{#if expanded}
+						<FolderOpen class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-folder" />
+					{:else}
+						<Folder class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-folder" />
+					{/if}
 				{/if}
 			{:else}
 				<span class="file-tree-disclosure-slot shrink-0" aria-hidden="true"></span>
-				{@const kind = iconType()}
-				{#if kind === 'code'}
-					<FileCode2 class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-code" />
-				{:else if kind === 'document'}
-					<FileText class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-doc" />
-				{:else if kind === 'image'}
-					<FileImage class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-image" />
-				{:else}
-					<File class="file-tree-entry-icon mr-2 shrink-0 text-muted-foreground" />
+				{#if store.showIcons}
+					{@const kind = iconType()}
+					{#if kind === 'code'}
+						<FileCode2 class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-code" />
+					{:else if kind === 'document'}
+						<FileText class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-doc" />
+					{:else if kind === 'image'}
+						<FileImage class="file-tree-entry-icon mr-2 shrink-0 text-file-icon-image" />
+					{:else}
+						<File class="file-tree-entry-icon mr-2 shrink-0 text-muted-foreground" />
+					{/if}
 				{/if}
 			{/if}
 			<div

--- a/web/src/lib/components/files/FileTreeToolbar.svelte
+++ b/web/src/lib/components/files/FileTreeToolbar.svelte
@@ -2,6 +2,7 @@
 	import FolderRoot from '@lucide/svelte/icons/folder-root';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Search from '@lucide/svelte/icons/search';
+	import Settings from '@lucide/svelte/icons/settings';
 	import X from '@lucide/svelte/icons/x';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import ResponsiveSurfaceActions, {
@@ -78,13 +79,18 @@
 	<FileTreeMenuContent {overflowActions} {store} {viewMode} />
 {/snippet}
 
-<div bind:this={root} class="shrink-0 border-b border-border bg-card" data-file-tree-toolbar>
+<div bind:this={root} class="shrink-0 border-b border-border bg-background" data-file-tree-toolbar>
 	<div
 		role="toolbar"
 		aria-label={m.filetree_actions()}
 		class="flex min-h-11 min-w-0 items-center px-2 py-1.5"
 	>
-		<ResponsiveSurfaceActions {actions} menuLabel={m.filetree_actions()} menuContent={fileMenu} />
+		<ResponsiveSurfaceActions
+			{actions}
+			menuLabel={m.filetree_actions()}
+			menuContent={fileMenu}
+			menuIcon={Settings}
+		/>
 	</div>
 
 	{#if store.filterOpen}

--- a/web/src/lib/components/files/__tests__/FileTree.test.ts
+++ b/web/src/lib/components/files/__tests__/FileTree.test.ts
@@ -94,6 +94,22 @@ describe('FileTree', () => {
 		restoreResizeObserver();
 	});
 
+	it('uses the workspace background across the Files surface', async () => {
+		const { container } = renderReady([entry('README.md', 'file')]);
+		await setFileTreeWidth(container, 700);
+
+		for (const selector of [
+			'[data-file-tree-root]',
+			'[data-file-tree-toolbar]',
+			'[data-file-tree-breadcrumbs]',
+			'[data-file-tree-column-grid]',
+		]) {
+			const element = container.querySelector(selector);
+			expect(element?.classList.contains('bg-background')).toBe(true);
+			expect(element?.classList.contains('bg-card')).toBe(false);
+		}
+	});
+
 	it('expands only from disclosure and enters from the rest of the directory row', async () => {
 		const src = entry('src', 'directory');
 		const { container, store } = renderReady([src]);
@@ -276,7 +292,45 @@ describe('FileTree', () => {
 		expect(screen.queryByRole('navigation', { name: 'File location' })).toBeNull();
 	});
 
-	it('pins detailed rows and sorts without reopening the actions menu', async () => {
+	it('shows entry icons by default and toggles them from the settings menu', async () => {
+		const readme = entry('README.md', 'file');
+		const src = entry('src', 'directory');
+		const { container, store } = renderReady([readme, src]);
+		const readmeRow = container.querySelector<HTMLElement>(
+			`[data-file-tree-row-key="${readme.path}"]`,
+		);
+		const srcRow = container.querySelector<HTMLElement>(`[data-file-tree-row-key="${src.path}"]`);
+		const parentRow = container.querySelector<HTMLElement>('[data-file-tree-parent-row]');
+		if (!readmeRow || !srcRow || !parentRow) throw new Error('Expected file tree rows');
+
+		expect(store.showIcons).toBe(true);
+		expect(readmeRow.querySelector('.file-tree-entry-icon')).toBeTruthy();
+		expect(srcRow.querySelector('.file-tree-entry-icon')).toBeTruthy();
+		expect(parentRow.querySelector('.file-tree-entry-icon')).toBeTruthy();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
+		const showIcons = screen.getByRole('menuitemcheckbox', { name: 'Show icons' });
+		expect(showIcons.getAttribute('aria-checked')).toBe('true');
+		await fireEvent.click(showIcons);
+
+		expect(store.showIcons).toBe(false);
+		expect(readmeRow.querySelector('.file-tree-entry-icon')).toBeNull();
+		expect(srcRow.querySelector('.file-tree-entry-icon')).toBeNull();
+		expect(parentRow.querySelector('.file-tree-entry-icon')).toBeNull();
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+
+		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
+		const hiddenIcons = screen.getByRole('menuitemcheckbox', { name: 'Show icons' });
+		expect(hiddenIcons.getAttribute('aria-checked')).toBe('false');
+		await fireEvent.click(hiddenIcons);
+
+		expect(store.showIcons).toBe(true);
+		expect(readmeRow.querySelector('.file-tree-entry-icon')).toBeTruthy();
+		expect(srcRow.querySelector('.file-tree-entry-icon')).toBeTruthy();
+		expect(parentRow.querySelector('.file-tree-entry-icon')).toBeTruthy();
+	});
+
+	it('pins detailed rows, closes the menu, and exposes detail sorting when reopened', async () => {
 		const { container, store } = renderReady([entry('README.md', 'file')]);
 		await setFileTreeWidth(container, 700);
 		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
@@ -287,22 +341,26 @@ describe('FileTree', () => {
 
 		await fireEvent.click(detailsMode);
 		expect(store.viewPreference).toBe('always-details');
-		expect(detailsMode.getAttribute('aria-checked')).toBe('true');
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
 		expect(
 			container.querySelector('[data-file-tree-root]')?.getAttribute('data-file-tree-layout'),
 		).toBe('details');
-		expect(screen.getByText('Details')).toBeTruthy();
-		expect(screen.queryByRole('menuitem', { name: 'Reset column widths' })).toBeNull();
 		await setFileTreeWidth(container, 480);
-		expect(detailsMode.getAttribute('aria-checked')).toBe('true');
 		expect(
 			container.querySelector('[data-file-tree-root]')?.getAttribute('data-file-tree-layout'),
 		).toBe('details');
 		await setFileTreeWidth(container, 700, 'details');
-		expect(detailsMode.getAttribute('aria-checked')).toBe('true');
 		expect(
 			container.querySelector('[data-file-tree-root]')?.getAttribute('data-file-tree-layout'),
 		).toBe('details');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
+		const pinnedDetailsMode = screen.getByRole('menuitemcheckbox', {
+			name: 'Always use detailed rows',
+		});
+		expect(pinnedDetailsMode.getAttribute('aria-checked')).toBe('true');
+		expect(screen.getByText('Details')).toBeTruthy();
+		expect(screen.queryByRole('menuitem', { name: 'Reset column widths' })).toBeNull();
 		expect(screen.getAllByRole('menuitemradio').map((item) => item.textContent?.trim())).toEqual([
 			'Name',
 			'Size',
@@ -323,11 +381,13 @@ describe('FileTree', () => {
 			screen.getByRole('menuitemradio', { name: 'Descending' }).getAttribute('aria-checked'),
 		).toBe('true');
 
-		await fireEvent.click(detailsMode);
+		await fireEvent.click(pinnedDetailsMode);
 		expect(store.viewPreference).toBe('responsive');
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
 		expect(
 			container.querySelector('[data-file-tree-root]')?.getAttribute('data-file-tree-layout'),
 		).toBe('columns');
+		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
 		expect(screen.getByText('Columns')).toBeTruthy();
 		expect(screen.getByRole('menuitem', { name: 'Reset column widths' })).toBeTruthy();
 		expect(screen.queryByRole('menuitemradio')).toBeNull();
@@ -356,9 +416,16 @@ describe('FileTree', () => {
 		await fireEvent.click(alwaysDetails);
 		expect(store.viewPreference).toBe('always-details');
 		expect(root.dataset.fileTreeLayout).toBe('details');
-		await fireEvent.click(alwaysDetails);
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
+		const pinnedAlwaysDetails = screen.getByRole('menuitemcheckbox', {
+			name: 'Always use detailed rows',
+		});
+		expect(pinnedAlwaysDetails.getAttribute('aria-checked')).toBe('true');
+		await fireEvent.click(pinnedAlwaysDetails);
 		expect(store.viewPreference).toBe('responsive');
 		expect(root.dataset.fileTreeLayout).toBe('details');
+		await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
 
 		await setFileTreeWidth(container, 520);
 		expect(screen.getByRole('treegrid')).toBe(treegrid);

--- a/web/src/lib/components/files/__tests__/FileTreeToolbar.test.ts
+++ b/web/src/lib/components/files/__tests__/FileTreeToolbar.test.ts
@@ -80,6 +80,13 @@ describe('FileTreeToolbar', () => {
 		restoreResizeObserver();
 	});
 
+	it('uses a settings icon for its persistent view menu', async () => {
+		await renderMeasuredToolbar();
+		const trigger = screen.getByRole('button', { name: 'File browser actions' });
+
+		expect(trigger.querySelector('svg')?.classList.contains('lucide-settings')).toBe(true);
+	});
+
 	it('moves Refresh from its toolbar button into the persistent menu when space runs out', async () => {
 		const { setWidth } = await renderMeasuredToolbar();
 		expect(screen.getByRole('button', { name: 'Refresh files' })).toBeTruthy();

--- a/web/src/lib/components/shared/ResponsiveSurfaceActions.svelte
+++ b/web/src/lib/components/shared/ResponsiveSurfaceActions.svelte
@@ -29,12 +29,14 @@
 		actions,
 		menuLabel,
 		menuContent,
+		menuIcon: MenuIcon = Ellipsis,
 		fixed,
 		class: className,
 	}: {
 		actions: readonly ResponsiveSurfaceAction[];
 		menuLabel: string;
 		menuContent?: Snippet<[readonly ResponsiveSurfaceAction[]]>;
+		menuIcon?: Component<{ class?: string }>;
 		fixed?: Snippet;
 		class?: string;
 	} = $props();
@@ -176,7 +178,7 @@
 				title={menuLabel}
 				data-responsive-surface-menu-trigger
 			>
-				<Ellipsis class="h-4 w-4" />
+				<MenuIcon class="h-4 w-4" />
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" class={menuContent ? 'w-64' : 'w-56'}>
 				{#if menuContent}
@@ -213,7 +215,7 @@
 			class="inline-flex h-8 w-8 items-center justify-center rounded-md"
 			data-surface-action-overflow-measure
 		>
-			<Ellipsis class="h-4 w-4" />
+			<MenuIcon class="h-4 w-4" />
 		</button>
 	</div>
 </div>

--- a/web/src/lib/files/tree/__tests__/file-tree.test.ts
+++ b/web/src/lib/files/tree/__tests__/file-tree.test.ts
@@ -380,16 +380,19 @@ describe('FileTreeStore', () => {
 		expect(sortEntries).toHaveBeenCalledTimes(callsAfterMaterialization);
 	});
 
-	it('persists breadcrumb and optional-column defaults and changes', () => {
+	it('persists breadcrumb, icon, view, and optional-column preferences', () => {
 		expect(store.showBreadcrumbs).toBe(true);
+		expect(store.showIcons).toBe(true);
 		expect(store.viewPreference).toBe('responsive');
 		expect(store.visibleColumns).toEqual(DEFAULT_FILE_TREE_COLUMN_VISIBILITY);
 
 		store.setShowBreadcrumbs(false);
+		store.setShowIcons(false);
 		store.setAlwaysUseDetailedRows(true);
 		store.setColumnVisible('permissions', true);
 
 		expect(mockStorage.get(LOCAL_STORAGE_KEYS.fileTreeShowBreadcrumbs)).toBe('false');
+		expect(mockStorage.get(LOCAL_STORAGE_KEYS.fileTreeShowIcons)).toBe('false');
 		expect(mockStorage.get(LOCAL_STORAGE_KEYS.fileTreeViewPreference)).toBe('always-details');
 		expect(JSON.parse(mockStorage.get(LOCAL_STORAGE_KEYS.fileTreeColumnVisibility) ?? '')).toEqual({
 			size: true,
@@ -400,6 +403,7 @@ describe('FileTreeStore', () => {
 
 	it('loads valid preferences and ignores malformed values', () => {
 		mockStorage.set(LOCAL_STORAGE_KEYS.fileTreeShowBreadcrumbs, 'false');
+		mockStorage.set(LOCAL_STORAGE_KEYS.fileTreeShowIcons, 'false');
 		mockStorage.set(LOCAL_STORAGE_KEYS.fileTreeViewPreference, 'always-details');
 		mockStorage.set(
 			LOCAL_STORAGE_KEYS.fileTreeColumnVisibility,
@@ -407,13 +411,16 @@ describe('FileTreeStore', () => {
 		);
 		const loaded = new FileTreeStore();
 		expect(loaded.showBreadcrumbs).toBe(false);
+		expect(loaded.showIcons).toBe(false);
 		expect(loaded.viewPreference).toBe('always-details');
 		expect(loaded.visibleColumnKeys).toEqual(['name', 'modified', 'permissions']);
 
 		mockStorage.set(LOCAL_STORAGE_KEYS.fileTreeColumnVisibility, '{bad');
+		mockStorage.set(LOCAL_STORAGE_KEYS.fileTreeShowIcons, 'sometimes');
 		mockStorage.set(LOCAL_STORAGE_KEYS.fileTreeViewPreference, 'tiles');
 		const malformed = new FileTreeStore();
 		expect(malformed.viewPreference).toBe('responsive');
+		expect(malformed.showIcons).toBe(true);
 		expect(malformed.visibleColumns).toEqual(DEFAULT_FILE_TREE_COLUMN_VISIBILITY);
 	});
 

--- a/web/src/lib/files/tree/file-tree.svelte.ts
+++ b/web/src/lib/files/tree/file-tree.svelte.ts
@@ -193,6 +193,7 @@ export class FileTreeStore {
 	foldersFirst = $state(true);
 	showHiddenFiles = $state(true);
 	showBreadcrumbs = $state(true);
+	showIcons = $state(true);
 	viewPreference = $state<FileTreeViewPreference>('responsive');
 	visibleColumns = $state.raw<FileTreeColumnVisibility>(
 		copyColumnVisibility(DEFAULT_FILE_TREE_COLUMN_VISIBILITY),
@@ -585,6 +586,11 @@ export class FileTreeStore {
 		this.#persist(LOCAL_STORAGE_KEYS.fileTreeShowBreadcrumbs, String(value));
 	}
 
+	setShowIcons(value: boolean): void {
+		this.showIcons = value;
+		this.#persist(LOCAL_STORAGE_KEYS.fileTreeShowIcons, String(value));
+	}
+
 	setColumnVisible(column: OptionalFileTreeColumnKey, visible: boolean): void {
 		this.visibleColumns = { ...this.visibleColumns, [column]: visible };
 		this.#persist(LOCAL_STORAGE_KEYS.fileTreeColumnVisibility, JSON.stringify(this.visibleColumns));
@@ -784,6 +790,10 @@ export class FileTreeStore {
 		const showBreadcrumbs = getLocalStorageItem(LOCAL_STORAGE_KEYS.fileTreeShowBreadcrumbs);
 		if (showBreadcrumbs === 'true' || showBreadcrumbs === 'false') {
 			this.showBreadcrumbs = showBreadcrumbs === 'true';
+		}
+		const showIcons = getLocalStorageItem(LOCAL_STORAGE_KEYS.fileTreeShowIcons);
+		if (showIcons === 'true' || showIcons === 'false') {
+			this.showIcons = showIcons === 'true';
 		}
 		const viewPreference = getLocalStorageItem(LOCAL_STORAGE_KEYS.fileTreeViewPreference);
 		if (isFileTreeViewPreference(viewPreference)) this.viewPreference = viewPreference;

--- a/web/src/lib/utils/local-persistence.ts
+++ b/web/src/lib/utils/local-persistence.ts
@@ -10,6 +10,7 @@ export const LOCAL_STORAGE_KEYS = {
 	fileTreeColumnWidths: 'file-tree-column-widths',
 	fileTreeShowBreadcrumbs: 'file-tree-show-breadcrumbs',
 	fileTreeShowHiddenFiles: 'file-tree-show-hidden-files',
+	fileTreeShowIcons: 'file-tree-show-icons',
 	fileTreeSortDirection: 'file-tree-sort-direction',
 	fileTreeSortKey: 'file-tree-sort-key',
 	fileTreeViewPreference: 'file-tree-view-preference',


### PR DESCRIPTION
Aligns Files with sibling workspace surfaces by using the standard background token and Settings trigger, adds a persisted default-on Show icons preference for file and folder rows, and restores normal menu dismissal for Always use detailed rows so Files presentation controls look and behave consistently.