### PR TITLE
Preserve file viewer scroll positions

### DIFF
--- a/integration-tests/tests/e2e/file-viewer-scrolling.test.ts
+++ b/integration-tests/tests/e2e/file-viewer-scrolling.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "bun:test";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Page } from "puppeteer-core";
+import { withE2eFixture } from "../../support/e2e-fixture.js";
+import { SpaDriver } from "../../support/spa-driver.js";
+
+const MARKDOWN_FILE = "scrolling.md";
+const TEXT_FILE = "scrolling.txt";
+const IMAGE_FILE = "scrolling.svg";
+
+type ScrollTarget = "markdown" | "editor" | "image";
+
+describe("Lightpanda desktop file viewer scrolling", () => {
+  test("preserves editor, Markdown, and image offsets across tab switches", async () => {
+    await withE2eFixture("file-viewer-scrolling", async (fixture) => {
+      const projectPath = fixture.integration.dirs.project;
+      await Promise.all([
+        writeFile(
+          join(projectPath, MARKDOWN_FILE),
+          Array.from(
+            { length: 240 },
+            (_, index) => `## Section ${index}\n\nBody ${index}.`,
+          ).join("\n\n"),
+          "utf8",
+        ),
+        writeFile(
+          join(projectPath, TEXT_FILE),
+          Array.from({ length: 500 }, (_, index) => `line ${index}`).join("\n"),
+          "utf8",
+        ),
+        writeFile(
+          join(projectPath, IMAGE_FILE),
+          '<svg xmlns="http://www.w3.org/2000/svg" width="2400" height="1800" viewBox="0 0 2400 1800"><rect width="2400" height="1800" fill="#fff"/><path d="M0 0 2400 1800M2400 0 0 1800" stroke="#111" stroke-width="24"/></svg>',
+          "utf8",
+        ),
+      ]);
+
+      await fixture.page.evaluateOnNewDocument(() => {
+        const key = "pref_local_settings";
+        const parsed = JSON.parse(
+          globalThis.localStorage.getItem(key) ?? "{}",
+        ) as unknown;
+        const stored =
+          parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? parsed
+            : {};
+        globalThis.localStorage.setItem(
+          key,
+          JSON.stringify({
+            ...stored,
+            textEditorOpenPlacement: "main",
+            imageViewerOpenPlacement: "main",
+            markdownViewerOpenPlacement: "main",
+          }),
+        );
+      });
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.setViewport(1_440, 900);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat("file-viewer-scroll-seed", {
+        projectPath,
+      });
+      if (await app.hasButton("Open sidebar"))
+        await app.clickButton("Open sidebar");
+      await app.selectSidebarWorkspaceSurface("Files");
+      await fixture.page.waitForSelector("[data-file-tree-grid]");
+
+      await openProjectFile(
+        fixture.page,
+        join(projectPath, MARKDOWN_FILE),
+        MARKDOWN_FILE,
+        "markdown",
+      );
+      await openProjectFile(
+        fixture.page,
+        join(projectPath, TEXT_FILE),
+        TEXT_FILE,
+        "editor",
+      );
+      await openProjectFile(
+        fixture.page,
+        join(projectPath, IMAGE_FILE),
+        IMAGE_FILE,
+        "image",
+      );
+
+      await app.selectMainWorkspaceSurface(MARKDOWN_FILE);
+      await waitForActiveTarget(fixture.page, MARKDOWN_FILE, "markdown");
+      const markdownOffset = await setScrollOffset(
+        fixture.page,
+        MARKDOWN_FILE,
+        "markdown",
+        420,
+      );
+      expect(markdownOffset).toBeGreaterThan(0);
+      await app.selectMainWorkspaceSurface(TEXT_FILE);
+      await app.selectMainWorkspaceSurface(MARKDOWN_FILE);
+      await expectRestoredOffset(
+        fixture.page,
+        MARKDOWN_FILE,
+        "markdown",
+        markdownOffset,
+      );
+
+      await app.selectMainWorkspaceSurface(TEXT_FILE);
+      await waitForActiveTarget(fixture.page, TEXT_FILE, "editor");
+      const editorOffset = await setScrollOffset(
+        fixture.page,
+        TEXT_FILE,
+        "editor",
+        560,
+      );
+      expect(editorOffset).toBeGreaterThan(0);
+      await app.selectMainWorkspaceSurface(IMAGE_FILE);
+      await app.selectMainWorkspaceSurface(TEXT_FILE);
+      await expectRestoredOffset(
+        fixture.page,
+        TEXT_FILE,
+        "editor",
+        editorOffset,
+      );
+
+      await app.selectMainWorkspaceSurface(IMAGE_FILE);
+      await waitForActiveTarget(fixture.page, IMAGE_FILE, "image");
+      await prepareScrollableImage(fixture.page, IMAGE_FILE);
+      await app.clickButton("Zoom in", { contains: true });
+      await app.clickButton("Zoom in", { contains: true });
+      await waitForAnimationFrames(fixture.page, 3);
+      const imageOffset = await setScrollOffset(
+        fixture.page,
+        IMAGE_FILE,
+        "image",
+        360,
+      );
+      expect(imageOffset).toBeGreaterThan(0);
+      await app.selectMainWorkspaceSurface(MARKDOWN_FILE);
+      await app.selectMainWorkspaceSurface(IMAGE_FILE);
+      await expectRestoredOffset(
+        fixture.page,
+        IMAGE_FILE,
+        "image",
+        imageOffset,
+      );
+
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});
+
+async function openProjectFile(
+  page: Page,
+  absolutePath: string,
+  fileName: string,
+  target: ScrollTarget,
+): Promise<void> {
+  await page.waitForFunction(
+    (path) =>
+      [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-file-tree-row] [role="rowheader"]',
+        ),
+      ].some((element) => element.getAttribute("title") === path),
+    { timeout: 20_000 },
+    absolutePath,
+  );
+  await page.evaluate((path) => {
+    const header = [
+      ...document.querySelectorAll<HTMLElement>(
+        '[data-file-tree-row] [role="rowheader"]',
+      ),
+    ].find((element) => element.getAttribute("title") === path);
+    const row = header?.closest<HTMLElement>("[data-file-tree-row]");
+    if (!row) throw new Error(`Missing file tree row: ${path}`);
+    row.click();
+  }, absolutePath);
+  await waitForActiveTarget(page, fileName, target);
+}
+
+async function waitForActiveTarget(
+  page: Page,
+  fileName: string,
+  target: ScrollTarget,
+): Promise<void> {
+  await page.waitForFunction(
+    ({ expectedFileName, expectedTarget }) => {
+      const surface = [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-workspace-surface-id^="file:"]',
+        ),
+      ].find(
+        (candidate) =>
+          candidate.querySelector("h2")?.textContent?.trim() ===
+          expectedFileName,
+      );
+      if (!surface) return false;
+      if (expectedTarget === "markdown")
+        return surface.querySelector(".markdown-viewer-content") !== null;
+      if (expectedTarget === "editor")
+        return surface.querySelector(".cm-scroller") !== null;
+      return surface.querySelector(`img[alt="${expectedFileName}"]`) !== null;
+    },
+    { timeout: 20_000 },
+    { expectedFileName: fileName, expectedTarget: target },
+  );
+}
+
+async function setScrollOffset(
+  page: Page,
+  fileName: string,
+  target: ScrollTarget,
+  offset: number,
+): Promise<number> {
+  return await page.evaluate(
+    ({ expectedFileName, expectedTarget, expectedOffset }) => {
+      const surface = [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-workspace-surface-id^="file:"]',
+        ),
+      ].find(
+        (candidate) =>
+          candidate.querySelector("h2")?.textContent?.trim() ===
+          expectedFileName,
+      );
+      const element =
+        expectedTarget === "markdown"
+          ? surface?.querySelector<HTMLElement>(".markdown-viewer-content")
+          : expectedTarget === "editor"
+            ? surface?.querySelector<HTMLElement>(".cm-scroller")
+            : surface?.querySelector<HTMLImageElement>(
+                `img[alt="${expectedFileName}"]`,
+              )?.parentElement;
+      if (!element)
+        throw new Error(
+          `Missing ${expectedTarget} scroll target for ${expectedFileName}`,
+        );
+      element.scrollTop = expectedOffset;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+      return element.scrollTop;
+    },
+    {
+      expectedFileName: fileName,
+      expectedTarget: target,
+      expectedOffset: offset,
+    },
+  );
+}
+
+async function expectRestoredOffset(
+  page: Page,
+  fileName: string,
+  target: ScrollTarget,
+  expectedOffset: number,
+): Promise<void> {
+  await page.waitForFunction(
+    ({ expectedFileName, expectedTarget, expected }) => {
+      const surface = [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-workspace-surface-id^="file:"]',
+        ),
+      ].find(
+        (candidate) =>
+          candidate.querySelector("h2")?.textContent?.trim() ===
+          expectedFileName,
+      );
+      const element =
+        expectedTarget === "markdown"
+          ? surface?.querySelector<HTMLElement>(".markdown-viewer-content")
+          : expectedTarget === "editor"
+            ? surface?.querySelector<HTMLElement>(".cm-scroller")
+            : surface?.querySelector<HTMLImageElement>(
+                `img[alt="${expectedFileName}"]`,
+              )?.parentElement;
+      const tolerance = expectedTarget === "image" ? 4 : 1;
+      return (
+        element != null && Math.abs(element.scrollTop - expected) <= tolerance
+      );
+    },
+    { timeout: 20_000 },
+    {
+      expectedFileName: fileName,
+      expectedTarget: target,
+      expected: expectedOffset,
+    },
+  );
+}
+
+async function prepareScrollableImage(
+  page: Page,
+  fileName: string,
+): Promise<void> {
+  await page.evaluate((expectedFileName) => {
+    const surface = [
+      ...document.querySelectorAll<HTMLElement>(
+        '[data-workspace-surface-id^="file:"]',
+      ),
+    ].find(
+      (candidate) =>
+        candidate.querySelector("h2")?.textContent?.trim() === expectedFileName,
+    );
+    const target = surface?.querySelector<HTMLImageElement>(
+      `img[alt="${expectedFileName}"]`,
+    );
+    if (!target) throw new Error(`Missing image: ${expectedFileName}`);
+    // Supplies layout dimensions because Lightpanda does not decode blob-backed SVG metadata.
+    const style = document.createElement("style");
+    style.textContent = `img[alt="${expectedFileName}"] { width: 2400px !important; height: 1800px !important; }`;
+    document.head.append(style);
+  }, fileName);
+}
+
+async function waitForAnimationFrames(
+  page: Page,
+  count: number,
+): Promise<void> {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+    }
+  }, count);
+}

