### PR TITLE
Add same-turn steering for Claude

### DIFF
--- a/integration-tests/support/fake-claude-model.ts
+++ b/integration-tests/support/fake-claude-model.ts
@@ -33,6 +33,7 @@ export interface HeldClaudeTurn {
 export interface RecordedClaudeModelRequest {
   readonly id: number;
   readonly body: Record<string, unknown>;
+  readonly userTexts: readonly string[];
   readonly lastUserText: string;
   readonly toolResults: ReadonlyArray<{ toolUseId: string; content: string }>;
   readonly receivedAt: number;
@@ -64,15 +65,15 @@ function textFromContent(content: unknown): string {
     .join('\n');
 }
 
-function lastUserText(body: Record<string, unknown>): string {
-  if (!Array.isArray(body.messages)) return '';
-  for (let index = body.messages.length - 1; index >= 0; index -= 1) {
-    const message = body.messages[index];
+function userTexts(body: Record<string, unknown>): string[] {
+  if (!Array.isArray(body.messages)) return [];
+  const texts: string[] = [];
+  for (const message of body.messages) {
     if (!isRecord(message) || message.role !== 'user') continue;
     const text = textFromContent(message.content);
-    if (text.length > 0) return text;
+    if (text.length > 0) texts.push(text);
   }
-  return '';
+  return texts;
 }
 
 function toolResults(
@@ -275,6 +276,14 @@ export class FakeClaudeModel {
     return this.#requests.slice();
   }
 
+  markRequests(): number {
+    return this.#requests.length;
+  }
+
+  requestsSince(index: number): readonly RecordedClaudeModelRequest[] {
+    return this.#requests.slice(index);
+  }
+
   // Non-messages traffic the CLI generated, kept for inspection rather than failure: telemetry
   // and auxiliary endpoints are the CLI's business, not the conversation contract.
   otherRequests(): readonly string[] {
@@ -329,10 +338,12 @@ export class FakeClaudeModel {
       this.#issues.push('Messages request body was not an object');
       return sseResponse(errorEvents('invalid request body'));
     }
+    const recordedUserTexts = userTexts(body);
     const recorded: RecordedClaudeModelRequest = {
       id: ++this.#requestId,
       body,
-      lastUserText: lastUserText(body),
+      userTexts: recordedUserTexts,
+      lastUserText: recordedUserTexts.at(-1) ?? '',
       toolResults: toolResults(body),
       receivedAt: Date.now(),
     };

--- a/integration-tests/support/fake-codex-model.ts
+++ b/integration-tests/support/fake-codex-model.ts
@@ -27,6 +27,7 @@ export interface HeldCodexTurn {
 export interface RecordedCodexModelRequest {
   readonly id: number;
   readonly body: Record<string, unknown>;
+  readonly userTexts: readonly string[];
   readonly lastUserText: string;
   readonly functionCallOutputs: ReadonlyArray<{ callId: string; output: string }>;
   readonly receivedAt: number;
@@ -58,20 +59,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function lastUserText(body: Record<string, unknown>): string {
-  if (!Array.isArray(body.input)) return '';
-  for (let index = body.input.length - 1; index >= 0; index -= 1) {
-    const item = body.input[index];
+function userTexts(body: Record<string, unknown>): string[] {
+  if (!Array.isArray(body.input)) return [];
+  const texts: string[] = [];
+  for (const item of body.input) {
     if (!isRecord(item) || item.type !== 'message' || item.role !== 'user') continue;
-    if (typeof item.content === 'string') return item.content;
+    if (typeof item.content === 'string') {
+      if (item.content.length > 0) texts.push(item.content);
+      continue;
+    }
     if (!Array.isArray(item.content)) continue;
-    return item.content
+    const text = item.content
       .filter((part): part is Record<string, unknown> =>
         isRecord(part) && part.type === 'input_text' && typeof part.text === 'string')
       .map((part) => String(part.text))
       .join('\n');
+    if (text.length > 0) texts.push(text);
   }
-  return '';
+  return texts;
 }
 
 function functionCallOutputs(
@@ -206,6 +211,14 @@ export class FakeCodexModel {
     return this.#requests.slice();
   }
 
+  markRequests(): number {
+    return this.#requests.length;
+  }
+
+  requestsSince(index: number): readonly RecordedCodexModelRequest[] {
+    return this.#requests.slice(index);
+  }
+
   issues(): readonly string[] {
     return this.#issues.slice();
   }
@@ -254,10 +267,12 @@ export class FakeCodexModel {
       this.#issues.push('Responses request body was not an object');
       return sseResponse(failedEvents('invalid request body'));
     }
+    const recordedUserTexts = userTexts(body);
     const recorded: RecordedCodexModelRequest = {
       id: ++this.#requestId,
       body,
-      lastUserText: lastUserText(body),
+      userTexts: recordedUserTexts,
+      lastUserText: recordedUserTexts.at(-1) ?? '',
       functionCallOutputs: functionCallOutputs(body),
       receivedAt: Date.now(),
     };

--- a/integration-tests/tests/server/claude-scripted-steer.test.ts
+++ b/integration-tests/tests/server/claude-scripted-steer.test.ts
@@ -2,56 +2,64 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { PendingUserInputUpdatedMessage } from '../../../common/ws-events.js';
 import { assistantContents, userContents } from '../../support/chat-assertions.js';
 import {
-  codexAssistantMessage,
-  codexExecCommandCall,
-} from '../../support/fake-codex-model.js';
+  claudeText,
+  claudeToolUse,
+} from '../../support/fake-claude-model.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
 import { expectFinished, LIVE_TURN_TIMEOUT_MS } from '../../support/live-agent.js';
-import { liveCodexStartRequest } from '../../support/live-codex.js';
+import { liveClaudeStartRequest } from '../../support/live-claude.js';
 import {
-  startScriptedCodexTestEnvironment,
-  type ScriptedCodexTestEnvironment,
-} from '../../support/scripted-codex.js';
+  startScriptedClaudeTestEnvironment,
+  type ScriptedClaudeTestEnvironment,
+} from '../../support/scripted-claude.js';
 
-describe('scripted Codex strict steering', () => {
-  let environment: ScriptedCodexTestEnvironment | undefined;
+const STEERING_PREFIX = 'The user sent steering guidance for the active task:\n\n';
+
+describe('scripted Claude strict steering', () => {
+  let environment: ScriptedClaudeTestEnvironment | undefined;
 
   beforeAll(async () => {
-    environment = await startScriptedCodexTestEnvironment();
+    environment = await startScriptedClaudeTestEnvironment();
   });
 
-  afterAll(async () => {
-    await environment?.dispose();
+  afterAll(() => {
+    environment?.dispose();
   });
 
-  test('steers the active turn once ahead of a paused future queue', async () => {
-    if (!environment) throw new Error('Scripted Codex environment was not initialized.');
+  test('keeps next-priority guidance in one turn ahead of a paused future queue', async () => {
+    if (!environment) throw new Error('Scripted Claude environment was not initialized.');
     const testEnvironment = environment;
     const firstPrompt = marker('FIRST_PROMPT');
-    const steerPrompt = marker('STEER_PROMPT');
+    const steerPrompt = `/review\n${marker('STEER_PROMPT')}`;
     const futurePrompt = marker('FUTURE_PROMPT');
     const firstReply = marker('FIRST_REPLY');
     const steerReply = marker('STEER_REPLY');
     const futureReply = marker('FUTURE_REPLY');
     const toolMarker = marker('TOOL_OUTPUT');
+    const requestCursor = testEnvironment.model.markRequests();
     testEnvironment.model.scriptTurn([
-      codexExecCommandCall('call_steer_context', `printf ${toolMarker}`),
+      claudeToolUse('toolu_steer_context', 'Bash', { command: `printf %s ${toolMarker}` }),
     ]);
-    const held = testEnvironment.model.scriptHeldTurn([codexAssistantMessage(firstReply)]);
-    testEnvironment.model.scriptTurn([codexAssistantMessage(steerReply)]);
-    testEnvironment.model.scriptTurn([codexAssistantMessage(futureReply)]);
+    const held = testEnvironment.model.scriptHeldTurn([claudeText(firstReply)]);
+    testEnvironment.model.scriptTurn([claudeText(steerReply)]);
+    testEnvironment.model.scriptTurn([claudeText(futureReply)]);
 
-    await withIntegrationFixture('codex-scripted-steer', async (fixture) => {
+    await withIntegrationFixture('claude-scripted-steer', async (fixture) => {
+      const catalog = await fixture.client.listAgentCatalog();
+      expect(catalog.agents.find((agent) => agent.id === 'claude')).toMatchObject({
+        supportsSteering: true,
+      });
+
       const chatId = fixture.newChatId();
       const firstCursor = fixture.client.markEvents();
-      const first = await fixture.client.startChat(liveCodexStartRequest({
+      const first = await fixture.client.startChat(liveClaudeStartRequest({
         chatId,
         projectPath: fixture.dirs.project,
         command: firstPrompt,
         permissionMode: 'bypassPermissions',
       }));
       const firstTurnId = first.turnId;
-      if (!firstTurnId) throw new Error('Scripted Codex start did not return a turn identity.');
+      if (!firstTurnId) throw new Error('Scripted Claude start did not return a turn identity.');
       await held.requested;
 
       await fixture.client.enqueueNew(chatId, futurePrompt);
@@ -72,6 +80,10 @@ describe('scripted Codex strict steering', () => {
       expect(steered.turnId).toBe(firstTurnId);
       expect(duplicate).toMatchObject({ status: 'duplicate', turnId: firstTurnId });
       expect(await fixture.client.getExecutionControl(chatId)).toEqual(beforeSteer);
+      expect(userContents((await fixture.client.getMessages(chatId)).messages)).toEqual([
+        firstPrompt,
+        steerPrompt,
+      ]);
 
       held.release();
       expectFinished((await fixture.client.waitForTurnTerminal(chatId, firstTurnId, {
@@ -79,21 +91,29 @@ describe('scripted Codex strict steering', () => {
         timeoutMs: LIVE_TURN_TIMEOUT_MS,
       })).type);
 
-      const activeRequests = testEnvironment.model.requests();
+      const activeRequests = testEnvironment.model.requestsSince(requestCursor);
       expect(activeRequests).toHaveLength(3);
-      const steeredModelRequest = activeRequests[2];
-      if (!steeredModelRequest) throw new Error('Codex did not make the steered model request.');
-      expect(steeredModelRequest.lastUserText).toContain(steerPrompt);
-      expect(steeredModelRequest.functionCallOutputs).toContainEqual(expect.objectContaining({
-        callId: 'call_steer_context',
-        output: expect.stringContaining(toolMarker),
+      const steeredModelRequest = activeRequests.at(-1);
+      if (!steeredModelRequest) throw new Error('Claude did not make the steered model request.');
+      expect(steeredModelRequest.lastUserText).toBe(`${STEERING_PREFIX}${steerPrompt}`);
+      expect(steeredModelRequest.toolResults).toContainEqual(expect.objectContaining({
+        toolUseId: 'toolu_steer_context',
+        content: expect.stringContaining(toolMarker),
       }));
-      expect(activeRequests.filter((requestRecord) =>
-        requestRecord.lastUserText.includes(steerPrompt))).toHaveLength(1);
+      expect(activeRequests.filter((record) =>
+        record.userTexts.some((text) => text.includes(steerPrompt)))).toHaveLength(1);
 
       const stillPaused = await fixture.client.getExecutionControl(chatId);
-      expect(stillPaused.queue.entries.map((entry) => entry.content)).toEqual([futurePrompt]);
-      expect(stillPaused.queue.pause?.kind).toBe('manual');
+      expect(stillPaused).toEqual(beforeSteer);
+      const activeTranscript = await fixture.client.getMessages(chatId);
+      expect(userContents(activeTranscript.messages)).toEqual([firstPrompt, steerPrompt]);
+      expect(JSON.stringify(activeTranscript.messages)).not.toContain(STEERING_PREFIX);
+      const activePreview = (await fixture.client.listChats()).sessions.find(
+        (entry) => entry.id === chatId,
+      )?.preview.lastMessage;
+      expect(activePreview).toContain(steerReply);
+      expect(activePreview).not.toContain(STEERING_PREFIX);
+
       const futureCursor = fixture.client.markEvents();
       await fixture.client.resumeQueue(chatId, stillPaused.queue.pause!.id);
       const futureInput = await fixture.client.waitForEvent(
@@ -102,9 +122,10 @@ describe('scripted Codex strict steering', () => {
           && event.input.chatId === chatId
           && event.input.content === futurePrompt
           && typeof event.input.turnId === 'string',
-        'scripted Codex future queued turn identity',
+        'scripted Claude future queued turn identity',
         { afterIndex: futureCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
       );
+      expect(futureInput.input.turnId).not.toBe(firstTurnId);
       expectFinished((await fixture.client.waitForTurnTerminal(chatId, futureInput.input.turnId, {
         afterIndex: futureCursor,
         timeoutMs: LIVE_TURN_TIMEOUT_MS,
@@ -112,6 +133,7 @@ describe('scripted Codex strict steering', () => {
 
       const transcript = await fixture.client.getMessages(chatId);
       expect(userContents(transcript.messages)).toEqual([firstPrompt, steerPrompt, futurePrompt]);
+      expect(JSON.stringify(transcript.messages)).not.toContain(STEERING_PREFIX);
       const assistants = assistantContents(transcript.messages);
       expect(assistants.some((content) => content.includes(firstReply))).toBe(true);
       expect(assistants.some((content) => content.includes(steerReply))).toBe(true);
@@ -119,12 +141,11 @@ describe('scripted Codex strict steering', () => {
       testEnvironment.model.assertSettled();
     }, {
       serverEnvironment: testEnvironment.serverEnvironment,
-      prepareWorkspace: testEnvironment.prepareWorkspace,
     });
   }, 120_000);
 
-  test('delivers two FIFO steers during an in-flight model request', async () => {
-    if (!environment) throw new Error('Scripted Codex environment was not initialized.');
+  test('delivers two FIFO steers despite a reused Garcon message identity', async () => {
+    if (!environment) throw new Error('Scripted Claude environment was not initialized.');
     const testEnvironment = environment;
     const firstPrompt = marker('BATCH_FIRST_PROMPT');
     const firstSteer = marker('BATCH_FIRST_STEER');
@@ -132,37 +153,41 @@ describe('scripted Codex strict steering', () => {
     const firstReply = marker('BATCH_FIRST_REPLY');
     const steeredReply = marker('BATCH_STEERED_REPLY');
     const requestCursor = testEnvironment.model.markRequests();
-    const held = testEnvironment.model.scriptHeldTurn([codexAssistantMessage(firstReply)]);
-    testEnvironment.model.scriptTurn([codexAssistantMessage(steeredReply)]);
+    const held = testEnvironment.model.scriptHeldTurn([claudeText(firstReply)]);
+    testEnvironment.model.scriptTurn([claudeText(steeredReply)]);
 
-    await withIntegrationFixture('codex-scripted-steer-batch', async (fixture) => {
+    await withIntegrationFixture('claude-scripted-steer-batch', async (fixture) => {
       const chatId = fixture.newChatId();
       const eventCursor = fixture.client.markEvents();
-      const first = await fixture.client.startChat(liveCodexStartRequest({
+      const first = await fixture.client.startChat(liveClaudeStartRequest({
         chatId,
         projectPath: fixture.dirs.project,
         command: firstPrompt,
         permissionMode: 'bypassPermissions',
       }));
-      if (!first.turnId) throw new Error('Scripted Codex start did not return a turn identity.');
+      if (!first.turnId) throw new Error('Scripted Claude start did not return a turn identity.');
       await held.requested;
 
+      const sharedMessageId = crypto.randomUUID();
       const [firstResult, secondResult] = await Promise.all([
         fixture.client.steer({
           clientRequestId: crypto.randomUUID(),
-          clientMessageId: crypto.randomUUID(),
+          clientMessageId: sharedMessageId,
           chatId,
           content: firstSteer,
         }),
         fixture.client.steer({
           clientRequestId: crypto.randomUUID(),
-          clientMessageId: crypto.randomUUID(),
+          clientMessageId: sharedMessageId,
           chatId,
           content: secondSteer,
         }),
       ]);
       expect(firstResult).toMatchObject({ status: 'accepted', turnId: first.turnId });
       expect(secondResult).toMatchObject({ status: 'accepted', turnId: first.turnId });
+      expect((await fixture.client.listChats()).sessions.find(
+        (entry) => entry.id === chatId,
+      )).toMatchObject({ isProcessing: true });
 
       held.release();
       expectFinished((await fixture.client.waitForTurnTerminal(chatId, first.turnId, {
@@ -173,25 +198,27 @@ describe('scripted Codex strict steering', () => {
       const requests = testEnvironment.model.requestsSince(requestCursor);
       expect(requests).toHaveLength(2);
       const steeredRequest = requests.at(-1);
-      if (!steeredRequest) throw new Error('Codex did not make the batched steering request.');
-      const firstIndex = steeredRequest.userTexts.indexOf(firstSteer);
-      const secondIndex = steeredRequest.userTexts.indexOf(secondSteer);
-      expect(firstIndex).toBeGreaterThanOrEqual(0);
-      expect(secondIndex).toBeGreaterThan(firstIndex);
+      if (!steeredRequest) throw new Error('Claude did not make the batched steering request.');
+      expect(steeredRequest.lastUserText).toBe([
+        `${STEERING_PREFIX}${firstSteer}`,
+        `${STEERING_PREFIX}${secondSteer}`,
+      ].join('\n'));
+      expect(steeredRequest.lastUserText.indexOf(firstSteer))
+        .toBeLessThan(steeredRequest.lastUserText.indexOf(secondSteer));
 
       const transcript = await fixture.client.getMessages(chatId);
       expect(userContents(transcript.messages)).toEqual([firstPrompt, firstSteer, secondSteer]);
+      expect(JSON.stringify(transcript.messages)).not.toContain(STEERING_PREFIX);
       const assistants = assistantContents(transcript.messages);
       expect(assistants.some((content) => content.includes(firstReply))).toBe(true);
       expect(assistants.some((content) => content.includes(steeredReply))).toBe(true);
       testEnvironment.model.assertSettled();
     }, {
       serverEnvironment: testEnvironment.serverEnvironment,
-      prepareWorkspace: testEnvironment.prepareWorkspace,
     });
   }, 120_000);
 });
 
 function marker(label: string): string {
-  return `SCRIPTED_CODEX_STEER_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+  return `SCRIPTED_CLAUDE_STEER_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
 }

--- a/integration-tests/tests/server/claude-scripted-steer.test.ts
+++ b/integration-tests/tests/server/claude-scripted-steer.test.ts
@@ -32,15 +32,13 @@ describe('scripted Claude strict steering', () => {
     const firstPrompt = marker('FIRST_PROMPT');
     const steerPrompt = `/review\n${marker('STEER_PROMPT')}`;
     const futurePrompt = marker('FUTURE_PROMPT');
-    const firstReply = marker('FIRST_REPLY');
     const steerReply = marker('STEER_REPLY');
     const futureReply = marker('FUTURE_REPLY');
     const toolMarker = marker('TOOL_OUTPUT');
     const requestCursor = testEnvironment.model.markRequests();
-    testEnvironment.model.scriptTurn([
+    const held = testEnvironment.model.scriptHeldTurn([
       claudeToolUse('toolu_steer_context', 'Bash', { command: `printf %s ${toolMarker}` }),
     ]);
-    const held = testEnvironment.model.scriptHeldTurn([claudeText(firstReply)]);
     testEnvironment.model.scriptTurn([claudeText(steerReply)]);
     testEnvironment.model.scriptTurn([claudeText(futureReply)]);
 
@@ -92,16 +90,19 @@ describe('scripted Claude strict steering', () => {
       })).type);
 
       const activeRequests = testEnvironment.model.requestsSince(requestCursor);
-      expect(activeRequests).toHaveLength(3);
+      expect(activeRequests).toHaveLength(2);
       const steeredModelRequest = activeRequests.at(-1);
       if (!steeredModelRequest) throw new Error('Claude did not make the steered model request.');
-      expect(steeredModelRequest.lastUserText).toBe(`${STEERING_PREFIX}${steerPrompt}`);
-      expect(steeredModelRequest.toolResults).toContainEqual(expect.objectContaining({
-        toolUseId: 'toolu_steer_context',
-        content: expect.stringContaining(toolMarker),
-      }));
+      const steeredToolResult = steeredModelRequest.toolResults.find(
+        (result) => result.toolUseId === 'toolu_steer_context',
+      );
+      if (!steeredToolResult) throw new Error('Claude omitted the steering tool result.');
+      expect(steeredToolResult.content).toContain(toolMarker);
+      expect(steeredToolResult.content).toContain(`${STEERING_PREFIX}${steerPrompt}`);
+      expect(steeredToolResult.content.indexOf(toolMarker))
+        .toBeLessThan(steeredToolResult.content.indexOf(`${STEERING_PREFIX}${steerPrompt}`));
       expect(activeRequests.filter((record) =>
-        record.userTexts.some((text) => text.includes(steerPrompt)))).toHaveLength(1);
+        record.toolResults.some((result) => result.content.includes(steerPrompt)))).toHaveLength(1);
 
       const stillPaused = await fixture.client.getExecutionControl(chatId);
       expect(stillPaused).toEqual(beforeSteer);
@@ -135,7 +136,6 @@ describe('scripted Claude strict steering', () => {
       expect(userContents(transcript.messages)).toEqual([firstPrompt, steerPrompt, futurePrompt]);
       expect(JSON.stringify(transcript.messages)).not.toContain(STEERING_PREFIX);
       const assistants = assistantContents(transcript.messages);
-      expect(assistants.some((content) => content.includes(firstReply))).toBe(true);
       expect(assistants.some((content) => content.includes(steerReply))).toBe(true);
       expect(assistants.some((content) => content.includes(futureReply))).toBe(true);
       testEnvironment.model.assertSettled();

--- a/integration-tests/tests/server/claude-scripted-steering-protocol.test.ts
+++ b/integration-tests/tests/server/claude-scripted-steering-protocol.test.ts
@@ -1,0 +1,494 @@
+import { mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  FakeClaudeModel,
+  claudeText,
+  claudeToolUse,
+} from '../../support/fake-claude-model.js';
+import { CLAUDE_BINARY } from '../../support/live-claude.js';
+
+const STEERING_PREFIX = 'The user sent steering guidance for the active task:\n\n';
+const createdHarnesses: DirectClaudeHarness[] = [];
+
+afterEach(async () => {
+  await Promise.all(createdHarnesses.splice(0).map((harness) => harness.dispose()));
+});
+
+describe('pinned Claude steering protocol', () => {
+  test('queues following guidance before replay and keeps result boundaries', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const steerId = crypto.randomUUID();
+    const original = marker('FOLLOWING_ORIGINAL');
+    const steering = marker('FOLLOWING_STEER');
+    const held = harness.model.scriptHeldTurn([claudeText(marker('FOLLOWING_REPLY'))]);
+    harness.model.scriptTurn([claudeText(marker('FOLLOWING_STEER_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, original));
+    await held.requested;
+    await harness.send(userFrame(
+      harness.sessionId,
+      steerId,
+      `${STEERING_PREFIX}${steering}`,
+      'next',
+    ));
+    await harness.waitFor(commandLifecycle(steerId, 'queued'), 'steering queued');
+    held.release();
+    await harness.waitFor(commandLifecycle(steerId, 'completed'), 'steering completed');
+    await harness.waitFor(providerState('idle'), 'provider idle');
+
+    const queuedAt = harness.messages.findIndex(commandLifecycle(steerId, 'queued'));
+    const replayAt = harness.messages.findIndex(userReplay(steerId));
+    const startedAt = harness.messages.findIndex(commandLifecycle(steerId, 'started'));
+    expect(queuedAt).toBeGreaterThanOrEqual(0);
+    expect(replayAt).toBeGreaterThan(queuedAt);
+    expect(startedAt).toBeGreaterThan(queuedAt);
+    expect(harness.results().map((result) => result.user_message_uuid)).toEqual([
+      originalId,
+      steerId,
+    ]);
+    expect(harness.model.requests().map((request) => request.lastUserText).at(-1))
+      .toBe(`${STEERING_PREFIX}${steering}`);
+    harness.model.assertSettled();
+  }, 30_000);
+
+  test('batches following guidance in FIFO native history order', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const firstId = crypto.randomUUID();
+    const secondId = crypto.randomUUID();
+    const first = marker('BATCH_FIRST');
+    const second = marker('BATCH_SECOND');
+    const held = harness.model.scriptHeldTurn([claudeText(marker('BATCH_ORIGINAL_REPLY'))]);
+    harness.model.scriptTurn([claudeText(marker('BATCH_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, marker('BATCH_ORIGINAL')));
+    await held.requested;
+    await harness.send(userFrame(harness.sessionId, firstId, `${STEERING_PREFIX}${first}`, 'next'));
+    await harness.send(userFrame(harness.sessionId, secondId, `${STEERING_PREFIX}${second}`, 'next'));
+    await harness.waitFor(commandLifecycle(firstId, 'queued'), 'first steering queued');
+    await harness.waitFor(commandLifecycle(secondId, 'queued'), 'second steering queued');
+    held.release();
+    await harness.waitFor(commandLifecycle(secondId, 'completed'), 'batched steering completed');
+    await harness.waitFor(providerState('idle'), 'provider idle');
+
+    const firstReplay = harness.messages.findIndex(userReplay(firstId));
+    const secondReplay = harness.messages.findIndex(userReplay(secondId));
+    expect(harness.messages.findIndex(commandLifecycle(firstId, 'queued'))).toBeLessThan(firstReplay);
+    expect(harness.messages.findIndex(commandLifecycle(secondId, 'queued'))).toBeLessThan(firstReplay);
+    expect(secondReplay).toBeGreaterThan(firstReplay);
+    expect(harness.model.requests().at(-1)?.lastUserText).toBe([
+      `${STEERING_PREFIX}${first}`,
+      `${STEERING_PREFIX}${second}`,
+    ].join('\n'));
+
+    const entries = await harness.waitForNativeEntries((nativeEntries) => (
+      nativeEntries.some((entry) => (
+        entry.type === 'user'
+        && Array.isArray(asRecord(entry.message).content)
+        && (asRecord(entry.message).content as unknown[]).length === 2
+      ))
+    ), 'batched steering native entry');
+    const batched = entries.find((entry) => (
+      entry.type === 'user'
+      && Array.isArray(asRecord(entry.message).content)
+      && (asRecord(entry.message).content as unknown[]).length === 2
+    ));
+    expect(asRecord(batched?.message).content).toEqual([
+      { type: 'text', text: `${STEERING_PREFIX}${first}` },
+      { type: 'text', text: `${STEERING_PREFIX}${second}` },
+    ]);
+    harness.model.assertSettled();
+  }, 30_000);
+
+  test('injects inline guidance into tool results and persists queued attachments', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const firstId = crypto.randomUUID();
+    const secondId = crypto.randomUUID();
+    const first = marker('INLINE_FIRST');
+    const second = marker('INLINE_SECOND');
+    const toolOutput = marker('INLINE_TOOL_OUTPUT');
+    const held = harness.model.scriptHeldTurn([
+      claudeToolUse('toolu_inline_protocol', 'Bash', { command: `printf %s ${toolOutput}` }),
+    ]);
+    harness.model.scriptTurn([claudeText(marker('INLINE_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, marker('INLINE_ORIGINAL')));
+    await held.requested;
+    await harness.send(userFrame(harness.sessionId, firstId, `${STEERING_PREFIX}${first}`, 'next'));
+    await harness.send(userFrame(harness.sessionId, secondId, `${STEERING_PREFIX}${second}`, 'next'));
+    await harness.waitFor(commandLifecycle(firstId, 'queued'), 'first inline steering queued');
+    await harness.waitFor(commandLifecycle(secondId, 'queued'), 'second inline steering queued');
+    held.release();
+    await harness.waitFor(commandLifecycle(secondId, 'completed'), 'inline steering completed');
+    await harness.waitFor(providerState('idle'), 'provider idle');
+
+    expect(harness.model.requests()).toHaveLength(2);
+    const toolResult = harness.model.requests().at(-1)?.toolResults.find(
+      (result) => result.toolUseId === 'toolu_inline_protocol',
+    );
+    expect(toolResult?.content).toContain(toolOutput);
+    expect(toolResult?.content).toContain(first);
+    expect(toolResult?.content).toContain(second);
+    expect(harness.results()).toHaveLength(1);
+    expect(harness.results()[0]?.user_message_uuid).toBe(originalId);
+
+    const entries = await harness.waitForNativeEntries((nativeEntries) => (
+      JSON.stringify(nativeEntries).includes(first)
+      && JSON.stringify(nativeEntries).includes(second)
+    ), 'inline queued-command attachments');
+    const queued = entries.filter((entry) => (
+      entry.type === 'attachment'
+      && asRecord(entry.attachment).type === 'queued_command'
+    ));
+    expect(queued.map((entry) => asRecord(entry.attachment).prompt)).toEqual([
+      [{ type: 'text', text: `${STEERING_PREFIX}${first}` }],
+      [{ type: 'text', text: `${STEERING_PREFIX}${second}` }],
+    ]);
+    harness.model.assertSettled();
+  }, 30_000);
+
+  test('replays but does not enqueue or sample a duplicate native UUID', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const duplicateId = crypto.randomUUID();
+    const first = marker('DUPLICATE_FIRST');
+    const skipped = marker('DUPLICATE_SKIPPED');
+    const held = harness.model.scriptHeldTurn([claudeText(marker('DUPLICATE_ORIGINAL_REPLY'))]);
+    harness.model.scriptTurn([claudeText(marker('DUPLICATE_STEER_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, marker('DUPLICATE_ORIGINAL')));
+    await held.requested;
+    await harness.send(userFrame(harness.sessionId, duplicateId, `${STEERING_PREFIX}${first}`, 'next'));
+    await harness.send(userFrame(harness.sessionId, duplicateId, `${STEERING_PREFIX}${skipped}`, 'next'));
+    await harness.waitFor(userReplay(duplicateId), 'duplicate replay');
+    held.release();
+    await harness.waitFor(commandLifecycle(duplicateId, 'completed'), 'first duplicate input completed');
+    await harness.waitFor(providerState('idle'), 'provider idle');
+
+    expect(harness.messages.filter(commandLifecycle(duplicateId, 'queued'))).toHaveLength(1);
+    expect(harness.messages.filter(commandLifecycle(duplicateId, 'started'))).toHaveLength(1);
+    expect(harness.messages.filter(userReplay(duplicateId))).toHaveLength(2);
+    const requests = harness.model.requests();
+    expect(requests.filter((request) => request.userTexts.some((text) => text.includes(first))))
+      .toHaveLength(1);
+    expect(requests.every((request) => request.userTexts.every((text) => !text.includes(skipped))))
+      .toBe(true);
+    harness.model.assertSettled();
+  }, 30_000);
+
+  test('keeps prefixed slash guidance on the model-input path', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const steerId = crypto.randomUUID();
+    const slash = `/review ${marker('LITERAL_SLASH')}`;
+    const held = harness.model.scriptHeldTurn([claudeText(marker('SLASH_ORIGINAL_REPLY'))]);
+    harness.model.scriptTurn([claudeText(marker('SLASH_STEER_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, marker('SLASH_ORIGINAL')));
+    await held.requested;
+    await harness.send(userFrame(harness.sessionId, steerId, `${STEERING_PREFIX}${slash}`, 'next'));
+    await harness.waitFor(commandLifecycle(steerId, 'queued'), 'slash steering queued');
+    held.release();
+    await harness.waitFor(commandLifecycle(steerId, 'completed'), 'slash steering completed');
+    await harness.waitFor(providerState('idle'), 'provider idle');
+
+    expect(harness.model.requests().at(-1)?.lastUserText).toBe(`${STEERING_PREFIX}${slash}`);
+    harness.model.assertSettled();
+  }, 30_000);
+
+  test('routes bare slash input through Claude command handling', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const steerId = crypto.randomUUID();
+    const bareMarker = marker('BARE_SLASH');
+    const held = harness.model.scriptHeldTurn([claudeText(marker('BARE_SLASH_ORIGINAL_REPLY'))]);
+    harness.model.scriptTurn([claudeText(marker('BARE_SLASH_REVIEW_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, marker('BARE_SLASH_ORIGINAL')));
+    await held.requested;
+    await harness.send(userFrame(harness.sessionId, steerId, `/review ${bareMarker}`, 'next'));
+    await harness.waitFor(commandLifecycle(steerId, 'queued'), 'bare slash queued');
+    held.release();
+    await harness.waitFor(userReplay(steerId), 'bare slash replay');
+    await harness.waitFor(commandLifecycle(steerId, 'completed'), 'bare slash completed');
+    await harness.waitFor(providerState('idle'), 'provider idle');
+
+    expect(harness.model.requests()).toHaveLength(2);
+    expect(harness.model.requests()[1]?.lastUserText).toContain('<command-name>/review</command-name>');
+    expect(harness.model.requests()[1]?.lastUserText).toContain(`<command-args>${bareMarker}</command-args>`);
+    expect(harness.model.requests()[1]?.lastUserText).not.toContain(STEERING_PREFIX);
+    harness.model.assertSettled();
+  }, 30_000);
+
+  test('reports queued steering UUIDs cancelled by interrupt', async () => {
+    const harness = await createHarness();
+    const originalId = crypto.randomUUID();
+    const steerId = crypto.randomUUID();
+    const requestId = crypto.randomUUID();
+    const held = harness.model.scriptHeldTurn([claudeText(marker('INTERRUPT_ORIGINAL_REPLY'))]);
+
+    await harness.send(userFrame(harness.sessionId, originalId, marker('INTERRUPT_ORIGINAL')));
+    await held.requested;
+    await harness.send(userFrame(
+      harness.sessionId,
+      steerId,
+      `${STEERING_PREFIX}${marker('INTERRUPT_STEER')}`,
+      'next',
+    ));
+    await harness.waitFor(commandLifecycle(steerId, 'queued'), 'interrupt steering queued');
+    await harness.send({
+      type: 'control_request',
+      request_id: requestId,
+      request: { subtype: 'interrupt', cancel_queued: true },
+    });
+    const response = await harness.waitFor(
+      (message) => message.type === 'control_response'
+        && asRecord(message.response).request_id === requestId,
+      'interrupt receipt',
+    );
+    held.release();
+
+    const receipt = asRecord(asRecord(response.response).response);
+    expect(receipt.cancelled).toContain(steerId);
+    expect(receipt.still_queued).not.toContain(steerId);
+    expect(harness.messages.filter(commandLifecycle(steerId, 'started'))).toEqual([]);
+    harness.allowNonzeroExit();
+  }, 30_000);
+});
+
+type JsonRecord = Record<string, unknown>;
+
+class DirectClaudeHarness {
+  readonly model = FakeClaudeModel.start();
+  readonly sessionId = crypto.randomUUID();
+  readonly messages: JsonRecord[] = [];
+  readonly #root: string;
+  readonly #project: string;
+  readonly #configHome: string;
+  readonly #process: Bun.Subprocess<'pipe', 'pipe', 'pipe'>;
+  readonly #stdout: Promise<void>;
+  readonly #stderr: Promise<string>;
+  #parseFailure: Error | null = null;
+  #disposed = false;
+  #nonzeroExitAllowed = false;
+  #inputClosed = false;
+
+  private constructor(root: string, project: string, configHome: string) {
+    this.#root = root;
+    this.#project = project;
+    this.#configHome = configHome;
+    const environment = { ...process.env };
+    delete environment.CLAUDECODE;
+    delete environment.CLAUDE_CONFIG_DIR;
+    delete environment.CLAUDE_CODE_DISABLE_TERMINAL_TITLE;
+    Object.assign(environment, {
+      HOME: join(root, 'home'),
+      CLAUDE_CONFIG_DIR: configHome,
+      ANTHROPIC_API_KEY: 'garcon-scripted-claude-key',
+      ANTHROPIC_AUTH_TOKEN: '',
+      ANTHROPIC_BASE_URL: this.model.baseUrl,
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+      CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+    });
+    this.#process = Bun.spawn([
+      CLAUDE_BINARY,
+      '--print',
+      '--output-format', 'stream-json',
+      '--input-format', 'stream-json',
+      '--replay-user-messages',
+      '--verbose',
+      '--model', 'haiku',
+      '--permission-mode', 'bypassPermissions',
+      '--effort', 'low',
+      `--session-id=${this.sessionId}`,
+      '-p', '',
+    ], {
+      cwd: project,
+      env: environment,
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    this.#stdout = this.#readStdout();
+    this.#stderr = new Response(this.#process.stderr).text();
+  }
+
+  static async create(): Promise<DirectClaudeHarness> {
+    const root = await mkdtemp(join(tmpdir(), 'garcon-claude-steering-protocol-'));
+    const project = join(root, 'project');
+    const configHome = join(root, 'claude-config');
+    await Promise.all([
+      mkdir(project, { recursive: true }),
+      mkdir(configHome, { recursive: true }),
+      mkdir(join(root, 'home'), { recursive: true }),
+    ]);
+    return new DirectClaudeHarness(root, project, configHome);
+  }
+
+  async send(message: JsonRecord): Promise<void> {
+    const input = this.#process.stdin;
+    if (typeof input === 'number') throw new Error('Claude stdin was not piped.');
+    input.write(`${JSON.stringify(message)}\n`);
+    await input.flush();
+  }
+
+  async closeInput(): Promise<void> {
+    if (this.#inputClosed) return;
+    this.#inputClosed = true;
+    const input = this.#process.stdin;
+    if (typeof input !== 'number') await input.end();
+  }
+
+  async waitFor(
+    predicate: (message: JsonRecord) => boolean,
+    description: string,
+    timeoutMs = 10_000,
+  ): Promise<JsonRecord> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const match = this.messages.find(predicate);
+      if (match) return match;
+      if (this.#parseFailure) throw this.#parseFailure;
+      await Bun.sleep(10);
+    }
+    throw new Error(`Timed out waiting for ${description}`);
+  }
+
+  results(): JsonRecord[] {
+    return this.messages.filter((message) => message.type === 'result');
+  }
+
+  async nativeEntries(): Promise<JsonRecord[]> {
+    const projectKey = resolve(this.#project).normalize('NFC').replace(/[^a-zA-Z0-9]/g, '-');
+    const filePath = join(this.#configHome, 'projects', projectKey, `${this.sessionId}.jsonl`);
+    const content = await readFile(filePath, 'utf8');
+    return content.split('\n').filter(Boolean).map((line) => JSON.parse(line) as JsonRecord);
+  }
+
+  async waitForNativeEntries(
+    predicate: (entries: JsonRecord[]) => boolean,
+    description: string,
+    timeoutMs = 10_000,
+  ): Promise<JsonRecord[]> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const entries = await this.nativeEntries();
+        if (predicate(entries)) return entries;
+      } catch {
+        // The CLI creates the transcript lazily after the first persisted entry.
+      }
+      await Bun.sleep(10);
+    }
+    throw new Error(`Timed out waiting for ${description}`);
+  }
+
+  allowNonzeroExit(): void {
+    this.#nonzeroExitAllowed = true;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    await this.closeInput();
+    const exited = await Promise.race([
+      this.#process.exited.then(() => true),
+      Bun.sleep(5_000).then(() => false),
+    ]);
+    if (!exited) {
+      this.#process.kill();
+      await this.#process.exited;
+    }
+    await this.#stdout;
+    const stderr = await this.#stderr;
+    this.model.stop();
+    await rm(this.#root, { recursive: true, force: true });
+    if (this.#parseFailure) throw this.#parseFailure;
+    if (
+      !this.#nonzeroExitAllowed
+      && this.#process.exitCode
+      && this.#process.exitCode !== 0
+      && !stderr.includes('Interrupted')
+    ) {
+      throw new Error(`Claude protocol probe exited ${this.#process.exitCode}: ${stderr}`);
+    }
+  }
+
+  async #readStdout(): Promise<void> {
+    try {
+      const output = this.#process.stdout;
+      if (typeof output === 'number') throw new Error('Claude stdout was not piped.');
+      const reader = output.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (line.trim()) this.messages.push(JSON.parse(line) as JsonRecord);
+        }
+      }
+      buffer += decoder.decode();
+      if (buffer.trim()) this.messages.push(JSON.parse(buffer) as JsonRecord);
+    } catch (error) {
+      this.#parseFailure = error instanceof Error ? error : new Error(String(error));
+    }
+  }
+}
+
+async function createHarness(): Promise<DirectClaudeHarness> {
+  const harness = await DirectClaudeHarness.create();
+  createdHarnesses.push(harness);
+  return harness;
+}
+
+function userFrame(
+  sessionId: string,
+  uuid: string,
+  text: string,
+  priority?: 'next',
+): JsonRecord {
+  return {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text }] },
+    parent_tool_use_id: null,
+    session_id: sessionId,
+    uuid,
+    ...(priority ? { priority } : {}),
+  };
+}
+
+function commandLifecycle(uuid: string, state: string): (message: JsonRecord) => boolean {
+  return (message) => message.type === 'command_lifecycle'
+    && message.command_uuid === uuid
+    && message.state === state;
+}
+
+function userReplay(uuid: string): (message: JsonRecord) => boolean {
+  return (message) => message.type === 'user'
+    && message.uuid === uuid
+    && message.isReplay === true;
+}
+
+function providerState(state: string): (message: JsonRecord) => boolean {
+  return (message) => message.type === 'system'
+    && message.subtype === 'session_state_changed'
+    && message.state === state;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as JsonRecord
+    : {};
+}
+
+function marker(label: string): string {
+  return `CLAUDE_PROTOCOL_STEER_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+}

--- a/integration-tests/tests/server/scripted-steering-conformance.test.ts
+++ b/integration-tests/tests/server/scripted-steering-conformance.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type {
+  AgentRunCommandRequest,
+  StartChatCommandRequest,
+} from '../../../common/chat-command-contracts.js';
+import { assistantContents } from '../../support/chat-assertions.js';
+import { claudeText } from '../../support/fake-claude-model.js';
+import { codexAssistantMessage } from '../../support/fake-codex-model.js';
+import {
+  type IntegrationDirectories,
+  withIntegrationFixture,
+} from '../../support/integration-fixture.js';
+import {
+  expectStoppedTurnEventOrder,
+  LIVE_TURN_TIMEOUT_MS,
+  waitForVisibleResponse,
+} from '../../support/live-agent.js';
+import {
+  liveClaudeRunRequest,
+  liveClaudeStartRequest,
+} from '../../support/live-claude.js';
+import {
+  liveCodexRunRequest,
+  liveCodexStartRequest,
+} from '../../support/live-codex.js';
+import { startScriptedClaudeTestEnvironment } from '../../support/scripted-claude.js';
+import { startScriptedCodexTestEnvironment } from '../../support/scripted-codex.js';
+
+interface HeldModelTurn {
+  readonly requested: Promise<unknown>;
+  release(): void;
+}
+
+interface SteeringContractDriver {
+  readonly id: string;
+  readonly serverEnvironment: Record<string, string>;
+  readonly prepareWorkspace?: (directories: IntegrationDirectories) => Promise<void>;
+  startRequest(input: {
+    chatId: string;
+    projectPath: string;
+    command: string;
+  }): StartChatCommandRequest;
+  runRequest(input: { chatId: string; command: string }): AgentRunCommandRequest;
+  holdReply(reply: string): HeldModelTurn;
+  scriptReply(reply: string): void;
+  markRequests(): number;
+  userTextsSince(cursor: number): readonly string[];
+  assertSettled(): void;
+  reset(): void;
+}
+
+interface SteeringContractEnvironment {
+  readonly driver: SteeringContractDriver;
+  dispose(): void | Promise<void>;
+}
+
+function defineSteeringConformance(
+  providerName: string,
+  startEnvironment: () => Promise<SteeringContractEnvironment>,
+): void {
+  describe(`${providerName} scripted steering conformance`, () => {
+    let environment: SteeringContractEnvironment | undefined;
+
+    beforeAll(async () => {
+      environment = await startEnvironment();
+    });
+
+    afterAll(async () => {
+      await environment?.dispose();
+    });
+
+    test('does not execute accepted guidance after stop', async () => {
+      if (!environment) throw new Error(`${providerName} environment was not initialized.`);
+      const { driver } = environment;
+      const firstPrompt = marker(driver.id, 'STOP_FIRST_PROMPT');
+      const steerPrompt = marker(driver.id, 'STOP_STEER_PROMPT');
+      const cancelledReply = marker(driver.id, 'STOP_CANCELLED_REPLY');
+      const recoveryPrompt = marker(driver.id, 'STOP_RECOVERY_PROMPT');
+      const recoveryReply = marker(driver.id, 'STOP_RECOVERY_REPLY');
+      const requestCursor = driver.markRequests();
+      const held = driver.holdReply(cancelledReply);
+
+      try {
+        await withIntegrationFixture(`${driver.id}-scripted-steering-stop`, async (fixture) => {
+          const chatId = fixture.newChatId();
+          const active = await fixture.client.startChat(driver.startRequest({
+            chatId,
+            projectPath: fixture.dirs.project,
+            command: firstPrompt,
+          }));
+          if (!active.turnId) throw new Error(`${providerName} omitted the active turn id.`);
+          await held.requested;
+
+          expect(await fixture.client.steer({
+            clientRequestId: crypto.randomUUID(),
+            clientMessageId: crypto.randomUUID(),
+            chatId,
+            content: steerPrompt,
+          })).toMatchObject({ status: 'accepted', turnId: active.turnId });
+
+          const stopCursor = fixture.client.markEvents();
+          expect(await fixture.client.stopChat({
+            clientRequestId: crypto.randomUUID(),
+            chatId,
+          })).toMatchObject({ outcome: 'interrupt-requested' });
+          await fixture.client.waitForProcessing(chatId, false, {
+            afterIndex: stopCursor,
+            timeoutMs: LIVE_TURN_TIMEOUT_MS,
+          });
+          await fixture.client.waitForTurnTerminal(chatId, active.turnId, {
+            afterIndex: stopCursor,
+            timeoutMs: LIVE_TURN_TIMEOUT_MS,
+          });
+          expectStoppedTurnEventOrder(
+            fixture.client.eventsSince(stopCursor),
+            chatId,
+            active.turnId,
+          );
+
+          held.release();
+          driver.scriptReply(recoveryReply);
+          const recoveryCursor = fixture.client.markEvents();
+          const recovery = await fixture.client.runChat(driver.runRequest({
+            chatId,
+            command: recoveryPrompt,
+          }));
+          await waitForVisibleResponse({
+            fixture,
+            chatId,
+            turnId: recovery.turnId,
+            marker: recoveryReply,
+            afterIndex: recoveryCursor,
+          });
+
+          const sampledUserText = driver.userTextsSince(requestCursor).join('\n');
+          expect(sampledUserText).not.toContain(steerPrompt);
+          expect(assistantContents((await fixture.client.getMessages(chatId)).messages).join('\n'))
+            .not.toContain(cancelledReply);
+          driver.assertSettled();
+        }, {
+          serverEnvironment: driver.serverEnvironment,
+          prepareWorkspace: driver.prepareWorkspace,
+        });
+      } finally {
+        held.release();
+        driver.reset();
+      }
+    }, 120_000);
+  });
+}
+
+defineSteeringConformance('Claude', async () => {
+  const environment = await startScriptedClaudeTestEnvironment();
+  return {
+    driver: {
+      id: 'claude',
+      serverEnvironment: environment.serverEnvironment,
+      startRequest: liveClaudeStartRequest,
+      runRequest: liveClaudeRunRequest,
+      holdReply: (reply) => environment.model.scriptHeldTurn([claudeText(reply)]),
+      scriptReply: (reply) => environment.model.scriptTurn([claudeText(reply)]),
+      markRequests: () => environment.model.markRequests(),
+      userTextsSince: (cursor) => environment.model.requestsSince(cursor)
+        .flatMap((request) => request.userTexts),
+      assertSettled: () => environment.model.assertSettled(),
+      reset: () => environment.model.reset(),
+    },
+    dispose: () => environment.dispose(),
+  };
+});
+
+defineSteeringConformance('Codex', async () => {
+  const environment = await startScriptedCodexTestEnvironment();
+  return {
+    driver: {
+      id: 'codex',
+      serverEnvironment: environment.serverEnvironment,
+      prepareWorkspace: environment.prepareWorkspace,
+      startRequest: liveCodexStartRequest,
+      runRequest: liveCodexRunRequest,
+      holdReply: (reply) => environment.model.scriptHeldTurn([codexAssistantMessage(reply)]),
+      scriptReply: (reply) => environment.model.scriptTurn([codexAssistantMessage(reply)]),
+      markRequests: () => environment.model.markRequests(),
+      userTextsSince: (cursor) => environment.model.requestsSince(cursor)
+        .flatMap((request) => request.userTexts),
+      assertSettled: () => environment.model.assertSettled(),
+      reset: () => environment.model.reset(),
+    },
+    dispose: () => environment.dispose(),
+  };
+});
+
+function marker(provider: string, label: string): string {
+  return `SCRIPTED_${provider.toUpperCase()}_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+}

--- a/integration-tests/tests/server/support-contract.test.ts
+++ b/integration-tests/tests/server/support-contract.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import { BoundedLog } from '../../support/bounded-log.js';
 import { Deferred } from '../../support/deferred.js';
 import { FakeAnthropicServer } from '../../support/fake-anthropic-server.js';
+import { FakeClaudeModel } from '../../support/fake-claude-model.js';
+import { FakeCodexModel } from '../../support/fake-codex-model.js';
 import { FakeOpenAiServer } from '../../support/fake-openai-server.js';
 import { FakeOpenAiResponsesServer } from '../../support/fake-openai-responses-server.js';
 import { GarconTestClient } from '../../support/garcon-client.js';
@@ -225,6 +227,77 @@ describe('integration support contracts', () => {
       });
       expect(fake.requests()[0].lastUserText).toBe('hello');
       fake.assertNoProtocolViolations();
+    } finally {
+      fake.stop();
+    }
+  });
+
+  test('projects ordered Claude user text and cursor-relative requests', async () => {
+    const fake = FakeClaudeModel.start();
+    try {
+      fake.scriptTurn([]);
+      const cursor = fake.markRequests();
+      const response = await fetch(`${fake.baseUrl}/v1/messages`, {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'scripted',
+          messages: [
+            { role: 'user', content: 'first' },
+            { role: 'assistant', content: 'reply' },
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'second' },
+                { type: 'text', text: 'third' },
+              ],
+            },
+          ],
+        }),
+      });
+      await response.text();
+
+      expect(fake.requestsSince(cursor)).toHaveLength(1);
+      expect(fake.requestsSince(cursor)[0]).toMatchObject({
+        userTexts: ['first', 'second\nthird'],
+        lastUserText: 'second\nthird',
+      });
+      fake.assertSettled();
+    } finally {
+      fake.stop();
+    }
+  });
+
+  test('projects ordered Codex user text and cursor-relative requests', async () => {
+    const fake = FakeCodexModel.start();
+    try {
+      fake.scriptTurn([]);
+      const cursor = fake.markRequests();
+      const response = await fetch(fake.responsesUrl, {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'scripted',
+          input: [
+            { type: 'message', role: 'user', content: 'first' },
+            { type: 'message', role: 'assistant', content: 'reply' },
+            {
+              type: 'message',
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'second' },
+                { type: 'input_text', text: 'third' },
+              ],
+            },
+          ],
+        }),
+      });
+      await response.text();
+
+      expect(fake.requestsSince(cursor)).toHaveLength(1);
+      expect(fake.requestsSince(cursor)[0]).toMatchObject({
+        userTexts: ['first', 'second\nthird'],
+        lastUserText: 'second\nthird',
+      });
+      fake.assertSettled();
     } finally {
       fake.stop();
     }

--- a/server-agents/claude/src/__tests__/integration.test.js
+++ b/server-agents/claude/src/__tests__/integration.test.js
@@ -37,6 +37,10 @@ describe('ClaudeAgentIntegration', () => {
       supportsAtMessage: true,
       supportsWhileRunning: true,
     });
+    expect(integration.steering).toEqual({
+      captureTarget: expect.any(Function),
+      steer: expect.any(Function),
+    });
     expect(integration.auth).toBeDefined();
     expect(integration.commands).toBeDefined();
     expect(integration.endpoints).toBeDefined();

--- a/server-agents/claude/src/agents/claude/__tests__/cli-process-transport.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-process-transport.test.js
@@ -240,6 +240,83 @@ describe('ClaudeProcessTransport', () => {
     expect(fake.failures).toEqual([{ kind: 'write', message: 'flush exploded' }]);
   });
 
+  it('marks the native attempt immediately before write and preserves FIFO hooks', async () => {
+    const fake = createTransport();
+    const order = [];
+    fake.process.stdin.write.mockImplementation((line) => {
+      order.push(`write:${JSON.parse(line).order}`);
+      fake.writes.push(line);
+    });
+    fake.process.stdin.flush.mockImplementation(() => order.push('flush'));
+
+    await Promise.all([
+      fake.transport.writeLine('{"order":1}', {
+        beforeWrite: () => order.push('attempt:1'),
+      }),
+      fake.transport.writeLine('{"order":2}', {
+        beforeWrite: () => order.push('attempt:2'),
+      }),
+    ]);
+
+    expect(order).toEqual([
+      'attempt:1',
+      'write:1',
+      'flush',
+      'attempt:2',
+      'write:2',
+      'flush',
+    ]);
+  });
+
+  it('does not mark or kill a strict write that fails before the attempt', async () => {
+    const fake = createTransport();
+    const beforeWrite = mock(() => undefined);
+    fake.process.stdin = null;
+
+    await expect(fake.transport.writeLine('{"order":1}', {
+      beforeWrite,
+      killProcessAfterAttemptFailure: true,
+    })).rejects.toThrow('no writable stdin');
+    expect(beforeWrite).not.toHaveBeenCalled();
+    expect(fake.process.kill).not.toHaveBeenCalled();
+  });
+
+  it('kills before reporting a strict attempted write failure', async () => {
+    let killedWhenReported = false;
+    const fake = createTransport({
+      onFailure: (failure) => {
+        killedWhenReported = fake.process.killed;
+        fake.failures.push(failure);
+      },
+    });
+    fake.process.stdin.write.mockImplementationOnce(() => {
+      throw new Error('strict write exploded');
+    });
+
+    await expect(fake.transport.writeLine('{"order":1}', {
+      beforeWrite: () => undefined,
+      killProcessAfterAttemptFailure: true,
+    })).rejects.toThrow('strict write exploded');
+    expect(killedWhenReported).toBe(true);
+    expect(fake.process.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out and kills a stalled strict write', async () => {
+    const fake = createTransport();
+    fake.process.stdin.write.mockImplementationOnce(() => new Promise(() => {}));
+
+    await expect(fake.transport.writeLine('{"order":1}', {
+      beforeWrite: () => undefined,
+      attemptTimeoutMs: 1,
+      killProcessAfterAttemptFailure: true,
+    })).rejects.toThrow('stdin write timed out');
+    expect(fake.process.kill).toHaveBeenCalledTimes(1);
+    expect(fake.failures).toEqual([{
+      kind: 'write',
+      message: 'Claude CLI stdin write timed out',
+    }]);
+  });
+
   it('closes stdin and awaits natural exit during retirement', async () => {
     const fake = createTransport();
 

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -1927,7 +1927,7 @@ describe('ClaudeCliRuntime steering', () => {
     }
   });
 
-  it('defers provider idle across preparation and settles after steering completes', async () => {
+  it('settles deferred provider idle after steering completes without a new state frame', async () => {
     const originalSpawn = Bun.spawn;
     const fake = createFakeClaudeProcess();
     Bun.spawn = mock(() => fake.proc);
@@ -1970,14 +1970,12 @@ describe('ClaudeCliRuntime steering', () => {
         command_uuid: nativeId,
         state: 'started',
       });
-      enqueueProviderState(fake, 'running');
       enqueueAssistantAndResult(fake, nativeId, 'steered reply');
       enqueueCliMessage(fake, {
         type: 'command_lifecycle',
         command_uuid: nativeId,
         state: 'completed',
       });
-      enqueueProviderState(fake, 'idle');
 
       await run;
       expect(failures).toEqual([]);

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -13,13 +13,14 @@ function createLogger() {
   };
 }
 
-function createRuntime(logger = createLogger()) {
+function createRuntime(logger = createLogger(), overrides = {}) {
   return new ClaudeCliRuntime({
     binary: () => 'claude',
     logger,
     versionProbe: {
       assertCompatible: mock(() => Promise.resolve([2, 1, 220])),
     },
+    ...overrides,
   });
 }
 
@@ -144,6 +145,44 @@ function writtenUserMessage(fake) {
     .map(([line]) => JSON.parse(line))
     .filter((message) => message.type === 'user');
   return writes.at(-1);
+}
+
+function writtenUserMessages(fake) {
+  return fake.proc.stdin.write.mock.calls
+    .map(([line]) => JSON.parse(line))
+    .filter((message) => message.type === 'user');
+}
+
+function enqueueCliMessage(fake, message) {
+  fake.stdout.enqueue(encoder.encode(`${JSON.stringify(message)}\n`));
+}
+
+function steerRequest(target, overrides = {}) {
+  return {
+    chatId: 'chat-1',
+    projectPath: '/tmp',
+    agentSessionId: 'expected-session',
+    nativeSession: null,
+    target,
+    input: 'focus on the failing test',
+    clientMessageId: 'message-steer',
+    prepareDelivery: async () => undefined,
+    ...overrides,
+  };
+}
+
+function enqueueAssistantAndResult(fake, inputUuid, text) {
+  enqueueCliMessage(fake, {
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+  });
+  enqueueCliMessage(fake, {
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    result: text,
+    user_message_uuid: inputUuid,
+  });
 }
 
 const startedInputByFake = new WeakMap();
@@ -1799,6 +1838,256 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       globalThis.setTimeout = originalSetTimeout;
       fake.exit(137);
       runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+});
+
+describe('ClaudeCliRuntime steering', () => {
+  it('captures only a started input and prepares before one next-priority write', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    const logger = createLogger();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime(logger);
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      await waitForWrittenUserMessage(fake);
+      expect(runtime.captureSteerTarget('expected-session')).toBeNull();
+
+      const original = await enqueueInputStarted(fake);
+      const target = runtime.captureSteerTarget('expected-session');
+      expect(target).not.toBeNull();
+      expect(Object.isFrozen(target)).toBe(true);
+      expect(Object.keys(target)).toEqual([]);
+
+      const preparation = deferred();
+      let prepareCalls = 0;
+      const steering = runtime.steer(steerRequest(target, {
+        input: '/review\nCheck cafe',
+        prepareDelivery: async () => {
+          prepareCalls += 1;
+          await preparation.promise;
+        },
+      }));
+      await Promise.resolve();
+      expect(prepareCalls).toBe(1);
+      expect(writtenUserMessages(fake)).toHaveLength(1);
+
+      preparation.resolve();
+      await expect(steering).resolves.toEqual({ kind: 'accepted' });
+      const frame = writtenUserMessages(fake).at(-1);
+      expect(frame).toMatchObject({
+        priority: 'next',
+        session_id: 'expected-session',
+        message: {
+          content: [{
+            type: 'text',
+            text: 'The user sent steering guidance for the active task:\n\n/review\nCheck cafe',
+          }],
+        },
+      });
+      expect(frame.uuid).toMatch(/^[0-9a-f-]{36}$/);
+      expect(frame.uuid).not.toBe('message-steer');
+      expect(frame.uuid).not.toBe(original.uuid);
+      expect(JSON.stringify(Object.values(logger).flatMap((entry) => entry.mock.calls)))
+        .not.toContain('/review\nCheck cafe');
+
+      await expect(runtime.steer(steerRequest(target))).resolves.toMatchObject({
+        kind: 'rejected',
+        reason: 'no-active-turn',
+      });
+
+      enqueueAssistantAndResult(fake, original.uuid, 'initial reply');
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: frame.uuid,
+        state: 'queued',
+      });
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: frame.uuid,
+        state: 'started',
+      });
+      enqueueAssistantAndResult(fake, frame.uuid, 'steered reply');
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: frame.uuid,
+        state: 'completed',
+      });
+      enqueueProviderState(fake, 'idle');
+      await expect(run).resolves.toBe('expected-session');
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('defers provider idle across preparation and settles after steering completes', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime();
+      const finishes = [];
+      const failures = [];
+      runtime.onFinished((chatId, exitCode, metadata) => {
+        finishes.push({ chatId, exitCode, metadata });
+      });
+      runtime.onFailed((chatId, message, metadata) => {
+        failures.push({ chatId, message, metadata });
+      });
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      const original = await enqueueInputStarted(fake);
+      const preparation = deferred();
+      const steering = runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+        { prepareDelivery: async () => preparation.promise },
+      ));
+
+      enqueueAssistantAndResult(fake, original.uuid, 'initial reply');
+      enqueueProviderState(fake, 'idle');
+      await Bun.sleep(1);
+      expect(finishes).toEqual([]);
+      expect(failures).toEqual([]);
+
+      preparation.resolve();
+      await expect(steering).resolves.toEqual({ kind: 'accepted' });
+      const nativeId = writtenUserMessages(fake).at(-1).uuid;
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: nativeId,
+        state: 'queued',
+      });
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: nativeId,
+        state: 'started',
+      });
+      enqueueProviderState(fake, 'running');
+      enqueueAssistantAndResult(fake, nativeId, 'steered reply');
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: nativeId,
+        state: 'completed',
+      });
+      enqueueProviderState(fake, 'idle');
+
+      await run;
+      expect(failures).toEqual([]);
+      expect(finishes).toMatchObject([{
+        chatId: 'chat-1',
+        exitCode: 0,
+        metadata: { turnId: 'turn-active' },
+      }]);
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('keeps two native steering UUIDs fenced through their terminal lifecycle', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime();
+      const finishes = [];
+      runtime.onFinished((_chatId, _exitCode, metadata) => finishes.push(metadata));
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      const original = await enqueueInputStarted(fake);
+      const first = runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+        { input: 'first', clientMessageId: 'shared-message' },
+      ));
+      const second = runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+        { input: 'second', clientMessageId: 'shared-message' },
+      ));
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        { kind: 'accepted' },
+        { kind: 'accepted' },
+      ]);
+      const [, firstFrame, secondFrame] = writtenUserMessages(fake);
+      expect(firstFrame.uuid).not.toBe(secondFrame.uuid);
+      expect(firstFrame.uuid).not.toBe('shared-message');
+      expect(secondFrame.uuid).not.toBe('shared-message');
+
+      enqueueAssistantAndResult(fake, original.uuid, 'initial reply');
+      for (const frame of [firstFrame, secondFrame]) {
+        enqueueCliMessage(fake, {
+          type: 'command_lifecycle',
+          command_uuid: frame.uuid,
+          state: 'queued',
+        });
+      }
+      for (const frame of [firstFrame, secondFrame]) {
+        enqueueCliMessage(fake, {
+          type: 'command_lifecycle',
+          command_uuid: frame.uuid,
+          state: 'started',
+        });
+      }
+      enqueueAssistantAndResult(fake, secondFrame.uuid, 'batched reply');
+      enqueueProviderState(fake, 'idle');
+      await Bun.sleep(1);
+      expect(finishes).toEqual([]);
+
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: firstFrame.uuid,
+        state: 'completed',
+      });
+      await Bun.sleep(1);
+      expect(finishes).toEqual([]);
+      enqueueCliMessage(fake, {
+        type: 'command_lifecycle',
+        command_uuid: secondFrame.uuid,
+        state: 'completed',
+      });
+
+      await run;
+      expect(finishes).toMatchObject([{ turnId: 'turn-active' }]);
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('fails and retires when accepted steering remains idle without starting', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime(createLogger(), { steerIdleFenceTimeoutMs: 2 });
+      const failures = [];
+      runtime.onFailed((_chatId, message, metadata) => failures.push({ message, metadata }));
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      const original = await enqueueInputStarted(fake);
+      await expect(runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+      ))).resolves.toEqual({ kind: 'accepted' });
+
+      enqueueAssistantAndResult(fake, original.uuid, 'initial reply');
+      enqueueProviderState(fake, 'idle');
+      await Bun.sleep(10);
+      await run;
+
+      expect(failures).toMatchObject([{
+        message: 'Claude CLI did not make progress on accepted steering input.',
+        metadata: { turnId: 'turn-active' },
+      }]);
+      expect(fake.proc.stdin.end).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime?.shutdown();
       Bun.spawn = originalSpawn;
     }
   });

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -26,10 +26,12 @@ function createRuntime(logger = createLogger(), overrides = {}) {
 
 function deferred() {
   let resolve;
-  const promise = new Promise((res) => {
+  let reject;
+  const promise = new Promise((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function createFakeClaudeProcess(options = {}) {
@@ -2086,6 +2088,161 @@ describe('ClaudeCliRuntime steering', () => {
         metadata: { turnId: 'turn-active' },
       }]);
       expect(fake.proc.stdin.end).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('releases an idle reservation when delivery preparation fails', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime();
+      const finishes = [];
+      runtime.onFinished((_chatId, _exitCode, metadata) => finishes.push(metadata));
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      const original = await enqueueInputStarted(fake);
+      const preparation = deferred();
+      const steering = runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+        { prepareDelivery: async () => preparation.promise },
+      ));
+
+      enqueueAssistantAndResult(fake, original.uuid, 'initial reply');
+      enqueueProviderState(fake, 'idle');
+      await Bun.sleep(1);
+      expect(finishes).toEqual([]);
+
+      const preparationError = new Error('delivery preparation failed');
+      preparation.reject(preparationError);
+      await expect(steering).rejects.toBe(preparationError);
+      await run;
+      expect(finishes).toMatchObject([{ turnId: 'turn-active' }]);
+      expect(writtenUserMessages(fake)).toHaveLength(1);
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('classifies attempted write failure as unknown and kills the process', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime();
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      await enqueueInputStarted(fake);
+      fake.proc.stdin.write.mockImplementationOnce(() => {
+        throw new Error('steering write failed');
+      });
+
+      await expect(runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+      ))).resolves.toEqual({
+        kind: 'failed',
+        outcome: 'unknown',
+        message: 'Claude steering delivery could not be confirmed',
+      });
+      await run;
+      expect(fake.proc.kill).toHaveBeenCalledTimes(1);
+      expect(runtime.captureSteerTarget('expected-session')).toBeNull();
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('fails a replay that was never accepted into Claude command lifecycle', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime();
+      const failures = [];
+      runtime.onFailed((_chatId, message, metadata) => failures.push({ message, metadata }));
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      const original = await enqueueInputStarted(fake);
+      await expect(runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+      ))).resolves.toEqual({ kind: 'accepted' });
+      const steeringFrame = writtenUserMessages(fake).at(-1);
+
+      enqueueAssistantAndResult(fake, original.uuid, 'initial reply');
+      enqueueProviderState(fake, 'idle');
+      enqueueCliMessage(fake, {
+        type: 'user',
+        uuid: steeringFrame.uuid,
+        isReplay: true,
+        message: steeringFrame.message,
+      });
+      await run;
+
+      expect(failures).toMatchObject([{
+        message: 'Claude CLI replayed steering input without accepting it into the command queue.',
+        metadata: { turnId: 'turn-active' },
+      }]);
+    } finally {
+      await runtime?.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('removes queued steering input from the interrupt receipt before stopping', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+    let runtime;
+
+    try {
+      runtime = createRuntime();
+      const run = runtime.startClaudeCliSession(startOptions({ turnId: 'turn-active' }));
+      const original = await enqueueInputStarted(fake);
+      await expect(runtime.steer(steerRequest(
+        runtime.captureSteerTarget('expected-session'),
+      ))).resolves.toEqual({ kind: 'accepted' });
+      const steeringFrame = writtenUserMessages(fake).at(-1);
+
+      const abort = runtime.abortClaudeInternalSession('expected-session');
+      let interrupt;
+      for (let attempt = 0; attempt < 100 && !interrupt; attempt += 1) {
+        interrupt = fake.proc.stdin.write.mock.calls
+          .map(([line]) => JSON.parse(line))
+          .find((message) =>
+            message.type === 'control_request'
+            && message.request?.subtype === 'interrupt');
+        if (!interrupt) await Promise.resolve();
+      }
+      if (!interrupt) throw new Error('Claude interrupt request was not written.');
+      enqueueCliMessage(fake, {
+        type: 'control_response',
+        response: {
+          subtype: 'success',
+          request_id: interrupt.request_id,
+          response: { cancelled: [steeringFrame.uuid], still_queued: [] },
+        },
+      });
+      await expect(abort).resolves.toBe(true);
+
+      enqueueCliMessage(fake, {
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        terminal_reason: 'aborted_streaming',
+        user_message_uuid: original.uuid,
+      });
+      enqueueProviderState(fake, 'idle');
+      await run;
+      expect(fake.proc.killed).toBe(false);
+      expect(runtime.captureSteerTarget('expected-session')).toBeNull();
     } finally {
       await runtime?.shutdown();
       Bun.spawn = originalSpawn;

--- a/server-agents/claude/src/agents/claude/__tests__/cli.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli.test.js
@@ -8,6 +8,73 @@ import {
 } from '../cli-protocol.js';
 import { convertClaudePermissionTool } from '../permission-tool-converter.js';
 import { AskUserQuestionToolUseMessage, BashToolUseMessage, ExitPlanModeToolUseMessage } from '@garcon/common/chat-types';
+import {
+  buildClaudeInitialUserContent,
+  buildClaudeUserInputFrame,
+} from '../user-input.js';
+
+describe('Claude SDK user input', () => {
+  it('builds the existing stream-json user frame', () => {
+    expect(JSON.parse(buildClaudeUserInputFrame({
+      content: 'hello',
+      sessionId: 'session-1',
+      uuid: 'input-1',
+    }))).toEqual({
+      type: 'user',
+      message: { role: 'user', content: 'hello' },
+      parent_tool_use_id: null,
+      session_id: 'session-1',
+      uuid: 'input-1',
+    });
+  });
+
+  it('keeps image, document, and text attachment content in canonical order', () => {
+    const text = Buffer.from('notes').toString('base64');
+    expect(buildClaudeInitialUserContent('prompt', [
+      {
+        kind: 'image',
+        name: 'screen.png',
+        mimeType: 'image/png',
+        data: 'data:image/png;base64,aW1hZ2U=',
+      },
+      {
+        kind: 'image',
+        name: 'spec.pdf',
+        mimeType: 'application/pdf',
+        data: 'data:application/pdf;base64,cGRm',
+      },
+      {
+        kind: 'image',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        data: `data:text/plain;base64,${text}`,
+      },
+    ])).toEqual([
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'aW1hZ2U=' },
+      },
+      {
+        type: 'document',
+        source: { type: 'base64', media_type: 'application/pdf', data: 'cGRm' },
+        title: 'spec.pdf',
+      },
+      {
+        type: 'text',
+        text: 'prompt\n\n<attached-file name="notes.txt" mime="text/plain">\nnotes\n\n</attached-file>',
+      },
+    ]);
+  });
+
+  it('preserves the content-block shape when a rich attachment has invalid data', () => {
+    expect(buildClaudeInitialUserContent('prompt', [{
+      kind: 'image',
+      name: 'broken.png',
+      mimeType: 'image/png',
+      data: 'not-a-data-url',
+    }])).toEqual([{ type: 'text', text: 'prompt' }]);
+  });
+});
 
 describe('buildClaudeCLIArgs', () => {
 

--- a/server-agents/claude/src/agents/claude/__tests__/cli.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli.test.js
@@ -9,9 +9,13 @@ import {
 import { convertClaudePermissionTool } from '../permission-tool-converter.js';
 import { AskUserQuestionToolUseMessage, BashToolUseMessage, ExitPlanModeToolUseMessage } from '@garcon/common/chat-types';
 import {
+  CLAUDE_STEERING_PROMPT_PREFIX,
   buildClaudeInitialUserContent,
+  buildClaudeSteeringUserContent,
   buildClaudeUserInputFrame,
+  claudeSteeringInputsFromNativeContent,
 } from '../user-input.js';
+import { ClaudeTurnSteeringState } from '../steering.js';
 
 describe('Claude SDK user input', () => {
   it('builds the existing stream-json user frame', () => {
@@ -73,6 +77,161 @@ describe('Claude SDK user input', () => {
       mimeType: 'image/png',
       data: 'not-a-data-url',
     }])).toEqual([{ type: 'text', text: 'prompt' }]);
+  });
+
+  it('builds an explicit next-priority steering frame with literal slash input', () => {
+    expect(JSON.parse(buildClaudeUserInputFrame({
+      content: buildClaudeSteeringUserContent('/review the failing test'),
+      sessionId: 'session-1',
+      uuid: 'native-steer-1',
+      priority: 'next',
+    }))).toEqual({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'text',
+          text: `${CLAUDE_STEERING_PROMPT_PREFIX}/review the failing test`,
+        }],
+      },
+      parent_tool_use_id: null,
+      session_id: 'session-1',
+      uuid: 'native-steer-1',
+      priority: 'next',
+    });
+  });
+
+  it('extracts only complete provider-owned steering block arrays', () => {
+    const content = [
+      { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}first` },
+      { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}/second` },
+    ];
+    expect(claudeSteeringInputsFromNativeContent(content)).toEqual(['first', '/second']);
+    expect(claudeSteeringInputsFromNativeContent('first')).toBeNull();
+    expect(claudeSteeringInputsFromNativeContent([
+      content[0],
+      { type: 'text', text: 'ordinary' },
+    ])).toBeNull();
+  });
+});
+
+describe('ClaudeTurnSteeringState', () => {
+  it('holds idempotent delivery reservations', () => {
+    const steering = new ClaudeTurnSteeringState();
+    const release = steering.reserveDelivery();
+    expect(steering.blocksIdleSettlement).toBe(true);
+    expect(steering.reservationCount).toBe(1);
+    release();
+    release();
+    expect(steering.blocksIdleSettlement).toBe(false);
+    expect(steering.reservationCount).toBe(0);
+  });
+
+  it('tracks queued, started, replay, and terminal lifecycle idempotently', () => {
+    const steering = new ClaudeTurnSteeringState();
+    steering.markSubmitted('steer-1');
+    steering.rememberProviderIdle();
+    expect(steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'queued',
+    })).toEqual({ kind: 'queued', uuid: 'steer-1' });
+    expect(steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'started',
+    })).toMatchObject({ kind: 'started', uuid: 'steer-1', source: 'lifecycle' });
+    expect(steering.hasDeferredIdle).toBe(false);
+    expect(steering.activeCount).toBe(1);
+    expect(steering.observe({
+      type: 'user',
+      uuid: 'steer-1',
+      isReplay: true,
+    })).toBeNull();
+    expect(steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'completed',
+    })).toEqual({
+      kind: 'terminal',
+      uuid: 'steer-1',
+      phase: 'after-start',
+      state: 'completed',
+    });
+    expect(steering.blocksIdleSettlement).toBe(false);
+  });
+
+  it('accepts queued replay as a start fallback', () => {
+    const steering = new ClaudeTurnSteeringState();
+    steering.markSubmitted('steer-1');
+    steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'queued',
+    });
+    expect(steering.observe({
+      type: 'user',
+      uuid: 'steer-1',
+      isReplay: true,
+    })).toMatchObject({ kind: 'started', source: 'replay' });
+    expect(steering.activeCount).toBe(1);
+  });
+
+  it('rejects replay without prior queue acceptance', () => {
+    const steering = new ClaudeTurnSteeringState();
+    steering.markSubmitted('steer-1');
+    expect(steering.observe({
+      type: 'user',
+      uuid: 'steer-1',
+      isReplay: true,
+    })).toEqual({ kind: 'duplicate-replay', uuid: 'steer-1' });
+    expect(steering.blocksIdleSettlement).toBe(false);
+  });
+
+  it('reports terminal lifecycle before start and keeps other inputs fenced', () => {
+    const steering = new ClaudeTurnSteeringState();
+    steering.markSubmitted('steer-1');
+    steering.markSubmitted('steer-2');
+    expect(steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'discarded',
+    })).toEqual({
+      kind: 'terminal',
+      uuid: 'steer-1',
+      phase: 'before-start',
+      state: 'discarded',
+    });
+    expect(steering.submittedCount).toBe(1);
+    expect(steering.blocksIdleSettlement).toBe(true);
+  });
+
+  it('intersects interrupt receipts with owned native UUIDs', () => {
+    const steering = new ClaudeTurnSteeringState();
+    steering.markSubmitted('cancelled');
+    steering.markSubmitted('survivor');
+    expect(steering.observeInterruptReceipt({
+      cancelled: ['cancelled', 'provider-owned'],
+      stillQueued: ['survivor'],
+    })).toEqual({ cancelledCount: 1, stillQueuedCount: 1 });
+    expect(steering.submittedCount).toBe(1);
+  });
+
+  it('bounds deferred idle only while native work remains', async () => {
+    const steering = new ClaudeTurnSteeringState();
+    let timedOut = 0;
+    const release = steering.reserveDelivery();
+    steering.deferIdle(() => timedOut += 1, 1);
+    await Bun.sleep(5);
+    expect(timedOut).toBe(0);
+
+    steering.markSubmitted('steer-1');
+    release();
+    steering.deferIdle(() => timedOut += 1, 1);
+    await Bun.sleep(5);
+    expect(timedOut).toBe(1);
+    steering.clear();
+    expect(steering.blocksIdleSettlement).toBe(false);
   });
 });
 

--- a/server-agents/claude/src/agents/claude/__tests__/cli.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli.test.js
@@ -141,7 +141,7 @@ describe('ClaudeTurnSteeringState', () => {
       command_uuid: 'steer-1',
       state: 'started',
     })).toMatchObject({ kind: 'started', uuid: 'steer-1', source: 'lifecycle' });
-    expect(steering.hasDeferredIdle).toBe(false);
+    expect(steering.hasDeferredIdle).toBe(true);
     expect(steering.activeCount).toBe(1);
     expect(steering.observe({
       type: 'user',
@@ -175,6 +175,27 @@ describe('ClaudeTurnSteeringState', () => {
       isReplay: true,
     })).toMatchObject({ kind: 'started', source: 'replay' });
     expect(steering.activeCount).toBe(1);
+  });
+
+  it('keeps deferred idle fenced when one of several native inputs starts', () => {
+    const steering = new ClaudeTurnSteeringState();
+    steering.markSubmitted('steer-1');
+    steering.markSubmitted('steer-2');
+    steering.rememberProviderIdle();
+    steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'queued',
+    });
+    steering.observe({
+      type: 'command_lifecycle',
+      command_uuid: 'steer-1',
+      state: 'started',
+    });
+
+    expect(steering.hasDeferredIdle).toBe(true);
+    expect(steering.activeCount).toBe(1);
+    expect(steering.submittedCount).toBe(1);
   });
 
   it('rejects replay without prior queue acceptance', () => {

--- a/server-agents/claude/src/agents/claude/__tests__/fork-transcript.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/fork-transcript.test.js
@@ -6,6 +6,7 @@ import {
   transformClaudeForkTranscript,
 } from '../fork-transcript.js';
 import { convertClaudeEntries } from '../history-loader.js';
+import { CLAUDE_STEERING_PROMPT_PREFIX } from '../user-input.js';
 
 const context = {
   sourceAgentSessionId: '11111111-1111-1111-1111-111111111111',
@@ -71,6 +72,30 @@ describe('projectClaudeForkEntry', () => {
       ...context,
       retainedMessageCount: 0,
     })).toEqual({ ...entry, isMeta: true });
+  });
+
+  it('splits a batched steering entry while preserving native prefixes', () => {
+    const entry = {
+      sessionId: context.sourceAgentSessionId,
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}first` },
+          { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}second` },
+        ],
+      },
+    };
+
+    const projected = projectClaudeForkEntry(entry, {
+      ...context,
+      retainedMessageCount: 1,
+    });
+    expect(projected.message.content).toEqual([entry.message.content[0]]);
+    expect(convertClaudeEntries([projected])).toMatchObject([{
+      type: 'user-message',
+      content: 'first',
+    }]);
   });
 });
 

--- a/server-agents/claude/src/agents/claude/__tests__/history-loader.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/history-loader.test.js
@@ -12,6 +12,7 @@ import {
 import { PendingUserInputService } from '../../../../../../server/chats/pending-user-input-service.js';
 import { getNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { transcriptRevision } from '@garcon/server-agent-common/lib/transcript-revision';
+import { CLAUDE_STEERING_PROMPT_PREFIX } from '../user-input.js';
 
 async function withTempJsonl(lines, fn) {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-load-test-'));
@@ -143,6 +144,102 @@ describe('Claude pending-input evidence', () => {
         entryId: 'normal-user',
         lineNumber: 5,
       });
+    });
+  });
+});
+
+describe('Claude steering history projection', () => {
+  it('projects following-command batches and inline queued commands as separate inputs', async () => {
+    const entries = [
+      {
+        sessionId: 'session',
+        type: 'user',
+        uuid: 'original',
+        timestamp: '2026-07-21T14:00:00.000Z',
+        message: { role: 'user', content: 'original prompt' },
+      },
+      {
+        sessionId: 'session',
+        type: 'user',
+        uuid: 'following-batch',
+        timestamp: '2026-07-21T14:00:01.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}first steer` },
+            { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}/second steer` },
+          ],
+        },
+      },
+      {
+        sessionId: 'session',
+        type: 'attachment',
+        uuid: 'inline-steer',
+        timestamp: '2026-07-21T14:00:02.000Z',
+        attachment: {
+          type: 'queued_command',
+          commandMode: 'prompt',
+          prompt: [{
+            type: 'text',
+            text: `${CLAUDE_STEERING_PROMPT_PREFIX}inline steer`,
+          }],
+          timestamp: '2026-07-21T14:00:02.500Z',
+        },
+      },
+    ];
+    const original = structuredClone(entries);
+
+    await withTempJsonl(entries.map(JSON.stringify), async (filePath) => {
+      const messages = await loadClaudeChatMessages(filePath);
+      expect(messages.map((message) => [message.type, message.content])).toEqual([
+        ['user-message', 'original prompt'],
+        ['user-message', 'first steer'],
+        ['user-message', '/second steer'],
+        ['user-message', 'inline steer'],
+      ]);
+
+      const page = await loadClaudeChatMessagePage(filePath, 2, 1);
+      expect(page.messages.map((message) => message.content)).toEqual([
+        'first steer',
+        '/second steer',
+      ]);
+      expect(page.total).toBe(4);
+    });
+    expect(entries).toEqual(original);
+  });
+
+  it('normalizes steering previews without changing ordinary strings', async () => {
+    const ordinaryPrefixText = `${CLAUDE_STEERING_PROMPT_PREFIX}ordinary string`;
+    const entries = [
+      {
+        sessionId: 'session',
+        type: 'user',
+        uuid: 'ordinary',
+        timestamp: '2026-07-21T14:00:00.000Z',
+        message: { role: 'user', content: ordinaryPrefixText },
+      },
+      {
+        sessionId: 'session',
+        type: 'user',
+        uuid: 'steering-batch',
+        timestamp: '2026-07-21T14:00:01.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}first` },
+            { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}last` },
+          ],
+        },
+      },
+    ];
+
+    await withTempJsonl(entries.map(JSON.stringify), async (filePath) => {
+      const preview = await getClaudePreviewFromNativePath(filePath);
+      expect(preview).toMatchObject({
+        firstMessage: ordinaryPrefixText.trim(),
+        lastMessage: '> last',
+      });
+      expect(preview.lastMessage).not.toContain(CLAUDE_STEERING_PROMPT_PREFIX);
     });
   });
 });

--- a/server-agents/claude/src/agents/claude/__tests__/history-loader.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/history-loader.test.js
@@ -149,6 +149,72 @@ describe('Claude pending-input evidence', () => {
 });
 
 describe('Claude steering history projection', () => {
+  it('preserves exact recognized steering text and bypasses provider-owned filters', async () => {
+    const spaced = '  keep boundary whitespace  ';
+    const filtered = 'Caveat: keep the existing fallback';
+    const entries = [
+      {
+        sessionId: 'session',
+        type: 'user',
+        uuid: 'following-batch',
+        timestamp: '2026-07-21T14:00:01.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}${spaced}` },
+            { type: 'text', text: `${CLAUDE_STEERING_PROMPT_PREFIX}${filtered}` },
+          ],
+        },
+      },
+      {
+        sessionId: 'session',
+        type: 'attachment',
+        uuid: 'inline-steer',
+        timestamp: '2026-07-21T14:00:02.000Z',
+        attachment: {
+          type: 'queued_command',
+          commandMode: 'prompt',
+          prompt: [{
+            type: 'text',
+            text: `${CLAUDE_STEERING_PROMPT_PREFIX}<system-reminder>literal guidance</system-reminder>`,
+          }],
+        },
+      },
+    ];
+
+    await withTempJsonl(entries.map(JSON.stringify), async (filePath) => {
+      const messages = await loadClaudeChatMessages(filePath);
+      expect(messages.map((message) => message.content)).toEqual([
+        spaced,
+        filtered,
+        '<system-reminder>literal guidance</system-reminder>',
+      ]);
+
+      const service = new PendingUserInputService({
+        loadNativeMessages: () => loadClaudeChatMessages(filePath),
+        getRetainedHistoryMessages: () => [],
+      });
+      await service.register('chat-1', spaced, {
+        clientRequestId: 'request-spaced',
+        createdAt: '2026-07-21T14:00:00.500Z',
+        deliveryStatus: 'accepted',
+      });
+      await service.register('chat-1', filtered, {
+        clientRequestId: 'request-filtered',
+        createdAt: '2026-07-21T14:00:00.500Z',
+        deliveryStatus: 'accepted',
+      });
+      await service.reconcileNativeHistory('chat-1');
+      expect(service.listForChat('chat-1')).toEqual([]);
+
+      const preview = await getClaudePreviewFromNativePath(filePath);
+      expect(preview).toMatchObject({
+        firstMessage: spaced,
+        lastMessage: '> <system-reminder>literal guidance</system-reminder>',
+      });
+    });
+  });
+
   it('projects following-command batches and inline queued commands as separate inputs', async () => {
     const entries = [
       {

--- a/server-agents/claude/src/agents/claude/__tests__/interrupt-receipt.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/interrupt-receipt.test.js
@@ -9,7 +9,7 @@ const logger = {
   error() {},
 };
 
-function createFixture() {
+function createFixture({ settleOnFlush = false } = {}) {
   const activeTurn = new ClaudeActiveTurn({ turnId: 'turn-1' }, 0);
   const session = {
     id: 'session-1',
@@ -23,7 +23,10 @@ function createFixture() {
     finish: () => calls.push('finish'),
     clearAbortTimer: () => calls.push('clear'),
     armCompletionFallback: () => calls.push('arm'),
-    flushDeferredIdle: () => calls.push('flush'),
+    flushDeferredIdle: () => {
+      calls.push('flush');
+      if (settleOnFlush) session.activeTurn = null;
+    },
   };
   return { activeTurn, session, calls, handlers };
 }
@@ -102,6 +105,26 @@ describe('handleClaudeInterruptReceipt', () => {
     )).toBe(true);
     expect(fixture.activeTurn.steering.blocksIdleSettlement).toBe(false);
     expect(fixture.calls).toEqual(['flush', 'arm']);
+  });
+
+  it('does not arm a fallback after cancellation flush settles the turn', () => {
+    const fixture = createFixture({ settleOnFlush: true });
+    startInput(fixture.activeTurn);
+    fixture.activeTurn.protocol.recordAcceptedResult({
+      type: 'result',
+      user_message_uuid: fixture.activeTurn.protocol.inputUuid,
+    });
+    fixture.activeTurn.steering.markSubmitted('steer-1');
+    fixture.activeTurn.steering.rememberProviderIdle();
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { cancelled: ['steer-1'] },
+      fixture.handlers,
+    )).toBe(true);
+    expect(fixture.session.activeTurn).toBeNull();
+    expect(fixture.calls).toEqual(['flush']);
   });
 
   it('retains a steering fence reported still queued', () => {

--- a/server-agents/claude/src/agents/claude/__tests__/interrupt-receipt.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/interrupt-receipt.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import { ClaudeActiveTurn } from '../active-turn.js';
+import { handleClaudeInterruptReceipt } from '../interrupt-receipt.js';
+
+const logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function createFixture() {
+  const activeTurn = new ClaudeActiveTurn({ turnId: 'turn-1' }, 0);
+  const session = {
+    id: 'session-1',
+    chatId: 'chat-1',
+    activeTurn,
+    process: { pid: 42 },
+  };
+  const calls = [];
+  const handlers = {
+    logger,
+    finish: () => calls.push('finish'),
+    clearAbortTimer: () => calls.push('clear'),
+    armCompletionFallback: () => calls.push('arm'),
+  };
+  return { activeTurn, session, calls, handlers };
+}
+
+function startInput(activeTurn) {
+  activeTurn.protocol.observeInput({
+    type: 'command_lifecycle',
+    command_uuid: activeTurn.protocol.inputUuid,
+    state: 'started',
+  });
+}
+
+describe('handleClaudeInterruptReceipt', () => {
+  it('finishes a current pre-start input confirmed cancelled', () => {
+    const fixture = createFixture();
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { cancelled: [fixture.activeTurn.protocol.inputUuid] },
+      fixture.handlers,
+    )).toBe(true);
+    expect(fixture.calls).toEqual(['finish']);
+  });
+
+  it('rejects a pre-start receipt that leaves the input queued', () => {
+    const fixture = createFixture();
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { still_queued: [fixture.activeTurn.protocol.inputUuid] },
+      fixture.handlers,
+    )).toBe(false);
+    expect(fixture.calls).toEqual(['clear']);
+    expect(fixture.activeTurn.protocol.abortRequested).toBe(false);
+  });
+
+  it('arms the completion fallback for an acknowledged started input', () => {
+    const fixture = createFixture();
+    startInput(fixture.activeTurn);
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { cancelled: [], still_queued: [] },
+      fixture.handlers,
+    )).toBe(true);
+    expect(fixture.calls).toEqual(['arm']);
+  });
+
+  it('does not mutate a replacement active turn', () => {
+    const fixture = createFixture();
+    startInput(fixture.activeTurn);
+    fixture.session.activeTurn = new ClaudeActiveTurn({ turnId: 'turn-2' }, 0);
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { cancelled: [], still_queued: [] },
+      fixture.handlers,
+    )).toBe(true);
+    expect(fixture.calls).toEqual([]);
+  });
+});

--- a/server-agents/claude/src/agents/claude/__tests__/interrupt-receipt.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/interrupt-receipt.test.js
@@ -23,6 +23,7 @@ function createFixture() {
     finish: () => calls.push('finish'),
     clearAbortTimer: () => calls.push('clear'),
     armCompletionFallback: () => calls.push('arm'),
+    flushDeferredIdle: () => calls.push('flush'),
   };
   return { activeTurn, session, calls, handlers };
 }
@@ -86,5 +87,35 @@ describe('handleClaudeInterruptReceipt', () => {
       fixture.handlers,
     )).toBe(true);
     expect(fixture.calls).toEqual([]);
+  });
+
+  it('cancels only steering UUIDs owned by the active turn', () => {
+    const fixture = createFixture();
+    startInput(fixture.activeTurn);
+    fixture.activeTurn.steering.markSubmitted('steer-1');
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { cancelled: ['steer-1', 'provider-internal'] },
+      fixture.handlers,
+    )).toBe(true);
+    expect(fixture.activeTurn.steering.blocksIdleSettlement).toBe(false);
+    expect(fixture.calls).toEqual(['flush', 'arm']);
+  });
+
+  it('retains a steering fence reported still queued', () => {
+    const fixture = createFixture();
+    startInput(fixture.activeTurn);
+    fixture.activeTurn.steering.markSubmitted('steer-1');
+
+    expect(handleClaudeInterruptReceipt(
+      fixture.session,
+      fixture.activeTurn,
+      { still_queued: ['steer-1'] },
+      fixture.handlers,
+    )).toBe(true);
+    expect(fixture.activeTurn.steering.blocksIdleSettlement).toBe(true);
+    expect(fixture.calls).toEqual(['clear', 'arm']);
   });
 });

--- a/server-agents/claude/src/agents/claude/active-turn.ts
+++ b/server-agents/claude/src/agents/claude/active-turn.ts
@@ -2,9 +2,11 @@ import crypto from 'node:crypto';
 import type { CompactionTrigger } from '@garcon/common/chat-types';
 import type { RuntimeEventMetadata } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import { ClaudeTurnState } from './cli-protocol.js';
+import { ClaudeTurnSteeringState } from './steering.js';
 
 export class ClaudeActiveTurn {
   readonly protocol: ClaudeTurnState;
+  readonly steering = new ClaudeTurnSteeringState();
   readonly startedAt = Date.now();
   readonly completion: Promise<void>;
   readonly preStartAbortConfirmation: Promise<void>;
@@ -29,6 +31,7 @@ export class ClaudeActiveTurn {
   }
 
   finish(): void {
+    this.steering.clear();
     this.#resolve?.();
     this.#resolve = null;
   }

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -9,7 +9,12 @@ import {
   AgentEventEmitterRuntime,
   type RuntimeEventMetadata,
 } from '@garcon/server-agent-common/shared/event-emitter-runtime';
-import type { AgentLogger } from '@garcon/server-agent-interface';
+import type {
+  AgentLogger,
+  AgentSteerRequest,
+  AgentSteerResult,
+  AgentSteerTarget,
+} from '@garcon/server-agent-interface';
 import type { ClaudeThinkingMode, PermissionMode, ThinkingMode } from '@garcon/common/chat-modes';
 import {
   assertClaudeExecutionOpen,
@@ -48,13 +53,22 @@ import {
   type ClaudeProviderSessionState,
   type ClaudeTurnTerminalState,
 } from './cli-protocol.js';
-import { handleClaudeProviderLifecycleMessage } from './cli-session-state.js';
+import {
+  flushDeferredClaudeProviderIdle,
+  handleClaudeProviderLifecycleMessage,
+  type ClaudeProviderStateHandlers,
+} from './cli-session-state.js';
 import { ClaudeActiveTurn } from './active-turn.js';
 import {
   buildClaudeInitialUserContent,
   buildClaudeUserInputFrame,
 } from './user-input.js';
 import { handleClaudeInterruptReceipt } from './interrupt-receipt.js';
+import {
+  CLAUDE_STEER_IDLE_FENCE_TIMEOUT_MS,
+  CLAUDE_STEER_WRITE_TIMEOUT_MS,
+  ClaudeSteeringController,
+} from './steering.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -103,6 +117,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   #processRetirements = new ClaudeProcessRetirementTracker();
   #pendingPermissions = new Map<string, PendingPermission>();
   #controlBroker: ClaudeControlBroker;
+  #steering: ClaudeSteeringController;
   #idlePurger: IdleSessionPurger<ClaudeRunningSession>;
   #shuttingDown = false;
   readonly #dependencies: ClaudeCliDependencies;
@@ -113,6 +128,17 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     this.#controlBroker = new ClaudeControlBroker(
       (agentSessionId, jsonl) => this.#writeToCLI(agentSessionId, jsonl),
     );
+    this.#steering = new ClaudeSteeringController({
+      session: agentSessionId => this.#runningSessions.get(agentSessionId) ?? null,
+      isShuttingDown: () => this.#shuttingDown,
+      logger: dependencies.logger,
+      writeTimeoutMs: dependencies.steerWriteTimeoutMs ?? CLAUDE_STEER_WRITE_TIMEOUT_MS,
+      flushDeferredIdle: (session, activeTurn) => {
+        const runningSession = this.#runningSessions.get(session.id);
+        if (!runningSession || runningSession.activeTurn !== activeTurn) return;
+        this.#flushDeferredProviderIdle(runningSession, runningSession.activeTurn);
+      },
+    });
     this.#idlePurger = new IdleSessionPurger({
       sessions: () => this.#runningSessions.entries(),
       isRunning: (session) => session.activeTurn !== null,
@@ -184,6 +210,10 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     } else if (inputEvent?.type === 'terminal-before-start') {
       this.#handleInputTerminalBeforeStart(session, inputEvent.state);
       return;
+    }
+    const steeringEvent = activeTurn?.steering.observe(msg) ?? null;
+    if (steeringEvent) {
+      this.#steering.handleObservation(session, activeTurn!, steeringEvent);
     }
 
     switch (msg.type) {
@@ -257,12 +287,11 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
   }
 
   #handleSystemMessage(session: ClaudeRunningSession, msg: ClaudeCLIMessage): void {
-    if (handleClaudeProviderLifecycleMessage(msg, session, {
-      logger: this.#dependencies.logger,
-      finish: () => this.#finishTurn(session),
-      fail: message => this.#failSession(session, message),
-      retire: () => this.#retireSessionProcessInBackground(session),
-    })) return;
+    if (handleClaudeProviderLifecycleMessage(
+      msg,
+      session,
+      this.#providerStateHandlers(session),
+    )) return;
 
     const activeTurn = session.activeTurn;
     if (msg.subtype === 'init') {
@@ -312,6 +341,25 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       if (!activeTurn?.protocol.inputStarted) return;
       activeTurn.pendingCompaction = parseCompactMetadata(msg.compact_metadata);
     }
+  }
+
+  #providerStateHandlers(session: ClaudeRunningSession): ClaudeProviderStateHandlers {
+    return {
+      logger: this.#dependencies.logger,
+      finish: () => this.#finishTurn(session),
+      fail: message => this.#failSession(session, message),
+      retire: () => this.#retireSessionProcessInBackground(session),
+      steeringIdleFenceTimeoutMs:
+        this.#dependencies.steerIdleFenceTimeoutMs ?? CLAUDE_STEER_IDLE_FENCE_TIMEOUT_MS,
+    };
+  }
+
+  #flushDeferredProviderIdle(
+    session: ClaudeRunningSession,
+    activeTurn: ClaudeActiveTurn,
+  ): void {
+    if (session.activeTurn !== activeTurn) return;
+    flushDeferredClaudeProviderIdle(session, this.#providerStateHandlers(session));
   }
 
   // Folds the post-compaction summary (delivered as a synthetic user message)
@@ -761,6 +809,14 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       sessionId: session.id || '',
       uuid: activeTurn.protocol.inputUuid,
     }));
