### PR TITLE
fix(codex): preserve GPT-5.6 max effort

### DIFF
--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -673,15 +673,31 @@ describe('Codex app-server request builders', () => {
     expect(mapThinkingModeToCodexEffort('medium')).toBe('medium');
     expect(mapThinkingModeToCodexEffort('high')).toBe('high');
     expect(mapThinkingModeToCodexEffort('xhigh')).toBe('xhigh');
-    expect(mapThinkingModeToCodexEffort('max')).toBe('xhigh');
+    expect(mapThinkingModeToCodexEffort('max', 'gpt-5.5')).toBe('xhigh');
+    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+      expect(mapThinkingModeToCodexEffort('max', model)).toBe('max');
+    }
     expect(mapThinkingModeToCodexEffort('ultra')).toBe('ultra');
   });
 
-  it('preserves the interactive max effort mapping in turn params', () => {
+  it('uses max effort for GPT-5.6 turn params', () => {
     const params = buildTurnStartParams({
       threadId: 'thread-1',
       command: 'hello',
-      model: 'gpt-5.4-codex',
+      model: 'gpt-5.6-luna',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      thinkingMode: 'max',
+    });
+
+    expect(params.effort).toBe('max');
+  });
+
+  it('keeps max compatible with models that only support xhigh', () => {
+    const params = buildTurnStartParams({
+      threadId: 'thread-1',
+      command: 'hello',
+      model: 'gpt-5.5',
       projectPath: '/repo',
       permissionMode: 'default',
       thinkingMode: 'max',

--- a/server-agents/codex/src/agents/codex/app-server/request-builders.ts
+++ b/server-agents/codex/src/agents/codex/app-server/request-builders.ts
@@ -50,15 +50,18 @@ export function codexSandboxSettings(permissionMode: PermissionMode): CodexSandb
   return CODEX_SANDBOX[effectivePermissionMode] ?? CODEX_SANDBOX.default;
 }
 
-// Preserves the established interactive mapping. One-shot generation owns its
-// stricter exact-effort mapping in run-single-query.ts.
-export function mapThinkingModeToCodexEffort(thinkingMode: ThinkingMode | undefined): string | undefined {
+// Preserves xhigh compatibility for older models while allowing GPT-5.6 to use
+// the max effort introduced for that model family.
+export function mapThinkingModeToCodexEffort(
+  thinkingMode: ThinkingMode | undefined,
+  model?: string,
+): string | undefined {
   switch (thinkingMode) {
     case 'low': return 'low';
     case 'medium': return 'medium';
     case 'high': return 'high';
     case 'xhigh': return 'xhigh';
-    case 'max': return 'xhigh';
+    case 'max': return model === 'gpt-5.6' || model?.startsWith('gpt-5.6-') ? 'max' : 'xhigh';
     case 'ultra': return 'ultra';
     default: return undefined;
   }
@@ -156,7 +159,7 @@ export function buildTurnStartParams(request: {
     model: request.model,
   };
   if (request.clientMessageId) params.clientUserMessageId = request.clientMessageId;
-  const effort = mapThinkingModeToCodexEffort(request.thinkingMode);
+  const effort = mapThinkingModeToCodexEffort(request.thinkingMode, request.model);
   if (effort) params.effort = effort;
   return params;
 }


### PR DESCRIPTION
## Before
- OpenAI documents `max` reasoning effort for the GPT-5.6 family, including Luna.
- Garcon converted the interactive Max setting to `xhigh` for every Codex model.

```mermaid
flowchart LR
  A[Max setting] --> B[thinkingMode: max]
  B --> C[Codex turn builder]
  C --> D[effort: xhigh]
```

## After

```mermaid
flowchart LR
  A[Max setting] --> B[thinkingMode: max]
  B --> C{GPT-5.6 family?}
  C -->|Yes| D[effort: max]
  C -->|No| E[effort: xhigh]
```

The interactive Codex path now preserves literal `max` for GPT-5.6, Sol, Terra, and Luna while retaining the existing `xhigh` compatibility fallback for older models.

Official contract: https://developers.openai.com/api/docs/guides/latest-model

## Files
- `request-builders.ts` selects the effort using both thinking mode and model family.
- `app-server.test.js` covers all GPT-5.6 variants, Luna turn payloads, and the older-model fallback.

## Tests
- Codex app-server suite: 168 passed
- Codex package typecheck: passed
- `bun run check`: passed
- `bun run start --port 0`: production build and startup completed before timeout
- Hosted build, server, web, protocol integration, live conformance, Chromium, and Lightpanda checks: passed

Prompted by: yk (@chiayong)