--- a/web/src/lib/components/files/ImageViewer.svelte
+++ b/web/src/lib/components/files/ImageViewer.svelte
@@ -140,7 +140,6 @@
 	$effect(() => {
 		const viewport = viewportElement;
 		if (!viewport) return;
-		let restored = false;
 		correctingScroll = true;
 		const observer = new ResizeObserver(() => {
 			if (session.image.mode === 'fit') fitToWindow();
@@ -153,20 +152,13 @@
 			if (session.image.mode === 'fit') fitToWindow();
 			else restoreSavedManualFocalPoint();
 			scheduleScrollRelease();
-			restored = true;
 		});
+		// Scroll events persist offsets before detached browser viewports report zero.
 		return () => {
 			cancelAnimationFrame(frame);
 			cancelPendingManualZoom();
 			if (scrollReleaseFrame !== null) cancelAnimationFrame(scrollReleaseFrame);
 			observer.disconnect();
-			if (restored) {
-				session.image = {
-					...session.image,
-					scrollLeft: viewport.scrollLeft,
-					scrollTop: viewport.scrollTop,
-				};
-			}
 		};
 	});
 </script>

--- a/web/src/lib/components/files/MarkdownViewer.svelte
+++ b/web/src/lib/components/files/MarkdownViewer.svelte
@@ -25,16 +25,12 @@
 	$effect(() => {
 		const element = contentElement;
 		if (!element) return;
-		let restored = false;
 		const frame = requestAnimationFrame(() => {
 			element.scrollLeft = session.markdownScrollLeft;
 			element.scrollTop = session.markdownScrollTop;
-			restored = true;
 		});
-		return () => {
-			cancelAnimationFrame(frame);
-			if (restored) captureScroll(element);
-		};
+		// Scroll events persist offsets before detached browser elements report zero.
+		return () => cancelAnimationFrame(frame);
 	});
 
 	function captureScroll(element: HTMLDivElement): void {

--- a/web/src/lib/components/files/__tests__/ImageViewer.test.ts
+++ b/web/src/lib/components/files/__tests__/ImageViewer.test.ts
@@ -3,6 +3,7 @@ import { tick } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ImageViewer from '../ImageViewer.svelte';
 import { FileSession } from '$lib/files/sessions/file-session.svelte.js';
+import { emulateDetachedScrollReset } from '../../../../test/detached-scroll.js';
 
 describe('ImageViewer', () => {
 	afterEach(() => {
@@ -50,6 +51,7 @@ describe('ImageViewer', () => {
 		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 		const firstViewport = screen.getByRole('img').closest('.overflow-auto') as HTMLDivElement;
+		emulateDetachedScrollReset(firstViewport);
 		expect(firstViewport.scrollLeft).toBe(31);
 		expect(firstViewport.scrollTop).toBe(79);
 		firstViewport.scrollLeft = 47;

--- a/web/src/lib/components/files/__tests__/MarkdownViewer.test.ts
+++ b/web/src/lib/components/files/__tests__/MarkdownViewer.test.ts
@@ -11,6 +11,7 @@ import {
 	reduceWorkspaceLayout,
 } from '$lib/workspace/workspace-layout.svelte.js';
 import MarkdownViewerTestHost from './MarkdownViewerTestHost.svelte';
+import { emulateDetachedScrollReset } from '../../../../test/detached-scroll.js';
 
 afterEach(() => {
 	cleanup();
@@ -69,6 +70,7 @@ describe('MarkdownViewer', () => {
 		});
 		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 		const mainContent = screen.getByRole('region', { name: 'current.md' });
+		emulateDetachedScrollReset(mainContent);
 		mainContent.scrollLeft = 11;
 		mainContent.scrollTop = 137;
 		await fireEvent.scroll(mainContent);

--- a/web/src/lib/files/editor/__tests__/code-editor-controller.test.ts
+++ b/web/src/lib/files/editor/__tests__/code-editor-controller.test.ts
@@ -4,6 +4,7 @@ import { history } from '@codemirror/commands';
 import type { CanonicalFileIdentity } from '$shared/file-contracts';
 import { FileSession } from '$lib/files/sessions/file-session.svelte.js';
 import { CodeEditorController } from '$lib/files/editor/code-editor-controller.svelte.js';
+import { emulateDetachedScrollReset } from '../../../../test/detached-scroll.js';
 
 const mounted: HTMLElement[] = [];
 
@@ -60,9 +61,11 @@ describe('CodeEditorController', () => {
 		const firstLease = controller.attach(firstParent);
 		const firstScroller = firstParent.querySelector<HTMLElement>('.cm-scroller');
 		if (!firstScroller) throw new Error('Expected CodeMirror scroller');
+		emulateDetachedScrollReset(firstScroller);
 		firstScroller.scrollLeft = 9;
 		firstScroller.scrollTop = 24;
 		firstScroller.dispatchEvent(new Event('scroll'));
+		firstParent.remove();
 		controller.prepareRendererTransfer();
 		const secondLease = controller.attach(secondParent);
 		controller.detach(firstLease);

--- a/web/src/lib/files/editor/code-editor-controller.svelte.ts
+++ b/web/src/lib/files/editor/code-editor-controller.svelte.ts
@@ -117,7 +117,8 @@ export class CodeEditorController {
 	#detachCurrent(): void {
 		const view = this.#view;
 		if (!view) return;
-		this.#captureScroll(view);
+		// Detached browser scroll containers report zero after Svelte removes the surface DOM.
+		if (view.scrollDOM.isConnected) this.#captureScroll(view);
 		view.scrollDOM.removeEventListener('scroll', this.#handleScroll);
 		this.session.editorState = view.state;
 		this.session.content = this.#serializeDocument(view.state.doc);

--- a/web/src/test/detached-scroll.ts
+++ b/web/src/test/detached-scroll.ts
@@ -1,0 +1,16 @@
+export function emulateDetachedScrollReset(element: HTMLElement): void {
+	let scrollLeft = element.scrollLeft;
+	let scrollTop = element.scrollTop;
+	Object.defineProperties(element, {
+		scrollLeft: {
+			configurable: true,
+			get: () => (element.isConnected ? scrollLeft : 0),
+			set: (value: number) => (scrollLeft = value),
+		},
+		scrollTop: {
+			configurable: true,
+			get: () => (element.isConnected ? scrollTop : 0),
+			set: (value: number) => (scrollTop = value),
+		},
+	});
+}


### PR DESCRIPTION
Desktop file surfaces are remounted when tabs change, and teardown was overwriting saved offsets with zero after the DOM detached. This change keeps connected scroll snapshots authoritative for the file editor, Markdown viewer, and image viewer, preventing each surface from jumping back to the top when users return to its tab.