+  }
+
+  captureSteerTarget(agentSessionId: string): AgentSteerTarget | null {
+    return this.#steering.captureTarget(agentSessionId);
+  }
+
+  steer(request: AgentSteerRequest): Promise<AgentSteerResult> {
+    return this.#steering.steer(request);
   }
 
   #waitForTurnComplete(activeTurn: ClaudeActiveTurn): Promise<void> {
@@ -1289,6 +1345,7 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
           INTERRUPT_COMPLETION_TIMEOUT_MS,
           'completion',
         ),
+        flushDeferredIdle: () => this.#flushDeferredProviderIdle(session, activeTurn),
       });
     } catch (error) {
       if (session.activeTurn !== activeTurn) {

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -19,7 +19,6 @@ import {
   type ClaudeStartRequest,
 } from './runtime-types.js';
 import type { AgentAttachment } from '@garcon/common/agent-execution';
-import { appendTextAttachmentContext, attachmentDocumentBlock, documentAttachments, imageAttachments, parseAttachmentDataUrl } from '@garcon/server-agent-common/shared/attachments';
 import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import { isRecord } from '@garcon/common/json';
 import { isManualBypassMode, providerStartupPermissionMode } from '@garcon/server-agent-common/execution/permission-modes';
@@ -51,6 +50,11 @@ import {
 } from './cli-protocol.js';
 import { handleClaudeProviderLifecycleMessage } from './cli-session-state.js';
 import { ClaudeActiveTurn } from './active-turn.js';
+import {
+  buildClaudeInitialUserContent,
+  buildClaudeUserInputFrame,
+} from './user-input.js';
+import { handleClaudeInterruptReceipt } from './interrupt-receipt.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -752,40 +756,11 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     command: string,
     images?: readonly AgentAttachment[],
   ): Promise<void> {
-    const prompt = appendTextAttachmentContext(command, images);
-    const imageParts = imageAttachments(images);
-    const documentParts = documentAttachments(images);
-    let content: unknown;
-    if (imageParts.length || documentParts.length) {
-      const blocks: unknown[] = [];
-      for (const img of imageParts) {
-        const parts = parseAttachmentDataUrl(img.data);
-        if (parts) {
-          blocks.push({
-            type: 'image',
-            source: { type: 'base64', media_type: parts.mimeType, data: parts.base64 },
-          });
-        }
-      }
-      for (const doc of documentParts) {
-        const block = attachmentDocumentBlock(doc);
-        if (block) blocks.push(block);
-      }
-      blocks.push({ type: 'text', text: prompt });
-      content = blocks;
-    } else {
-      content = prompt;
-    }
-
-    const jsonl = JSON.stringify({
-      type: 'user',
-      message: { role: 'user', content },
-      parent_tool_use_id: null,
-      session_id: session.id || '',
+    await this.#writeToCLI(session.id, buildClaudeUserInputFrame({
+      content: buildClaudeInitialUserContent(command, images),
+      sessionId: session.id || '',
       uuid: activeTurn.protocol.inputUuid,
-    });
-
-    await this.#writeToCLI(session.id, jsonl);
+    }));
   }
 
   #waitForTurnComplete(activeTurn: ClaudeActiveTurn): Promise<void> {
