### PR TITLE
Fix server bind address reporting

### DIFF
--- a/server/lib/__tests__/server-runtime.test.js
+++ b/server/lib/__tests__/server-runtime.test.js
@@ -5,6 +5,7 @@ import path from 'path';
 import {
   advertisedServerUrl,
   createServerRuntimeState,
+  listeningServerUrl,
   publishServerRuntime,
   removeServerRuntime,
 } from '../server-runtime.js';
@@ -47,5 +48,10 @@ describe('server runtime publication', () => {
   it('advertises wildcard listeners through loopback', () => {
     expect(advertisedServerUrl('0.0.0.0', 8080)).toBe('http://127.0.0.1:8080');
     expect(advertisedServerUrl('::', 8080)).toBe('http://127.0.0.1:8080');
+  });
+
+  it('reports the actual listener address', () => {
+    expect(listeningServerUrl('0.0.0.0', 8080)).toBe('http://0.0.0.0:8080');
+    expect(listeningServerUrl('::', 8080)).toBe('http://[::]:8080');
   });
 });

--- a/server/lib/server-runtime.ts
+++ b/server/lib/server-runtime.ts
@@ -42,6 +42,11 @@ export function createServerRuntimeProof(
 export function advertisedServerUrl(bindAddress: string, port: number): string {
   let hostname = bindAddress;
   if (hostname === '0.0.0.0' || hostname === '::' || hostname === '[::]') hostname = '127.0.0.1';
+  return listeningServerUrl(hostname, port);
+}
+
+export function listeningServerUrl(bindAddress: string, port: number): string {
+  let hostname = bindAddress;
   if (hostname.includes(':') && !hostname.startsWith('[')) hostname = `[${hostname}]`;
   return `http://${hostname}:${port}`;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -102,6 +102,7 @@ import { acquireWorkspaceLease, type WorkspaceLease } from './lib/workspace-leas
 import {
   advertisedServerUrl,
   createServerRuntimeState,
+  listeningServerUrl,
   publishServerRuntime,
   removeServerRuntime,
 } from './lib/server-runtime.js';
@@ -720,14 +721,15 @@ export async function startServer(): Promise<void> {
 
     const server = Bun.serve<WsConnectionData>(serveOptions);
     webSocketPublisher = server;
-    const baseUrl = advertisedServerUrl(bindAddress, server.port ?? listenPort);
+    const actualPort = server.port ?? listenPort;
+    const runtimeBaseUrl = advertisedServerUrl(bindAddress, actualPort);
     let runtimeFilePath: string | null = null;
     if (config.workspaceName !== null) {
       try {
-        const publishedRuntime = await publishServerRuntime(runtimeState, baseUrl);
+        const publishedRuntime = await publishServerRuntime(runtimeState, runtimeBaseUrl);
         runtimeFilePath = publishedRuntime.filePath;
         logger.info(
-          `Published workspace ${config.workspaceName} runtime at ${runtimeFilePath} (${baseUrl})`,
+          `Published workspace ${config.workspaceName} runtime at ${runtimeFilePath} (${runtimeBaseUrl})`,
         );
       } catch (error) {
         await server.stop(true);
@@ -811,7 +813,7 @@ export async function startServer(): Promise<void> {
     process.on('SIGINT', shutdown);
 
     logger.info(
-      `Started at ${baseUrl}`,
+      `Started at ${listeningServerUrl(bindAddress, actualPort)}`,
     );
     logger.info(`Authentication: ${authDisabled ? 'DISABLED' : 'ENABLED'}`);
     if (


### PR DESCRIPTION
Garcon began logging the loopback runtime-discovery URL as its startup listener address, which made wildcard binds appear to listen only on localhost. This change keeps the loopback URL in the CLI runtime descriptor while reporting the actual configured bind address in server startup logs, including correct IPv6 formatting.