### PR TITLE
Reconcile queue controls after server restarts

### DIFF
--- a/common/__tests__/chat-execution-control.test.js
+++ b/common/__tests__/chat-execution-control.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  MAX_CHAT_EXECUTION_CONTROL_SERVER_INSTANCE_ID_LENGTH,
+  emptyChatExecutionControlState,
+  parseChatExecutionControlState,
+  parseExecutionControlServerInstanceId,
+} from '../chat-execution-control.ts';
+
+describe('chat execution control contract', () => {
+  it('requires an explicit server instance for empty controls', () => {
+    expect(emptyChatExecutionControlState('server-instance-test')).toMatchObject({
+      serverInstanceId: 'server-instance-test',
+      version: 0,
+      updatedAt: null,
+    });
+  });
+
+  it('parses bounded opaque server instance IDs without normalizing them', () => {
+    expect(parseExecutionControlServerInstanceId('server-a')).toBe('server-a');
+    expect(
+      parseExecutionControlServerInstanceId(
+        'x'.repeat(MAX_CHAT_EXECUTION_CONTROL_SERVER_INSTANCE_ID_LENGTH),
+      ),
+    ).toHaveLength(MAX_CHAT_EXECUTION_CONTROL_SERVER_INSTANCE_ID_LENGTH);
+
+    for (const value of [
+      undefined,
+      null,
+      '',
+      ' server-a',
+      'server-a ',
+      'x'.repeat(MAX_CHAT_EXECUTION_CONTROL_SERVER_INSTANCE_ID_LENGTH + 1),
+    ]) {
+      expect(parseExecutionControlServerInstanceId(value)).toBeNull();
+    }
+  });
+
+  it('rejects controls without a valid server instance ID', () => {
+    const valid = emptyChatExecutionControlState('server-a');
+    expect(parseChatExecutionControlState(valid)).toEqual(valid);
+
+    for (const serverInstanceId of [undefined, null, '', ' server-a', 'server-a ']) {
+      expect(parseChatExecutionControlState({ ...valid, serverInstanceId })).toBeNull();
+    }
+  });
+});