@@ -1257,62 +1232,6 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
     }
   }
 
-  #handleInterruptReceipt(
-    session: ClaudeRunningSession,
-    activeTurn: ClaudeActiveTurn,
-    value: unknown,
-  ): boolean {
-    const turnIsCurrent = session.activeTurn === activeTurn;
-    const receipt = isRecord(value) ? value : {};
-    const cancelled = Array.isArray(receipt.cancelled)
-      ? receipt.cancelled.filter((entry): entry is string => typeof entry === 'string')
-      : [];
-    const stillQueued = Array.isArray(receipt.still_queued)
-      ? receipt.still_queued.filter((entry): entry is string => typeof entry === 'string')
-      : [];
-    const inputUuid = activeTurn.protocol.inputUuid;
-    const details = {
-      chatId: session.chatId,
-      turnId: activeTurn.eventMetadata.turnId ?? null,
-      sessionId: session.id.slice(0, 8),
-      processId: session.process?.pid ?? null,
-      inputId: inputUuid.slice(0, 8),
-      cancelledCount: cancelled.length,
-      stillQueuedCount: stillQueued.length,
-    };
-
-    if (!activeTurn.protocol.inputStarted && cancelled.includes(inputUuid)) {
-      this.#dependencies.logger.info('Claude CLI confirmed queued input cancellation', details);
-      if (turnIsCurrent) this.#finishTurn(session);
-      return true;
-    }
-    if (!activeTurn.protocol.inputStarted && !stillQueued.includes(inputUuid)) {
-      this.#dependencies.logger.warn(
-        'Claude CLI interrupt did not confirm queued input cancellation',
-        details,
-      );
-      return false;
-    }
-    if (stillQueued.includes(inputUuid)) {
-      if (turnIsCurrent) {
-        this.#clearAbortTimer(session);
-        activeTurn.protocol.markAbortRejected();
-      }
-      this.#dependencies.logger.warn('Claude CLI interrupt left the submitted input queued', details);
-      return false;
-    }
-    this.#dependencies.logger.debug('Claude CLI acknowledged interrupt', details);
-    if (turnIsCurrent && activeTurn.protocol.inputStarted) {
-      this.#armAbortFallback(
-        session,
-        activeTurn,
-        INTERRUPT_COMPLETION_TIMEOUT_MS,
-        'completion',
-      );
-    }
-    return true;
-  }
-
   #forceAbortProcess(
     session: ClaudeRunningSession,
     activeTurn: ClaudeActiveTurn,
