### PR TITLE
Combine Git diff settings with responsive actions

### DIFF
--- a/integration-tests/tests/chromium/git-history-breakpoints.test.ts
+++ b/integration-tests/tests/chromium/git-history-breakpoints.test.ts
@@ -13,6 +13,8 @@ const WEB_BUILD_INDEX = join(REPO_ROOT, 'web', 'build', 'index.html');
 const ARTIFACT_ROOT = join(REPO_ROOT, 'integration-tests', 'artifacts', 'chromium');
 const PANEL_SELECTOR =
   '[role="tabpanel"][data-workspace-surface-id="singleton:git-history"][aria-hidden="false"]';
+const COMPARE_PANEL_SELECTOR =
+  '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"][aria-hidden="false"]';
 const DETAILS_SELECTOR = `${PANEL_SELECTOR} [data-git-diff-document]`;
 const SEGMENTED_SELECTOR = `${DETAILS_SELECTOR} [data-git-history-segmented-navigation]`;
 const FILES_PANE_SELECTOR = `${DETAILS_SELECTOR} [data-git-history-files-pane]`;
@@ -182,38 +184,48 @@ async function waitForLayout(page: Page, layout: 'narrow' | 'wide'): Promise<voi
   );
 }
 
-describe('Chromium Git History breakpoint presentation', () => {
+async function openChatWorkspace(
+  fixture: ChromiumFixture,
+  projectPath: string,
+  seed: string,
+): Promise<void> {
+  const chatId = fixture.integration.newChatId();
+  const started = await fixture.integration.client.startDirectChat({
+    chatId,
+    content: seed,
+    projectPath,
+    agent: fixture.integration.directAgents.openAi,
+  });
+  await fixture.integration.client.waitForTurnTerminal(chatId, started.turnId);
+
+  const response = await fixture.page.goto(
+    `${fixture.integration.garcon.baseUrl}/chat/${encodeURIComponent(chatId)}`,
+    { waitUntil: 'domcontentloaded' },
+  );
+  if (!response?.ok()) throw new Error(`SPA navigation failed with ${response?.status()}.`);
+  await fixture.page.locator('[data-floating-workspace-toolbar]').waitFor({
+    state: 'visible',
+    timeout: 20_000,
+  });
+}
+
+async function openWorkspaceSurface(page: Page, label: string): Promise<void> {
+  await page
+    .locator(
+      '[data-floating-workspace-toolbar] [data-workspace-taskbar-end]' +
+        ' [data-slot="dropdown-menu-trigger"]',
+    )
+    .click();
+  await page.getByRole('menuitem', { name: label }).click();
+}
+
+describe('Chromium Git responsive presentation', () => {
   test('segments commit details in the 560-839px band and keeps the tree toggle in wide', async () => {
     await withChromiumFixture('git-history-breakpoints', async (fixture) => {
       const project = fixture.integration.dirs.project;
       await createHistoryFixture(project);
-
-      const chatId = fixture.integration.newChatId();
-      const started = await fixture.integration.client.startDirectChat({
-        chatId,
-        content: 'history-breakpoints-seed',
-        projectPath: project,
-        agent: fixture.integration.directAgents.openAi,
-      });
-      await fixture.integration.client.waitForTurnTerminal(chatId, started.turnId);
-
-      const response = await fixture.page.goto(
-        `${fixture.integration.garcon.baseUrl}/chat/${encodeURIComponent(chatId)}`,
-        { waitUntil: 'domcontentloaded' },
-      );
-      if (!response?.ok()) throw new Error(`SPA navigation failed with ${response?.status()}.`);
-      await fixture.page.locator('[data-floating-workspace-toolbar]').waitFor({
-        state: 'visible',
-        timeout: 20_000,
-      });
-
-      await fixture.page
-        .locator(
-          '[data-floating-workspace-toolbar] [data-workspace-taskbar-end]'
-            + ' [data-slot="dropdown-menu-trigger"]',
-        )
-        .click();
-      await fixture.page.getByRole('menuitem', { name: 'Open Git History' }).click();
+      await openChatWorkspace(fixture, project, 'history-breakpoints-seed');
+      await openWorkspaceSurface(fixture.page, 'Open Git History');
       await fixture.page.locator(PANEL_SELECTOR).waitFor({ state: 'visible', timeout: 20_000 });
       await fixture.page.waitForFunction(
         (selector) => document.querySelector(selector)?.textContent?.includes('second revision')
@@ -292,6 +304,99 @@ describe('Chromium Git History breakpoint presentation', () => {
       });
       expect(await fixture.page.locator(`${DETAILS_SELECTOR} [data-git-tree-resizer]`).count())
         .toBe(1);
+      expect(fixture.browserErrors).toEqual([]);
+    });
+  });
+
+  test('keeps narrow Compare controls in one ordered non-overlapping menu', async () => {
+    await withChromiumFixture('git-compare-responsive-actions', async (fixture) => {
+      const project = fixture.integration.dirs.project;
+      await createHistoryFixture(project);
+      await writeFile(join(project, 'review.txt'), 'working tree revision\n', 'utf8');
+      await openChatWorkspace(fixture, project, 'compare-responsive-actions-seed');
+      await openWorkspaceSurface(fixture.page, 'Open Git Compare');
+
+      await fixture.page.locator(COMPARE_PANEL_SELECTOR).waitFor({
+        state: 'visible',
+        timeout: 20_000,
+      });
+      await fixture.page.locator(`${COMPARE_PANEL_SELECTOR} [data-git-diff-document]`).waitFor({
+        state: 'visible',
+        timeout: 20_000,
+      });
+      const actionRoot = fixture.page.locator(
+        `${COMPARE_PANEL_SELECTOR} [data-responsive-surface-actions]`,
+      );
+      await actionRoot.evaluate((element: HTMLElement) => {
+        element.style.flex = '0 0 32px';
+        element.style.width = '32px';
+      });
+      await fixture.page.waitForFunction(
+        (selector) => {
+          const root = document.querySelector(selector);
+          return root?.querySelectorAll('[data-surface-action-id]').length === 0;
+        },
+        `${COMPARE_PANEL_SELECTOR} [data-responsive-surface-actions]`,
+        { timeout: 20_000 },
+      );
+
+      const visibleButtons = await actionRoot.locator('button').evaluateAll((buttons) =>
+        buttons
+          .filter((button) => {
+            const style = getComputedStyle(button);
+            return style.visibility !== 'hidden' && button.getBoundingClientRect().width > 0;
+          })
+          .map((button) => {
+            const rect = button.getBoundingClientRect();
+            return {
+              left: rect.left,
+              right: rect.right,
+              width: rect.width,
+            };
+          }),
+      );
+      expect(visibleButtons).toHaveLength(1);
+      expect(visibleButtons[0]?.width).toBe(32);
+      expect(await actionRoot.locator('[data-responsive-surface-menu-trigger]').count()).toBe(1);
+      expect(
+        await fixture.page
+          .locator(COMPARE_PANEL_SELECTOR)
+          .getByRole('button', { name: 'Diff settings' })
+          .count(),
+      ).toBe(0);
+
+      await actionRoot.locator('[data-responsive-surface-menu-trigger]').click();
+      const menu = fixture.page.locator('[data-slot="dropdown-menu-content"]');
+      await menu.getByText('Diff settings', { exact: true }).waitFor({ state: 'visible' });
+      const order = await menu.evaluate((element) => {
+        const settings = Array.from(element.querySelectorAll('*')).find(
+          (candidate) => candidate.textContent?.trim() === 'Diff settings',
+        );
+        const separator = element.querySelector('[data-slot="dropdown-menu-separator"]');
+        const edit = Array.from(element.querySelectorAll('[role="menuitem"]')).find(
+          (candidate) => candidate.textContent?.trim() === 'Edit',
+        );
+        const refresh = Array.from(element.querySelectorAll('[role="menuitem"]')).find(
+          (candidate) => candidate.textContent?.trim() === 'Refresh',
+        );
+        if (!settings || !separator || !edit || !refresh) return null;
+        return {
+          settingsBeforeSeparator: Boolean(
+            settings.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING,
+          ),
+          separatorBeforeEdit: Boolean(
+            separator.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING,
+          ),
+          editBeforeRefresh: Boolean(
+            edit.compareDocumentPosition(refresh) & Node.DOCUMENT_POSITION_FOLLOWING,
+          ),
+        };
+      });
+      expect(order).toEqual({
+        settingsBeforeSeparator: true,
+        separatorBeforeEdit: true,
+        editBeforeRefresh: true,
+      });
       expect(fixture.browserErrors).toEqual([]);
     });
   });

--- a/integration-tests/tests/e2e/git-multi-repo-chat-switch.test.ts
+++ b/integration-tests/tests/e2e/git-multi-repo-chat-switch.test.ts
@@ -218,25 +218,62 @@ async function clickPanelButton(
   await fixture.page.waitForFunction(
     ({ panelSelector, label }) => {
       const panel = document.querySelector(panelSelector);
-      const button = [...(panel?.querySelectorAll('button') ?? [])].find((element) => {
+      const button = [...(panel?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find((element) => {
+        if (element.hasAttribute('data-surface-action-measure')) return false;
         const accessible = element.getAttribute('aria-label') || element.textContent?.trim() || '';
         return accessible === label;
       });
-      return button instanceof HTMLButtonElement && !button.disabled;
+      if (button) return !button.disabled && button.getAttribute('aria-disabled') !== 'true';
+      const menuTrigger = panel?.querySelector<HTMLButtonElement>(
+        '[data-responsive-surface-menu-trigger]',
+      );
+      return Boolean(menuTrigger && !menuTrigger.disabled);
     },
     { timeout: 20_000 },
     { panelSelector: GIT_PANEL, label: name },
   );
-  await fixture.page.evaluate(
+  const destination = await fixture.page.evaluate(
     ({ panelSelector, label }) => {
       const panel = document.querySelector(panelSelector);
-      const button = [...(panel?.querySelectorAll('button') ?? [])].find((element) => {
+      const button = [...(panel?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find((element) => {
+        if (element.hasAttribute('data-surface-action-measure')) return false;
         const accessible = element.getAttribute('aria-label') || element.textContent?.trim() || '';
         return accessible === label;
       });
-      if (!(button instanceof HTMLButtonElement)) throw new Error(`Missing panel button: ${label}`);
-      button.click();
+      if (button) {
+        button.click();
+        return 'direct';
+      }
+      const menuTrigger = panel?.querySelector<HTMLButtonElement>(
+        '[data-responsive-surface-menu-trigger]',
+      );
+      if (!menuTrigger) throw new Error(`Missing panel action: ${label}`);
+      menuTrigger.click();
+      return 'menu';
     },
     { panelSelector: GIT_PANEL, label: name },
   );
+  if (destination === 'direct') return;
+
+  await fixture.page.waitForFunction(
+    (label) => {
+      const item = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((element) => {
+        const accessible = element.getAttribute('aria-label') || element.textContent?.trim() || '';
+        return accessible === label;
+      });
+      return Boolean(
+        item && !item.hasAttribute('data-disabled') && item.getAttribute('aria-disabled') !== 'true',
+      );
+    },
+    { timeout: 20_000 },
+    name,
+  );
+  await fixture.page.evaluate((label) => {
+    const item = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((element) => {
+      const accessible = element.getAttribute('aria-label') || element.textContent?.trim() || '';
+      return accessible === label;
+    });
+    if (!item) throw new Error(`Missing panel menu action: ${label}`);
+    item.click();
+  }, name);
 }

--- a/web/src/lib/components/git/GitCompareToolbar.svelte
+++ b/web/src/lib/components/git/GitCompareToolbar.svelte
@@ -3,11 +3,8 @@
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import type { GitCompareSurfaceController } from '$lib/git/review/git-compare-surface.svelte.js';
 	import type { ResponsiveSurfaceAction } from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
-	import {
-		getGitReviewDisplay,
-		getLocalSettings,
-	} from '$lib/context';
-	import GitDiffSettingsMenu from './GitDiffSettingsMenu.svelte';
+	import { getGitReviewDisplay, getLocalSettings } from '$lib/context';
+	import GitDiffSettingsMenuContent from './GitDiffSettingsMenuContent.svelte';
 	import GitSurfaceToolbar from './GitSurfaceToolbar.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -49,21 +46,22 @@
 	]);
 </script>
 
+{#snippet diffSettings()}
+	<GitDiffSettingsMenuContent
+		diffMode={reviewDisplay.diffMode}
+		contextLines={reviewDisplay.contextLines}
+		diffFontSize={localSettings.gitDiffFontSize}
+		onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}
+		onSetContextLines={(lines) => reviewDisplay.setContextLines(lines)}
+		onSetDiffFontSize={(size) => localSettings.set('gitDiffFontSize', size)}
+	/>
+{/snippet}
+
 <GitSurfaceToolbar
 	target={controller.target}
 	{presentation}
 	{actions}
 	{onClose}
 	{closeDisabled}
->
-	{#snippet fixed()}
-		<GitDiffSettingsMenu
-			diffMode={reviewDisplay.diffMode}
-			contextLines={reviewDisplay.contextLines}
-			diffFontSize={localSettings.gitDiffFontSize}
-			onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}
-			onSetContextLines={(lines) => reviewDisplay.setContextLines(lines)}
-			onSetDiffFontSize={(size) => localSettings.set('gitDiffFontSize', size)}
-		/>
-	{/snippet}
-</GitSurfaceToolbar>
+	menuLeadingContent={diffSettings}
+/>

--- a/web/src/lib/components/git/GitDiffSettingsMenuContent.svelte
+++ b/web/src/lib/components/git/GitDiffSettingsMenuContent.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import {
+		DropdownMenuLabel,
+		DropdownMenuRadioGroup,
+		DropdownMenuRadioItem,
+		DropdownMenuSub,
+		DropdownMenuSubContent,
+		DropdownMenuSubTrigger,
+	} from '$lib/components/ui/dropdown-menu';
+	import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
+	import { FONT_SIZE_OPTIONS } from '$lib/utils/font-size.js';
+	import * as m from '$lib/paraglide/messages.js';
+
+	let {
+		diffMode,
+		contextLines,
+		diffFontSize,
+		onSetDiffMode,
+		onSetContextLines,
+		onSetDiffFontSize,
+	}: {
+		diffMode: DiffMode;
+		contextLines: number;
+		diffFontSize: string;
+		onSetDiffMode: (mode: DiffMode) => void;
+		onSetContextLines: (lines: number) => boolean | void;
+		onSetDiffFontSize: (size: string) => void;
+	} = $props();
+
+	const contextOptions = [3, 5, 10, 20] as const;
+	let contextChangeBlocked = $state(false);
+
+	function setDiffMode(value: string): void {
+		if (value === 'unified' || value === 'split') onSetDiffMode(value);
+	}
+
+	function setContextLines(value: string): void {
+		const lines = Number(value);
+		if (!contextOptions.includes(lines as (typeof contextOptions)[number])) return;
+		contextChangeBlocked = onSetContextLines(lines) === false;
+	}
+</script>
+
+<DropdownMenuLabel class="text-xs text-muted-foreground">
+	{m.git_diff_settings()}
+</DropdownMenuLabel>
+
+<DropdownMenuSub>
+	<DropdownMenuSubTrigger>
+		<span class="flex min-w-0 flex-1 items-center justify-between gap-4">
+			<span>Font size</span>
+			<span class="text-xs text-muted-foreground">{diffFontSize}px</span>
+		</span>
+	</DropdownMenuSubTrigger>
+	<DropdownMenuSubContent class="w-36">
+		<DropdownMenuRadioGroup value={diffFontSize} onValueChange={onSetDiffFontSize}>
+			{#each FONT_SIZE_OPTIONS as size (size)}
+				<DropdownMenuRadioItem value={size} closeOnSelect={false}>
+					{size}px
+				</DropdownMenuRadioItem>
+			{/each}
+		</DropdownMenuRadioGroup>
+	</DropdownMenuSubContent>
+</DropdownMenuSub>
+
+<DropdownMenuSub>
+	<DropdownMenuSubTrigger>
+		<span class="flex min-w-0 flex-1 items-center justify-between gap-4">
+			<span>Diff mode</span>
+			<span class="text-xs text-muted-foreground">
+				{diffMode === 'unified' ? 'Unified' : 'Split'}
+			</span>
+		</span>
+	</DropdownMenuSubTrigger>
+	<DropdownMenuSubContent class="w-36">
+		<DropdownMenuRadioGroup value={diffMode} onValueChange={setDiffMode}>
+			<DropdownMenuRadioItem value="unified" closeOnSelect={false}>Unified</DropdownMenuRadioItem>
+			<DropdownMenuRadioItem value="split" closeOnSelect={false}>Split</DropdownMenuRadioItem>
+		</DropdownMenuRadioGroup>
+	</DropdownMenuSubContent>
+</DropdownMenuSub>
+
+<DropdownMenuSub>
+	<DropdownMenuSubTrigger>
+		<span class="flex min-w-0 flex-1 items-center justify-between gap-4">
+			<span>Context lines</span>
+			<span class="text-xs text-muted-foreground">{contextLines}</span>
+		</span>
+	</DropdownMenuSubTrigger>
+	<DropdownMenuSubContent class="w-40">
+		<DropdownMenuRadioGroup bind:value={() => String(contextLines), setContextLines}>
+			{#each contextOptions as lines (lines)}
+				<DropdownMenuRadioItem value={String(lines)} closeOnSelect={false}>
+					{lines} lines
+				</DropdownMenuRadioItem>
+			{/each}
+		</DropdownMenuRadioGroup>
+		{#if contextChangeBlocked}
+			<DropdownMenuLabel class="max-w-56 whitespace-normal text-xs text-destructive" role="status">
+				{m.git_comment_finish_before_context_change()}
+			</DropdownMenuLabel>
+		{/if}
+	</DropdownMenuSubContent>
+</DropdownMenuSub>

--- a/web/src/lib/components/git/GitHistoryToolbar.svelte
+++ b/web/src/lib/components/git/GitHistoryToolbar.svelte
@@ -2,11 +2,8 @@
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import type { GitHistorySurfaceController } from '$lib/git/history/git-history-surface.svelte.js';
 	import type { ResponsiveSurfaceAction } from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
-	import {
-		getGitReviewDisplay,
-		getLocalSettings,
-	} from '$lib/context';
-	import GitDiffSettingsMenu from './GitDiffSettingsMenu.svelte';
+	import { getGitReviewDisplay, getLocalSettings } from '$lib/context';
+	import GitDiffSettingsMenuContent from './GitDiffSettingsMenuContent.svelte';
 	import GitSurfaceToolbar from './GitSurfaceToolbar.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -39,21 +36,22 @@
 	]);
 </script>
 
+{#snippet diffSettings()}
+	<GitDiffSettingsMenuContent
+		diffMode={reviewDisplay.diffMode}
+		contextLines={reviewDisplay.contextLines}
+		diffFontSize={localSettings.gitDiffFontSize}
+		onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}
+		onSetContextLines={(lines) => reviewDisplay.setContextLines(lines)}
+		onSetDiffFontSize={(size) => localSettings.set('gitDiffFontSize', size)}
+	/>
+{/snippet}
+
 <GitSurfaceToolbar
 	target={controller.target}
 	{presentation}
 	{actions}
 	{onClose}
 	{closeDisabled}
->
-	{#snippet fixed()}
-		<GitDiffSettingsMenu
-			diffMode={reviewDisplay.diffMode}
-			contextLines={reviewDisplay.contextLines}
-			diffFontSize={localSettings.gitDiffFontSize}
-			onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}
-			onSetContextLines={(lines) => reviewDisplay.setContextLines(lines)}
-			onSetDiffFontSize={(size) => localSettings.set('gitDiffFontSize', size)}
-		/>
-	{/snippet}
-</GitSurfaceToolbar>
+	menuLeadingContent={diffSettings}
+/>

--- a/web/src/lib/components/git/GitSurfaceToolbar.svelte
+++ b/web/src/lib/components/git/GitSurfaceToolbar.svelte
@@ -12,22 +12,18 @@
 		target,
 		presentation,
 		actions,
-		fixed,
+		menuLeadingContent,
 		onClose,
 		closeDisabled = false,
 	}: {
 		target: GitTargetSessionController;
 		presentation: 'main' | 'sidebar' | 'mobile';
 		actions: readonly ResponsiveSurfaceAction[];
-		fixed?: Snippet;
+		menuLeadingContent?: Snippet;
 		onClose?: () => void;
 		closeDisabled?: boolean;
 	} = $props();
 </script>
-
-{#snippet fixedControls()}
-	{@render fixed?.()}
-{/snippet}
 
 <div
 	class="flex min-h-10 min-w-0 items-center gap-2 border-b border-border bg-background px-2"
@@ -38,7 +34,7 @@
 		isMobile={presentation === 'mobile'}
 		disabled={!target.canChangeTarget}
 	/>
-	<ResponsiveSurfaceActions {actions} menuLabel={m.git_more_actions()} fixed={fixedControls} />
+	<ResponsiveSurfaceActions {actions} menuLabel={m.git_more_actions()} {menuLeadingContent} />
 	{#if presentation === 'mobile' && onClose}
 		<button
 			type="button"

--- a/web/src/lib/components/git/GitWorkbenchToolbar.svelte
+++ b/web/src/lib/components/git/GitWorkbenchToolbar.svelte
@@ -4,11 +4,8 @@
 	import Upload from '@lucide/svelte/icons/upload';
 	import type { GitWorkbenchSurfaceController } from '$lib/git/workbench/git-workbench-surface.svelte.js';
 	import type { ResponsiveSurfaceAction } from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
-	import {
-		getGitReviewDisplay,
-		getLocalSettings,
-	} from '$lib/context';
-	import GitDiffSettingsMenu from './GitDiffSettingsMenu.svelte';
+	import { getGitReviewDisplay, getLocalSettings } from '$lib/context';
+	import GitDiffSettingsMenuContent from './GitDiffSettingsMenuContent.svelte';
 	import GitSurfaceToolbar from './GitSurfaceToolbar.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -65,15 +62,20 @@
 	]);
 </script>
 
-<GitSurfaceToolbar target={controller.target} {presentation} {actions}>
-	{#snippet fixed()}
-		<GitDiffSettingsMenu
-			diffMode={reviewDisplay.diffMode}
-			contextLines={reviewDisplay.contextLines}
-			diffFontSize={localSettings.gitDiffFontSize}
-			onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}
-			onSetContextLines={(lines) => reviewDisplay.setContextLines(lines)}
-			onSetDiffFontSize={(size) => localSettings.set('gitDiffFontSize', size)}
-		/>
-	{/snippet}
-</GitSurfaceToolbar>
+{#snippet diffSettings()}
+	<GitDiffSettingsMenuContent
+		diffMode={reviewDisplay.diffMode}
+		contextLines={reviewDisplay.contextLines}
+		diffFontSize={localSettings.gitDiffFontSize}
+		onSetDiffMode={(mode) => reviewDisplay.setDiffMode(mode)}
+		onSetContextLines={(lines) => reviewDisplay.setContextLines(lines)}
+		onSetDiffFontSize={(size) => localSettings.set('gitDiffFontSize', size)}
+	/>
+{/snippet}
+
+<GitSurfaceToolbar
+	target={controller.target}
+	{presentation}
+	{actions}
+	menuLeadingContent={diffSettings}
+/>

--- a/web/src/lib/components/git/__tests__/GitDiffSettingsMenuContent.test.ts
+++ b/web/src/lib/components/git/__tests__/GitDiffSettingsMenuContent.test.ts
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as m from '$lib/paraglide/messages.js';
+import GitDiffSettingsMenuContentTestHost from './GitDiffSettingsMenuContentTestHost.svelte';
+
+afterEach(cleanup);
+
+describe('GitDiffSettingsMenuContent', () => {
+	it('renders diff controls before the responsive action section', async () => {
+		render(GitDiffSettingsMenuContentTestHost, {
+			onSetDiffMode: vi.fn(),
+			onSetContextLines: vi.fn(),
+			onSetDiffFontSize: vi.fn(),
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Git actions' }));
+
+		const settings = screen.getByText(m.git_diff_settings());
+		const separator = document.querySelector<HTMLElement>('[data-slot="dropdown-menu-separator"]');
+		const edit = screen.getByRole('menuitem', { name: 'Edit endpoints' });
+		if (!separator) throw new Error('Expected action separator');
+		expect(screen.getByRole('menuitem', { name: /Font size 13px/ })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: /Diff mode Unified/ })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: /Context lines 5/ })).toBeTruthy();
+		expect(settings.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(
+			0,
+		);
+		expect(separator.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+	});
+
+	it('updates submenu settings and preserves blocked context feedback', async () => {
+		const onSetDiffMode = vi.fn();
+		const onSetContextLines = vi.fn(() => false);
+		render(GitDiffSettingsMenuContentTestHost, {
+			onSetDiffMode,
+			onSetContextLines,
+			onSetDiffFontSize: vi.fn(),
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Git actions' }));
+
+		const mode = screen.getByRole('menuitem', { name: /Diff mode Unified/ });
+		mode.focus();
+		await fireEvent.keyDown(mode, { key: 'ArrowRight' });
+		await fireEvent.click(await screen.findByRole('menuitemradio', { name: 'Split' }));
+		expect(onSetDiffMode).toHaveBeenCalledWith('split');
+
+		const context = screen.getByRole('menuitem', { name: /Context lines 5/ });
+		context.focus();
+		await fireEvent.keyDown(context, { key: 'ArrowRight' });
+		await fireEvent.click(await screen.findByRole('menuitemradio', { name: '10 lines' }));
+		expect(onSetContextLines).toHaveBeenCalledWith(10);
+		expect(
+			screen.getByRole('menuitemradio', { name: '5 lines' }).getAttribute('aria-checked'),
+		).toBe('true');
+		expect(
+			screen.getByRole('menuitemradio', { name: '10 lines' }).getAttribute('aria-checked'),
+		).toBe('false');
+		expect(screen.getByRole('status').textContent).toContain(
+			m.git_comment_finish_before_context_change(),
+		);
+	});
+});

--- a/web/src/lib/components/git/__tests__/GitDiffSettingsMenuContentTestHost.svelte
+++ b/web/src/lib/components/git/__tests__/GitDiffSettingsMenuContentTestHost.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import {
+		DropdownMenu,
+		DropdownMenuContent,
+		DropdownMenuItem,
+		DropdownMenuSeparator,
+		DropdownMenuTrigger,
+	} from '$lib/components/ui/dropdown-menu';
+	import type { DiffMode } from '$lib/git/workbench/git-workbench-types.js';
+	import GitDiffSettingsMenuContent from '../GitDiffSettingsMenuContent.svelte';
+
+	let {
+		onSetDiffMode,
+		onSetContextLines,
+		onSetDiffFontSize,
+	}: {
+		onSetDiffMode: (mode: DiffMode) => void;
+		onSetContextLines: (lines: number) => boolean | void;
+		onSetDiffFontSize: (size: string) => void;
+	} = $props();
+</script>
+
+<DropdownMenu>
+	<DropdownMenuTrigger>Git actions</DropdownMenuTrigger>
+	<DropdownMenuContent>
+		<GitDiffSettingsMenuContent
+			diffMode="unified"
+			contextLines={5}
+			diffFontSize="13"
+			{onSetDiffMode}
+			{onSetContextLines}
+			{onSetDiffFontSize}
+		/>
+		<DropdownMenuSeparator />
+		<DropdownMenuItem>Edit endpoints</DropdownMenuItem>
+	</DropdownMenuContent>
+</DropdownMenu>

--- a/web/src/lib/components/git/__tests__/GitSurfaceToolbar.test.ts
+++ b/web/src/lib/components/git/__tests__/GitSurfaceToolbar.test.ts
@@ -102,8 +102,20 @@ describe('GitSurfaceToolbar', () => {
 			onClose,
 			closeDisabled: false,
 		});
-		expect(
-			screen.queryByRole('button', { name: m.workspace_close_view() }),
-		).toBeNull();
+		expect(screen.queryByRole('button', { name: m.workspace_close_view() })).toBeNull();
+	});
+
+	it('places persistent Git controls in the responsive action menu', async () => {
+		render(GitSurfaceToolbarTestHost, {
+			props: {
+				target: target(),
+				presentation: 'main',
+				showMenuLeadingContent: true,
+			},
+		});
+
+		expect(screen.getAllByRole('button', { name: m.git_more_actions() })).toHaveLength(1);
+		await fireEvent.click(screen.getByRole('button', { name: m.git_more_actions() }));
+		expect(document.querySelector('[data-test-diff-settings]')).toBeTruthy();
 	});
 });

--- a/web/src/lib/components/git/__tests__/GitSurfaceToolbarTestHost.svelte
+++ b/web/src/lib/components/git/__tests__/GitSurfaceToolbarTestHost.svelte
@@ -3,10 +3,7 @@
 	import GitSurfaceToolbar from '../GitSurfaceToolbar.svelte';
 	import type { GitTargetSessionController } from '$lib/git/targets/git-target-session.svelte.js';
 	import type { ResponsiveSurfaceAction } from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
-	import {
-		setRemoteSettings,
-		setTransientLayers,
-	} from '$lib/context';
+	import { setRemoteSettings, setTransientLayers } from '$lib/context';
 	import { createRemoteSettingsStore } from '$lib/stores/remote-settings.svelte.js';
 	import { ChatInteractionGate } from '$lib/workspace/chat-interaction-gate.svelte.js';
 	import { TransientLayerRegistry } from '$lib/workspace/transient-layers.svelte.js';
@@ -16,11 +13,13 @@
 		presentation,
 		onClose,
 		closeDisabled = false,
+		showMenuLeadingContent = false,
 	}: {
 		target: GitTargetSessionController;
 		presentation: 'main' | 'sidebar' | 'mobile';
 		onClose?: () => void;
 		closeDisabled?: boolean;
+		showMenuLeadingContent?: boolean;
 	} = $props();
 
 	setRemoteSettings(createRemoteSettingsStore());
@@ -37,10 +36,15 @@
 	];
 </script>
 
+{#snippet menuLeadingContent()}
+	<span data-test-diff-settings>Diff settings</span>
+{/snippet}
+
 <GitSurfaceToolbar
 	{target}
 	{presentation}
 	{actions}
 	{onClose}
 	{closeDisabled}
+	menuLeadingContent={showMenuLeadingContent ? menuLeadingContent : undefined}
 />

--- a/web/src/lib/components/shared/ResponsiveSurfaceActions.svelte
+++ b/web/src/lib/components/shared/ResponsiveSurfaceActions.svelte
@@ -5,6 +5,7 @@
 		DropdownMenu,
 		DropdownMenuContent,
 		DropdownMenuItem,
+		DropdownMenuSeparator,
 		DropdownMenuTrigger,
 	} from '$lib/components/ui/dropdown-menu';
 	import { cn } from '$lib/utils/cn';
@@ -30,6 +31,7 @@
 		actions,
 		menuLabel,
 		menuContent,
+		menuLeadingContent,
 		menuIcon: MenuIcon = Ellipsis,
 		fixed,
 		class: className,
@@ -37,6 +39,7 @@
 		actions: readonly ResponsiveSurfaceAction[];
 		menuLabel: string;
 		menuContent?: Snippet<[readonly ResponsiveSurfaceAction[]]>;
+		menuLeadingContent?: Snippet;
 		menuIcon?: Component<{ class?: string }>;
 		fixed?: Snippet;
 		class?: string;
@@ -57,7 +60,8 @@
 			(action) => !(visibleActionIds ?? new Set(actions.map(({ id }) => id))).has(action.id),
 		),
 	);
-	const showMenu = $derived(Boolean(menuContent) || overflowActions.length > 0);
+	const hasPersistentMenuContent = $derived(Boolean(menuContent) || Boolean(menuLeadingContent));
+	const showMenu = $derived(hasPersistentMenuContent || overflowActions.length > 0);
 
 	function actionClass(action: ResponsiveSurfaceAction): string {
 		return cn(
@@ -87,13 +91,13 @@
 				.querySelector<HTMLElement>('[data-surface-action-overflow-measure]')
 				?.getBoundingClientRect().width ?? 0;
 		const fixedWidth = fixedControl?.getBoundingClientRect().width ?? 0;
-		const fixedGap = fixedWidth > 0 && (actions.length > 0 || Boolean(menuContent)) ? gap : 0;
+		const fixedGap = fixedWidth > 0 && (actions.length > 0 || hasPersistentMenuContent) ? gap : 0;
 		visibleActionIds = selectVisibleSurfaceActionIds({
 			actions: actions.map(({ id, priority = 100 }) => ({ id, priority })),
 			availableWidth: Math.max(0, actionRoot.clientWidth - fixedWidth - fixedGap),
 			widths,
 			menuButtonWidth,
-			menuVisibility: menuContent ? 'persistent' : 'overflow',
+			menuVisibility: hasPersistentMenuContent ? 'persistent' : 'overflow',
 			gap,
 		});
 	}
@@ -182,7 +186,13 @@
 			>
 				<MenuIcon class="h-4 w-4" />
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end" class={menuContent ? 'w-64' : 'w-56'}>
+			<DropdownMenuContent align="end" class={hasPersistentMenuContent ? 'w-64' : 'w-56'}>
+				{#if menuLeadingContent}
+					{@render menuLeadingContent()}
+					{#if overflowActions.length > 0 || menuContent}
+						<DropdownMenuSeparator />
+					{/if}
+				{/if}
 				{#if menuContent}
 					{@render menuContent(overflowActions)}
 				{:else}

--- a/web/src/lib/components/shared/__tests__/ResponsiveSurfaceActions.test.ts
+++ b/web/src/lib/components/shared/__tests__/ResponsiveSurfaceActions.test.ts
@@ -57,6 +57,49 @@ describe('ResponsiveSurfaceActions', () => {
 		expect(screen.getByText('Preferences')).toBeTruthy();
 	});
 
+	it('places leading menu content before a separator and overflow actions', async () => {
+		const { container } = render(ResponsiveSurfaceActionsTestHost, {
+			props: { leadingContent: true },
+		});
+		await Promise.resolve();
+		const root = container.querySelector<HTMLElement>('[data-responsive-surface-actions]');
+		if (!root) throw new Error('Expected responsive action root');
+		Object.defineProperty(root, 'clientWidth', { get: () => 240 });
+		for (const element of container.querySelectorAll<HTMLElement>(
+			'[data-surface-action-measure]',
+		)) {
+			const width =
+				element.dataset.surfaceActionMeasure === 'filter'
+					? 80
+					: element.dataset.surfaceActionMeasure === 'project'
+						? 100
+						: 32;
+			element.getBoundingClientRect = () => ({ width }) as DOMRect;
+		}
+		const menuMeasure = container.querySelector<HTMLElement>(
+			'[data-surface-action-overflow-measure]',
+		);
+		if (!menuMeasure) throw new Error('Expected menu measurement control');
+		menuMeasure.getBoundingClientRect = () => ({ width: 32 }) as DOMRect;
+
+		ResizeObserverHarness.emit(root, 240);
+		await Promise.resolve();
+		expect(screen.getAllByRole('button', { name: 'File browser actions' })).toHaveLength(1);
+		expect(screen.queryByRole('button', { name: 'Refresh files' })).toBeNull();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'File browser actions' }));
+		const leading = document.querySelector<HTMLElement>('[data-leading-menu-content]');
+		const separator = document.querySelector<HTMLElement>('[data-slot="dropdown-menu-separator"]');
+		const overflowAction = screen.getByRole('menuitem', { name: 'Refresh files' });
+		if (!leading || !separator) throw new Error('Expected ordered menu content');
+		expect(leading.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(
+			0,
+		);
+		expect(
+			separator.compareDocumentPosition(overflowAction) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).not.toBe(0);
+	});
+
 	it('disconnects every observer on destroy', async () => {
 		const rendered = render(ResponsiveSurfaceActionsTestHost);
 		await Promise.resolve();

--- a/web/src/lib/components/shared/__tests__/ResponsiveSurfaceActionsTestHost.svelte
+++ b/web/src/lib/components/shared/__tests__/ResponsiveSurfaceActionsTestHost.svelte
@@ -6,6 +6,8 @@
 		type ResponsiveSurfaceAction,
 	} from '../ResponsiveSurfaceActions.svelte';
 
+	let { leadingContent = false }: { leadingContent?: boolean } = $props();
+
 	const actions: ResponsiveSurfaceAction[] = [
 		{
 			id: 'filter',
@@ -40,4 +42,13 @@
 	<span>Preferences</span>
 {/snippet}
 
-<ResponsiveSurfaceActions {actions} menuLabel="File browser actions" menuContent={menu} />
+{#snippet leadingMenuContent()}
+	<span data-leading-menu-content>Diff options</span>
+{/snippet}
+
+<ResponsiveSurfaceActions
+	{actions}
+	menuLabel="File browser actions"
+	menuContent={leadingContent ? undefined : menu}
+	menuLeadingContent={leadingContent ? leadingMenuContent : undefined}
+/>


### PR DESCRIPTION
Git comparison toolbars could expose overlapping settings and overflow buttons at narrow widths. This change moves diff display controls into the existing responsive action menu across Compare, History, and Changes, keeps direct actions visible while space permits, and adds regression coverage for ordering and minimum-width behavior.