--- a/common/chat-execution-control.ts
+++ b/common/chat-execution-control.ts
@@ -5,9 +5,20 @@ import {
 } from './queue-state.js';
 
 export interface ChatExecutionControlState {
+  serverInstanceId: string;
   queue: ChatQueueState;
   version: number;
   updatedAt: string | null;
+}
+
+export const MAX_CHAT_EXECUTION_CONTROL_SERVER_INSTANCE_ID_LENGTH = 128;
+
+export function parseExecutionControlServerInstanceId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  if (value.length === 0 || value.length > MAX_CHAT_EXECUTION_CONTROL_SERVER_INSTANCE_ID_LENGTH) {
+    return null;
+  }
+  return value.trim() === value ? value : null;
 }
 
 function isCanonicalIsoTimestamp(value: unknown): value is string {
@@ -16,8 +27,11 @@ function isCanonicalIsoTimestamp(value: unknown): value is string {
   return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
 }
 
-export function emptyChatExecutionControlState(): ChatExecutionControlState {
+export function emptyChatExecutionControlState(
+  serverInstanceId: string,
+): ChatExecutionControlState {
   return {
+    serverInstanceId,
     queue: emptyChatQueueState(),
     version: 0,
     updatedAt: null,
@@ -27,11 +41,13 @@ export function emptyChatExecutionControlState(): ChatExecutionControlState {
 export function parseChatExecutionControlState(value: unknown): ChatExecutionControlState | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const raw = value as Record<string, unknown>;
+  const serverInstanceId = parseExecutionControlServerInstanceId(raw.serverInstanceId);
   const queue = parseChatQueueState(raw.queue);
-  if (!queue) return null;
+  if (!serverInstanceId || !queue) return null;
   if (typeof raw.version !== 'number' || !Number.isSafeInteger(raw.version) || raw.version < 0) return null;
   if (raw.updatedAt !== null && !isCanonicalIsoTimestamp(raw.updatedAt)) return null;
   return {
+    serverInstanceId,
     queue,
     version: raw.version,
     updatedAt: raw.updatedAt,

--- a/common/ws-events.ts
+++ b/common/ws-events.ts
@@ -15,7 +15,10 @@ import type {
 } from './pending-user-input';
 import { normalizePendingUserInput } from './pending-user-input';
 import type { ChatExecutionControlState } from './chat-execution-control';
-import { parseChatExecutionControlState } from './chat-execution-control';
+import {
+  parseChatExecutionControlState,
+  parseExecutionControlServerInstanceId,
+} from './chat-execution-control';
 import type { RemoteSettingsSnapshot } from './settings';
 import type { ErrorCode } from './error-codes';
 import { normalizeRemoteSettingsSnapshot } from './settings';
@@ -172,6 +175,7 @@ export class ReconnectStateMessage {
   constructor(
     public processing: ChatProcessingSnapshotResult,
     public controlResults: ReconnectControlResult[],
+    public serverInstanceId: string,
     public clientRequestId?: string,
   ) {}
 }
@@ -211,6 +215,7 @@ export class WsPongMessage {
     public sentAt: number,
     public serverTime: string,
     public processing: ChatProcessingSnapshotResult,
+    public serverInstanceId: string,
   ) {}
 }
 
@@ -636,10 +641,23 @@ export function parseServerWsMessage(
     case 'reconnect-state': {
       const processing = chatProcessingSnapshotResult(data.processing);
       const controlResults = reconnectControlResults(data.controlResults);
-      if (!processing || !controlResults) return null;
+      const serverInstanceId = parseExecutionControlServerInstanceId(data.serverInstanceId);
+      if (
+        !processing ||
+        !controlResults ||
+        !serverInstanceId ||
+        controlResults.some(
+          (result) =>
+            result.outcome === 'snapshot' &&
+            result.control.serverInstanceId !== serverInstanceId,
+        )
+      ) {
+        return null;
+      }
       return new ReconnectStateMessage(
         processing,
         controlResults,
+        serverInstanceId,
         typeof data.clientRequestId === 'string'
           ? data.clientRequestId
           : undefined,
@@ -682,8 +700,15 @@ export function parseServerWsMessage(
           : null;
       const serverTime = requiredStr(data.serverTime);
       const processing = chatProcessingSnapshotResult(data.processing);
-      return clientRequestId && sentAt !== null && serverTime && processing
-        ? new WsPongMessage(clientRequestId, sentAt, serverTime, processing)
+      const serverInstanceId = parseExecutionControlServerInstanceId(data.serverInstanceId);
+      return clientRequestId && sentAt !== null && serverTime && processing && serverInstanceId
+        ? new WsPongMessage(
+            clientRequestId,
+            sentAt,
+            serverTime,
+            processing,
+            serverInstanceId,
+          )
         : null;
     }
     case 'chat-title-updated': {

--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -10,6 +10,7 @@ interface ClickOptions {
 
 type QueueRowAction = 'Edit queued message' | 'Remove from queue';
 type QueueMoveDirection = 'up' | 'down';
+type ComposerAction = 'Send message' | 'Queue message';
 
 export class SpaDriver {
   readonly #page: Page;
@@ -318,6 +319,40 @@ export class SpaDriver {
     }, { timeout: 20_000 }).then((handle) => handle.jsonValue());
     if (typeof title !== 'string') throw new Error('Composer send action did not become available.');
     await this.clickButton(title);
+  }
+
+  async waitForComposerAction(action: ComposerAction): Promise<void> {
+    await this.#page.waitForFunction(
+      (expected) => [...document.querySelectorAll('button')].some((element) => {
+        const name = element.getAttribute('aria-label') || element.textContent?.trim();
+        return !element.closest('[aria-hidden="true"]') && name === expected;
+      }),
+      { timeout: 20_000 },
+      action,
+    );
+  }
+
+  async submitComposerWithEnter(content: string, expectedAction: ComposerAction): Promise<void> {
+    const selector = 'textarea[placeholder="Reply..."]';
+    await this.fill(selector, content);
+    await this.#page.waitForFunction(
+      (expected) => [...document.querySelectorAll('button')].some((element) => {
+        const name = element.getAttribute('aria-label') || element.textContent?.trim();
+        return !element.closest('[aria-hidden="true"]')
+          && name === expected
+          && !(element as HTMLButtonElement).disabled;
+      }),
+      { timeout: 20_000 },
+      expectedAction,
+    );
+    await this.#page.$eval(selector, (element) => {
+      (element as HTMLTextAreaElement).focus();
+      element.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
   }
 
   async fill(selector: string, value: string): Promise<void> {

--- a/integration-tests/tests/e2e/queue-workflow.test.ts
+++ b/integration-tests/tests/e2e/queue-workflow.test.ts
@@ -7,6 +7,82 @@ import {
 } from '../../support/accepted-response-loss.js';
 
 describe('Lightpanda queue workflow', () => {
+	test('clears stale controls and shows an Enter-queued message after restart', async () => {
+		await withE2eFixture('queue-controls-after-restart', async (fixture) => {
+			const app = new SpaDriver(fixture.page, fixture.integration);
+			const before = fixture.integration.fakeProviders.openAi.holdNext({
+				lastUserText: 'before-restart-active',
+			});
+			await app.open();
+			await fixture.waitForSpaWebSocket();
+			await app.startOpenAiDirectChat('before-restart-active');
+			await before.received;
+
+			await app.sendComposer('before-restart-queued');
+			await app.waitForQueuedPreview('before-restart-queued');
+			const chat = (await fixture.integration.client.listChats()).sessions.find(
+				(entry) => entry.preview.firstMessage === 'before-restart-active',
+			);
+			if (!chat) throw new Error('Restart queue chat was not listed.');
+			await fixture.integration.client.pauseQueue(chat.id);
+			await app.waitForText('Resume queue');
+
+			const terminalCursor = fixture.integration.client.markEvents();
+			before.releaseEcho();
+			await fixture.integration.client.waitForProcessing(chat.id, false, {
+				afterIndex: terminalCursor,
+			});
+			const priorConnectionCount = await fixture.spaWebSocketConnectionCount();
+			expect(fixture.browserErrors).toEqual([]);
+			const errorsBeforeCrash = fixture.browserErrors.length;
+
+			await fixture.integration.crashAndRestartGarcon({ reusePort: true });
+			await fixture.page.evaluate((previousCount) => {
+				const scope = globalThis as typeof globalThis & {
+					__garconSpaWsOpenCount?: number;
+				};
+				if ((scope.__garconSpaWsOpenCount ?? 0) <= previousCount) {
+					globalThis.dispatchEvent(new Event('online'));
+				}
+			}, priorConnectionCount);
+			await fixture.waitForSpaWebSocket({ afterConnectionCount: priorConnectionCount });
+			const errorsAfterReconnect = fixture.browserErrors.length;
+			await fixture.page.waitForFunction(
+				() => document.querySelector('[data-queue-preview]') === null,
+				{ timeout: 20_000 },
+			);
+			await app.waitForTextAbsent('Resume queue');
+			await app.waitForComposerAction('Send message');
+
+			const after = fixture.integration.fakeProviders.openAi.holdNext({
+				lastUserText: 'after-restart-active',
+			});
+			await app.sendComposer('after-restart-active');
+			await after.received;
+			await app.submitComposerWithEnter('after-restart-queued', 'Queue message');
+
+			await app.waitForQueuedPreview('after-restart-queued');
+			const control = await fixture.integration.client.getExecutionControl(chat.id);
+			expect(control.queue.entries.map((entry) => entry.content)).toEqual([
+				'after-restart-queued',
+			]);
+
+			const afterTerminalCursor = fixture.integration.client.markEvents();
+			after.releaseEcho();
+			await fixture.integration.client.waitForProcessing(chat.id, false, {
+				afterIndex: afterTerminalCursor,
+			});
+			const reconnectWindowErrors = fixture.browserErrors.slice(
+				errorsBeforeCrash,
+				errorsAfterReconnect,
+			);
+			expect(reconnectWindowErrors.filter(
+				(message) => !message.startsWith('console.error: WebSocket error:'),
+			)).toEqual([]);
+			expect(fixture.browserErrors.slice(errorsAfterReconnect)).toEqual([]);
+		});
+	});
+
 	test('moves queued messages with buttons and executes the authoritative order', async () => {
 		await withE2eFixture('queue-reorder-workflow', async (fixture) => {
 			const app = new SpaDriver(fixture.page, fixture.integration);

--- a/integration-tests/tests/server/persistence-lifecycle.test.ts
+++ b/integration-tests/tests/server/persistence-lifecycle.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { randomBytes } from 'node:crypto';
+import { parseServerRuntimeProbe } from '../../../common/server-runtime.js';
 import type { ChatViewMessage } from '../../../common/chat-view.js';
 import { GarconApiError } from '../../support/garcon-client.js';
 import {
@@ -7,6 +9,13 @@ import {
   userContents,
 } from '../../support/chat-assertions.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+async function getRuntimeInstanceId(baseUrl: string): Promise<string> {
+  const challenge = randomBytes(32).toString('base64url');
+  const response = await fetch(`${baseUrl}/api/v1/runtime?challenge=${challenge}`);
+  expect(response.ok).toBe(true);
+  return parseServerRuntimeProbe(await response.json()).instanceId;
+}
 
 describe('persistence lifecycle', () => {
   test('restores an idle direct chat and provider configuration after graceful restart', async () => {
@@ -77,11 +86,20 @@ describe('persistence lifecycle', () => {
         agent: fixture.directAgents.openAi,
       });
       await held.received;
+      const initialInstanceId = await getRuntimeInstanceId(fixture.garcon.baseUrl);
       await fixture.client.enqueueNew(chatId, 'discard-on-restart');
       const paused = await fixture.client.pauseQueue(chatId);
+      expect(paused.control.serverInstanceId).toBe(initialInstanceId);
       expect(paused.control.queue.entries.map((entry) => entry.content)).toEqual(['discard-on-restart']);
       expect(paused.control.queue.pause?.kind).toBe('manual');
-      expect((await fixture.client.reconnectState([chatId])).processing).toEqual({
+      const initialReconnect = await fixture.client.reconnectState([chatId]);
+      expect(initialReconnect.serverInstanceId).toBe(initialInstanceId);
+      const initialControl = initialReconnect.controlResults[0];
+      if (!initialControl || initialControl.outcome !== 'snapshot') {
+        throw new Error('Initial reconnect did not return the queue snapshot.');
+      }
+      expect(initialControl.control.serverInstanceId).toBe(initialInstanceId);
+      expect(initialReconnect.processing).toEqual({
         outcome: 'snapshot',
         chats: [{ chatId, phase: 'running' }],
       });
@@ -99,7 +117,10 @@ describe('persistence lifecycle', () => {
       await activeAborted;
       held.releaseTruncatedStream();
 
+      const restartedInstanceId = await getRuntimeInstanceId(fixture.garcon.baseUrl);
+      expect(restartedInstanceId).not.toBe(initialInstanceId);
       const restarted = await fixture.client.reconnectState([chatId]);
+      expect(restarted.serverInstanceId).toBe(restartedInstanceId);
       expect(restarted.processing).toEqual({
         outcome: 'snapshot',
         chats: [],
@@ -108,6 +129,7 @@ describe('persistence lifecycle', () => {
         chatId,
         outcome: 'snapshot',
         control: {
+          serverInstanceId: restartedInstanceId,
           queue: {
             entries: [],
             dispatchingEntryId: null,
@@ -120,6 +142,7 @@ describe('persistence lifecycle', () => {
         },
       }]);
       expect(await fixture.client.getExecutionControl(chatId)).toEqual({
+        serverInstanceId: restartedInstanceId,
         queue: {
           entries: [],
           dispatchingEntryId: null,

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -14,6 +14,7 @@ import { waitForMaterializedThread } from '../durability.ts';
 import { CodexAppServerRuntime } from '../runtime.ts';
 import { loadCodexChatMessages } from '../../history-loader.ts';
 import { ChatExecutionCoordinator } from '../../../../../../../server/chat-execution/chat-execution-coordinator.ts';
+import { InMemoryChatExecutionControlRepository } from '../../../../../../../server/chat-execution/chat-execution-control-repository.ts';
 import { PendingUserInputService } from '../../../../../../../server/chats/pending-user-input-service.ts';
 import {
   buildThreadForkParams,
@@ -1544,6 +1545,7 @@ describe('CodexAppServerRuntime', () => {
         ampAgentMode: 'default',
       }),
       () => true,
+      new InMemoryChatExecutionControlRepository('server-instance-test'),
     );
   }
 
@@ -4690,6 +4692,7 @@ describe('CodexAppServerRuntime', () => {
         ampAgentMode: 'default',
       }),
       () => true,
+      new InMemoryChatExecutionControlRepository('server-instance-test'),
     );
 
     const result = await queue.deliverGoalControlInput('chat-1', 'Steer from the queue', {

--- a/server/__tests__/architecture-budgets.test.js
+++ b/server/__tests__/architecture-budgets.test.js
@@ -28,7 +28,9 @@ const MAX_LINES = 1000;
 // 564-line ledger, projection, result budget, terminal-race handling, ordered
 // deletion publication, replay-safe admission, and atomic resume-admission
 // increment for the consultation CLI.
-const EXECUTION_FOOTPRINT_BUDGET = 7929;
+// Runtime-scoped execution controls add 9 lines for repository identity injection,
+// client projection, and rejection of foreign-instance state.
+const EXECUTION_FOOTPRINT_BUDGET = 7938;
 
 const GRANDFATHER = {
   'server/git/diff-engine.ts': 1575,

--- a/server/__tests__/queue-transcript-stability.test.js
+++ b/server/__tests__/queue-transcript-stability.test.js
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { UserMessage } from '../../common/chat-types.js';
 import { ChatExecutionCoordinator } from '../chat-execution/chat-execution-coordinator.js';
+import { InMemoryChatExecutionControlRepository } from '../chat-execution/chat-execution-control-repository.ts';
 import { ChatNativeReloader } from '../chats/chat-native-reload.js';
 import { ChatRunningError } from '../chats/errors.js';
 import { ChatViewStore } from '../chats/chat-view-store.js';
@@ -22,6 +23,10 @@ function deferred() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+function controlRepository(serverInstanceId = 'server-instance-test') {
+  return new InMemoryChatExecutionControlRepository(serverInstanceId);
 }
 
 describe('queue and transcript stability', () => {
@@ -89,6 +94,7 @@ describe('queue and transcript stability', () => {
         { appendMessages: mock(async () => ({ generationId: 'generation-1', messages: [] })) },
         () => ({}),
         () => true,
+        controlRepository(),
       );
       const settled = deferred();
       queue.onTurnSettled((chatId, turn) => settled.resolve({ chatId, turn }));
@@ -198,6 +204,7 @@ describe('queue and transcript stability', () => {
         },
         () => ({}),
         () => true,
+        controlRepository(),
       );
       queue.onSessionStopRequested((requestedChatId, stopId, turn) => {
         coordinator.onStopRequested(requestedChatId, stopId, turn);
@@ -296,6 +303,7 @@ describe('queue and transcript stability', () => {
         },
         () => ({}),
         () => true,
+        controlRepository(),
       );
       queue.onSessionStopRequested((requestedChatId, stopId, turn) => {
         coordinator.onStopRequested(requestedChatId, stopId, turn);
@@ -386,6 +394,7 @@ describe('queue and transcript stability', () => {
         },
         () => ({}),
         () => true,
+        controlRepository(),
       );
       executionCoordinator = queue;
       const reloader = new ChatNativeReloader(
@@ -455,7 +464,11 @@ describe('queue and transcript stability', () => {
         () => ({}),
         () => true,
       ];
-      const queue = new ChatExecutionCoordinator(workspaceDir, ...queueDeps);
+      const queue = new ChatExecutionCoordinator(
+        workspaceDir,
+        ...queueDeps,
+        controlRepository('server-instance-a'),
+      );
       await queue.createChatQueueEntry(chatId, 'discard on restart');
       await queue.popNextChat(chatId);
 
@@ -470,8 +483,14 @@ describe('queue and transcript stability', () => {
       expect(accepted.kind).toBe('accepted');
       await ledger.update(accepted.record.key, { status: 'scheduled' });
 
-      const restartedQueue = new ChatExecutionCoordinator(workspaceDir, ...queueDeps);
-      expect((await restartedQueue.readChatExecutionControl(chatId)).entries).toEqual([]);
+      const restartedQueue = new ChatExecutionCoordinator(
+        workspaceDir,
+        ...queueDeps,
+        controlRepository('server-instance-b'),
+      );
+      const restartedControl = await restartedQueue.readChatExecutionControl(chatId);
+      expect(restartedControl.serverInstanceId).toBe('server-instance-b');
+      expect(restartedControl.entries).toEqual([]);
 
       const restartedLedger = new CommandLedger(workspaceDir);
       const duplicate = await restartedLedger.accept(ledgerInput);

--- a/server/__tests__/server-event-wiring.test.js
+++ b/server/__tests__/server-event-wiring.test.js
@@ -3,6 +3,7 @@ import { AssistantMessage, UserMessage } from '../../common/chat-types.js';
 import { PendingUserInputService } from '../chats/pending-user-input-service.js';
 import { projectAgentTurnReceipt } from '../commands/agent-turn-receipt-projector.ts';
 import { CommandLedger } from '../commands/command-ledger.ts';
+import { emptyStoredChatExecutionControl } from '../chat-execution/control-state.ts';
 import { wireServerEvents } from '../server-event-wiring.js';
 
 function deferred() {
@@ -35,7 +36,7 @@ function createWiringFixture(overrides = {}) {
     settleTurn: mock(() => undefined),
   };
   const queue = {
-    onExecutionControlUpdated: noOpSubscription,
+    onExecutionControlUpdated: mock((callback) => { queueListeners.executionControl = callback; }),
     onSessionStopRequested: noOpSubscription,
     onDispatching: noOpSubscription,
     onChatIdle: noOpSubscription,
@@ -130,6 +131,36 @@ function createWiringFixture(overrides = {}) {
 }
 
 describe('server event wiring', () => {
+  it('broadcasts the server instance with execution control updates', () => {
+    const published = [];
+    const fixture = createWiringFixture({
+      server: {
+        publish: mock((_topic, payload) => published.push(JSON.parse(payload))),
+      },
+    });
+    const control = emptyStoredChatExecutionControl('server-instance-a');
+    control.version = 3;
+
+    fixture.queueListeners.executionControl('chat-1', control);
+
+    expect(published).toEqual([{
+      type: 'chat-execution-control-updated',
+      chatId: 'chat-1',
+      control: {
+        serverInstanceId: 'server-instance-a',
+        queue: {
+          entries: [],
+          dispatchingEntryId: null,
+          recentlyDispatched: [],
+          pause: null,
+          reorderRevision: 0,
+        },
+        version: 3,
+        updatedAt: null,
+      },
+    }]);
+  });
+
   it('broadcasts the generic chat reorder invalidation', () => {
     const published = [];
     const fixture = createWiringFixture({

--- a/server/chat-execution/__tests__/chat-execution-control-repository.test.js
+++ b/server/chat-execution/__tests__/chat-execution-control-repository.test.js
@@ -6,11 +6,11 @@ import { emptyStoredChatExecutionControl } from '../control-state.ts';
 
 describe('InMemoryChatExecutionControlRepository', () => {
   it('loads missing state, isolates returned values, and deletes', async () => {
-    const repository = new InMemoryChatExecutionControlRepository();
+    const repository = new InMemoryChatExecutionControlRepository('server-instance-test');
     const missing = await repository.load('chat-1');
-    expect(missing).toEqual(emptyStoredChatExecutionControl());
+    expect(missing).toEqual(emptyStoredChatExecutionControl('server-instance-test'));
 
-    const stored = emptyStoredChatExecutionControl();
+    const stored = emptyStoredChatExecutionControl('server-instance-test');
     stored.version = 1;
     stored.updatedAt = '2026-07-19T00:00:00.000Z';
     stored.entries.push({
@@ -27,12 +27,12 @@ describe('InMemoryChatExecutionControlRepository', () => {
 
     expect((await repository.load('chat-1')).entries[0].content).toBe('queued');
     await repository.delete('chat-1');
-    expect(await repository.load('chat-1')).toEqual(emptyStoredChatExecutionControl());
+    expect(await repository.load('chat-1')).toEqual(emptyStoredChatExecutionControl('server-instance-test'));
   });
 
   it('preserves every applied receipt while cloning storage', async () => {
-    const repository = new InMemoryChatExecutionControlRepository();
-    const control = emptyStoredChatExecutionControl();
+    const repository = new InMemoryChatExecutionControlRepository('server-instance-test');
+    const control = emptyStoredChatExecutionControl('server-instance-test');
     control.appliedCommands = Array.from({ length: 1_005 }, (_, index) => ({
       key: `key-${index}`,
       operation: 'create',
@@ -42,5 +42,23 @@ describe('InMemoryChatExecutionControlRepository', () => {
 
     await repository.save('chat-1', control);
     expect((await repository.load('chat-1')).appliedCommands).toHaveLength(1_005);
+  });
+
+  it('uses one identity until the repository is replaced', async () => {
+    const repository = new InMemoryChatExecutionControlRepository('server-a');
+    expect((await repository.load('chat-1')).serverInstanceId).toBe('server-a');
+    expect((await repository.load('chat-2')).serverInstanceId).toBe('server-a');
+
+    const replacement = new InMemoryChatExecutionControlRepository('server-b');
+    expect(await replacement.load('chat-1')).toEqual(
+      emptyStoredChatExecutionControl('server-b'),
+    );
+  });
+
+  it('rejects controls owned by another repository instance', async () => {
+    const repository = new InMemoryChatExecutionControlRepository('server-a');
+    await expect(
+      repository.save('chat-1', emptyStoredChatExecutionControl('server-b')),
+    ).rejects.toThrow('another server instance');
   });
 });

--- a/server/chat-execution/__tests__/chat-execution-control-transitions.test.js
+++ b/server/chat-execution/__tests__/chat-execution-control-transitions.test.js
@@ -45,9 +45,9 @@ function storedEntry(id, status = 'queued', revision = 1) {
 
 describe('chat execution control transitions', () => {
   it('creates, replaces, dispatches, returns, and removes one entry without mutating inputs', () => {
-    const initial = emptyStoredChatExecutionControl();
+    const initial = emptyStoredChatExecutionControl('server-instance-test');
     const created = createQueueEntry(initial, { content: 'first' }, context());
-    expect(initial).toEqual(emptyStoredChatExecutionControl());
+    expect(initial).toEqual(emptyStoredChatExecutionControl('server-instance-test'));
     expect(created.next).toMatchObject({ version: 1, entries: [{ content: 'first', revision: 1 }] });
 
     const entryId = value(created).entryId;
@@ -79,7 +79,7 @@ describe('chat execution control transitions', () => {
 
   it('returns typed mutation rejections with the input state unchanged', () => {
     const created = createQueueEntry(
-      emptyStoredChatExecutionControl(),
+      emptyStoredChatExecutionControl('server-instance-test'),
       { content: 'first' },
       context(),
     );
@@ -106,7 +106,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('retains unresolved receipts while enforcing the receipt bound', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.appliedCommands = Array.from(
       { length: MAX_STORED_APPLIED_QUEUE_COMMANDS + 3 },
       (_, index) => ({
@@ -133,7 +133,7 @@ describe('chat execution control transitions', () => {
   it('replays queue command receipts without applying a mutation twice', () => {
     const command = { key: 'queue:create:request', entryId: 'entry-1' };
     const first = createQueueEntry(
-      emptyStoredChatExecutionControl(),
+      emptyStoredChatExecutionControl('server-instance-test'),
       { content: 'first', command },
       context(0, new Set([command.key])),
     );
@@ -148,7 +148,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('moves entries by stable target identity without changing entry revisions', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries = [
       storedEntry('a', 'queued', 2),
       storedEntry('b'),
@@ -173,7 +173,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('records no-op moves and rejects stale reorder revisions', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries = [storedEntry('a'), storedEntry('b'), storedEntry('c')];
     const noOp = moveQueueEntry(current, {
       entryId: 'b',
@@ -217,7 +217,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('rebases past a dispatching target while preserving its retry priority', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries = [
       storedEntry('target', 'sending'),
       storedEntry('a'),
@@ -252,7 +252,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('rebases past a completed target only when its dispatched revision still matches', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries = [storedEntry('a'), storedEntry('source'), storedEntry('b')];
     current.recentlyDispatched = [{
       entryId: 'target',
@@ -291,7 +291,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('rejects moved entries or targets whose content changed', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries = [storedEntry('a', 'queued', 2), storedEntry('b', 'queued', 3)];
     const sourceConflict = moveQueueEntry(current, {
       entryId: 'b',
@@ -321,7 +321,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('restores pause stacks and rejects stale pause identities', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries.push({
       id: 'entry-1',
       content: 'queued',
@@ -341,7 +341,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('applies stage-specific queue compensation without changing delivery identity', () => {
-    const current = emptyStoredChatExecutionControl();
+    const current = emptyStoredChatExecutionControl('server-instance-test');
     current.entries.push({
       id: 'entry-1',
       content: 'queued',
@@ -375,7 +375,7 @@ describe('chat execution control transitions', () => {
   });
 
   it('stages only the queue head with the supplied active delivery identity', () => {
-    const initial = emptyStoredChatExecutionControl();
+    const initial = emptyStoredChatExecutionControl('server-instance-test');
     const first = createQueueEntry(initial, {
       content: 'first',
       command: { key: 'first-command', entryId: 'first-entry' },
@@ -417,7 +417,7 @@ describe('chat execution control transitions', () => {
       seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
       return seed;
     };
-    let control = emptyStoredChatExecutionControl();
+    let control = emptyStoredChatExecutionControl('server-instance-test');
     let ordinal = 0;
     const knownIds = [];
 

--- a/server/chat-execution/__tests__/chat-execution-coordinator.test.js
+++ b/server/chat-execution/__tests__/chat-execution-coordinator.test.js
@@ -4,6 +4,7 @@ import os from 'os';
 import { promises as fs } from 'fs';
 import { randomUUID } from 'crypto';
 import { ChatExecutionCoordinator } from '../chat-execution-coordinator.js';
+import { InMemoryChatExecutionControlRepository } from '../chat-execution-control-repository.ts';
 import { GOAL_CONTROL_NOT_DELIVERED_MESSAGE, GOAL_CONTROL_OUTCOME_UNKNOWN_MESSAGE } from '../../lib/domain-error.js';
 
 let workspaceDir = '';
@@ -56,6 +57,10 @@ function emptyDrainOptions() {
   return {};
 }
 
+function createControlRepository(serverInstanceId = 'server-instance-test') {
+  return new InMemoryChatExecutionControlRepository(serverInstanceId);
+}
+
 function deferred() {
   let resolve;
   let reject;
@@ -76,6 +81,7 @@ beforeEach(async () => {
     createChatMessages(),
     emptyDrainOptions,
     () => true,
+    createControlRepository(),
   );
 });
 
@@ -108,6 +114,7 @@ describe('transcript snapshot ownership', () => {
       createChatMessages(),
       emptyDrainOptions,
       () => true,
+      createControlRepository(),
     );
     await queue.createChatQueueEntry('snapshot-chat', 'queued input');
     const snapshot = queue.reserveTranscriptSnapshot('snapshot-chat');
@@ -563,6 +570,18 @@ describe('queue invariants', () => {
   it('requires execution dependencies at construction', () => {
     expect(() => new ChatExecutionCoordinator(workspaceDir)).toThrow('ChatExecutionCoordinator requires an agent turn runner');
   });
+
+  it('requires an explicitly identified control repository', () => {
+    expect(() => new ChatExecutionCoordinator(
+      workspaceDir,
+      createStateOnlyAgents(),
+      createPendingInputs(),
+      createChatMessages(),
+      emptyDrainOptions,
+      () => true,
+      undefined,
+    )).toThrow('requires an execution control repository');
+  });
 });
 
 describe('queue-updated event', () => {
@@ -655,6 +674,7 @@ describe('orchestration', () => {
       mockChatMessages,
       mockDrainOptions,
       () => true,
+      createControlRepository(),
     );
   });
 
@@ -783,6 +803,7 @@ describe('orchestration', () => {
         createChatMessages(),
         emptyDrainOptions,
         () => chatExists,
+        createControlRepository(),
       );
       const reservation = deletingQueue.reserveDirectTurn('deleted');
       const turn = deletingQueue.runReservedTurn(reservation, 'running', {});
@@ -2744,6 +2765,7 @@ describe('orchestration', () => {
         createChatMessages(),
         emptyDrainOptions,
         () => chatExists,
+        createControlRepository(),
       );
       await deletingQueue.createChatQueueEntry('deleted', 'queued');
 
@@ -2868,9 +2890,17 @@ describe('orchestration', () => {
     });
 
     it('pauses and requeues when queued turn option resolution fails', async () => {
-      const failingQueue = new ChatExecutionCoordinator(workspaceDir, mockAgents, mockPendingInputs, mockChatMessages, () => {
-        throw new Error('settings unavailable');
-      }, () => true);
+      const failingQueue = new ChatExecutionCoordinator(
+        workspaceDir,
+        mockAgents,
+        mockPendingInputs,
+        mockChatMessages,
+        () => {
+          throw new Error('settings unavailable');
+        },
+        () => true,
+        createControlRepository(),
+      );
       await failingQueue.createChatQueueEntry('c1', 'will fail before registration');
       const dispatches = [];
       const failures = [];

--- a/server/chat-execution/__tests__/client-chat-execution-control-state.test.js
+++ b/server/chat-execution/__tests__/client-chat-execution-control-state.test.js
@@ -17,6 +17,7 @@ function entry(id, status, revision = 1) {
 
 function control(entries, overrides = {}) {
   return {
+    serverInstanceId: 'server-instance-test',
     entries,
     recentlyDispatched: [],
     appliedCommands: [],
@@ -45,6 +46,7 @@ describe('chat execution-control projection', () => {
     expect(result.queue.entries[0]).not.toHaveProperty('delivery');
     expect(result.queue.dispatchingEntryId).toBe('s1');
     expect(result.queue.reorderRevision).toBe(2);
+    expect(result.serverInstanceId).toBe('server-instance-test');
     expect(result.version).toBe(4);
   });
 

--- a/server/chat-execution/chat-execution-control-repository.ts
+++ b/server/chat-execution/chat-execution-control-repository.ts
@@ -13,9 +13,11 @@ export interface ChatExecutionControlRepository {
 export class InMemoryChatExecutionControlRepository implements ChatExecutionControlRepository {
   readonly #controlsByChatId = new Map<string, StoredChatExecutionControlState>();
 
+  constructor(readonly serverInstanceId: string) {}
+
   async load(chatId: string): Promise<StoredChatExecutionControlState> {
     return cloneStoredChatExecutionControl(
-      this.#controlsByChatId.get(chatId) ?? emptyStoredChatExecutionControl(),
+      this.#controlsByChatId.get(chatId) ?? emptyStoredChatExecutionControl(this.serverInstanceId),
     );
   }
 
@@ -23,6 +25,9 @@ export class InMemoryChatExecutionControlRepository implements ChatExecutionCont
     chatId: string,
     control: StoredChatExecutionControlState,
   ): Promise<StoredChatExecutionControlState> {
+    if (control.serverInstanceId !== this.serverInstanceId) {
+      throw new Error('Cannot save execution controls from another server instance');
+    }
     const saved = cloneStoredChatExecutionControl(control);
     this.#controlsByChatId.set(chatId, saved);
     return cloneStoredChatExecutionControl(saved);

--- a/server/chat-execution/chat-execution-coordinator.ts
+++ b/server/chat-execution/chat-execution-coordinator.ts
@@ -24,10 +24,7 @@ import {
   type StoredChatExecutionControlState,
   type StoredQueueEntry,
 } from './control-state.ts';
-import {
-  InMemoryChatExecutionControlRepository,
-  type ChatExecutionControlRepository,
-} from './chat-execution-control-repository.ts';
+import type { ChatExecutionControlRepository } from './chat-execution-control-repository.ts';
 import {
   type QueueCommandIdentity,
 } from './chat-execution-control-transitions.ts';
@@ -131,7 +128,7 @@ export class ChatExecutionCoordinator extends EventEmitter<ChatExecutionCoordina
     chatMessages: ChatMessagesPort,
     getDrainOptions: QueueDrainOptionsResolver,
     chatExists: ChatExistsResolver,
-    controls: ChatExecutionControlRepository = new InMemoryChatExecutionControlRepository(),
+    controls: ChatExecutionControlRepository,
     unsettledQueueReceiptKeys: (chatId: string) => ReadonlySet<string> = () => new Set(),
   ) {
     super();
@@ -143,6 +140,9 @@ export class ChatExecutionCoordinator extends EventEmitter<ChatExecutionCoordina
     if (!chatMessages) throw new Error('ChatExecutionCoordinator requires chat message storage');
     if (!getDrainOptions) throw new Error('ChatExecutionCoordinator requires a drain option resolver');
     if (!chatExists) throw new Error('ChatExecutionCoordinator requires a chat existence resolver');
+    if (!controls) {
+      throw new Error('ChatExecutionCoordinator requires an execution control repository');
+    }
     this.#turnRunner = turnRunner;
     this.#pendingInputs = pendingInputs;
     this.#getDrainOptions = getDrainOptions;

--- a/server/chat-execution/control-state.ts
+++ b/server/chat-execution/control-state.ts
@@ -29,6 +29,7 @@ export interface StoredAppliedQueueCommand {
 }
 
 export interface StoredChatExecutionControlState {
+  serverInstanceId: string;
   entries: StoredQueueEntry[];
   recentlyDispatched: RecentlyDispatchedQueueEntry[];
   appliedCommands: StoredAppliedQueueCommand[];
@@ -41,8 +42,11 @@ export interface StoredChatExecutionControlState {
 
 export const MAX_STORED_APPLIED_QUEUE_COMMANDS = 1000;
 
-export function emptyStoredChatExecutionControl(): StoredChatExecutionControlState {
+export function emptyStoredChatExecutionControl(
+  serverInstanceId: string,
+): StoredChatExecutionControlState {
   return {
+    serverInstanceId,
     entries: [],
     recentlyDispatched: [],
     appliedCommands: [],
@@ -78,6 +82,7 @@ export function toClientChatExecutionControlState(
   control: StoredChatExecutionControlState,
 ): ChatExecutionControlState {
   return {
+    serverInstanceId: control.serverInstanceId,
     queue: {
       entries: control.entries
         .filter((entry) => entry.status === 'queued')

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -21,6 +21,7 @@ import {
   QueueEntryMutationError,
   ChatExecutionCoordinator,
 } from '../../chat-execution/chat-execution-coordinator.js';
+import { InMemoryChatExecutionControlRepository } from '../../chat-execution/chat-execution-control-repository.ts';
 import { ChatViewStore } from '../../chats/chat-view-store.js';
 import { PendingUserInputService } from '../../chats/pending-user-input-service.js';
 import { KeyedPromiseLock } from '../../lib/keyed-lock.js';
@@ -639,6 +640,7 @@ function makeRealQueue(pendingInputsService, turnRunnerOverrides = {}) {
     { appendMessages: mock(async () => ({ generationId: 'generation-1', messages: [] })) },
     () => ({}),
     () => true,
+    new InMemoryChatExecutionControlRepository('server-instance-test'),
   );
 }
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -30,6 +30,7 @@ import { SettingsStore } from './settings/store.js';
 import {
   ChatExecutionCoordinator,
 } from './chat-execution/chat-execution-coordinator.js';
+import { InMemoryChatExecutionControlRepository } from './chat-execution/chat-execution-control-repository.js';
 import { queueDrainOptions } from './chats/chat-execution-options.js';
 import { PathCache } from './chats/path-cache.js';
 import { TerminalManager } from './terminals/terminal-manager.js';
@@ -434,7 +435,7 @@ export async function startServer(): Promise<void> {
       chatMessageAppender,
       (chatId) => queueDrainOptions(chatId, chatRegistry),
       (chatId) => Boolean(chatRegistry.getChat(chatId)),
-      undefined,
+      new InMemoryChatExecutionControlRepository(runtimeState.identity.instanceId),
       (chatId) => commandLedger.unsettledQueueReceiptKeys(chatId),
     );
     executionCoordinator = queue;
@@ -585,6 +586,7 @@ export async function startServer(): Promise<void> {
     });
 
     const chatHandler = new ChatHandler({
+      serverInstanceId: runtimeState.identity.instanceId,
       processing: chatProcessingActivity,
       chatViews: {
         ...chatViewPages,

--- a/server/terminals/__tests__/terminal-contracts.test.js
+++ b/server/terminals/__tests__/terminal-contracts.test.js
@@ -185,6 +185,7 @@ describe('terminal contracts', () => {
         sentAt: 42,
         serverTime: '2026-07-16T00:00:00.000Z',
         processing: { outcome: 'snapshot', chats: [] },
+        serverInstanceId: 'server-instance-test',
       }),
     ).toMatchObject({ type: 'ws-pong', clientRequestId: 'request-1' });
   });

--- a/server/ws/__tests__/chat-contracts.test.js
+++ b/server/ws/__tests__/chat-contracts.test.js
@@ -51,6 +51,7 @@ const mockPendingInputs = {
 
 function storedQueue() {
   return {
+    serverInstanceId: 'server-instance-test',
     entries: [],
     recentlyDispatched: [],
     appliedCommands: [],
@@ -74,6 +75,7 @@ const moduleMocks = [sendWebSocketJson];
 
 function createHandler() {
   const instance = new ChatHandler({
+    serverInstanceId: 'server-instance-test',
     processing: mockProcessing,
     chatViews: mockChatViews,
     nativeReloader: mockNativeReloader,
@@ -153,6 +155,7 @@ describe('chat WebSocket handler', () => {
     expect(lastSentPayload()).toEqual({
       type: 'reconnect-state',
       clientRequestId: 'req-reconnect-1',
+      serverInstanceId: 'server-instance-test',
       processing: {
         outcome: 'snapshot',
         chats: [{ chatId: 'chat-running', phase: 'running' }],
@@ -208,6 +211,7 @@ describe('chat WebSocket handler', () => {
     expect(lastSentPayload()).toEqual({
       type: 'reconnect-state',
       clientRequestId: 'req-reconnect-empty',
+      serverInstanceId: 'server-instance-test',
       processing: { outcome: 'snapshot', chats: [] },
       controlResults: [],
     });
@@ -234,6 +238,7 @@ describe('chat WebSocket handler', () => {
     expect(mockQueue.readChatExecutionControl).toHaveBeenCalledTimes(2);
     expect(lastSentPayload()).toMatchObject({
       type: 'reconnect-state',
+      serverInstanceId: 'server-instance-test',
       processing: {
         outcome: 'snapshot',
         chats: [{ chatId: 'chat-running', phase: 'running' }],
@@ -270,6 +275,7 @@ describe('chat WebSocket handler', () => {
     expect(lastSentPayload()).toMatchObject({
       type: 'reconnect-state',
       clientRequestId: 'req-reconnect-processing-unavailable',
+      serverInstanceId: 'server-instance-test',
       processing: { outcome: 'unavailable' },
       controlResults: [
         { chatId: 'chat-1', outcome: 'snapshot' },
@@ -299,6 +305,7 @@ describe('chat WebSocket handler', () => {
 
     expect(lastSentPayload()).toMatchObject({
       type: 'reconnect-state',
+      serverInstanceId: 'server-instance-test',
       processing: {
         outcome: 'snapshot',
         chats: [{ chatId: 'chat-after', phase: 'stopping' }],
@@ -358,6 +365,7 @@ describe('chat WebSocket handler', () => {
       type: 'ws-pong',
       clientRequestId: 'req-ping-1',
       sentAt: 1234,
+      serverInstanceId: 'server-instance-test',
       processing: {
         outcome: 'snapshot',
         chats: [{ chatId: 'chat-running', phase: 'running' }],

--- a/server/ws/__tests__/primary.test.js
+++ b/server/ws/__tests__/primary.test.js
@@ -112,7 +112,8 @@ describe('PrimaryWsHandler', () => {
       detachTerminal: mock(() => undefined),
     };
     const chat = new ChatHandler({
-      agents: { getRunningChatIdsSnapshot: () => [] },
+      serverInstanceId: 'server-instance-test',
+      processing: { snapshot: () => [] },
       chatViews: { readReplay: () => ({}) },
       nativeReloader: { reloadFromNative: async () => ({}) },
       queue: { readChatExecutionControl: async () => ({}) },
@@ -167,6 +168,7 @@ describe('PrimaryWsHandler', () => {
       type: 'ws-pong',
       clientRequestId: 'ping-1',
       sentAt: 42,
+      serverInstanceId: 'server-instance-test',
     });
     expect(socket.closes).toEqual([]);
     expect(terminalManager.detachPeer).toHaveBeenCalledTimes(1);
@@ -184,7 +186,8 @@ describe('PrimaryWsHandler', () => {
       detachTerminal: mock(() => undefined),
     };
     const chat = new ChatHandler({
-      agents: { getRunningChatIdsSnapshot: () => [] },
+      serverInstanceId: 'server-instance-test',
+      processing: { snapshot: () => [] },
       chatViews: { readReplay: () => ({}) },
       nativeReloader: { reloadFromNative: async () => ({}) },
       queue: { readChatExecutionControl: async () => ({}) },

--- a/server/ws/chat.ts
+++ b/server/ws/chat.ts
@@ -52,6 +52,7 @@ type WsRequestHandler = (data: ClientWsMessage, writer: WebSocketWriter) => Prom
 type ChatIdRequest = { type: string; chatId?: string | null };
 
 interface ChatHandlerDeps {
+  serverInstanceId: string;
   processing: Pick<ChatProcessingActivity, 'snapshot'>;
   chatViews: ChatViewsDep;
   nativeReloader: NativeReloaderDep;
@@ -109,6 +110,7 @@ function reloadErrorCode(error: unknown): ClientRequestErrorCode {
 }
 
 export class ChatHandler {
+  #serverInstanceId: string;
   #processing: Pick<ChatProcessingActivity, 'snapshot'>;
   #chatViews: ChatViewsDep;
   #nativeReloader: NativeReloaderDep;
@@ -118,6 +120,7 @@ export class ChatHandler {
   #requestHandlers: Record<ClientWsMessage['type'], WsRequestHandler>;
 
   constructor({
+    serverInstanceId,
     processing,
     chatViews,
     nativeReloader,
@@ -125,6 +128,7 @@ export class ChatHandler {
     pendingInputs,
     registry,
   }: ChatHandlerDeps) {
+    this.#serverInstanceId = serverInstanceId;
     this.#processing = processing;
     this.#chatViews = chatViews;
     this.#nativeReloader = nativeReloader;
@@ -187,6 +191,7 @@ export class ChatHandler {
       writer.send(new ReconnectStateMessage(
         processing,
         controlResults,
+        this.#serverInstanceId,
         data.clientRequestId ?? undefined,
       ));
     } catch (error: unknown) {
@@ -215,6 +220,7 @@ export class ChatHandler {
       data.sentAt,
       new Date().toISOString(),
       readProcessingSnapshot(this.#processing),
+      this.#serverInstanceId,
     ));
   }
 

--- a/web/src/lib/api/__tests__/chats-contract.test.ts
+++ b/web/src/lib/api/__tests__/chats-contract.test.ts
@@ -61,6 +61,7 @@ describe('chats API contract', () => {
 
 	function emptyControl() {
 		return {
+			serverInstanceId: 'server-instance-test',
 			queue: {
 				entries: [],
 				dispatchingEntryId: null,
@@ -663,6 +664,28 @@ describe('chats API contract', () => {
 			chatId: 'c/1',
 			pauseId: 'pause/1',
 		});
+	});
+
+	it('rejects queue controls without a bounded opaque server instance ID', async () => {
+		for (const serverInstanceId of [
+			undefined,
+			null,
+			'',
+			' server-a',
+			'server-a ',
+			'x'.repeat(129),
+		]) {
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse({
+					success: true,
+					chatId: 'chat-1',
+					control: { ...emptyControl(), serverInstanceId },
+				}),
+			);
+			await expect(getChatExecutionControl('chat-1')).rejects.toThrow(
+				'Invalid chat execution control response',
+			);
+		}
 	});
 
 	it('settings, model, project path, and history helpers use REST endpoints', async () => {

--- a/web/src/lib/api/__tests__/ws-message-contract.logic.test.ts
+++ b/web/src/lib/api/__tests__/ws-message-contract.logic.test.ts
@@ -40,8 +40,9 @@ const chatViewMessage = {
 	message: { type: 'assistant-message', timestamp: '2025-01-01T00:00:00Z', content: 'hi' },
 };
 
-function emptyExecutionControl(version = 4) {
+function emptyExecutionControl(version = 4, serverInstanceId = 'server-instance-test') {
 	return {
+		serverInstanceId,
 		queue: {
 			entries: [],
 			dispatchingEntryId: null,
@@ -342,6 +343,7 @@ describe('parseServerWsMessage', () => {
 			parseServerWsMessage({
 				type: 'reconnect-state',
 				clientRequestId: 'req-reconnect',
+				serverInstanceId: 'server-instance-test',
 				processing: {
 					outcome: 'snapshot',
 					chats: [{ chatId: 'running-1', phase: 'running' }],
@@ -518,6 +520,7 @@ describe('parseServerWsMessage', () => {
 			parseServerWsMessage({
 				type: 'ws-pong',
 				clientRequestId: 'req-ping',
+				serverInstanceId: 'server-instance-test',
 				sentAt: 1234,
 				serverTime: '2026-06-17T00:00:00.000Z',
 				processing: { outcome: 'snapshot', chats: [] },
@@ -571,6 +574,7 @@ describe('parseServerWsMessage', () => {
 		const snapshot = parseServerWsMessage({
 			type: 'reconnect-state',
 			clientRequestId: 'req-reconnect',
+			serverInstanceId: 'server-instance-test',
 			processing: {
 				outcome: 'snapshot',
 				chats: [
@@ -589,9 +593,11 @@ describe('parseServerWsMessage', () => {
 			],
 		});
 		expect((snapshot as ReconnectStateMessage).clientRequestId).toBe('req-reconnect');
+		expect((snapshot as ReconnectStateMessage).serverInstanceId).toBe('server-instance-test');
 
 		const emptySnapshot = parseServerWsMessage({
 			type: 'reconnect-state',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'snapshot', chats: [] },
 			controlResults: [],
 		});
@@ -602,6 +608,7 @@ describe('parseServerWsMessage', () => {
 
 		const unavailable = parseServerWsMessage({
 			type: 'reconnect-state',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'unavailable' },
 			controlResults: [],
 		});
@@ -612,6 +619,7 @@ describe('parseServerWsMessage', () => {
 		const pong = parseServerWsMessage({
 			type: 'ws-pong',
 			clientRequestId: 'req-ping',
+			serverInstanceId: 'server-instance-test',
 			sentAt: 42,
 			serverTime: '2026-07-27T00:00:00.000Z',
 			processing: {
@@ -624,9 +632,11 @@ describe('parseServerWsMessage', () => {
 			outcome: 'snapshot',
 			chats: [{ chatId: 'chat-a', phase: 'stopping' }],
 		});
+		expect((pong as WsPongMessage).serverInstanceId).toBe('server-instance-test');
 		const unavailablePong = parseServerWsMessage({
 			type: 'ws-pong',
 			clientRequestId: 'req-ping-unavailable',
+			serverInstanceId: 'server-instance-test',
 			sentAt: 43,
 			serverTime: '2026-07-27T00:00:00.000Z',
 			processing: { outcome: 'unavailable' },
@@ -635,6 +645,56 @@ describe('parseServerWsMessage', () => {
 		expect((unavailablePong as WsPongMessage).processing).toEqual({
 			outcome: 'unavailable',
 		});
+	});
+
+	it('rejects missing, malformed, and mixed execution-control instance identities', () => {
+		const reconnect = {
+			type: 'reconnect-state',
+			serverInstanceId: 'server-a',
+			processing: { outcome: 'snapshot', chats: [] },
+			controlResults: [
+				{ chatId: 'chat-1', outcome: 'snapshot', control: emptyExecutionControl(1, 'server-a') },
+			],
+		};
+		const pong = {
+			type: 'ws-pong',
+			clientRequestId: 'req-ping',
+			sentAt: 42,
+			serverTime: '2026-07-27T00:00:00.000Z',
+			processing: { outcome: 'snapshot', chats: [] },
+			serverInstanceId: 'server-a',
+		};
+
+		for (const serverInstanceId of [
+			undefined,
+			null,
+			'',
+			' server-a',
+			'server-a ',
+			'x'.repeat(129),
+		]) {
+			expect(parseServerWsMessage({ ...reconnect, serverInstanceId })).toBeNull();
+			expect(parseServerWsMessage({ ...pong, serverInstanceId })).toBeNull();
+		}
+		expect(
+			parseServerWsMessage({
+				type: 'reconnect-state',
+				processing: { outcome: 'snapshot', chats: [] },
+				controlResults: [],
+			}),
+		).toBeNull();
+		expect(
+			parseServerWsMessage({
+				...reconnect,
+				controlResults: [
+					{
+						chatId: 'chat-1',
+						outcome: 'snapshot',
+						control: emptyExecutionControl(1, 'server-b'),
+					},
+				],
+			}),
+		).toBeNull();
 	});
 
 	it('rejects malformed reconnect processing data and legacy session payloads', () => {
@@ -663,6 +723,7 @@ describe('parseServerWsMessage', () => {
 			expect(
 				parseServerWsMessage({
 					type: 'reconnect-state',
+					serverInstanceId: 'server-instance-test',
 					processing,
 					controlResults: [],
 				}),
@@ -671,6 +732,7 @@ describe('parseServerWsMessage', () => {
 				parseServerWsMessage({
 					type: 'ws-pong',
 					clientRequestId: 'req-ping',
+					serverInstanceId: 'server-instance-test',
 					sentAt: 42,
 					serverTime: '2026-07-27T00:00:00.000Z',
 					processing,
@@ -681,6 +743,7 @@ describe('parseServerWsMessage', () => {
 		expect(
 			parseServerWsMessage({
 				type: 'reconnect-state',
+				serverInstanceId: 'server-instance-test',
 				sessions: { claude: [{ id: 'running-1' }] },
 				controlResults: [],
 			}),
@@ -715,6 +778,7 @@ describe('parseServerWsMessage', () => {
 		expect(
 			parseServerWsMessage({
 				type: 'reconnect-state',
+				serverInstanceId: 'server-instance-test',
 				processing: { outcome: 'snapshot', chats: [] },
 				controlResults: [{ chatId: 'c-1', outcome: 'snapshot' }],
 			}),

--- a/web/src/lib/chat/conversation/__tests__/conversation-queue-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-queue-controller.test.ts
@@ -39,7 +39,7 @@ function createHarness() {
 	};
 	const lifecycle = { currentChatId: 'chat-1' as string | null };
 	const conversationUi = {
-		setExecutionControl: vi.fn(),
+		setExecutionControlFromLiveUpdate: vi.fn(),
 		setExecutionControlFromRefresh: vi.fn(),
 	};
 	const acceptedInputs = {
@@ -54,7 +54,7 @@ function createHarness() {
 				status: 'accepted' as const,
 				acceptedAt: '2026-07-20T00:00:00.000Z',
 				entryId: 'entry-1',
-				control: emptyChatExecutionControlState(),
+				control: emptyChatExecutionControlState('server-instance-test'),
 			})),
 		})),
 	};
@@ -118,7 +118,7 @@ describe('ConversationQueueController', () => {
 
 	it('applies refreshed execution control through the version-aware store method', async () => {
 		const { controller, conversationUi } = createHarness();
-		const control = emptyChatExecutionControlState();
+		const control = emptyChatExecutionControlState('server-instance-test');
 		vi.mocked(getChatExecutionControl).mockResolvedValueOnce({
 			success: true,
 			chatId: 'chat-1',
@@ -133,7 +133,7 @@ describe('ConversationQueueController', () => {
 
 	it('moves queue entries with stable identity and explicit concurrency preconditions', async () => {
 		const { controller, conversationUi } = createHarness();
-		const control = emptyChatExecutionControlState();
+		const control = emptyChatExecutionControlState('server-instance-test');
 		vi.mocked(moveQueuedInput).mockResolvedValueOnce({
 			success: true,
 			commandType: 'queue-entry-move',
@@ -163,12 +163,15 @@ describe('ConversationQueueController', () => {
 			expectedSourceRevision: 4,
 			expectedTargetRevision: 3,
 		});
-		expect(conversationUi.setExecutionControl).toHaveBeenCalledWith('chat-1', control);
+		expect(conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenCalledWith(
+			'chat-1',
+			control,
+		);
 	});
 
 	it('retries an ambiguous move once with the same client request id', async () => {
 		const { controller } = createHarness();
-		const control = emptyChatExecutionControlState();
+		const control = emptyChatExecutionControlState('server-instance-test');
 		vi.mocked(moveQueuedInput)
 			.mockRejectedValueOnce(new ApiError(500, 'Connection lost'))
 			.mockResolvedValueOnce({
@@ -199,7 +202,7 @@ describe('ConversationQueueController', () => {
 
 	it('refreshes the latest queue after an unconfirmed move outcome', async () => {
 		const { controller, conversationUi } = createHarness();
-		const control = emptyChatExecutionControlState();
+		const control = emptyChatExecutionControlState('server-instance-test');
 		vi.mocked(moveQueuedInput)
 			.mockRejectedValueOnce(new Error('network failure'))
 			.mockRejectedValueOnce(new Error('network failure'));

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -147,6 +147,7 @@ function createRunningChat(overrides: Partial<ChatSessionRecord> = {}): ChatSess
 
 function emptyControl(): ChatExecutionControlState {
 	return {
+		serverInstanceId: 'server-instance-test',
 		queue: {
 			entries: [],
 			dispatchingEntryId: null,
@@ -283,7 +284,7 @@ function createDeps(chat = createRunningChat()) {
 			conversationUi.previousPermissionMode = mode;
 		}),
 		getExecutionControl: vi.fn((): ChatExecutionControlState | null => null),
-		setExecutionControl: vi.fn(),
+		setExecutionControlFromLiveUpdate: vi.fn(),
 		setExecutionControlFromRefresh: vi.fn(),
 	};
 	const deps = {
@@ -829,6 +830,7 @@ describe('ConversationSessionController', () => {
 	it('applies the paused queue snapshot returned by Stop', async () => {
 		const { deps } = createDeps(createRunningChat({ isProcessing: true }));
 		const control: ChatExecutionControlState = {
+			serverInstanceId: 'server-instance-test',
 			queue: {
 				entries: [
 					{
@@ -864,7 +866,10 @@ describe('ConversationSessionController', () => {
 
 		await controller.handleAbort();
 
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledWith('chat-1', control);
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenCalledWith(
+			'chat-1',
+			control,
+		);
 		expect(deps.lifecycle.beginStopping).toHaveBeenCalledWith('chat-1', expect.any(String));
 		expect(deps.requestProcessingSnapshot).toHaveBeenCalledOnce();
 		expect(deps.lifecycle.clearTurnStatus).not.toHaveBeenCalled();
@@ -1685,7 +1690,7 @@ describe('ConversationSessionController', () => {
 		expect(mockRunChat).not.toHaveBeenCalled();
 		expect(deps.chatState.chatMessages).toHaveLength(0);
 		expect(deps.chatState.clearLocalNotices).toHaveBeenCalledOnce();
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledWith(
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenCalledWith(
 			'chat-1',
 			expect.objectContaining({
 				queue: expect.objectContaining({
@@ -2030,7 +2035,10 @@ describe('ConversationSessionController', () => {
 
 		expect(mockCreateQueuedInput).toHaveBeenCalledTimes(2);
 		expect(mockCreateQueuedInput.mock.calls[1][0]).toEqual(mockCreateQueuedInput.mock.calls[0][0]);
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledWith('chat-1', nextControl);
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenCalledWith(
+			'chat-1',
+			nextControl,
+		);
 	});
 
 	it('replaces and deletes queued entries by ID through separate commands', async () => {
@@ -2079,7 +2087,7 @@ describe('ConversationSessionController', () => {
 			chatId: 'chat-1',
 			entryId: 'entry-3',
 		});
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledTimes(2);
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenCalledTimes(2);
 	});
 
 	it('applies a conflict queue snapshot before rethrowing the edit error', async () => {
@@ -2124,7 +2132,10 @@ describe('ConversationSessionController', () => {
 		await expect(
 			controller.replaceQueueEntryForChat('chat-1', 'entry-1', 'local draft', 1),
 		).rejects.toBe(error);
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledWith('chat-1', conflictControl);
+		expect(deps.conversationUi.setExecutionControlFromRefresh).toHaveBeenCalledWith(
+			'chat-1',
+			conflictControl,
+		);
 	});
 
 	it('reconciles a departed inline delete without showing a failure notice', async () => {
@@ -2167,7 +2178,10 @@ describe('ConversationSessionController', () => {
 
 		await controller.handleDeleteQueuedInput('entry-1');
 
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledWith('chat-1', latestControl);
+		expect(deps.conversationUi.setExecutionControlFromRefresh).toHaveBeenCalledWith(
+			'chat-1',
+			latestControl,
+		);
 		expect(deps.chatState.appendLocalNotice).not.toHaveBeenCalled();
 	});
 
@@ -2197,12 +2211,12 @@ describe('ConversationSessionController', () => {
 
 		expect(mockPauseChatQueue).toHaveBeenCalledWith('chat-1');
 		expect(mockResumeChatQueue).toHaveBeenCalledWith('chat-1', 'pause-rendered');
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenNthCalledWith(
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenNthCalledWith(
 			1,
 			'chat-1',
 			pausedControl,
 		);
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenNthCalledWith(
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).toHaveBeenNthCalledWith(
 			2,
 			'chat-1',
 			expect.objectContaining({ version: 3 }),
@@ -2237,7 +2251,10 @@ describe('ConversationSessionController', () => {
 
 		await expect(controller.handleQueueResume('pause-stale')).rejects.toBe(error);
 
-		expect(deps.conversationUi.setExecutionControl).toHaveBeenCalledWith('chat-1', latestControl);
+		expect(deps.conversationUi.setExecutionControlFromRefresh).toHaveBeenCalledWith(
+			'chat-1',
+			latestControl,
+		);
 	});
 
 	it('steers through the capability without reading or mutating a paused queue', async () => {
@@ -2291,7 +2308,7 @@ describe('ConversationSessionController', () => {
 		});
 		expect(deps.lifecycle.beginTurn).not.toHaveBeenCalled();
 		expect(deps.conversationUi.getExecutionControl).not.toHaveBeenCalled();
-		expect(deps.conversationUi.setExecutionControl).not.toHaveBeenCalled();
+		expect(deps.conversationUi.setExecutionControlFromLiveUpdate).not.toHaveBeenCalled();
 	});
 
 	it('restores untouched steering text after a definitive turn-state failure', async () => {

--- a/web/src/lib/chat/conversation/__tests__/conversation-ui-state.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-ui-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ConversationUiState } from '../conversation-ui-state.svelte.js';
 import type {
 	ChatExecutionControlState,
@@ -23,6 +23,7 @@ function makeControl(
 	overrides: Partial<ChatExecutionControlState> = {},
 ): ChatExecutionControlState {
 	return {
+		serverInstanceId: 'server-instance-test',
 		queue,
 		version: 0,
 		updatedAt: null,
@@ -87,8 +88,8 @@ describe('ConversationUiState', () => {
 		const store = new ConversationUiState();
 		const control = makeControl();
 
-		store.setExecutionControl('chat-a', control);
-		store.setExecutionControl('chat-b', null);
+		store.setExecutionControlFromLiveUpdate('chat-a', control);
+		store.setExecutionControlFromLiveUpdate('chat-b', control);
 		store.pruneExecutionControls(new Set(['chat-a']));
 
 		expect(store.getExecutionControl('chat-a')).toEqual(control);
@@ -109,9 +110,187 @@ describe('ConversationUiState', () => {
 			{ version: 4 },
 		);
 
-		store.setExecutionControl('chat-a', live);
+		store.setExecutionControlFromLiveUpdate('chat-a', live);
 		store.setExecutionControlFromRefresh('chat-a', staleRefresh);
 
 		expect(store.getExecutionControl('chat-a')).toEqual(live);
+	});
+
+	it('orders live and refresh revisions only within one server instance', () => {
+		const store = new ConversationUiState();
+		const versionFour = makeControl(makeQueue({ entries: [makeEntry('entry-four', 'four')] }), {
+			version: 4,
+		});
+		const equalLive = makeControl(
+			makeQueue({ entries: [makeEntry('entry-equal', 'equal-live')] }),
+			{ version: 4 },
+		);
+		store.setExecutionControlFromLiveUpdate('chat-a', versionFour);
+
+		store.setExecutionControlFromLiveUpdate('chat-a', equalLive);
+		expect(store.getExecutionControl('chat-a')).toEqual(equalLive);
+		store.setExecutionControlFromLiveUpdate('chat-a', makeControl(makeQueue(), { version: 3 }));
+		expect(store.getExecutionControl('chat-a')).toEqual(equalLive);
+
+		const versionFive = makeControl(makeQueue(), { version: 5 });
+		store.setExecutionControlFromLiveUpdate('chat-a', versionFive);
+		expect(store.getExecutionControl('chat-a')).toEqual(versionFive);
+		store.setExecutionControlFromRefresh('chat-a', makeControl(makeQueue(), { version: 5 }));
+		store.setExecutionControlFromRefresh('chat-a', makeControl(makeQueue(), { version: 4 }));
+		expect(store.getExecutionControl('chat-a')).toEqual(versionFive);
+
+		const versionSix = makeControl(makeQueue(), { version: 6 });
+		store.setExecutionControlFromRefresh('chat-a', versionSix);
+		expect(store.getExecutionControl('chat-a')).toEqual(versionSix);
+	});
+
+	it('replaces every cached control when correlated socket authority changes', () => {
+		const store = new ConversationUiState();
+		store.setExecutionControlFromLiveUpdate(
+			'chat-a',
+			makeControl(makeQueue(), {
+				serverInstanceId: 'server-a',
+				version: 8,
+			}),
+		);
+		store.setExecutionControlFromLiveUpdate(
+			'chat-b',
+			makeControl(makeQueue(), {
+				serverInstanceId: 'server-a',
+				version: 3,
+			}),
+		);
+
+		store.confirmExecutionControlSocketInstance('server-b');
+
+		expect(store.executionControlChatIds).toEqual([]);
+		expect(store.getExecutionControl('chat-a')).toBeNull();
+	});
+
+	it('retains controls across a transient socket disconnect', () => {
+		const store = new ConversationUiState();
+		const control = makeControl(makeQueue(), { serverInstanceId: 'server-a', version: 2 });
+		store.confirmExecutionControlSocketInstance('server-a');
+		store.setExecutionControlFromLiveUpdate('chat-a', control);
+
+		store.markExecutionControlSocketDisconnected();
+
+		expect(store.getExecutionControl('chat-a')).toEqual(control);
+	});
+
+	it('preserves instance authority when chat controls are pruned', () => {
+		const store = new ConversationUiState();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		store.confirmExecutionControlSocketInstance('server-a');
+		store.setExecutionControlFromLiveUpdate(
+			'chat-a',
+			makeControl(makeQueue(), { serverInstanceId: 'server-a' }),
+		);
+		store.pruneExecutionControls(new Set());
+		store.markExecutionControlSocketDisconnected();
+		store.setExecutionControlFromLiveUpdate(
+			'chat-b',
+			makeControl(makeQueue(), { serverInstanceId: 'server-b' }),
+		);
+
+		store.setExecutionControlFromRefresh(
+			'chat-a',
+			makeControl(makeQueue(), { serverInstanceId: 'server-a', version: 99 }),
+		);
+
+		expect(store.getExecutionControl('chat-a')).toBeNull();
+		expect(store.getExecutionControl('chat-b')?.serverInstanceId).toBe('server-b');
+		warn.mockRestore();
+	});
+
+	it('accepts a lower version when an unseen provisional instance replaces the old process', () => {
+		const store = new ConversationUiState();
+		store.confirmExecutionControlSocketInstance('server-a');
+		store.setExecutionControlFromLiveUpdate(
+			'chat-a',
+			makeControl(makeQueue(), {
+				serverInstanceId: 'server-a',
+				version: 9,
+			}),
+		);
+		store.markExecutionControlSocketDisconnected();
+		const replacement = makeControl(makeQueue({ entries: [makeEntry('new', 'new')] }), {
+			serverInstanceId: 'server-b',
+			version: 1,
+		});
+
+		store.setExecutionControlFromRefresh('chat-a', replacement);
+
+		expect(store.getExecutionControl('chat-a')).toEqual(replacement);
+	});
+
+	it('rejects delayed superseded input and logs only reconciliation metadata', () => {
+		const store = new ConversationUiState();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		store.confirmExecutionControlSocketInstance('server-a');
+		store.markExecutionControlSocketDisconnected();
+		const current = makeControl(makeQueue({ entries: [makeEntry('current', 'secret')] }), {
+			serverInstanceId: 'server-b',
+			version: 1,
+		});
+		store.setExecutionControlFromLiveUpdate('chat-b', current);
+
+		store.setExecutionControlFromLiveUpdate(
+			'chat-a',
+			makeControl(makeQueue(), {
+				serverInstanceId: 'server-a',
+				version: 99,
+			}),
+		);
+
+		expect(store.getExecutionControl('chat-b')).toEqual(current);
+		expect(store.getExecutionControl('chat-a')).toBeNull();
+		expect(warn).toHaveBeenCalledWith(
+			'[ConversationUiState] Rejected execution control instance',
+			expect.objectContaining({
+				reason: 'superseded-instance',
+				incomingInstanceId: 'server-a',
+				currentInstanceId: 'server-b',
+			}),
+		);
+		expect(JSON.stringify(warn.mock.calls)).not.toContain('secret');
+		warn.mockRestore();
+	});
+
+	it('rejects every differing instance while the socket is confirmed', () => {
+		const store = new ConversationUiState();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		store.confirmExecutionControlSocketInstance('server-b');
+		const current = makeControl(makeQueue(), { serverInstanceId: 'server-b', version: 1 });
+		store.setExecutionControlFromLiveUpdate('chat-a', current);
+
+		store.setExecutionControlFromRefresh(
+			'chat-a',
+			makeControl(makeQueue(), {
+				serverInstanceId: 'server-c',
+				version: 99,
+			}),
+		);
+
+		expect(store.getExecutionControl('chat-a')).toEqual(current);
+		expect(warn).toHaveBeenCalledWith(
+			'[ConversationUiState] Rejected execution control instance',
+			expect.objectContaining({ reason: 'confirmed-socket-mismatch' }),
+		);
+		warn.mockRestore();
+	});
+
+	it('keeps ordinary same-instance stale-version rejection silent', () => {
+		const store = new ConversationUiState();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const current = makeControl(makeQueue(), { version: 5 });
+		store.setExecutionControlFromLiveUpdate('chat-a', current);
+
+		store.setExecutionControlFromLiveUpdate('chat-a', makeControl(makeQueue(), { version: 4 }));
+		store.setExecutionControlFromRefresh('chat-a', makeControl(makeQueue(), { version: 5 }));
+
+		expect(store.getExecutionControl('chat-a')).toEqual(current);
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
 	});
 });

--- a/web/src/lib/chat/conversation/__tests__/execution-control-instance-authority.logic.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/execution-control-instance-authority.logic.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ExecutionControlInstanceAuthority } from '../execution-control-instance-authority.js';
+
+describe('ExecutionControlInstanceAuthority', () => {
+	it('treats live input as provisional until the current socket confirms it', () => {
+		const authority = new ExecutionControlInstanceAuthority();
+
+		expect(authority.classifyNonAuthoritativeInstance('server-a')).toEqual({ kind: 'replace' });
+		expect(authority.classifyNonAuthoritativeInstance('server-a')).toEqual({ kind: 'current' });
+		expect(authority.confirmSocketInstance('server-a')).toEqual({ kind: 'current' });
+		expect(authority.classifyNonAuthoritativeInstance('server-b')).toMatchObject({
+			kind: 'reject',
+			reason: 'confirmed-socket-mismatch',
+			currentInstanceId: 'server-a',
+			confirmedSocketInstanceId: 'server-a',
+		});
+	});
+
+	it('retains superseded identities across socket outages', () => {
+		const authority = new ExecutionControlInstanceAuthority();
+		authority.confirmSocketInstance('server-a');
+		authority.markSocketDisconnected();
+		expect(authority.classifyNonAuthoritativeInstance('server-b')).toEqual({ kind: 'replace' });
+		expect(authority.classifyNonAuthoritativeInstance('server-a')).toMatchObject({
+			kind: 'reject',
+			reason: 'superseded-instance',
+		});
+
+		authority.confirmSocketInstance('server-b');
+		authority.markSocketDisconnected();
+		expect(authority.classifyNonAuthoritativeInstance('server-a')).toMatchObject({
+			kind: 'reject',
+			reason: 'superseded-instance',
+		});
+	});
+
+	it('lets correlated socket authority reauthorize a retired identity', () => {
+		const authority = new ExecutionControlInstanceAuthority();
+		authority.confirmSocketInstance('server-a');
+		authority.markSocketDisconnected();
+		authority.classifyNonAuthoritativeInstance('server-b');
+
+		expect(authority.confirmSocketInstance('server-a')).toEqual({ kind: 'replace' });
+		expect(authority.classifyNonAuthoritativeInstance('server-a')).toEqual({ kind: 'current' });
+		expect(authority.classifyNonAuthoritativeInstance('server-b')).toMatchObject({
+			kind: 'reject',
+			reason: 'confirmed-socket-mismatch',
+		});
+	});
+
+	it('allows unseen fallback instances while unconfirmed and preserves reauthorization', () => {
+		const authority = new ExecutionControlInstanceAuthority();
+		expect(authority.classifyNonAuthoritativeInstance('server-d')).toEqual({ kind: 'replace' });
+		expect(authority.classifyNonAuthoritativeInstance('server-c')).toEqual({ kind: 'replace' });
+		expect(authority.classifyNonAuthoritativeInstance('server-b')).toEqual({ kind: 'replace' });
+
+		expect(authority.confirmSocketInstance('server-d')).toEqual({ kind: 'replace' });
+		expect(authority.classifyNonAuthoritativeInstance('server-c')).toMatchObject({
+			kind: 'reject',
+			reason: 'confirmed-socket-mismatch',
+		});
+	});
+});

--- a/web/src/lib/chat/conversation/__tests__/submission-classifier.logic.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/submission-classifier.logic.test.ts
@@ -8,7 +8,7 @@ function input(
 	return {
 		isDraft: false,
 		isProcessing: false,
-		control: emptyChatExecutionControlState(),
+		control: emptyChatExecutionControlState('server-instance-test'),
 		hasAttachments: false,
 		...overrides,
 	};
@@ -23,9 +23,9 @@ describe('classifySubmission', () => {
 			'queued predecessor',
 			input({
 				control: {
-					...emptyChatExecutionControlState(),
+					...emptyChatExecutionControlState('server-instance-test'),
 					queue: {
-						...emptyChatExecutionControlState().queue,
+						...emptyChatExecutionControlState('server-instance-test').queue,
 						entries: [
 							{
 								id: 'entry-1',
@@ -44,9 +44,9 @@ describe('classifySubmission', () => {
 			'paused queue',
 			input({
 				control: {
-					...emptyChatExecutionControlState(),
+					...emptyChatExecutionControlState('server-instance-test'),
 					queue: {
-						...emptyChatExecutionControlState().queue,
+						...emptyChatExecutionControlState('server-instance-test').queue,
 						pause: {
 							id: 'pause-1',
 							kind: 'manual',

--- a/web/src/lib/chat/conversation/conversation-queue-controller.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-queue-controller.svelte.ts
@@ -43,7 +43,7 @@ export interface ConversationQueueControllerOptions {
 	get lifecycle(): Pick<SessionControllerDeps['lifecycle'], 'currentChatId'>;
 	get conversationUi(): Pick<
 		SessionControllerDeps['conversationUi'],
-		'setExecutionControl' | 'setExecutionControlFromRefresh'
+		'setExecutionControlFromLiveUpdate' | 'setExecutionControlFromRefresh'
 	>;
 	get acceptedInputs(): Pick<AcceptedInputSubmissionService, 'enqueue'>;
 }
@@ -144,13 +144,13 @@ export class ConversationQueueController {
 
 	async pauseForChat(chatId: string): Promise<void> {
 		const result = await pauseChatQueue(chatId);
-		this.options.conversationUi.setExecutionControl(chatId, result.control);
+		this.options.conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 	}
 
 	async resumeForChat(chatId: string, pauseId: string): Promise<void> {
 		try {
 			const result = await resumeChatQueue(chatId, pauseId);
-			this.options.conversationUi.setExecutionControl(chatId, result.control);
+			this.options.conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		} catch (error) {
 			this.#applyMutationErrorControl(chatId, error);
 			throw error;
@@ -161,7 +161,7 @@ export class ConversationQueueController {
 		const submission = this.options.acceptedInputs.enqueue({ chatId, content });
 		try {
 			const result = await submission.submit();
-			this.options.conversationUi.setExecutionControl(chatId, result.control);
+			this.options.conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		} catch (error) {
 			this.#applyMutationErrorControl(chatId, error);
 			throw error;
@@ -182,7 +182,7 @@ export class ConversationQueueController {
 				content,
 				expectedRevision,
 			});
-			this.options.conversationUi.setExecutionControl(chatId, result.control);
+			this.options.conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		} catch (error) {
 			this.#applyMutationErrorControl(chatId, error);
 			throw error;
@@ -196,7 +196,7 @@ export class ConversationQueueController {
 				chatId,
 				entryId,
 			});
-			this.options.conversationUi.setExecutionControl(chatId, result.control);
+			this.options.conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		} catch (error) {
 			this.#applyMutationErrorControl(chatId, error);
 			throw error;
@@ -222,7 +222,7 @@ export class ConversationQueueController {
 		};
 		try {
 			const result = await submitIdempotentCommand(() => moveQueuedInput(request));
-			this.options.conversationUi.setExecutionControl(chatId, result.control);
+			this.options.conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		} catch (error) {
 			this.#applyMutationErrorControl(chatId, error);
 			if (error instanceof CommandOutcomeUnknownError) {
@@ -248,7 +248,7 @@ export class ConversationQueueController {
 
 	#applyMutationErrorControl(chatId: string, error: unknown): void {
 		const control = controlFromMutationError(error);
-		if (control) this.options.conversationUi.setExecutionControl(chatId, control);
+		if (control) this.options.conversationUi.setExecutionControlFromRefresh(chatId, control);
 	}
 }
 

--- a/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
@@ -129,7 +129,7 @@ type SessionConversationUiState = Pick<
 	| 'previousPermissionMode'
 	| 'clearPendingPermissionRequests'
 	| 'getExecutionControl'
-	| 'setExecutionControl'
+	| 'setExecutionControlFromLiveUpdate'
 	| 'setExecutionControlFromRefresh'
 	| 'setPendingPermissionRequests'
 	| 'setPreviousPermissionMode'
@@ -570,14 +570,14 @@ export class ConversationSessionController {
 	handleAbort(): Promise<void> {
 		const { conversationUi } = this.deps;
 		return this.#requestTurnStop(stopChat, (chatId, result) => {
-			conversationUi.setExecutionControl(chatId, result.control);
+			conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		});
 	}
 
 	handleInterruptAndSend(): Promise<void> {
 		const { conversationUi } = this.deps;
 		return this.#requestTurnStop(interruptAndSendChat, (chatId, result) => {
-			conversationUi.setExecutionControl(chatId, result.control);
+			conversationUi.setExecutionControlFromLiveUpdate(chatId, result.control);
 		});
 	}
 

--- a/web/src/lib/chat/conversation/conversation-ui-state.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-ui-state.svelte.ts
@@ -4,6 +4,10 @@ import type {
 	PermissionMode,
 	ChatExecutionControlState,
 } from '$lib/types/chat';
+import {
+	ExecutionControlInstanceAuthority,
+	type ExecutionControlInstanceDecision,
+} from './execution-control-instance-authority.js';
 
 export type PendingPermissionRequestUpdate =
 	| PendingPermissionRequest[]
@@ -11,10 +15,6 @@ export type PendingPermissionRequestUpdate =
 
 export interface ExecutionControlPruningOptions {
 	getActiveChatIds: () => Set<string>;
-}
-
-function controlVersion(control: ChatExecutionControlState | null): number {
-	return control?.version ?? -1;
 }
 
 export interface ConversationUiPort {
@@ -28,8 +28,10 @@ export interface ConversationUiPort {
 	setPendingViewChat(chat: PendingViewChat | null): void;
 	setPreviousPermissionMode(mode: PermissionMode | null): void;
 	getExecutionControl(chatId: string | null | undefined): ChatExecutionControlState | null;
-	setExecutionControl(chatId: string, control: ChatExecutionControlState | null): void;
-	setExecutionControlFromRefresh(chatId: string, control: ChatExecutionControlState | null): void;
+	markExecutionControlSocketDisconnected(): void;
+	confirmExecutionControlSocketInstance(serverInstanceId: string): void;
+	setExecutionControlFromLiveUpdate(chatId: string, control: ChatExecutionControlState): void;
+	setExecutionControlFromRefresh(chatId: string, control: ChatExecutionControlState): void;
 	removeExecutionControl(chatId: string): void;
 	pruneExecutionControls(activeChatIds: Set<string>): void;
 }
@@ -38,7 +40,8 @@ export class ConversationUiState implements ConversationUiPort {
 	pendingPermissionRequests = $state<PendingPermissionRequest[]>([]);
 	pendingViewChat = $state<PendingViewChat | null>(null);
 	previousPermissionMode = $state<PermissionMode | null>(null);
-	private executionControlByChatId = $state<Record<string, ChatExecutionControlState | null>>({});
+	private executionControlByChatId = $state<Record<string, ChatExecutionControlState>>({});
+	private readonly executionControlAuthority = new ExecutionControlInstanceAuthority();
 
 	get executionControlChatIds(): string[] {
 		return Object.keys(this.executionControlByChatId);
@@ -72,16 +75,58 @@ export class ConversationUiState implements ConversationUiPort {
 		return this.executionControlByChatId[chatId] ?? null;
 	}
 
-	setExecutionControl(chatId: string, control: ChatExecutionControlState | null): void {
+	markExecutionControlSocketDisconnected(): void {
+		this.executionControlAuthority.markSocketDisconnected();
+	}
+
+	confirmExecutionControlSocketInstance(serverInstanceId: string): void {
+		const decision = this.executionControlAuthority.confirmSocketInstance(serverInstanceId);
+		if (decision.kind === 'replace') this.executionControlByChatId = {};
+	}
+
+	setExecutionControlFromLiveUpdate(chatId: string, control: ChatExecutionControlState): void {
+		const decision = this.executionControlAuthority.classifyNonAuthoritativeInstance(
+			control.serverInstanceId,
+		);
+		if (this.#handleExecutionControlInstanceDecision(decision, chatId, control)) return;
 		const current = this.executionControlByChatId[chatId] ?? null;
-		if (controlVersion(control) < controlVersion(current)) return;
+		if (current && control.version < current.version) return;
 		this.executionControlByChatId = { ...this.executionControlByChatId, [chatId]: control };
 	}
 
-	setExecutionControlFromRefresh(chatId: string, control: ChatExecutionControlState | null): void {
+	setExecutionControlFromRefresh(chatId: string, control: ChatExecutionControlState): void {
+		const decision = this.executionControlAuthority.classifyNonAuthoritativeInstance(
+			control.serverInstanceId,
+		);
+		if (this.#handleExecutionControlInstanceDecision(decision, chatId, control)) return;
 		const current = this.executionControlByChatId[chatId] ?? null;
-		if (current && controlVersion(control) <= controlVersion(current)) return;
+		if (current && control.version <= current.version) return;
 		this.executionControlByChatId = { ...this.executionControlByChatId, [chatId]: control };
+	}
+
+	#handleExecutionControlInstanceDecision(
+		decision: ExecutionControlInstanceDecision,
+		chatId: string,
+		control: ChatExecutionControlState,
+	): boolean {
+		if (decision.kind === 'reject') {
+			const cached = this.executionControlByChatId[chatId] ?? null;
+			console.warn('[ConversationUiState] Rejected execution control instance', {
+				reason: decision.reason,
+				chatId,
+				incomingInstanceId: control.serverInstanceId,
+				currentInstanceId: decision.currentInstanceId,
+				confirmedSocketInstanceId: decision.confirmedSocketInstanceId,
+				incomingVersion: control.version,
+				cachedVersion: cached?.version ?? null,
+			});
+			return true;
+		}
+		if (decision.kind === 'replace') {
+			this.executionControlByChatId = { [chatId]: control };
+			return true;
+		}
+		return false;
 	}
 
 	removeExecutionControl(chatId: string): void {

--- a/web/src/lib/chat/conversation/execution-control-instance-authority.ts
+++ b/web/src/lib/chat/conversation/execution-control-instance-authority.ts
@@ -1,0 +1,61 @@
+export type ExecutionControlInstanceAcceptance = { kind: 'current' } | { kind: 'replace' };
+
+export type ExecutionControlInstanceDecision =
+	| ExecutionControlInstanceAcceptance
+	| {
+			kind: 'reject';
+			reason: 'confirmed-socket-mismatch' | 'superseded-instance';
+			currentInstanceId: string | null;
+			confirmedSocketInstanceId: string | null;
+	  };
+
+/** Resolves opaque process identities using correlated socket responses as authority. */
+export class ExecutionControlInstanceAuthority {
+	#currentInstanceId: string | null = null;
+	#confirmedSocketInstanceId: string | null = null;
+	readonly #supersededInstanceIds = new Set<string>();
+
+	markSocketDisconnected(): void {
+		this.#confirmedSocketInstanceId = null;
+	}
+
+	confirmSocketInstance(serverInstanceId: string): ExecutionControlInstanceAcceptance {
+		this.#confirmedSocketInstanceId = serverInstanceId;
+		if (this.#currentInstanceId === serverInstanceId) return { kind: 'current' };
+		return this.#replaceCurrent(serverInstanceId);
+	}
+
+	classifyNonAuthoritativeInstance(serverInstanceId: string): ExecutionControlInstanceDecision {
+		if (
+			this.#confirmedSocketInstanceId !== null &&
+			serverInstanceId !== this.#confirmedSocketInstanceId
+		) {
+			return this.#reject('confirmed-socket-mismatch');
+		}
+		if (this.#currentInstanceId === serverInstanceId) return { kind: 'current' };
+		if (this.#supersededInstanceIds.has(serverInstanceId)) {
+			return this.#reject('superseded-instance');
+		}
+		return this.#replaceCurrent(serverInstanceId);
+	}
+
+	#replaceCurrent(serverInstanceId: string): ExecutionControlInstanceAcceptance {
+		if (this.#currentInstanceId !== null) {
+			this.#supersededInstanceIds.add(this.#currentInstanceId);
+		}
+		this.#supersededInstanceIds.delete(serverInstanceId);
+		this.#currentInstanceId = serverInstanceId;
+		return { kind: 'replace' };
+	}
+
+	#reject(
+		reason: 'confirmed-socket-mismatch' | 'superseded-instance',
+	): ExecutionControlInstanceDecision {
+		return {
+			kind: 'reject',
+			reason,
+			currentInstanceId: this.#currentInstanceId,
+			confirmedSocketInstanceId: this.#confirmedSocketInstanceId,
+		};
+	}
+}

--- a/web/src/lib/chat/conversation/submission-routes.ts
+++ b/web/src/lib/chat/conversation/submission-routes.ts
@@ -54,7 +54,7 @@ export async function submitQueueRoute(
 	const submission = acceptedInputs.enqueue({ chatId: context.chatId, content: context.content });
 	try {
 		const result = await submission.submit();
-		deps.conversationUi.setExecutionControl(context.chatId, result.control);
+		deps.conversationUi.setExecutionControlFromLiveUpdate(context.chatId, result.control);
 		return 'accepted';
 	} catch (error) {
 		return settleSubmissionFailure(deps, context, error, {
@@ -89,7 +89,7 @@ export async function submitGoalControlRoute(
 	});
 	try {
 		const result = await submission.submit();
-		deps.conversationUi.setExecutionControl(context.chatId, result.control);
+		deps.conversationUi.setExecutionControlFromLiveUpdate(context.chatId, result.control);
 		return 'accepted';
 	} catch (error) {
 		return settleSubmissionFailure(deps, context, error, {

--- a/web/src/lib/components/chat/__tests__/ConversationWorkspace.escape.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationWorkspace.escape.test.ts
@@ -76,6 +76,7 @@ describe('ConversationWorkspace Escape abort handling', () => {
 			success: true,
 			chatId: 'chat-1',
 			control: {
+				serverInstanceId: 'server-instance-test',
 				queue: {
 					entries: [],
 					dispatchingEntryId: null,
@@ -95,6 +96,7 @@ describe('ConversationWorkspace Escape abort handling', () => {
 			status: 'accepted',
 			acceptedAt: '2026-01-01T00:00:00.000Z',
 			control: {
+				serverInstanceId: 'server-instance-test',
 				queue: {
 					entries: [],
 					dispatchingEntryId: null,

--- a/web/src/lib/events/__tests__/queue-contract.logic.test.ts
+++ b/web/src/lib/events/__tests__/queue-contract.logic.test.ts
@@ -5,6 +5,7 @@ const installedAt = '2026-07-18T00:00:00.000Z';
 
 function control(overrides: Record<string, unknown> = {}) {
 	return {
+		serverInstanceId: 'server-instance-test',
 		queue: {
 			entries: [],
 			dispatchingEntryId: null,

--- a/web/src/lib/events/__tests__/queue-handler.logic.test.ts
+++ b/web/src/lib/events/__tests__/queue-handler.logic.test.ts
@@ -7,20 +7,21 @@ import {
 
 function makeQueueContext(overrides: Partial<QueueContext> = {}): {
 	ctx: QueueContext;
-	setExecutionControl: ReturnType<typeof vi.fn>;
+	setExecutionControlFromLiveUpdate: ReturnType<typeof vi.fn>;
 } {
-	const setExecutionControl = vi.fn();
+	const setExecutionControlFromLiveUpdate = vi.fn();
 	const ctx: QueueContext = {
-		conversationUi: { setExecutionControl },
+		conversationUi: { setExecutionControlFromLiveUpdate },
 		...overrides,
 	};
-	return { ctx, setExecutionControl };
+	return { ctx, setExecutionControlFromLiveUpdate };
 }
 
 describe('queue handler', () => {
 	it('caches execution-control updates by chat id regardless of selection', () => {
-		const { ctx, setExecutionControl } = makeQueueContext();
+		const { ctx, setExecutionControlFromLiveUpdate } = makeQueueContext();
 		const control = {
+			serverInstanceId: 'server-instance-test',
 			queue: {
 				entries: [],
 				dispatchingEntryId: null,
@@ -34,6 +35,6 @@ describe('queue handler', () => {
 
 		handleExecutionControlUpdated(new ChatExecutionControlUpdatedMessage('chat-b', control), ctx);
 
-		expect(setExecutionControl).toHaveBeenCalledWith('chat-b', control);
+		expect(setExecutionControlFromLiveUpdate).toHaveBeenCalledWith('chat-b', control);
 	});
 });

--- a/web/src/lib/events/__tests__/queue-routing.logic.test.ts
+++ b/web/src/lib/events/__tests__/queue-routing.logic.test.ts
@@ -5,17 +5,18 @@ import { filterByChat } from '../chat-filter';
 import { handleExecutionControlUpdated, type QueueContext } from '../handlers/queue';
 
 function makeContext(
-	setExecutionControl: (chatId: string, control: ChatExecutionControlState | null) => void,
+	setExecutionControlFromLiveUpdate: (chatId: string, control: ChatExecutionControlState) => void,
 ): QueueContext {
 	return {
-		conversationUi: { setExecutionControl },
+		conversationUi: { setExecutionControlFromLiveUpdate },
 	};
 }
 
 describe('queue routing integration', () => {
 	it('applies execution-control updates for background chats through filter + handler path', () => {
-		const setExecutionControl = vi.fn();
+		const setExecutionControlFromLiveUpdate = vi.fn();
 		const control = {
+			serverInstanceId: 'server-instance-test',
 			queue: {
 				entries: [],
 				dispatchingEntryId: null,
@@ -34,10 +35,10 @@ describe('queue routing integration', () => {
 		});
 
 		if (filterResult.action === 'process') {
-			handleExecutionControlUpdated(message, makeContext(setExecutionControl));
+			handleExecutionControlUpdated(message, makeContext(setExecutionControlFromLiveUpdate));
 		}
 
 		expect(filterResult).toEqual({ action: 'process' });
-		expect(setExecutionControl).toHaveBeenCalledWith('chat-b', control);
+		expect(setExecutionControlFromLiveUpdate).toHaveBeenCalledWith('chat-b', control);
 	});
 });

--- a/web/src/lib/events/__tests__/router-integration.test.ts
+++ b/web/src/lib/events/__tests__/router-integration.test.ts
@@ -12,6 +12,29 @@ import { StartupCoordinator } from '$lib/chat/conversation/startup-coordinator.j
 
 const TS = '2026-05-14T00:00:01.000Z';
 
+function executionControl(serverInstanceId: string, version: number, content: string) {
+	return {
+		serverInstanceId,
+		queue: {
+			entries: [
+				{
+					id: `entry-${serverInstanceId}`,
+					content,
+					revision: 1,
+					createdAt: TS,
+					updatedAt: TS,
+				},
+			],
+			dispatchingEntryId: null,
+			recentlyDispatched: [],
+			pause: null,
+			reorderRevision: 0,
+		},
+		version,
+		updatedAt: TS,
+	};
+}
+
 function chatRecord(): ChatSessionRecord {
 	return {
 		id: 'chat-a',
@@ -306,6 +329,35 @@ describe('event router integration', () => {
 			'chat-a',
 			'queued message',
 		);
+	});
+
+	it('does not let a retained old-socket control demote the confirmed instance', () => {
+		const stores = createStores();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const current = executionControl('server-b', 1, 'current');
+		stores.conversationUi.confirmExecutionControlSocketInstance('server-b');
+		stores.conversationUi.setExecutionControlFromLiveUpdate('chat-a', current);
+
+		renderRouterWithRawMessages(
+			[
+				{
+					type: 'chat-execution-control-updated',
+					chatId: 'chat-a',
+					control: executionControl('server-a', 99, 'retained-old-socket'),
+				},
+			],
+			stores,
+		);
+
+		expect(stores.conversationUi.getExecutionControl('chat-a')).toEqual(current);
+		expect(warn).toHaveBeenCalledWith(
+			'[ConversationUiState] Rejected execution control instance',
+			expect.objectContaining({
+				reason: 'confirmed-socket-mismatch',
+				incomingInstanceId: 'server-a',
+			}),
+		);
+		warn.mockRestore();
 	});
 
 	it('warms visible split-pane previews before background chat filtering skips them', () => {

--- a/web/src/lib/events/handlers/queue.ts
+++ b/web/src/lib/events/handlers/queue.ts
@@ -6,12 +6,12 @@ import type {
 import type { ConversationUiPort } from '$lib/chat/conversation/conversation-ui-state.svelte.js';
 
 export interface QueueContext {
-	conversationUi: Pick<ConversationUiPort, 'setExecutionControl'>;
+	conversationUi: Pick<ConversationUiPort, 'setExecutionControlFromLiveUpdate'>;
 }
 
 export function handleExecutionControlUpdated(
 	msg: ChatExecutionControlUpdatedMessage,
 	ctx: QueueContext,
 ) {
-	ctx.conversationUi.setExecutionControl(msg.chatId, msg.control);
+	ctx.conversationUi.setExecutionControlFromLiveUpdate(msg.chatId, msg.control);
 }

--- a/web/src/lib/ws/__tests__/ReconnectCoordinatorTestHost.svelte
+++ b/web/src/lib/ws/__tests__/ReconnectCoordinatorTestHost.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import {
+		ChatReconnectCoordinator,
+		type ChatReconnectCoordinatorOptions,
+	} from '../reconnect-coordinator.svelte.js';
+
+	let { options }: { options: ChatReconnectCoordinatorOptions } = $props();
+
+	function mountCoordinator(): void {
+		new ChatReconnectCoordinator(options).mount();
+	}
+
+	mountCoordinator();
+</script>

--- a/web/src/lib/ws/__tests__/chat-processing-reconciler.test.ts
+++ b/web/src/lib/ws/__tests__/chat-processing-reconciler.test.ts
@@ -84,6 +84,7 @@ function pong(chats: Array<{ chatId: string; phase: ChatProcessingPhase }> = [],
 		clientRequestId: 'probe-1',
 		sentAt,
 		serverTime: '2026-07-27T00:00:00.000Z',
+		serverInstanceId: 'server-instance-test',
 		processing: { outcome: 'snapshot', chats },
 	};
 }
@@ -202,6 +203,7 @@ describe('ChatProcessingReconciler', () => {
 			socket.consume({
 				type: 'reconnect-state',
 				clientRequestId: 'reconnect-1',
+				serverInstanceId: 'server-instance-test',
 				processing: { outcome: 'unavailable' },
 				controlResults: [],
 			});

--- a/web/src/lib/ws/__tests__/connection.test.ts
+++ b/web/src/lib/ws/__tests__/connection.test.ts
@@ -329,6 +329,7 @@ describe('WsConnection', () => {
 			clientRequestId: ping.clientRequestId,
 			sentAt: ping.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'snapshot', chats: [] },
 		});
 		await flushPromises();
@@ -363,6 +364,7 @@ describe('WsConnection', () => {
 			clientRequestId: ping.clientRequestId,
 			sentAt: ping.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: {
 				outcome: 'snapshot',
 				chats: [{ chatId: 'chat-1', phase: 'stopping' }],
@@ -396,6 +398,7 @@ describe('WsConnection', () => {
 			clientRequestId: fresh.clientRequestId,
 			sentAt: fresh.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'snapshot', chats: [] },
 		});
 		await expect(probe).resolves.toEqual({ outcome: 'snapshot', chats: [] });
@@ -418,6 +421,7 @@ describe('WsConnection', () => {
 			clientRequestId: ping.clientRequestId,
 			sentAt: ping.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'snapshot', chats: [] },
 		});
 		await expect(probe).resolves.toEqual({ outcome: 'snapshot', chats: [] });
@@ -445,6 +449,7 @@ describe('WsConnection', () => {
 			clientRequestId: ping.clientRequestId,
 			sentAt: ping.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'snapshot', chats: [] },
 		});
 		await probe;
@@ -477,6 +482,7 @@ describe('WsConnection', () => {
 			clientRequestId: ping.clientRequestId,
 			sentAt: ping.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: {
 				outcome: 'snapshot',
 				chats: [{ chatId: 'chat-1', phase: 'unknown' }],
@@ -489,6 +495,35 @@ describe('WsConnection', () => {
 			'[WsConnection] Malformed processing snapshot response',
 			{ source: 'stop-probe' },
 		);
+		protocolError.mockRestore();
+		reconciler.destroy();
+		connection.disconnect();
+	});
+
+	it('rejects a pong without an instance identity before applying processing', async () => {
+		const connection = new WsConnection();
+		const processing = processingHarness();
+		const reconciler = new ChatProcessingReconciler(connection, processing.sessions);
+		const protocolError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		connection.connect('token');
+		const socket = mockSockets[0];
+		socket.open();
+
+		const probe = connection.requestProcessingSnapshot();
+		const ping = lastSentPayload(socket);
+		socket.message({
+			type: 'ws-pong',
+			clientRequestId: ping.clientRequestId,
+			sentAt: ping.sentAt,
+			serverTime: '2026-06-17T00:00:00.000Z',
+			processing: {
+				outcome: 'snapshot',
+				chats: [{ chatId: 'chat-1', phase: 'running' }],
+			},
+		});
+
+		await expect(probe).rejects.toThrow('Malformed processing snapshot response');
+		expect(processing.order).toEqual([]);
 		protocolError.mockRestore();
 		reconciler.destroy();
 		connection.disconnect();
@@ -524,6 +559,7 @@ describe('WsConnection', () => {
 			clientRequestId: ping.clientRequestId,
 			sentAt: ping.sentAt,
 			serverTime: '2026-06-17T00:00:00.000Z',
+			serverInstanceId: 'server-instance-test',
 			processing: { outcome: 'snapshot', chats: [] },
 		});
 		await flushPromises();

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
 
 import {
 	ChatReconnectCoordinator,
@@ -6,11 +7,18 @@ import {
 	type ReconnectTranscriptState,
 } from '../reconnect-coordinator.svelte';
 import type { ChatExecutionControlState } from '$shared/chat-execution-control';
+import ReconnectCoordinatorTestHost from './ReconnectCoordinatorTestHost.svelte';
+import { ConversationUiState } from '$lib/chat/conversation/conversation-ui-state.svelte.js';
+import type { WsMessageConsumer } from '../connection.svelte.js';
 
 const TS = '2024-01-01T00:00:00.000Z';
 
-function controlState(paused: boolean): ChatExecutionControlState {
+function controlState(
+	paused: boolean,
+	serverInstanceId = 'server-instance-test',
+): ChatExecutionControlState {
 	return {
+		serverInstanceId,
 		queue: {
 			entries: paused
 				? [
@@ -44,10 +52,12 @@ function reconnectStateResponse(
 	runningIds: string[] = [],
 	chatIds: string[] = [],
 	controlStates: Record<string, ChatExecutionControlState> | undefined = {},
+	serverInstanceId = 'server-instance-test',
 ) {
 	return {
 		type: 'reconnect-state',
 		clientRequestId: 'req-reconnect',
+		serverInstanceId,
 		processing: {
 			outcome: 'snapshot',
 			chats: runningIds.map((chatId) => ({ chatId, phase: 'running' })),
@@ -167,10 +177,13 @@ function createReconnectDeps(
 		executionControlChatIds: options.controlChatIds ?? [],
 		removeExecutionControl: vi.fn(),
 		setExecutionControlFromRefresh: vi.fn(),
+		markExecutionControlSocketDisconnected: vi.fn(),
+		confirmExecutionControlSocketInstance: vi.fn(),
 	};
+	const addMessageConsumer = vi.fn<(consumer: WsMessageConsumer) => () => void>(() => vi.fn());
 
 	return {
-		ws: { isConnected: true, sendRequest },
+		ws: { isConnected: true as boolean, sendRequest, addMessageConsumer },
 		chatState,
 		conversationUi,
 		sessions: {
@@ -203,6 +216,8 @@ function clearConnectionCalls(deps: ReturnType<typeof createReconnectDeps>): voi
 		deps.chatState.transcriptCache.markValidated,
 		deps.conversationUi.removeExecutionControl,
 		deps.conversationUi.setExecutionControlFromRefresh,
+		deps.conversationUi.markExecutionControlSocketDisconnected,
+		deps.conversationUi.confirmExecutionControlSocketInstance,
 		deps.getExecutionControl,
 		deps.sessions.quietRefreshChats,
 		deps.getBackgroundCursors,
@@ -228,6 +243,83 @@ async function reconnectAfterFirstConnection(
 }
 
 describe('ChatReconnectCoordinator', () => {
+	it('confirms identified pongs and unregisters the authority consumer on cleanup', async () => {
+		const deps = createReconnectDeps();
+		deps.ws.isConnected = false;
+		const view = render(ReconnectCoordinatorTestHost, { options: deps });
+		await vi.waitFor(() => expect(deps.ws.addMessageConsumer).toHaveBeenCalledOnce());
+		deps.conversationUi.confirmExecutionControlSocketInstance.mockClear();
+		const consumer = deps.ws.addMessageConsumer.mock.calls[0]?.[0];
+		if (!consumer) throw new Error('Reconnect authority consumer was not registered.');
+		expect(
+			consumer(
+				{
+					type: 'ws-pong',
+					clientRequestId: 'probe-malformed',
+					sentAt: 1,
+					serverTime: TS,
+					processing: { outcome: 'snapshot', chats: [] },
+				},
+				{},
+			),
+		).toBe(false);
+		expect(deps.conversationUi.confirmExecutionControlSocketInstance).not.toHaveBeenCalled();
+
+		expect(
+			consumer(
+				{
+					type: 'ws-pong',
+					clientRequestId: 'probe-1',
+					sentAt: 1,
+					serverTime: TS,
+					serverInstanceId: 'server-b',
+					processing: { outcome: 'snapshot', chats: [] },
+				},
+				{},
+			),
+		).toBe(false);
+		expect(deps.conversationUi.confirmExecutionControlSocketInstance).toHaveBeenCalledWith(
+			'server-b',
+		);
+
+		const removeConsumer = deps.ws.addMessageConsumer.mock.results[0]?.value;
+		view.unmount();
+		expect(removeConsumer).toHaveBeenCalledOnce();
+	});
+
+	it('lets a correlated pong replace provisional controls with the current socket instance', async () => {
+		const conversationUi = new ConversationUiState();
+		conversationUi.setExecutionControlFromLiveUpdate('chat-1', controlState(true, 'server-b'));
+		const deps = createReconnectDeps();
+		deps.ws.isConnected = false;
+		const view = render(ReconnectCoordinatorTestHost, {
+			options: { ...deps, conversationUi },
+		});
+		await vi.waitFor(() => expect(deps.ws.addMessageConsumer).toHaveBeenCalledOnce());
+		const consumer = deps.ws.addMessageConsumer.mock.calls[0]?.[0];
+		if (!consumer) throw new Error('Reconnect authority consumer was not registered.');
+
+		consumer(
+			{
+				type: 'ws-pong',
+				clientRequestId: 'probe-1',
+				sentAt: 1,
+				serverTime: TS,
+				serverInstanceId: 'server-c',
+				processing: { outcome: 'snapshot', chats: [] },
+			},
+			{},
+		);
+
+		expect(conversationUi.getExecutionControl('chat-1')).toBeNull();
+		conversationUi.setExecutionControlFromLiveUpdate('chat-1', controlState(false, 'server-c'));
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		conversationUi.setExecutionControlFromLiveUpdate('chat-1', controlState(true, 'server-d'));
+		expect(conversationUi.getExecutionControl('chat-1')).toEqual(controlState(false, 'server-c'));
+		warn.mockRestore();
+		view.unmount();
+	});
+
 	it('reconciles control state without transcript replay on first connection', async () => {
 		const deps = createReconnectDeps({ runningIds: ['chat-1'] });
 		const coordinator = new ChatReconnectCoordinator(deps);
@@ -242,6 +334,9 @@ describe('ChatReconnectCoordinator', () => {
 		expect(deps.conversationUi.setExecutionControlFromRefresh).toHaveBeenCalledWith(
 			'chat-1',
 			controlState(false),
+		);
+		expect(deps.conversationUi.confirmExecutionControlSocketInstance).toHaveBeenCalledWith(
+			'server-instance-test',
 		);
 		expect(deps.sessions.quietRefreshChats).toHaveBeenCalledOnce();
 		expect(deps.ws.sendRequest).not.toHaveBeenCalledWith(
@@ -460,6 +555,7 @@ describe('ChatReconnectCoordinator', () => {
 					return {
 						type: 'reconnect-state',
 						clientRequestId: 'req-reconnect',
+						serverInstanceId: 'server-instance-test',
 						processing: { outcome: 'snapshot', chats: [] },
 						controlResults: [
 							{ chatId: 'chat-1', outcome: 'snapshot', control: controlState(true) },
@@ -502,6 +598,7 @@ describe('ChatReconnectCoordinator', () => {
 					return {
 						type: 'reconnect-state',
 						clientRequestId: 'req-reconnect',
+						serverInstanceId: 'server-instance-test',
 						processing: { outcome: 'unavailable' },
 						controlResults: [
 							{ chatId: 'chat-1', outcome: 'snapshot', control: controlState(true) },
@@ -535,6 +632,7 @@ describe('ChatReconnectCoordinator', () => {
 		clearConnectionCalls(deps);
 
 		await coordinator.handleConnectionState(false);
+		expect(deps.conversationUi.markExecutionControlSocketDisconnected).toHaveBeenCalledOnce();
 		deps.ws.sendRequest.mockImplementation(async (request: object) => {
 			if (!('type' in request)) throw new Error('Request is missing a type');
 			if (request.type === 'reconnect-state-query') {
@@ -548,6 +646,53 @@ describe('ChatReconnectCoordinator', () => {
 		expect(deps.sessions.quietRefreshChats).toHaveBeenCalledOnce();
 	});
 
+	it('lets fallback C clear provisional B after the reconnect envelope fails', async () => {
+		const conversationUi = new ConversationUiState();
+		conversationUi.confirmExecutionControlSocketInstance('server-a');
+		conversationUi.setExecutionControlFromLiveUpdate('chat-1', controlState(true, 'server-a'));
+		const deps = createReconnectDeps();
+		deps.ws.sendRequest.mockImplementation(async (request: object) => {
+			if ('type' in request && request.type === 'reconnect-state-query') {
+				throw new Error('reconnect state unavailable');
+			}
+			throw new Error('Unexpected request');
+		});
+		deps.getExecutionControl.mockResolvedValue({
+			control: controlState(false, 'server-c'),
+		});
+		const coordinator = new ChatReconnectCoordinator({ ...deps, conversationUi });
+
+		await coordinator.handleConnectionState(false);
+		conversationUi.setExecutionControlFromLiveUpdate('chat-1', controlState(true, 'server-b'));
+		await coordinator.handleConnectionState(true);
+
+		expect(conversationUi.getExecutionControl('chat-1')).toEqual(controlState(false, 'server-c'));
+	});
+
+	it('does not apply fallback results that straddle a newer socket epoch', async () => {
+		const firstFallback = deferred<{ control: ChatExecutionControlState }>();
+		const conversationUi = new ConversationUiState();
+		conversationUi.confirmExecutionControlSocketInstance('server-a');
+		conversationUi.setExecutionControlFromLiveUpdate('chat-1', controlState(true, 'server-a'));
+		const deps = createReconnectDeps();
+		deps.ws.sendRequest.mockRejectedValue(new Error('reconnect state unavailable'));
+		deps.getExecutionControl
+			.mockImplementationOnce(() => firstFallback.promise)
+			.mockResolvedValueOnce({ control: controlState(false, 'server-c') });
+		const coordinator = new ChatReconnectCoordinator({ ...deps, conversationUi });
+
+		await coordinator.handleConnectionState(false);
+		const first = coordinator.handleConnectionState(true);
+		await flushUntil(() => deps.getExecutionControl.mock.calls.length === 1);
+		await coordinator.handleConnectionState(false);
+		const second = coordinator.handleConnectionState(true);
+		await second;
+		firstFallback.resolve({ control: controlState(true, 'server-b') });
+		await first;
+
+		expect(conversationUi.getExecutionControl('chat-1')).toEqual(controlState(false, 'server-c'));
+	});
+
 	it('falls back queue reads but preserves processing state when reconnect control data is malformed', async () => {
 		const deps = createReconnectDeps({
 			selectedChatId: 'chat-1',
@@ -558,6 +703,7 @@ describe('ChatReconnectCoordinator', () => {
 				if (request.type === 'reconnect-state-query') {
 					return {
 						type: 'reconnect-state',
+						serverInstanceId: 'server-instance-test',
 						processing: {
 							outcome: 'snapshot',
 							chats: [{ chatId: 42, phase: 'running' }],
@@ -583,6 +729,33 @@ describe('ChatReconnectCoordinator', () => {
 			'chat-1',
 			controlState(true),
 		);
+	});
+
+	it('falls back without confirming a mixed-instance reconnect envelope', async () => {
+		const deps = createReconnectDeps();
+		const coordinator = new ChatReconnectCoordinator(deps);
+		await coordinator.handleConnectionState(true);
+		clearConnectionCalls(deps);
+		await coordinator.handleConnectionState(false);
+		deps.conversationUi.confirmExecutionControlSocketInstance.mockClear();
+		deps.ws.sendRequest.mockImplementation(async (request: object) => {
+			if (!('type' in request)) throw new Error('Request is missing a type');
+			if (request.type === 'reconnect-state-query') {
+				return reconnectStateResponse(
+					[],
+					['chat-1'],
+					{ 'chat-1': controlState(true, 'server-a') },
+					'server-b',
+				);
+			}
+			if (request.type === 'chat-subscribe') return deltaResponse('chat-1');
+			throw new Error(`Unexpected request: ${String(request.type)}`);
+		});
+
+		await coordinator.handleConnectionState(true);
+
+		expect(deps.conversationUi.confirmExecutionControlSocketInstance).not.toHaveBeenCalled();
+		expect(deps.getExecutionControl).toHaveBeenCalledWith('chat-1');
 	});
 
 	it('does not block transcript resume on the reconnect control-state request', async () => {

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -5,6 +5,7 @@ import { untrack } from 'svelte';
 import {
 	ChatSubscribedMessage,
 	ReconnectStateMessage,
+	WsPongMessage,
 	parseServerWsMessage,
 } from '$shared/ws-events';
 import type { ChatExecutionControlState } from '$shared/chat-execution-control';
@@ -14,10 +15,12 @@ import type { ActiveTranscriptPort } from '$lib/chat/transcript/active-transcrip
 import type { ConversationUiPort } from '$lib/chat/conversation/conversation-ui-state.svelte.js';
 import type { ChatSessionsPort } from '$lib/chat/sessions/chat-sessions.svelte.js';
 import { getChatExecutionControl } from '$lib/api/chats.js';
+import type { WsMessageConsumer } from './connection.svelte.js';
 
 export interface ReconnectWsPort {
 	isConnected: boolean;
 	sendRequest(message: object): Promise<Record<string, unknown>>;
+	addMessageConsumer(consumer: WsMessageConsumer): () => void;
 }
 
 export type ReconnectTranscriptState = Pick<
@@ -32,7 +35,11 @@ export type ReconnectTranscriptState = Pick<
 
 export type ReconnectConversationUiState = Pick<
 	ConversationUiPort,
-	'executionControlChatIds' | 'removeExecutionControl' | 'setExecutionControlFromRefresh'
+	| 'executionControlChatIds'
+	| 'removeExecutionControl'
+	| 'setExecutionControlFromRefresh'
+	| 'markExecutionControlSocketDisconnected'
+	| 'confirmExecutionControlSocketInstance'
 >;
 
 export interface ChatReconnectCoordinatorOptions {
@@ -75,6 +82,15 @@ export class ChatReconnectCoordinator {
 	constructor(private readonly options: ChatReconnectCoordinatorOptions) {}
 
 	mount(): void {
+		$effect(() =>
+			this.options.ws.addMessageConsumer((data) => {
+				if (data.type !== 'ws-pong') return false;
+				const message = parseServerWsMessage(data);
+				if (!(message instanceof WsPongMessage)) return false;
+				this.options.conversationUi.confirmExecutionControlSocketInstance(message.serverInstanceId);
+				return false;
+			}),
+		);
 		$effect(() => {
 			const connected = this.options.ws.isConnected;
 			untrack(() => {
@@ -87,6 +103,7 @@ export class ChatReconnectCoordinator {
 		if (!connected) {
 			this.#wasConnected = false;
 			this.#reconnectEpoch += 1;
+			this.options.conversationUi.markExecutionControlSocketDisconnected();
 			return;
 		}
 		if (this.#wasConnected) return;
@@ -165,6 +182,7 @@ export class ChatReconnectCoordinator {
 			if (!(message instanceof ReconnectStateMessage) || epoch !== this.#reconnectEpoch) {
 				throw new Error('Unexpected reconnect-state response');
 			}
+			this.options.conversationUi.confirmExecutionControlSocketInstance(message.serverInstanceId);
 
 			const requestedChatIds = new Set(controlChatIds);
 			const returnedChatIds = new Set<string>();


### PR DESCRIPTION
Queue controls could disappear in an open browser after a server restart because process-local control versions reset and were compared against values from the previous process. This change scopes execution-control versions to the server runtime instance, carries that identity through reconnect and heartbeat payloads, and reconciles process-local queue state in the client so stale controls are cleared and newly queued messages appear without a page reload.
