### PR TITLE
Allow Claude forks with forward parent references

### DIFF
--- a/integration-tests/tests/server/claude-scripted-fork-matrix.test.ts
+++ b/integration-tests/tests/server/claude-scripted-fork-matrix.test.ts
@@ -327,6 +327,89 @@ describe('scripted Claude fork lifecycle matrix', () => {
     });
   });
 
+  test('forks and reforks a transcript whose hook parent appears later in the file', async () => {
+    if (!environment) throw new Error('Scripted Claude environment was not initialized.');
+    const testEnvironment = environment;
+    const sourcePrompt = marker('FORWARD_PARENT_SOURCE_PROMPT');
+    const sourceReply = marker('FORWARD_PARENT_SOURCE_REPLY');
+    const childPrompt = marker('FORWARD_PARENT_CHILD_PROMPT');
+    const childReply = marker('FORWARD_PARENT_CHILD_REPLY');
+    testEnvironment.model.scriptTurn([claudeText(sourceReply)]);
+
+    await withIntegrationFixture('claude-scripted-fork-forward-parent', async (fixture) => {
+      const sourceChatId = fixture.newChatId();
+      const sourceCursor = fixture.client.markEvents();
+      const sourceTurn = await fixture.client.startChat(liveClaudeStartRequest({
+        chatId: sourceChatId,
+        projectPath: fixture.dirs.project,
+        command: sourcePrompt,
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: sourceChatId,
+        turnId: sourceTurn.turnId,
+        marker: sourceReply,
+        afterIndex: sourceCursor,
+      });
+      await reloadUntilNativeContains(fixture, sourceChatId, sourceReply);
+      const source = await readClaudeChat(fixture.dirs.workspace, sourceChatId);
+      const hookUuids = await injectOutOfOrderHookAttachments(source);
+
+      const forkChatId = fixture.newChatId();
+      await fixture.client.forkChat({ sourceChatId, chatId: forkChatId });
+      const fork = await fixture.client.getMessages(forkChatId);
+      expect(userContents(fork.messages)).toEqual([sourcePrompt]);
+      expect(assistantContents(fork.messages)).toContain(sourceReply);
+
+      const forkedChat = await readClaudeChat(fixture.dirs.workspace, forkChatId);
+      const forkedEntries = await readClaudeEntries(forkedChat.nativeSession.value.path);
+      const entriesBySourceUuid = new Map(forkedEntries.map((entry) => [
+        (entry.forkedFrom as { messageUuid?: unknown } | undefined)?.messageUuid,
+        entry,
+      ]));
+      const hookSuccess = entriesBySourceUuid.get(hookUuids.success);
+      const hookError = entriesBySourceUuid.get(hookUuids.error);
+      expect(hookSuccess).toBeDefined();
+      expect(hookError).toBeDefined();
+      expect(forkedEntries.indexOf(hookSuccess!)).toBeLessThan(forkedEntries.indexOf(hookError!));
+      expect(hookSuccess?.parentUuid).toBe(hookError?.uuid);
+
+      testEnvironment.model.scriptTurn((request) => {
+        expect(request.lastUserText).toContain(childPrompt);
+        expect(JSON.stringify(request.body.messages)).toContain(sourcePrompt);
+        expect(JSON.stringify(request.body.messages)).toContain(sourceReply);
+        return [claudeText(childReply)];
+      });
+      const childCursor = fixture.client.markEvents();
+      const childTurn = await fixture.client.runChat(liveClaudeRunRequest({
+        chatId: forkChatId,
+        command: childPrompt,
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: forkChatId,
+        turnId: childTurn.turnId,
+        marker: childReply,
+        afterIndex: childCursor,
+      });
+      await waitForNativeFileContains(fixture.dirs.workspace, forkChatId, childReply);
+
+      const reforkChatId = fixture.newChatId();
+      await forkAfterSourceSettles(fixture, forkChatId, reforkChatId);
+      const refork = await fixture.client.getMessages(reforkChatId);
+      expect(userContents(refork.messages)).toEqual([sourcePrompt, childPrompt]);
+      expect(assistantContents(refork.messages)).toEqual(expect.arrayContaining([
+        sourceReply,
+        childReply,
+      ]));
+      testEnvironment.model.assertSettled();
+    }, {
+      serverEnvironment: testEnvironment.serverEnvironment,
+    });
+  });
+
   test('forks a never-run chat as an unmaterialized child that starts fresh', async () => {
     if (!environment) throw new Error('Scripted Claude environment was not initialized.');
     const testEnvironment = environment;
@@ -602,4 +685,61 @@ async function appendMicrocompaction(chat: PersistedClaudeChat): Promise<void> {
     `${raw.endsWith('\n') || raw.length === 0 ? '' : '\n'}${appended.map((entry) => JSON.stringify(entry)).join('\n')}\n`,
     'utf8',
   );
+}
+
+async function injectOutOfOrderHookAttachments(
+  chat: PersistedClaudeChat,
+): Promise<{ success: string; error: string }> {
+  const entries = await readClaudeEntries(chat.nativeSession.value.path);
+  const assistantIndex = entries.findIndex(
+    (entry) => entry.type === 'assistant'
+      && typeof entry.uuid === 'string'
+      && typeof entry.parentUuid === 'string',
+  );
+  const assistant = entries[assistantIndex];
+  if (!assistant || typeof assistant.parentUuid !== 'string') {
+    throw new Error('Claude transcript lacks an assistant with a parent graph.');
+  }
+
+  const success = crypto.randomUUID();
+  const error = crypto.randomUUID();
+  const assistantTimestamp = typeof assistant.timestamp === 'string'
+    ? Date.parse(assistant.timestamp)
+    : Date.now();
+  const baseTimestamp = Number.isFinite(assistantTimestamp) ? assistantTimestamp : Date.now();
+  const hookEntries = [
+    {
+      type: 'attachment',
+      uuid: success,
+      parentUuid: error,
+      sessionId: chat.agentSessionId,
+      timestamp: new Date(baseTimestamp - 1).toISOString(),
+      isSidechain: false,
+      attachment: { type: 'hook_success' },
+    },
+    {
+      type: 'attachment',
+      uuid: error,
+      parentUuid: assistant.parentUuid,
+      sessionId: chat.agentSessionId,
+      timestamp: new Date(baseTimestamp - 2).toISOString(),
+      isSidechain: false,
+      attachment: { type: 'hook_non_blocking_error' },
+    },
+  ];
+  entries.splice(assistantIndex, 0, ...hookEntries);
+  entries[assistantIndex + hookEntries.length] = { ...assistant, parentUuid: success };
+  await writeFile(
+    chat.nativeSession.value.path,
+    `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`,
+    'utf8',
+  );
+  return { success, error };
+}
+
+async function readClaudeEntries(path: string): Promise<Record<string, unknown>[]> {
+  return (await readFile(path, 'utf8'))
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
 }

--- a/server-agents/claude/src/agents/claude/__tests__/claude-forking.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/claude-forking.test.js
@@ -35,7 +35,25 @@ describe('Claude JSONL forking', () => {
         timestamp: '2026-07-17T15:20:02.808Z',
       },
       {
+        parentUuid: '5ff2ba2d-fac5-421d-b522-df6cf579d2e4',
+        isSidechain: false,
+        sessionId: sourceAgentSessionId,
+        type: 'attachment',
+        attachment: { type: 'hook_success' },
+        uuid: '82a44863-8d08-40e1-8fa2-c5a0c79c3725',
+        timestamp: '2026-07-17T15:20:03.324Z',
+      },
+      {
         parentUuid: 'a4912601-44aa-469d-b00e-3eee75dd027e',
+        isSidechain: false,
+        sessionId: sourceAgentSessionId,
+        type: 'attachment',
+        attachment: { type: 'hook_non_blocking_error' },
+        uuid: '5ff2ba2d-fac5-421d-b522-df6cf579d2e4',
+        timestamp: '2026-07-17T15:20:03.262Z',
+      },
+      {
+        parentUuid: '82a44863-8d08-40e1-8fa2-c5a0c79c3725',
         isSidechain: false,
         sessionId: sourceAgentSessionId,
         type: 'assistant',
@@ -134,16 +152,24 @@ describe('Claude JSONL forking', () => {
     const forkedPath = nativeSessions.decode(forked.nativeSession).path;
     const forkedEntries = (await readFile(forkedPath, 'utf8')).trim().split('\n').map(JSON.parse);
 
-    expect(forkedEntries.map((entry) => entry.sessionId)).toEqual([
-      forked.agentSessionId,
-      forked.agentSessionId,
-      forked.agentSessionId,
-    ]);
-    expect(forkedEntries[0].uuid).not.toBe(sourceEntries[0].uuid);
-    expect(forkedEntries[1].uuid).not.toBe(sourceEntries[1].uuid);
-    expect(forkedEntries[2].uuid).not.toBe(sourceEntries[2].uuid);
-    expect(forkedEntries[1].parentUuid).toBe(forkedEntries[0].uuid);
-    expect(forkedEntries[2].parentUuid).toBe(forkedEntries[1].uuid);
+    expect(forkedEntries.every((entry) => entry.sessionId === forked.agentSessionId)).toBe(true);
+    const entriesBySourceUuid = new Map(forkedEntries.map((entry) => [
+      entry.forkedFrom.messageUuid,
+      entry,
+    ]));
+    for (const sourceEntry of sourceEntries) {
+      expect(entriesBySourceUuid.get(sourceEntry.uuid)?.uuid).not.toBe(sourceEntry.uuid);
+    }
+    const hookSuccess = entriesBySourceUuid.get('82a44863-8d08-40e1-8fa2-c5a0c79c3725');
+    const hookError = entriesBySourceUuid.get('5ff2ba2d-fac5-421d-b522-df6cf579d2e4');
+    expect(hookSuccess).toBeDefined();
+    expect(hookError).toBeDefined();
+    expect(forkedEntries.indexOf(hookSuccess)).toBeLessThan(forkedEntries.indexOf(hookError));
+    expect(hookSuccess.parentUuid).toBe(hookError.uuid);
+    const targetUuids = new Set(forkedEntries.map((entry) => entry.uuid));
+    for (const entry of forkedEntries) {
+      if (entry.parentUuid !== null) expect(targetUuids.has(entry.parentUuid)).toBe(true);
+    }
     expect((await stat(forkedPath)).mode & 0o777).toBe(0o600);
     expect(await readFile(sourcePath, 'utf8')).toBe(sourceContent);
     await expect(loadClaudeChatMessages(forkedPath)).resolves.toMatchObject([

--- a/server-agents/claude/src/agents/claude/__tests__/fork-transcript.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/fork-transcript.test.js
@@ -296,16 +296,54 @@ describe('transformClaudeForkTranscript', () => {
     expect(result.expectedSemanticDigest).toStartWith('ordered-v1:');
   });
 
-  it('rejects a child whose retained parent appears later in the file', () => {
-    const transform = createClaudeForkTranscriptTransformer({ randomUUID: crypto.randomUUID });
-    expect(() => transform({
-      selectedEntries: [
-        { type: 'assistant', uuid: 'child', parentUuid: 'parent', sessionId: context.sourceAgentSessionId },
-        { type: 'user', uuid: 'parent', parentUuid: null, sessionId: context.sourceAgentSessionId },
-      ],
-      sourceEntries: [],
+  it('remaps a retained parent that appears later in physical file order', () => {
+    const sourceEntries = [
+      {
+        type: 'user', uuid: 'source-root', parentUuid: null,
+        sessionId: context.sourceAgentSessionId, timestamp: '2026-08-01T02:43:12.000Z',
+        message: { role: 'user', content: 'Inspect the repository.' },
+      },
+      {
+        type: 'attachment', uuid: 'source-hook-success', parentUuid: 'source-hook-error',
+        sessionId: context.sourceAgentSessionId, timestamp: '2026-08-01T02:43:12.324Z',
+        attachment: { type: 'hook_success' },
+      },
+      {
+        type: 'attachment', uuid: 'source-hook-error', parentUuid: 'source-root',
+        sessionId: context.sourceAgentSessionId, timestamp: '2026-08-01T02:43:12.262Z',
+        attachment: { type: 'hook_non_blocking_error' },
+      },
+      {
+        type: 'assistant', uuid: 'source-leaf', parentUuid: 'source-hook-success',
+        sessionId: context.sourceAgentSessionId, timestamp: '2026-08-01T02:43:13.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+      },
+    ];
+
+    const result = transformClaudeForkTranscript({
+      selectedEntries: sourceEntries,
+      sourceEntries,
       ...context,
-    })).toThrow('parent appears after its child');
+    });
+    const entriesBySourceUuid = new Map(result.entries.map((entry) => [
+      entry.forkedFrom?.messageUuid,
+      entry,
+    ]));
+    const hookSuccess = entriesBySourceUuid.get('source-hook-success');
+    const hookError = entriesBySourceUuid.get('source-hook-error');
+    expect(hookSuccess).toBeDefined();
+    expect(hookError).toBeDefined();
+    expect(result.entries.indexOf(hookSuccess)).toBeLessThan(result.entries.indexOf(hookError));
+    expect(hookSuccess.parentUuid).toBe(hookError.uuid);
+
+    const targetUuids = new Set(result.entries.map((entry) => entry.uuid));
+    const sourceUuids = new Set(sourceEntries.map((entry) => entry.uuid));
+    for (const entry of result.entries) {
+      expect(entry.sessionId).toBe(context.targetAgentSessionId);
+      expect(sourceUuids.has(entry.uuid)).toBe(false);
+      if (entry.parentUuid !== null) expect(targetUuids.has(entry.parentUuid)).toBe(true);
+    }
+    expect(result.expectedSemanticDigest).toStartWith('ordered-v1:');
   });
 });
 

--- a/server-agents/claude/src/agents/claude/fork-transcript.ts
+++ b/server-agents/claude/src/agents/claude/fork-transcript.ts
@@ -95,7 +95,9 @@ export function createClaudeForkTranscriptTransformer(
   const randomUUID = options.randomUUID ?? crypto.randomUUID;
   const now = options.now ?? (() => new Date().toISOString());
 
-  // Mirrors the graph rewrite used by the official Claude Agent SDK filesystem fork.
+  // The Agent SDK indexes the full selected graph before resolving parent links, so
+  // parentUuid may refer to a record that appears later in physical JSONL order.
+  // https://github.com/anthropics/claude-agent-sdk-python/blob/f8b9ec923982082a02c485924e0f60367949c3a1/src/claude_agent_sdk/_internal/session_mutations.py#L385-L418
   return (input) => {
     const forkTimestamp = now();
     const transcript = input.selectedEntries
@@ -103,7 +105,6 @@ export function createClaudeForkTranscriptTransformer(
       .filter((entry) => entry.isSidechain !== true);
     const byUuid = new Map(transcript.map((entry) => [entry.uuid as string, entry]));
     const uuidMap = new Map(transcript.map((entry) => [entry.uuid as string, randomUUID()]));
-    const writtenSourceUuids = new Set<string>();
     const messages = transcript
       .filter((entry) => entry.type !== 'progress')
       .map((entry) => {
@@ -115,7 +116,6 @@ export function createClaudeForkTranscriptTransformer(
             stringOrNull(entry.parentUuid),
             byUuid,
             uuidMap,
-            writtenSourceUuids,
           ),
           sessionId: input.targetAgentSessionId,
           isSidechain: false,
@@ -132,7 +132,6 @@ export function createClaudeForkTranscriptTransformer(
         }
         for (const field of CLAUDE_SOURCE_ONLY_FIELDS) delete rewritten[field];
         stripTaskActivation(rewritten);
-        writtenSourceUuids.add(sourceUuid);
         return rewritten;
       });
 
@@ -207,7 +206,6 @@ function remapClaudeParent(
   parentUuid: string | null,
   byUuid: ReadonlyMap<string, Record<string, unknown>>,
   uuidMap: ReadonlyMap<string, string>,
-  writtenSourceUuids: ReadonlySet<string>,
 ): string | null {
   const visited = new Set<string>();
   let current = parentUuid;
@@ -216,9 +214,6 @@ function remapClaudeParent(
     const parent = byUuid.get(current);
     if (!parent) return null;
     if (parent.type !== 'progress') {
-      if (!writtenSourceUuids.has(current)) {
-        throw unavailable('Claude transcript parent appears after its child');
-      }
       return uuidMap.get(current) ?? null;
     }
     current = stringOrNull(parent.parentUuid);
@@ -233,7 +228,15 @@ function assertClaudeForkGraph(
   allowedUuidCounts: ReadonlyMap<string, number>,
 ): void {
   const sourceUuids = new Set(sourceEntries.map((entry) => entry.uuid));
-  const writtenUuids = new Set<string>();
+  // The Agent SDK resolves parents from its complete UUID map rather than treating file
+  // order as a topological order. Validation therefore checks closure over all emitted nodes.
+  // https://github.com/anthropics/claude-agent-sdk-python/blob/f8b9ec923982082a02c485924e0f60367949c3a1/src/claude_agent_sdk/_internal/session_mutations.py#L396-L418
+  const emittedUuids = new Set(
+    entries
+      .filter((entry) => entry.type !== 'content-replacement')
+      .map((entry) => entry.uuid)
+      .filter((uuid): uuid is string => typeof uuid === 'string'),
+  );
   const emittedUuidCounts = new Map<string, number>();
   for (const entry of entries) {
     if (entry.type === 'content-replacement') continue;
@@ -248,10 +251,9 @@ function assertClaudeForkGraph(
     if (entry.sessionId !== targetSessionId) {
       throw unavailable('Claude fork contains inconsistent session identity');
     }
-    if (entry.parentUuid !== null && !writtenUuids.has(String(entry.parentUuid))) {
+    if (entry.parentUuid !== null && !emittedUuids.has(String(entry.parentUuid))) {
       throw unavailable('Claude fork contains an invalid parent graph');
     }
-    writtenUuids.add(entry.uuid);
   }
 }
 


### PR DESCRIPTION
Claude can persist hook attachment children before their parent records, causing Garcon to reject otherwise valid full-chat forks. This updates the Claude transcript transformer to resolve parents against the complete retained UUID graph and validate graph closure independently of JSONL order, with regression coverage for fork, resume, and refork behavior.