@@ -1360,7 +1279,17 @@ class ClaudeCliRuntime extends AgentEventEmitterRuntime {
       if (acknowledgement.type === 'lifecycle') return true;
       if (acknowledgement.type === 'completion') return false;
       const receipt = acknowledgement.value;
-      return this.#handleInterruptReceipt(session, activeTurn, receipt);
+      return handleClaudeInterruptReceipt(session, activeTurn, receipt, {
+        logger: this.#dependencies.logger,
+        finish: () => this.#finishTurn(session),
+        clearAbortTimer: () => this.#clearAbortTimer(session),
+        armCompletionFallback: () => this.#armAbortFallback(
+          session,
+          activeTurn,
+          INTERRUPT_COMPLETION_TIMEOUT_MS,
+          'completion',
+        ),
+      });
     } catch (error) {
       if (session.activeTurn !== activeTurn) {
         if (activeTurn.interruptRequestFailed) throw error;

--- a/server-agents/claude/src/agents/claude/cli-invocation.ts
+++ b/server-agents/claude/src/agents/claude/cli-invocation.ts
@@ -43,6 +43,8 @@ export interface ClaudeCliDependencies {
   readonly binary: () => string;
   readonly logger: AgentLogger;
   readonly versionProbe: ClaudeCliVersionProbe;
+  readonly steerWriteTimeoutMs?: number;
+  readonly steerIdleFenceTimeoutMs?: number;
 }
 
 function defaultClaudeCliDependencies(): ClaudeCliDependencies {

--- a/server-agents/claude/src/agents/claude/cli-process-transport.ts
+++ b/server-agents/claude/src/agents/claude/cli-process-transport.ts
@@ -41,6 +41,12 @@ interface ClaudeProcessTransportOptions<Message> {
   readonly maxStdoutFrameBytes?: number;
 }
 
+export interface ClaudeWriteLineOptions {
+  readonly beforeWrite?: () => void;
+  readonly attemptTimeoutMs?: number;
+  readonly killProcessAfterAttemptFailure?: boolean;
+}
+
 interface StderrSummary {
   bytes: number;
   lines: number;
@@ -141,6 +147,30 @@ async function drainStderr(
   if (remainder) onChunk(remainder);
 }
 
+async function writeAndFlushWithTimeout(
+  stdin: import('bun').FileSink,
+  frame: string,
+  timeoutMs: number,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error('Claude CLI stdin write timed out'));
+    }, timeoutMs);
+  });
+  try {
+    await Promise.race([
+      (async () => {
+        await stdin.write(frame);
+        await stdin.flush();
+      })(),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export class ClaudeProcessTransport<Message> {
   readonly process: ClaudeSubprocess;
   readonly #options: ClaudeProcessTransportOptions<Message>;
@@ -160,16 +190,29 @@ export class ClaudeProcessTransport<Message> {
     this.#startReaders();
   }
 
-  writeLine(jsonl: string): Promise<void> {
+  writeLine(jsonl: string, options: ClaudeWriteLineOptions = {}): Promise<void> {
+    let attemptBegan = false;
     const write = this.#writeTail.then(async () => {
       if (this.#retiring || this.process.killed) {
         throw new Error('Claude CLI process is not writable');
       }
       const stdin = this.process.stdin as import('bun').FileSink;
       if (!stdin?.write) throw new Error('Claude CLI process has no writable stdin');
-      await stdin.write(jsonl + '\n');
-      await stdin.flush();
+      options.beforeWrite?.();
+      attemptBegan = true;
+      const frame = jsonl + '\n';
+      if (options.attemptTimeoutMs !== undefined) {
+        await writeAndFlushWithTimeout(stdin, frame, options.attemptTimeoutMs);
+      } else {
+        await stdin.write(frame);
+        await stdin.flush();
+      }
     }).catch((error: unknown) => {
+      if (
+        options.killProcessAfterAttemptFailure
+        && attemptBegan
+        && !this.process.killed
+      ) this.process.kill();
       this.#reportFailure({ kind: 'write', message: errorMessage(error) });
       throw error;
     });

--- a/server-agents/claude/src/agents/claude/cli-session-state.ts
+++ b/server-agents/claude/src/agents/claude/cli-session-state.ts
@@ -6,9 +6,11 @@ import {
   type ClaudeProviderSessionState,
   type ClaudeTurnState,
 } from './cli-protocol.js';
+import type { ClaudeTurnSteeringState } from './steering.js';
 
 interface ClaudeProviderStateTurn {
   readonly protocol: ClaudeTurnState;
+  readonly steering: ClaudeTurnSteeringState;
   readonly eventMetadata: { readonly turnId?: string };
 }
 
@@ -23,11 +25,115 @@ export interface ClaudeProviderStateSession {
   readonly activeTurn: ClaudeProviderStateTurn | null;
 }
 
-interface ClaudeProviderStateHandlers {
+export interface ClaudeProviderStateHandlers {
   readonly logger: AgentLogger;
   readonly finish: () => void;
   readonly fail: (message: string) => void;
   readonly retire: () => void;
+  readonly steeringIdleFenceTimeoutMs: number;
+}
+
+export function flushDeferredClaudeProviderIdle(
+  session: ClaudeProviderStateSession,
+  handlers: ClaudeProviderStateHandlers,
+): void {
+  const activeTurn = session.activeTurn;
+  if (
+    session.providerState !== 'idle'
+    || !activeTurn?.steering.hasDeferredIdle
+  ) return;
+  settleClaudeProviderIdle(session, handlers);
+}
+
+function settleClaudeProviderIdle(
+  session: ClaudeProviderStateSession,
+  handlers: ClaudeProviderStateHandlers,
+): void {
+  const activeTurn = session.activeTurn;
+  if (!activeTurn?.protocol.inputStarted) return;
+
+  const protocol = activeTurn.protocol;
+  const steering = activeTurn.steering;
+  steering.rememberProviderIdle();
+  const details = {
+    chatId: session.chatId,
+    turnId: activeTurn.eventMetadata.turnId ?? null,
+    sessionId: session.id.slice(0, 8),
+    processId: session.process?.pid ?? null,
+    inputId: protocol.inputUuid.slice(0, 8),
+    outputMessages: protocol.outputMessageCount,
+    resultSeen: protocol.hasAcceptedResult,
+    backgroundTaskCount: session.backgroundTaskCount,
+    backgroundContinuationPending: protocol.backgroundContinuationPending,
+    steeringReservations: steering.reservationCount,
+    submittedSteers: steering.submittedCount,
+    activeSteers: steering.activeCount,
+  };
+
+  if (steering.blocksIdleSettlement) {
+    handlers.logger.debug('Claude CLI provider idle deferred for steering work', details);
+    steering.deferIdle(() => {
+      if (
+        session.activeTurn !== activeTurn
+        || session.providerState !== 'idle'
+        || !steering.blocksIdleSettlement
+      ) return;
+      handlers.logger.warn('Claude CLI remained idle across accepted steering work', details);
+      handlers.fail('Claude CLI did not make progress on accepted steering input.');
+      handlers.retire();
+    }, handlers.steeringIdleFenceTimeoutMs);
+    return;
+  }
+
+  if (!protocol.hasAcceptedResult) {
+    handlers.logger.warn(
+      'Claude CLI became idle before producing a result for the submitted input',
+      details,
+    );
+    handlers.fail(
+      'Claude CLI became idle before the submitted message produced a terminal result.',
+    );
+    handlers.retire();
+    return;
+  }
+  // Waits for a continuation only while tasks are still outstanding. A task
+  // that completed before the input result was consumed mid-turn and produces
+  // no continuation, so idle with an empty task set is the run boundary even
+  // though the pending flag was never cleared by a continuation result. The
+  // Agent SDK reaches the same conclusion for its stdin-close decision: an
+  // empty in-flight set at a turn boundary must settle, because no bookkeeping
+  // can distinguish a consumed completion from one still owed. See
+  // https://github.com/anthropics/claude-agent-sdk-python/blob/f8b9ec92/src/claude_agent_sdk/_internal/query.py#L863-L894
+  if (
+    protocol.backgroundContinuationPending
+    && !protocol.abortRequested
+    && session.backgroundTaskCount > 0
+  ) {
+    handlers.logger.info(
+      'Claude CLI became idle while a background continuation remains pending',
+      details,
+    );
+    return;
+  }
+  const retireAfterSettlement =
+    protocol.backgroundContinuationPending && protocol.abortRequested;
+  if (retireAfterSettlement) session.backgroundTaskCount = 0;
+
+  const failure = protocol.settlementFailureMessage()
+    ?? steering.settlementFailureMessage;
+  if (failure) {
+    handlers.logger.warn('Claude CLI run settled with an error', details);
+    handlers.fail(failure);
+    if (retireAfterSettlement) handlers.retire();
+    return;
+  }
+  if (protocol.cleanAbortResultSeen) {
+    handlers.logger.info('Claude CLI run stopped after an interrupt', details);
+  } else {
+    handlers.logger.info('Claude CLI run settled at provider idle', details);
+  }
+  handlers.finish();
+  if (retireAfterSettlement) handlers.retire();
 }
 
 export function handleClaudeProviderLifecycleMessage(
@@ -93,66 +199,6 @@ export function handleClaudeProviderLifecycleMessage(
     return true;
   }
   if (next !== 'idle' || !activeTurn.protocol.inputStarted) return true;
-
-  const protocol = activeTurn.protocol;
-  const details = {
-    chatId: session.chatId,
-    turnId: activeTurn.eventMetadata.turnId ?? null,
-    sessionId: session.id.slice(0, 8),
-    processId: session.process?.pid ?? null,
-    inputId: protocol.inputUuid.slice(0, 8),
-    outputMessages: protocol.outputMessageCount,
-    resultSeen: protocol.hasAcceptedResult,
-    backgroundTaskCount: session.backgroundTaskCount,
-    backgroundContinuationPending: protocol.backgroundContinuationPending,
-  };
-  if (!protocol.hasAcceptedResult) {
-    handlers.logger.warn(
-      'Claude CLI became idle before producing a result for the submitted input',
-      details,
-    );
-    handlers.fail(
-      'Claude CLI became idle before the submitted message produced a terminal result.',
-    );
-    handlers.retire();
-    return true;
-  }
-  // Waits for a continuation only while tasks are still outstanding. A task
-  // that completed before the input result was consumed mid-turn and produces
-  // no continuation, so idle with an empty task set is the run boundary even
-  // though the pending flag was never cleared by a continuation result. The
-  // Agent SDK reaches the same conclusion for its stdin-close decision: an
-  // empty in-flight set at a turn boundary must settle, because no bookkeeping
-  // can distinguish a consumed completion from one still owed. See
-  // https://github.com/anthropics/claude-agent-sdk-python/blob/f8b9ec92/src/claude_agent_sdk/_internal/query.py#L863-L894
-  if (
-    protocol.backgroundContinuationPending
-    && !protocol.abortRequested
-    && session.backgroundTaskCount > 0
-  ) {
-    handlers.logger.info(
-      'Claude CLI became idle while a background continuation remains pending',
-      details,
-    );
-    return true;
-  }
-  const retireAfterSettlement =
-    protocol.backgroundContinuationPending && protocol.abortRequested;
-  if (retireAfterSettlement) session.backgroundTaskCount = 0;
-
-  const failure = protocol.settlementFailureMessage();
-  if (failure) {
-    handlers.logger.warn('Claude CLI run settled with an error', details);
-    handlers.fail(failure);
-    if (retireAfterSettlement) handlers.retire();
-    return true;
-  }
-  if (protocol.cleanAbortResultSeen) {
-    handlers.logger.info('Claude CLI run stopped after an interrupt', details);
-  } else {
-    handlers.logger.info('Claude CLI run settled at provider idle', details);
-  }
-  handlers.finish();
-  if (retireAfterSettlement) handlers.retire();
+  settleClaudeProviderIdle(session, handlers);
   return true;
 }

--- a/server-agents/claude/src/agents/claude/fork-transcript.ts
+++ b/server-agents/claude/src/agents/claude/fork-transcript.ts
@@ -11,6 +11,7 @@ import type {
   ForkTranscriptTransformResult,
 } from '@garcon/server-agent-common/forking/fork-jsonl';
 import { convertClaudeEntries, sortClaudeEntries } from './history-loader.js';
+import { claudeSteeringInputsFromNativeContent } from './user-input.js';
 
 const CLAUDE_TRANSCRIPT_TYPES = new Set([
   'user',
@@ -67,6 +68,13 @@ export function projectClaudeForkEntry(
   }
 
   if (message.role === 'user') {
+    const steeringInputs = claudeSteeringInputsFromNativeContent(content);
+    if (steeringInputs && retainedMessageCount <= steeringInputs.length) {
+      return {
+        ...entry,
+        message: { ...message, content: content.slice(0, retainedMessageCount) },
+      };
+    }
     const toolResults = content.filter((part) => isRecord(part) && part.type === 'tool_result');
     if (retainedMessageCount <= toolResults.length) {
       return {

--- a/server-agents/claude/src/agents/claude/history-loader.ts
+++ b/server-agents/claude/src/agents/claude/history-loader.ts
@@ -30,6 +30,7 @@ import {
 } from '@garcon/server-agent-common/lib/transcript-revision';
 import { deterministicTranscriptTimestamp } from '@garcon/server-agent-common/shared/transcript-timestamp';
 import { compareTranscriptTimestamps } from '@garcon/server-agent-common/shared/transcript-order';
+import { claudeSteeringInputsFromNativeContent } from './user-input.js';
 
 const NOOP_LOGGER: AgentLogger = {
   debug() {},
@@ -161,6 +162,12 @@ function getMessageText(content: unknown): string {
   return '';
 }
 
+function claudeUserTexts(content: unknown): readonly string[] {
+  const steeringInputs = claudeSteeringInputsFromNativeContent(content);
+  const values = steeringInputs ?? [getMessageText(content)];
+  return values.map((value) => value.trim()).filter(Boolean);
+}
+
 function isSystemUserMessage(text: string): boolean {
   return (
     text.startsWith('<command-name>') ||
@@ -185,14 +192,13 @@ function isProviderOwnedUserMessage(
   return asRecord(entry.origin).kind === 'task-notification' || isSystemUserMessage(text);
 }
 
-function queuedCommandPrompt(entry: Record<string, unknown>): string | null {
-  if (entry.type !== 'attachment') return null;
+function queuedCommandPrompts(entry: Record<string, unknown>): readonly string[] {
+  if (entry.type !== 'attachment') return [];
   const attachment = asRecord(entry.attachment);
-  if (attachment.type !== 'queued_command' || attachment.commandMode !== 'prompt') return null;
-  const prompt = asString(attachment.prompt)?.trim();
-  return prompt && !isProviderOwnedUserMessage(entry, prompt)
-    ? stripResolvedFileMentionContext(prompt)
-    : null;
+  if (attachment.type !== 'queued_command' || attachment.commandMode !== 'prompt') return [];
+  return claudeUserTexts(attachment.prompt)
+    .filter((prompt) => !isProviderOwnedUserMessage(entry, prompt))
+    .map(stripResolvedFileMentionContext);
 }
 
 function isSystemAssistantMessage(text: string): boolean {
@@ -289,10 +295,12 @@ export function convertClaudeEntries(rawEntries: Record<string, unknown>[]): Cha
       continue;
     }
 
-    const queuedPrompt = queuedCommandPrompt(entry);
-    if (queuedPrompt) {
+    const queuedPrompts = queuedCommandPrompts(entry);
+    if (queuedPrompts.length > 0) {
       const attachmentTimestamp = asString(asRecord(entry.attachment).timestamp);
-      pushMessage(entry, new UserMessage(attachmentTimestamp || ts, queuedPrompt));
+      for (const prompt of queuedPrompts) {
+        pushMessage(entry, new UserMessage(attachmentTimestamp || ts, prompt));
+      }
       continue;
     }
 
@@ -347,9 +355,10 @@ export function convertClaudeEntries(rawEntries: Record<string, unknown>[]): Cha
         }
       }
 
-      const text = getMessageText(content);
-      if (text && !isProviderOwnedUserMessage(entry, text)) {
-        pushMessage(entry, new UserMessage(ts, stripResolvedFileMentionContext(text)));
+      for (const text of claudeUserTexts(content)) {
+        if (!isProviderOwnedUserMessage(entry, text)) {
+          pushMessage(entry, new UserMessage(ts, stripResolvedFileMentionContext(text)));
+        }
       }
       continue;
     }
@@ -682,12 +691,13 @@ async function readFirstUserMessage(filePath: string): Promise<{
       }
       const message = asRecord(entry.message);
       if (message.role === 'user') {
-        const text = getMessageText(message.content);
-        if (!firstMessage && text && !isProviderOwnedUserMessage(entry, text)) {
-          firstMessage = text;
+        for (const text of claudeUserTexts(message.content)) {
+          if (!firstMessage && !isProviderOwnedUserMessage(entry, text)) {
+            firstMessage = text;
+          }
         }
       } else if (!firstMessage) {
-        firstMessage = queuedCommandPrompt(entry);
+        firstMessage = queuedCommandPrompts(entry)[0] ?? null;
       }
       if (firstMessage && firstTimestamp) break;
     }
@@ -746,10 +756,10 @@ export async function getClaudePreviewFromNativePath(
       const message = asRecord(entry.message);
       const role = message.role;
       if (role === 'user') {
-        const text = getMessageText(message.content);
-        if (!text || isProviderOwnedUserMessage(entry, text)) {
-          continue;
-        }
+        const text = claudeUserTexts(message.content)
+          .filter((candidate) => !isProviderOwnedUserMessage(entry, candidate))
+          .at(-1);
+        if (!text) continue;
         lastMessage = '> ' + text;
       } else if (role === 'assistant' && entry.isApiErrorMessage !== true) {
         const text = getMessageText(message.content);
@@ -758,7 +768,7 @@ export async function getClaudePreviewFromNativePath(
         }
         lastMessage = text;
       } else {
-        const prompt = queuedCommandPrompt(entry);
+        const prompt = queuedCommandPrompts(entry).at(-1);
         if (prompt) lastMessage = '> ' + prompt;
       }
     }

--- a/server-agents/claude/src/agents/claude/history-loader.ts
+++ b/server-agents/claude/src/agents/claude/history-loader.ts
@@ -162,10 +162,20 @@ function getMessageText(content: unknown): string {
   return '';
 }
 
-function claudeUserTexts(content: unknown): readonly string[] {
+interface ClaudeUserText {
+  readonly text: string;
+  readonly steering: boolean;
+}
+
+function claudeUserTexts(content: unknown): readonly ClaudeUserText[] {
   const steeringInputs = claudeSteeringInputsFromNativeContent(content);
-  const values = steeringInputs ?? [getMessageText(content)];
-  return values.map((value) => value.trim()).filter(Boolean);
+  if (steeringInputs) {
+    return steeringInputs
+      .filter((text) => text.trim().length > 0)
+      .map((text) => ({ text, steering: true }));
+  }
+  const text = getMessageText(content);
+  return text ? [{ text, steering: false }] : [];
 }
 
 function isSystemUserMessage(text: string): boolean {
@@ -197,8 +207,8 @@ function queuedCommandPrompts(entry: Record<string, unknown>): readonly string[]
   const attachment = asRecord(entry.attachment);
   if (attachment.type !== 'queued_command' || attachment.commandMode !== 'prompt') return [];
   return claudeUserTexts(attachment.prompt)
-    .filter((prompt) => !isProviderOwnedUserMessage(entry, prompt))
-    .map(stripResolvedFileMentionContext);
+    .filter((prompt) => prompt.steering || !isProviderOwnedUserMessage(entry, prompt.text))
+    .map((prompt) => stripResolvedFileMentionContext(prompt.text));
 }
 
 function isSystemAssistantMessage(text: string): boolean {
@@ -355,9 +365,12 @@ export function convertClaudeEntries(rawEntries: Record<string, unknown>[]): Cha
         }
       }
 
-      for (const text of claudeUserTexts(content)) {
-        if (!isProviderOwnedUserMessage(entry, text)) {
-          pushMessage(entry, new UserMessage(ts, stripResolvedFileMentionContext(text)));
+      for (const userText of claudeUserTexts(content)) {
+        if (userText.steering || !isProviderOwnedUserMessage(entry, userText.text)) {
+          pushMessage(entry, new UserMessage(
+            ts,
+            stripResolvedFileMentionContext(userText.text),
+          ));
         }
       }
       continue;
@@ -691,9 +704,12 @@ async function readFirstUserMessage(filePath: string): Promise<{
       }
       const message = asRecord(entry.message);
       if (message.role === 'user') {
-        for (const text of claudeUserTexts(message.content)) {
-          if (!firstMessage && !isProviderOwnedUserMessage(entry, text)) {
-            firstMessage = text;
+        for (const userText of claudeUserTexts(message.content)) {
+          if (
+            !firstMessage
+            && (userText.steering || !isProviderOwnedUserMessage(entry, userText.text))
+          ) {
+            firstMessage = userText.text;
           }
         }
       } else if (!firstMessage) {
@@ -757,10 +773,12 @@ export async function getClaudePreviewFromNativePath(
       const role = message.role;
       if (role === 'user') {
         const text = claudeUserTexts(message.content)
-          .filter((candidate) => !isProviderOwnedUserMessage(entry, candidate))
+          .filter((candidate) => (
+            candidate.steering || !isProviderOwnedUserMessage(entry, candidate.text)
+          ))
           .at(-1);
         if (!text) continue;
-        lastMessage = '> ' + text;
+        lastMessage = '> ' + text.text;
       } else if (role === 'assistant' && entry.isApiErrorMessage !== true) {
         const text = getMessageText(message.content);
         if (!text || isSystemAssistantMessage(text)) {

--- a/server-agents/claude/src/agents/claude/interrupt-receipt.ts
+++ b/server-agents/claude/src/agents/claude/interrupt-receipt.ts
@@ -1,0 +1,76 @@
+import type { AgentLogger } from '@garcon/server-agent-interface';
+import type { ClaudeActiveTurn } from './active-turn.js';
+
+export interface ClaudeInterruptSession {
+  readonly id: string;
+  readonly chatId: string;
+  readonly activeTurn: ClaudeActiveTurn | null;
+  readonly process: { readonly pid?: number } | null;
+}
+
+export interface ClaudeInterruptReceiptHandlers {
+  readonly logger: AgentLogger;
+  readonly finish: () => void;
+  readonly clearAbortTimer: () => void;
+  readonly armCompletionFallback: () => void;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function handleClaudeInterruptReceipt(
+  session: ClaudeInterruptSession,
+  activeTurn: ClaudeActiveTurn,
+  value: unknown,
+  handlers: ClaudeInterruptReceiptHandlers,
+): boolean {
+  const turnIsCurrent = session.activeTurn === activeTurn;
+  const receipt = record(value);
+  const cancelled = stringArray(receipt.cancelled);
+  const stillQueued = stringArray(receipt.still_queued);
+  const inputUuid = activeTurn.protocol.inputUuid;
+  const details = {
+    chatId: session.chatId,
+    turnId: activeTurn.eventMetadata.turnId ?? null,
+    sessionId: session.id.slice(0, 8),
+    processId: session.process?.pid ?? null,
+    inputId: inputUuid.slice(0, 8),
+    cancelledCount: cancelled.length,
+    stillQueuedCount: stillQueued.length,
+  };
+
+  if (!activeTurn.protocol.inputStarted && cancelled.includes(inputUuid)) {
+    handlers.logger.info('Claude CLI confirmed queued input cancellation', details);
+    if (turnIsCurrent) handlers.finish();
+    return true;
+  }
+  if (!activeTurn.protocol.inputStarted && !stillQueued.includes(inputUuid)) {
+    handlers.logger.warn(
+      'Claude CLI interrupt did not confirm queued input cancellation',
+      details,
+    );
+    return false;
+  }
+  if (stillQueued.includes(inputUuid)) {
+    if (turnIsCurrent) {
+      handlers.clearAbortTimer();
+      activeTurn.protocol.markAbortRejected();
+    }
+    handlers.logger.warn('Claude CLI interrupt left the submitted input queued', details);
+    return false;
+  }
+  handlers.logger.debug('Claude CLI acknowledged interrupt', details);
+  if (turnIsCurrent && activeTurn.protocol.inputStarted) {
+    handlers.armCompletionFallback();
+  }
+  return true;
+}

--- a/server-agents/claude/src/agents/claude/interrupt-receipt.ts
+++ b/server-agents/claude/src/agents/claude/interrupt-receipt.ts
@@ -13,6 +13,7 @@ export interface ClaudeInterruptReceiptHandlers {
   readonly finish: () => void;
   readonly clearAbortTimer: () => void;
   readonly armCompletionFallback: () => void;
+  readonly flushDeferredIdle: () => void;
 }
 
 function stringArray(value: unknown): string[] {
@@ -37,6 +38,11 @@ export function handleClaudeInterruptReceipt(
   const receipt = record(value);
   const cancelled = stringArray(receipt.cancelled);
   const stillQueued = stringArray(receipt.still_queued);
+  const steeringReceipt = activeTurn.steering.observeInterruptReceipt({
+    cancelled,
+    stillQueued,
+  });
+  if (steeringReceipt.cancelledCount > 0) handlers.flushDeferredIdle();
   const inputUuid = activeTurn.protocol.inputUuid;
   const details = {
     chatId: session.chatId,
@@ -46,6 +52,8 @@ export function handleClaudeInterruptReceipt(
     inputId: inputUuid.slice(0, 8),
     cancelledCount: cancelled.length,
     stillQueuedCount: stillQueued.length,
+    steeringCancelledCount: steeringReceipt.cancelledCount,
+    steeringStillQueuedCount: steeringReceipt.stillQueuedCount,
   };
 
   if (!activeTurn.protocol.inputStarted && cancelled.includes(inputUuid)) {
@@ -67,6 +75,14 @@ export function handleClaudeInterruptReceipt(
     }
     handlers.logger.warn('Claude CLI interrupt left the submitted input queued', details);
     return false;
+  }
+  if (steeringReceipt.stillQueuedCount > 0) {
+    handlers.logger.warn('Claude CLI interrupt left steering input queued', details);
+    if (turnIsCurrent) {
+      handlers.clearAbortTimer();
+      handlers.armCompletionFallback();
+    }
+    return true;
   }
   handlers.logger.debug('Claude CLI acknowledged interrupt', details);
   if (turnIsCurrent && activeTurn.protocol.inputStarted) {

--- a/server-agents/claude/src/agents/claude/interrupt-receipt.ts
+++ b/server-agents/claude/src/agents/claude/interrupt-receipt.ts
@@ -34,7 +34,6 @@ export function handleClaudeInterruptReceipt(
   value: unknown,
   handlers: ClaudeInterruptReceiptHandlers,
 ): boolean {
-  const turnIsCurrent = session.activeTurn === activeTurn;
   const receipt = record(value);
   const cancelled = stringArray(receipt.cancelled);
   const stillQueued = stringArray(receipt.still_queued);
@@ -43,6 +42,7 @@ export function handleClaudeInterruptReceipt(
     stillQueued,
   });
   if (steeringReceipt.cancelledCount > 0) handlers.flushDeferredIdle();
+  const turnIsCurrent = session.activeTurn === activeTurn;
   const inputUuid = activeTurn.protocol.inputUuid;
   const details = {
     chatId: session.chatId,

--- a/server-agents/claude/src/agents/claude/steering.ts
+++ b/server-agents/claude/src/agents/claude/steering.ts
@@ -1,0 +1,412 @@
+import crypto from 'node:crypto';
+import type {
+  AgentLogger,
+  AgentSteerRequest,
+  AgentSteerResult,
+  AgentSteerTarget,
+} from '@garcon/server-agent-interface';
+import type { ClaudeProcessTransport } from './cli-process-transport.js';
+import type { ClaudeCLIMessage, ClaudeTurnState } from './cli-protocol.js';
+import {
+  buildClaudeSteeringUserContent,
+  buildClaudeUserInputFrame,
+} from './user-input.js';
+
+export const CLAUDE_STEER_WRITE_TIMEOUT_MS = 15_000;
+export const CLAUDE_STEER_IDLE_FENCE_TIMEOUT_MS = 15_000;
+
+export type ClaudeSteeringInputObservation =
+  | { readonly kind: 'queued'; readonly uuid: string }
+  | {
+      readonly kind: 'started';
+      readonly uuid: string;
+      readonly source: 'lifecycle' | 'replay';
+      readonly waitMs: number;
+    }
+  | { readonly kind: 'duplicate-replay'; readonly uuid: string }
+  | {
+      readonly kind: 'terminal';
+      readonly uuid: string;
+      readonly phase: 'before-start' | 'after-start';
+      readonly state: 'completed' | 'cancelled' | 'discarded';
+    };
+
+type ClaudeSteeringInputPhase = 'submitted' | 'queued' | 'active';
+
+interface ClaudeSteeringNativeInput {
+  readonly submittedAt: number;
+  readonly phase: ClaudeSteeringInputPhase;
+}
+
+export class ClaudeTurnSteeringState {
+  #deliveryReservations = new Set<symbol>();
+  #inputs = new Map<string, ClaudeSteeringNativeInput>();
+  #idleDeferred = false;
+  #idleTimer: ReturnType<typeof setTimeout> | null = null;
+  #settlementFailure: string | null = null;
+
+  reserveDelivery(): () => void {
+    const reservation = Symbol('claude-steering-delivery');
+    this.#deliveryReservations.add(reservation);
+    return () => {
+      this.#deliveryReservations.delete(reservation);
+    };
+  }
+
+  markSubmitted(uuid: string): void {
+    this.#inputs.set(uuid, { submittedAt: Date.now(), phase: 'submitted' });
+  }
+
+  removeSubmitted(uuid: string): void {
+    this.#dropNativeInput(uuid);
+  }
+
+  observe(message: ClaudeCLIMessage): ClaudeSteeringInputObservation | null {
+    const uuid = message.type === 'command_lifecycle'
+      ? message.command_uuid
+      : message.type === 'user' && message.isReplay === true
+        ? message.uuid
+        : undefined;
+    if (!uuid) return null;
+    const input = this.#inputs.get(uuid);
+
+    if (
+      message.type === 'command_lifecycle'
+      && message.state === 'queued'
+      && input?.phase === 'submitted'
+    ) {
+      this.#inputs.set(uuid, { ...input, phase: 'queued' });
+      return { kind: 'queued', uuid };
+    }
+
+    if (message.type === 'command_lifecycle' && message.state === 'started') {
+      if (!input || input.phase === 'active') return null;
+      const waitMs = Date.now() - input.submittedAt;
+      this.#inputs.set(uuid, { ...input, phase: 'active' });
+      this.clearDeferredIdle();
+      return { kind: 'started', uuid, source: 'lifecycle', waitMs };
+    }
+
+    if (message.type === 'user' && message.isReplay === true) {
+      if (!input || input.phase === 'active') return null;
+      if (input.phase !== 'queued') {
+        this.#dropNativeInput(uuid);
+        return { kind: 'duplicate-replay', uuid };
+      }
+      const waitMs = Date.now() - input.submittedAt;
+      this.#inputs.set(uuid, { ...input, phase: 'active' });
+      this.clearDeferredIdle();
+      return { kind: 'started', uuid, source: 'replay', waitMs };
+    }
+
+    if (
+      message.type === 'command_lifecycle'
+      && (
+        message.state === 'completed'
+        || message.state === 'cancelled'
+        || message.state === 'discarded'
+      )
+    ) {
+      if (!input) return null;
+      const phase = input.phase === 'active' ? 'after-start' : 'before-start';
+      this.#dropNativeInput(uuid);
+      return { kind: 'terminal', uuid, phase, state: message.state };
+    }
+    return null;
+  }
+
+  get blocksIdleSettlement(): boolean {
+    return this.#deliveryReservations.size > 0 || this.#inputs.size > 0;
+  }
+
+  get hasDeferredIdle(): boolean {
+    return this.#idleDeferred;
+  }
+
+  get submittedCount(): number {
+    let count = 0;
+    for (const input of this.#inputs.values()) {
+      if (input.phase !== 'active') count += 1;
+    }
+    return count;
+  }
+
+  get activeCount(): number {
+    let count = 0;
+    for (const input of this.#inputs.values()) {
+      if (input.phase === 'active') count += 1;
+    }
+    return count;
+  }
+
+  get reservationCount(): number {
+    return this.#deliveryReservations.size;
+  }
+
+  rememberProviderIdle(): void {
+    this.#idleDeferred = true;
+  }
+
+  deferIdle(onTimeout: () => void, timeoutMs: number): void {
+    this.#idleDeferred = true;
+    if (!this.#hasNativeInputWork || this.#idleTimer) return;
+    this.#idleTimer = setTimeout(() => {
+      this.#idleTimer = null;
+      if (!this.#idleDeferred || !this.#hasNativeInputWork) return;
+      onTimeout();
+    }, timeoutMs);
+  }
+
+  clearDeferredIdle(): void {
+    this.#idleDeferred = false;
+    if (this.#idleTimer) clearTimeout(this.#idleTimer);
+    this.#idleTimer = null;
+  }
+
+  recordProtocolFailure(message: string): void {
+    this.#settlementFailure = message;
+  }
+
+  get settlementFailureMessage(): string | null {
+    return this.#settlementFailure;
+  }
+
+  observeInterruptReceipt(input: {
+    readonly cancelled: readonly string[];
+    readonly stillQueued: readonly string[];
+  }): { readonly cancelledCount: number; readonly stillQueuedCount: number } {
+    const cancelled = new Set(input.cancelled);
+    const stillQueued = new Set(input.stillQueued);
+    let cancelledCount = 0;
+    let stillQueuedCount = 0;
+    for (const uuid of this.#inputs.keys()) {
+      if (stillQueued.has(uuid)) {
+        stillQueuedCount += 1;
+      } else if (cancelled.has(uuid)) {
+        this.#dropNativeInput(uuid);
+        cancelledCount += 1;
+      }
+    }
+    return { cancelledCount, stillQueuedCount };
+  }
+
+  clear(): void {
+    this.clearDeferredIdle();
+    this.#inputs.clear();
+    this.#deliveryReservations.clear();
+  }
+
+  #dropNativeInput(uuid: string): void {
+    this.#inputs.delete(uuid);
+    if (!this.#hasNativeInputWork && this.#idleTimer) {
+      clearTimeout(this.#idleTimer);
+      this.#idleTimer = null;
+    }
+  }
+
+  get #hasNativeInputWork(): boolean {
+    return this.#inputs.size > 0;
+  }
+}
+
+export interface ClaudeSteerableTurn {
+  readonly protocol: Pick<ClaudeTurnState, 'inputStarted' | 'abortRequested'>;
+  readonly steering: ClaudeTurnSteeringState;
+  readonly eventMetadata: { readonly turnId?: string };
+}
+
+export interface ClaudeSteerableSession {
+  readonly id: string;
+  readonly chatId: string;
+  readonly activeTurn: ClaudeSteerableTurn | null;
+  readonly process: ReturnType<typeof Bun.spawn> | null;
+  readonly transport: ClaudeProcessTransport<ClaudeCLIMessage> | null;
+}
+
+interface CapturedClaudeSteerTarget {
+  readonly session: ClaudeSteerableSession;
+  readonly activeTurn: ClaudeSteerableTurn;
+  readonly process: ReturnType<typeof Bun.spawn>;
+  readonly transport: ClaudeProcessTransport<ClaudeCLIMessage>;
+}
+
+export interface ClaudeSteeringControllerOptions {
+  readonly session: (agentSessionId: string) => ClaudeSteerableSession | null;
+  readonly isShuttingDown: () => boolean;
+  readonly logger: AgentLogger;
+  readonly writeTimeoutMs: number;
+  readonly flushDeferredIdle: (
+    session: ClaudeSteerableSession,
+    activeTurn: ClaudeSteerableTurn,
+  ) => void;
+}
+
+export class ClaudeSteeringController {
+  readonly #targets = new WeakMap<AgentSteerTarget, CapturedClaudeSteerTarget>();
+  readonly #options: ClaudeSteeringControllerOptions;
+
+  constructor(options: ClaudeSteeringControllerOptions) {
+    this.#options = options;
+  }
+
+  captureTarget(agentSessionId: string): AgentSteerTarget | null {
+    if (this.#options.isShuttingDown()) return null;
+    const session = this.#options.session(agentSessionId);
+    const activeTurn = session?.activeTurn;
+    if (
+      !session
+      || !activeTurn
+      || !activeTurn.protocol.inputStarted
+      || activeTurn.protocol.abortRequested
+      || !session.process
+      || !session.transport
+    ) return null;
+
+    const target = Object.freeze({});
+    this.#targets.set(target, {
+      session,
+      activeTurn,
+      process: session.process,
+      transport: session.transport,
+    });
+    return target;
+  }
+
+  async steer(request: AgentSteerRequest): Promise<AgentSteerResult> {
+    const captured = request.target ? this.#targets.get(request.target) : undefined;
+    if (!captured) return rejectedClaudeSteer('no-active-turn', 'No active Claude turn');
+    this.#targets.delete(request.target!);
+
+    const initialRejection = this.#validateTarget(request, captured);
+    if (initialRejection) return initialRejection;
+
+    const release = captured.activeTurn.steering.reserveDelivery();
+    try {
+      const nativeInputId = crypto.randomUUID();
+      const frame = buildClaudeUserInputFrame({
+        content: buildClaudeSteeringUserContent(request.input),
+        sessionId: captured.session.id,
+        uuid: nativeInputId,
+        priority: 'next',
+      });
+
+      await request.prepareDelivery();
+      const commitRejection = this.#validateTarget(request, captured);
+      if (commitRejection) return commitRejection;
+
+      let attempted = false;
+      const writeStartedAt = Date.now();
+      try {
+        await captured.transport.writeLine(frame, {
+          beforeWrite: () => {
+            attempted = true;
+            captured.activeTurn.steering.markSubmitted(nativeInputId);
+          },
+          attemptTimeoutMs: this.#options.writeTimeoutMs,
+          killProcessAfterAttemptFailure: true,
+        });
+      } catch {
+        captured.activeTurn.steering.removeSubmitted(nativeInputId);
+        return {
+          kind: 'failed',
+          outcome: attempted ? 'unknown' : 'not-sent',
+          message: attempted
+            ? 'Claude steering delivery could not be confirmed'
+            : 'Claude steering input was not sent',
+        };
+      }
+      this.#options.logger.debug('Claude steering input accepted for native delivery', {
+        chatId: captured.session.chatId,
+        turnId: captured.activeTurn.eventMetadata.turnId ?? null,
+        sessionId: captured.session.id.slice(0, 8),
+        inputId: nativeInputId.slice(0, 8),
+        writeMs: Date.now() - writeStartedAt,
+        submittedSteers: captured.activeTurn.steering.submittedCount,
+      });
+      return { kind: 'accepted' };
+    } finally {
+      release();
+      this.#options.flushDeferredIdle(captured.session, captured.activeTurn);
+    }
+  }
+
+  handleObservation(
+    session: ClaudeSteerableSession,
+    activeTurn: ClaudeSteerableTurn,
+    observation: ClaudeSteeringInputObservation,
+  ): void {
+    if (session.activeTurn !== activeTurn) return;
+    if (observation.kind === 'queued') return;
+    if (observation.kind === 'started') {
+      this.#options.logger.debug('Claude steering input started', {
+        chatId: session.chatId,
+        turnId: activeTurn.eventMetadata.turnId ?? null,
+        sessionId: session.id.slice(0, 8),
+        inputId: observation.uuid.slice(0, 8),
+        source: observation.source,
+        submitToStartMs: observation.waitMs,
+        remainingSubmitted: activeTurn.steering.submittedCount,
+      });
+      return;
+    }
+
+    if (observation.kind === 'duplicate-replay') {
+      activeTurn.steering.recordProtocolFailure(
+        'Claude CLI replayed steering input without accepting it into the command queue.',
+      );
+      this.#options.flushDeferredIdle(session, activeTurn);
+      return;
+    }
+
+    if (observation.phase === 'after-start' && observation.state === 'completed') {
+      this.#options.flushDeferredIdle(session, activeTurn);
+      return;
+    }
+    if (!activeTurn.protocol.abortRequested) {
+      activeTurn.steering.recordProtocolFailure(
+        observation.phase === 'before-start'
+          ? `Claude CLI ${observation.state} accepted steering input before it started.`
+          : `Claude CLI ${observation.state} steering input before it completed.`,
+      );
+    }
+    this.#options.logger.warn('Claude steering input ended without normal completion', {
+      chatId: session.chatId,
+      turnId: activeTurn.eventMetadata.turnId ?? null,
+      sessionId: session.id.slice(0, 8),
+      inputId: observation.uuid.slice(0, 8),
+      phase: observation.phase,
+      state: observation.state,
+      abortRequested: activeTurn.protocol.abortRequested,
+    });
+    this.#options.flushDeferredIdle(session, activeTurn);
+  }
+
+  #validateTarget(
+    request: AgentSteerRequest,
+    captured: CapturedClaudeSteerTarget,
+  ): AgentSteerResult | null {
+    const current = this.#options.session(request.agentSessionId);
+    if (!current || !current.activeTurn || this.#options.isShuttingDown()) {
+      return rejectedClaudeSteer('no-active-turn', 'No active Claude turn');
+    }
+    if (
+      current !== captured.session
+      || current.chatId !== request.chatId
+      || current.activeTurn !== captured.activeTurn
+      || current.process !== captured.process
+      || current.transport !== captured.transport
+      || !captured.activeTurn.protocol.inputStarted
+      || captured.activeTurn.protocol.abortRequested
+    ) {
+      return rejectedClaudeSteer('turn-changed', 'The active Claude turn changed');
+    }
+    return null;
+  }
+}
+
+function rejectedClaudeSteer(
+  reason: Extract<AgentSteerResult, { kind: 'rejected' }>['reason'],
+  message: string,
+): AgentSteerResult {
+  return { kind: 'rejected', reason, message };
+}

--- a/server-agents/claude/src/agents/claude/steering.ts
+++ b/server-agents/claude/src/agents/claude/steering.ts
@@ -83,7 +83,6 @@ export class ClaudeTurnSteeringState {
       if (!input || input.phase === 'active') return null;
       const waitMs = Date.now() - input.submittedAt;
       this.#inputs.set(uuid, { ...input, phase: 'active' });
-      this.clearDeferredIdle();
       return { kind: 'started', uuid, source: 'lifecycle', waitMs };
     }
 
@@ -95,7 +94,6 @@ export class ClaudeTurnSteeringState {
       }
       const waitMs = Date.now() - input.submittedAt;
       this.#inputs.set(uuid, { ...input, phase: 'active' });
-      this.clearDeferredIdle();
       return { kind: 'started', uuid, source: 'replay', waitMs };
     }
 

--- a/server-agents/claude/src/agents/claude/user-input.ts
+++ b/server-agents/claude/src/agents/claude/user-input.ts
@@ -11,7 +11,11 @@ export interface ClaudeUserInputFrameOptions {
   readonly content: unknown;
   readonly sessionId: string;
   readonly uuid: string;
+  readonly priority?: 'next';
 }
+
+export const CLAUDE_STEERING_PROMPT_PREFIX =
+  'The user sent steering guidance for the active task:\n\n';
 
 export function buildClaudeUserInputFrame(options: ClaudeUserInputFrameOptions): string {
   return JSON.stringify({
@@ -20,6 +24,7 @@ export function buildClaudeUserInputFrame(options: ClaudeUserInputFrameOptions):
     parent_tool_use_id: null,
     session_id: options.sessionId,
     uuid: options.uuid,
+    ...(options.priority ? { priority: options.priority } : {}),
   });
 }
 
@@ -48,4 +53,29 @@ export function buildClaudeInitialUserContent(
   }
   blocks.push({ type: 'text', text: prompt });
   return blocks;
+}
+
+export function buildClaudeSteeringUserContent(input: string): readonly [{
+  readonly type: 'text';
+  readonly text: string;
+}] {
+  return [{
+    type: 'text',
+    text: `${CLAUDE_STEERING_PROMPT_PREFIX}${input}`,
+  }];
+}
+
+export function claudeSteeringInputsFromNativeContent(
+  content: unknown,
+): readonly string[] | null {
+  if (!Array.isArray(content) || content.length === 0) return null;
+  const inputs: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object' || Array.isArray(block)) return null;
+    if (!('type' in block) || block.type !== 'text') return null;
+    if (!('text' in block) || typeof block.text !== 'string') return null;
+    if (!block.text.startsWith(CLAUDE_STEERING_PROMPT_PREFIX)) return null;
+    inputs.push(block.text.slice(CLAUDE_STEERING_PROMPT_PREFIX.length));
+  }
+  return inputs;
 }

--- a/server-agents/claude/src/agents/claude/user-input.ts
+++ b/server-agents/claude/src/agents/claude/user-input.ts
@@ -1,0 +1,51 @@
+import type { AgentAttachment } from '@garcon/common/agent-execution';
+import {
+  appendTextAttachmentContext,
+  attachmentDocumentBlock,
+  documentAttachments,
+  imageAttachments,
+  parseAttachmentDataUrl,
+} from '@garcon/server-agent-common/shared/attachments';
+
+export interface ClaudeUserInputFrameOptions {
+  readonly content: unknown;
+  readonly sessionId: string;
+  readonly uuid: string;
+}
+
+export function buildClaudeUserInputFrame(options: ClaudeUserInputFrameOptions): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: options.content },
+    parent_tool_use_id: null,
+    session_id: options.sessionId,
+    uuid: options.uuid,
+  });
+}
+
+export function buildClaudeInitialUserContent(
+  command: string,
+  attachments?: readonly AgentAttachment[],
+): unknown {
+  const prompt = appendTextAttachmentContext(command, attachments);
+  const images = imageAttachments(attachments);
+  const documents = documentAttachments(attachments);
+  if (images.length === 0 && documents.length === 0) return prompt;
+
+  const blocks: unknown[] = [];
+  for (const image of images) {
+    const parts = parseAttachmentDataUrl(image.data);
+    if (parts) {
+      blocks.push({
+        type: 'image',
+        source: { type: 'base64', media_type: parts.mimeType, data: parts.base64 },
+      });
+    }
+  }
+  for (const document of documents) {
+    const block = attachmentDocumentBlock(document);
+    if (block) blocks.push(block);
+  }
+  blocks.push({ type: 'text', text: prompt });
+  return blocks;
+}

--- a/server-agents/claude/src/index.ts
+++ b/server-agents/claude/src/index.ts
@@ -86,7 +86,7 @@ export default class ClaudeAgentIntegration implements AgentIntegration {
   readonly auth: NonNullable<AgentIntegration['auth']>;
   readonly commands: NonNullable<AgentIntegration['commands']>;
   readonly forking;
-  readonly steering = null;
+  readonly steering: NonNullable<AgentIntegration['steering']>;
   readonly goals = null;
   readonly endpoints: NonNullable<AgentIntegration['endpoints']>;
   readonly singleQuery: NonNullable<AgentIntegration['singleQuery']>;
@@ -198,6 +198,10 @@ export default class ClaudeAgentIntegration implements AgentIntegration {
       semanticDigest: claudeForkSemanticDigest,
       allowUnmaterializedWholeSession: true,
     });
+    this.steering = {
+      captureTarget: request => runtime.captureSteerTarget(request.agentSessionId),
+      steer: request => runtime.steer(request),
+    };
     this.endpoints = {
       async validate(selection) {
         if (selection.protocol !== 'anthropic-messages') {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -237,7 +237,7 @@
 	"chat_notice_steer_prompt_required": "Add guidance after /steer.",
 	"chat_notice_steer_unsupported": "/steer is not supported by this agent.",
 	"chat_notice_steer_attachments_unavailable": "Remove attachments before steering the active turn.",
-	"chat_notice_steer_turn_unavailable": "There is no active turn to steer.",
+	"chat_notice_steer_turn_unavailable": "There isn't a turn ready for steering.",
 	"chat_notice_steer_turn_changed": "The active turn changed before steering could be applied.",
 	"chat_notice_steer_turn_not_steerable": "This kind of active turn cannot be steered.",
 	"chat_notice_steer_capacity_exhausted": "Steering is temporarily unavailable until the server restarts.",

--- a/web/src/lib/chat/composer/slash-commands.ts
+++ b/web/src/lib/chat/composer/slash-commands.ts
@@ -51,7 +51,7 @@ export const BUILTIN_SLASH_COMMANDS: readonly SlashCommand[] = [
 	{
 		name: 'steer',
 		source: 'command',
-		description: 'Send guidance to the active turn immediately',
+		description: 'Send guidance to the active turn',
 	},
 	{
 		name: 's',

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -2334,6 +2334,26 @@ describe('ConversationSessionController', () => {
 		});
 	});
 
+	it('uses a provider-neutral notice when a turn is not ready for steering', async () => {
+		const { deps } = createDeps(createRunningChat({ agentId: 'claude', isProcessing: true }));
+		deps.composerState.inputText = '/steer Keep the current turn';
+		deps.composerState.clearAfterSubmit.mockImplementation(() => {
+			deps.composerState.inputText = '';
+		});
+		mockSteerChat.mockRejectedValueOnce(new ApiError(
+			409,
+			'No active turn',
+			'STEER_TURN_UNAVAILABLE',
+		));
+
+		await new ConversationSessionController(deps).submitForChat('chat-1');
+
+		expect(deps.chatState.localNotices[0]).toMatchObject({
+			noticeType: 'error',
+			content: "There isn't a turn ready for steering.",
+		});
+	});
+
 	it('explains when the server has exhausted retained steering identities', async () => {
 		const { deps } = createDeps(createRunningChat({ agentId: 'codex', isProcessing: true }));
 		deps.composerState.inputText = '/steer Keep the current turn';

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -408,7 +408,7 @@ function createDeps(chat = createRunningChat()) {
 			]),
 			supportsFork: vi.fn(() => true),
 			supportsForkWhileRunning: vi.fn(() => false),
-			supportsSteering: vi.fn((agentId: string) => agentId === 'codex'),
+			supportsSteering: vi.fn((agentId: string) => agentId === 'claude' || agentId === 'codex'),
 			supportsGoals: vi.fn((agentId: string) => agentId === 'codex'),
 		},
 		readReceiptOutbox: {

--- a/web/src/lib/components/chat/__tests__/SlashCommandMenu.test.ts
+++ b/web/src/lib/components/chat/__tests__/SlashCommandMenu.test.ts
@@ -195,7 +195,7 @@ describe('SlashCommandMenu', () => {
 		});
 
 		expect(screen.getByText('/steer')).toBeTruthy();
-		expect(screen.getByText('Send guidance to the active turn immediately')).toBeTruthy();
+		expect(screen.getByText('Send guidance to the active turn')).toBeTruthy();
 		unmount();
 
 		render(SlashCommandMenuTestHost, {


### PR DESCRIPTION
Claude guidance previously had to wait as a future Garcon turn even though Claude Code supports next-priority input. This change exposes the existing provider-neutral steering capability for Claude, delivers guidance through the active SDK process with strict lifecycle, idle, failure, and cancellation fencing, preserves the user's exact text across native transcript projection, and adds deterministic pinned-binary coverage for inline delivery, FIFO batching, deduplication, slash handling, and Stop behavior.
