### PR TITLE
Improve Garcon CLI discovery and chat metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,16 +149,34 @@ garcon-cli \
   --model gpt-5.4 \
   --permissions acceptEdits \
   --reasoning-effort high \
+  --title "Implement validation" \
   "Implement the validation and run its focused tests."
 ```
 
 Resume the same agent session without repeating its persisted selection:
 
 ```bash
-garcon-cli --workspace default --resume 1785337200123456 "Now address the review findings."
+garcon-cli --workspace default --resume 1785337200123456 \
+  --title "Address review findings" \
+  "Now address the review findings."
 ```
 
-The CLI supports write-capable delegation and does not force `plan` mode. Permission and reasoning values use the selected agent's live Garcon catalog; inherited bypass modes require the matching explicit `--permissions` flag. A single `-` prompt reads stdin. Interrupting the terminal detaches the CLI without stopping work in Garcon.
+Query the running server for exact selection values before starting a chat:
+
+```bash
+garcon-cli list agents
+garcon-cli list providers --agent codex
+garcon-cli list endpoints --provider local-openai --agent codex
+garcon-cli list models --agent codex --provider local-openai
+garcon-cli list permissions --agent codex
+garcon-cli list reasoning-efforts --agent codex
+```
+
+List commands print compact tables by default and accept `--json` for scripts and agents. Add
+repeatable tags with `--tag review --tag delegated`; every started or resumed chat still receives
+the `cli` tag automatically. `--title` sets an explicit title on either a new or resumed chat.
+
+The CLI supports write-capable delegation and does not force `plan` mode. Permission and reasoning values use the selected agent's live Garcon catalog; inherited bypass modes require the matching explicit `--permissions` flag. A single `-` prompt reads stdin. Use `--` before a positional prompt whose first word is `list`. Interrupting the terminal detaches the CLI without stopping work in Garcon.
 
 Discovery requires the server to use a named `--workspace`; servers launched with `--workspace-dir` are intentionally not discoverable. `--server` may assert the descriptor's exact URL but cannot redirect credentials to another listener. Run `garcon-cli --help` for provider, endpoint, and complete mode options.
 

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -14,6 +14,7 @@ describe('parseCliArgs', () => {
       '--model', 'gpt-5.4',
       '--permissions', 'acceptEdits',
       '--reasoning-effort', 'high',
+      '--title', '  Implement auth validation  ',
       'Implement', 'the', 'change',
     ], ENV, '/repo')).toEqual({
       kind: 'start',
@@ -24,6 +25,7 @@ describe('parseCliArgs', () => {
       model: 'gpt-5.4',
       permissionMode: 'acceptEdits',
       thinkingMode: 'high',
+      title: 'Implement auth validation',
       prompt: 'Implement the change',
       readsPromptFromStdin: false,
     });
@@ -37,6 +39,47 @@ describe('parseCliArgs', () => {
       chatId: CHAT_ID,
       prompt: null,
       readsPromptFromStdin: true,
+    });
+  });
+
+  test('parses live catalog queries without submission arguments', () => {
+    expect(parseCliArgs([
+      'list', 'models',
+      '--workspace', 'work',
+      '--agent', 'codex',
+      '--provider', 'acme',
+      '--endpoint', 'east',
+      '--json',
+    ], ENV)).toEqual({
+      kind: 'list',
+      resource: 'models',
+      workspace: 'work',
+      configDir: '/home/test/.garcon',
+      agentId: 'codex',
+      providerId: 'acme',
+      endpointId: 'east',
+      json: true,
+    });
+    expect(parseCliArgs(['list', 'agents'], ENV)).toEqual({
+      kind: 'list',
+      resource: 'agents',
+      workspace: 'default',
+      configDir: '/home/test/.garcon',
+      json: false,
+    });
+  });
+
+  test('normalizes and deduplicates repeatable additional tags', () => {
+    expect(parseCliArgs([
+      '--agent', 'codex',
+      '--model', 'gpt',
+      '--tag', 'Review Needed',
+      '--tag', 'cli',
+      '--tag', 'Priority',
+      'Review',
+    ], ENV)).toMatchObject({
+      kind: 'start',
+      additionalTags: ['priority', 'review-needed'],
     });
   });
 
@@ -68,6 +111,17 @@ describe('parseCliArgs', () => {
     expect(result).toMatchObject({ prompt: '  preserve this spacing  ' });
   });
 
+  test('accepts a positional prompt beginning with list after the option terminator', () => {
+    expect(parseCliArgs([
+      '--agent', 'codex',
+      '--model', 'gpt',
+      '--', 'list', 'the', 'open', 'issues',
+    ], ENV)).toMatchObject({
+      kind: 'start',
+      prompt: 'list the open issues',
+    });
+  });
+
   test.each([
     { args: ['--agent', 'codex', 'prompt'], message: '--model is required' },
     { args: ['--model', 'gpt', 'prompt'], message: '--agent is required' },
@@ -79,6 +133,14 @@ describe('parseCliArgs', () => {
     { args: ['--resume', '123', 'prompt'], message: 'valid Garcon chat ID' },
     { args: ['--agent', 'codex', '--agent', 'claude', '--model', 'gpt', 'prompt'], message: 'only once' },
     { args: ['--agent', 'codex', '--model', 'gpt', 'prompt', '-'], message: 'must be the only prompt argument' },
+    { args: ['list', 'models'], message: 'requires --agent' },
+    { args: ['list', 'endpoints'], message: 'requires --provider' },
+    { args: ['list', 'models', '--agent', 'codex', '--endpoint', 'east'], message: 'requires --provider' },
+    { args: ['list', 'agents', '--agent', 'codex'], message: '--agent cannot be used' },
+    { args: ['--json', '--agent', 'codex', '--model', 'gpt', 'prompt'], message: 'only be used with list' },
+    { args: ['list', 'agents', '--title', 'Review'], message: '--title cannot be used' },
+    { args: ['--title', '  ', '--agent', 'codex', '--model', 'gpt', 'prompt'], message: '--title must not be empty' },
+    { args: ['--tag', '!!!', '--agent', 'codex', '--model', 'gpt', 'prompt'], message: 'letters or numbers' },
   ])('rejects invalid arguments: $message', ({ args, message }) => {
     expect(() => parseCliArgs(args, ENV)).toThrow(message);
     try {

--- a/cli/__tests__/catalog-query.test.ts
+++ b/cli/__tests__/catalog-query.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from 'bun:test';
+import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
+import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
+import type { ListCliCommand } from '../args.js';
+import { runCatalogQuery, type CatalogQueryClient } from '../catalog-query.js';
+import type { CliOutput } from '../output.js';
+
+const catalog: ModelCatalogResponse = {
+  catalog: {
+    agents: [{
+      id: 'codex',
+      label: 'Codex',
+      description: 'OpenAI Codex',
+      kind: 'agent',
+      supportsFork: true,
+      supportsForkAtMessage: true,
+      supportsForkWhileRunning: false,
+      supportsUpdateProjectPath: true,
+      supportsSteering: true,
+      supportsGoals: true,
+      supportsImages: true,
+      acceptsApiProviderEndpoints: true,
+      supportedProtocols: ['openai-compatible'],
+      authLoginSupported: true,
+      supportedPermissionModes: ['default', 'acceptEdits', 'plan'],
+      supportedThinkingModes: ['none', 'medium', 'high'],
+      settings: [],
+      defaultSettings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      requiresStrictModelDiscovery: true,
+      generation: null,
+      defaultModel: 'gpt-5.4',
+      models: [
+        { value: 'gpt-5.4', label: 'GPT 5.4' },
+        {
+          value: 'acme:east:qwen',
+          label: 'Qwen',
+          rawModel: 'qwen',
+          apiProviderId: 'acme',
+          endpointId: 'east',
+          protocol: 'openai-compatible',
+        },
+      ],
+    }],
+    apiProviders: [
+      {
+        id: 'acme',
+        label: 'Acme',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        endpoints: [
+          {
+            id: 'east',
+            protocol: 'openai-compatible',
+            baseUrl: 'http://127.0.0.1:9000',
+            defaultModel: 'qwen',
+            models: [{ value: 'qwen', label: 'Qwen' }],
+            supportsImages: false,
+            hasApiKey: true,
+          },
+          {
+            id: 'anthropic',
+            protocol: 'anthropic-messages',
+            baseUrl: 'http://127.0.0.1:9001',
+            defaultModel: 'sonnet',
+            models: [{ value: 'sonnet', label: 'Sonnet' }],
+            supportsImages: true,
+            hasApiKey: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const settings = {
+  executionDefaults: {
+    global: { permissionMode: 'acceptEdits', thinkingMode: 'medium', agentSettingsById: {} },
+    byAgent: {},
+  },
+} as RemoteSettingsSnapshot;
+
+function client(modelCatalog: ModelCatalogResponse = catalog): CatalogQueryClient {
+  return {
+    async getModelCatalog() { return modelCatalog; },
+    async getSettings() { return settings; },
+  };
+}
+
+function output(): CliOutput & { listings: string[] } {
+  return {
+    listings: [],
+    accepted() {},
+    completed() {},
+    listing(content) { this.listings.push(content); },
+    diagnostic() {},
+  };
+}
+
+function command(
+  resource: ListCliCommand['resource'],
+  options: Partial<ListCliCommand> = {},
+): ListCliCommand {
+  return {
+    kind: 'list',
+    resource,
+    workspace: 'default',
+    configDir: '/config',
+    json: false,
+    ...options,
+  };
+}
+
+describe('runCatalogQuery', () => {
+  test('prints actionable agent and model selections', async () => {
+    const agents = output();
+    await runCatalogQuery(command('agents'), client(), agents);
+    expect(agents.listings[0]).toContain('AGENT  LABEL  DEFAULT MODEL');
+    expect(agents.listings[0]).toContain('codex  Codex  gpt-5.4');
+
+    const models = output();
+    await runCatalogQuery(command('models', {
+      agentId: 'codex',
+      providerId: 'acme',
+      endpointId: 'east',
+      json: true,
+    }), client(), models);
+    expect(JSON.parse(models.listings[0]!)).toEqual({
+      agentId: 'codex',
+      defaultModel: 'gpt-5.4',
+      models: [{
+        value: 'acme:east:qwen',
+        label: 'Qwen',
+        rawModel: 'qwen',
+        providerId: 'acme',
+        endpointId: 'east',
+        protocol: 'openai-compatible',
+        isDefault: false,
+        supportsImages: true,
+        isLocal: false,
+      }],
+    });
+  });
+
+  test('filters provider endpoints to the selected agent protocol', async () => {
+    const providers = output();
+    await runCatalogQuery(command('providers', { agentId: 'codex', json: true }), client(), providers);
+    expect(JSON.parse(providers.listings[0]!)).toEqual({
+      agentId: 'codex',
+      providers: [{ id: 'acme', label: 'Acme', endpoints: ['east'] }],
+    });
+
+    const endpoints = output();
+    await runCatalogQuery(command('endpoints', {
+      agentId: 'codex',
+      providerId: 'acme',
+      json: true,
+    }), client(), endpoints);
+    expect(JSON.parse(endpoints.listings[0]!).endpoints).toEqual([{
+      providerId: 'acme',
+      id: 'east',
+      protocol: 'openai-compatible',
+      defaultModel: 'qwen',
+      supportsImages: false,
+      hasApiKey: true,
+    }]);
+  });
+
+  test('marks effective permission and reasoning defaults', async () => {
+    const permissions = output();
+    await runCatalogQuery(command('permissions', { agentId: 'codex', json: true }), client(), permissions);
+    expect(JSON.parse(permissions.listings[0]!)).toEqual({
+      agentId: 'codex',
+      defaultPermission: 'acceptEdits',
+      permissions: ['default', 'acceptEdits', 'plan'],
+    });
+
+    const efforts = output();
+    await runCatalogQuery(command('reasoning-efforts', { agentId: 'codex' }), client(), efforts);
+    expect(efforts.listings[0]).toContain('medium            yes');
+  });
+
+  test('reports unknown provider filters with available values', async () => {
+    await expect(runCatalogQuery(command('models', {
+      agentId: 'codex',
+      providerId: 'missing',
+    }), client(), output())).rejects.toThrow('available providers: acme');
+  });
+
+  test('rejects an explicitly selected endpoint that the agent cannot use', async () => {
+    await expect(runCatalogQuery(command('endpoints', {
+      agentId: 'codex',
+      providerId: 'acme',
+      endpointId: 'anthropic',
+    }), client(), output())).rejects.toThrow(
+      'endpoint anthropic is not compatible with agent codex',
+    );
+  });
+
+  test('rejects an explicitly selected provider with no compatible endpoints', async () => {
+    const incompatibleCatalog = structuredClone(catalog);
+    incompatibleCatalog.catalog.apiProviders.push({
+      id: 'anthropic-only',
+      label: 'Anthropic only',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      endpoints: [{
+        id: 'messages',
+        protocol: 'anthropic-messages',
+        baseUrl: 'http://127.0.0.1:9002',
+        defaultModel: 'sonnet',
+        models: [{ value: 'sonnet', label: 'Sonnet' }],
+        supportsImages: true,
+        hasApiKey: true,
+      }],
+    });
+
+    for (const resource of ['providers', 'endpoints'] as const) {
+      await expect(runCatalogQuery(command(resource, {
+        agentId: 'codex',
+        providerId: 'anthropic-only',
+      }), client(incompatibleCatalog), output())).rejects.toThrow(
+        'provider anthropic-only has no endpoints compatible with agent codex',
+      );
+    }
+  });
+
+  test('only strict model listings use the agent-scoped catalog route', async () => {
+    const requestedAgents: Array<string | undefined> = [];
+    const queryClient: CatalogQueryClient = {
+      async getModelCatalog(agentId) {
+        requestedAgents.push(agentId);
+        return catalog;
+      },
+      async getSettings() { return settings; },
+    };
+
+    await runCatalogQuery(command('permissions', { agentId: 'codex' }), queryClient, output());
+    await runCatalogQuery(command('reasoning-efforts', { agentId: 'codex' }), queryClient, output());
+    await runCatalogQuery(command('models', { agentId: 'codex' }), queryClient, output());
+
+    expect(requestedAgents).toEqual([undefined, undefined, 'codex']);
+  });
+});

--- a/cli/__tests__/consultation.test.ts
+++ b/cli/__tests__/consultation.test.ts
@@ -6,6 +6,7 @@ import type {
   StartChatCommandRequest,
 } from '@garcon/common/chat-command-contracts';
 import type { ChatListResponse } from '@garcon/common/chat-list';
+import type { UpdateChatTitleRequest } from '@garcon/common/chat-title-contracts';
 import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
 import type { CliInvocation } from '../args.js';
@@ -66,6 +67,7 @@ function output(): CliOutput & { acceptedIds: string[]; messages: string[][] } {
     acceptedIds: [], messages: [],
     accepted(chatId) { this.acceptedIds.push(chatId); },
     completed(messages) { this.messages.push([...messages]); },
+    listing() {},
     diagnostic() {},
   };
 }
@@ -73,14 +75,16 @@ function output(): CliOutput & { acceptedIds: string[]; messages: string[][] } {
 function client(overrides: Partial<ConsultationClient> = {}): ConsultationClient & {
   starts: StartChatCommandRequest[];
   runs: AgentRunCommandRequest[];
+  titles: UpdateChatTitleRequest[];
 } {
   return {
-    starts: [], runs: [],
+    starts: [], runs: [], titles: [],
     async getModelCatalog() { return catalog(); },
     async getSettings() { return settings; },
     async listChats() { throw new Error('chat list should not be loaded'); },
     async startChat(request) { this.starts.push(request); return accepted; },
     async runChat(request) { this.runs.push(request); return { ...accepted, commandType: 'agent-run' }; },
+    async updateChatTitle(request) { this.titles.push(request); },
     async getTurnReceipt() { return receipt; },
     async verifyRuntime() { return true; },
     ...overrides,
@@ -92,6 +96,8 @@ describe('runConsultation', () => {
     const invocation: CliInvocation = {
       kind: 'start', workspace: 'default', configDir: '/config', cwd: '/repo',
       agentId: 'codex', model: 'gpt-5.4', prompt: 'Implement it', readsPromptFromStdin: false,
+      title: 'Implementation review',
+      additionalTags: ['review-needed'],
     };
     const testClient = client();
     const testOutput = output();
@@ -100,9 +106,10 @@ describe('runConsultation', () => {
     });
     expect(testClient.starts[0]).toMatchObject({
       chatId: CHAT_ID, agentId: 'codex', projectPath: '/repo', command: 'Implement it',
-      permissionMode: 'acceptEdits', thinkingMode: 'high', tags: ['cli'],
+      permissionMode: 'acceptEdits', thinkingMode: 'high', tags: ['cli', 'review-needed'],
     });
     expect(testOutput.acceptedIds).toEqual([CHAT_ID]);
+    expect(testClient.titles).toEqual([{ chatId: CHAT_ID, title: 'Implementation review' }]);
     expect(testOutput.messages).toEqual([['Done']]);
   });
 
@@ -161,6 +168,8 @@ describe('runConsultation', () => {
     const invocation: CliInvocation = {
       kind: 'resume', workspace: 'default', configDir: '/config', chatId: CHAT_ID,
       prompt: 'Continue', readsPromptFromStdin: false,
+      title: 'Follow-up review',
+      additionalTags: ['follow-up'],
     };
     const testClient = client();
     await runConsultation(invocation, 'Continue', testClient, output(), undefined, {
@@ -168,9 +177,35 @@ describe('runConsultation', () => {
     });
     expect(testClient.runs[0]).toEqual({
       clientRequestId: 'request', clientMessageId: 'request', chatId: CHAT_ID,
-      command: 'Continue', tagsToAdd: ['cli'],
+      command: 'Continue', tagsToAdd: ['cli', 'follow-up'],
       permissionFallbackPolicy: 'require-explicit-bypass',
     });
+    expect(testClient.titles).toEqual([{ chatId: CHAT_ID, title: 'Follow-up review' }]);
+  });
+
+  test('returns the agent result before surfacing a title update failure', async () => {
+    const testOutput = output();
+    let receiptRead = false;
+    const testClient = client({
+      async updateChatTitle() {
+        throw new CliError('title update', 'rename failed', 3);
+      },
+      async getTurnReceipt() {
+        receiptRead = true;
+        return receipt;
+      },
+    });
+
+    await expect(runConsultation({
+      kind: 'resume', workspace: 'default', configDir: '/config', chatId: CHAT_ID,
+      prompt: 'Continue', readsPromptFromStdin: false, title: 'Follow-up review',
+    }, 'Continue', testClient, testOutput, undefined, {
+      createId: () => 'request',
+    })).rejects.toThrow('rename failed');
+
+    expect(receiptRead).toBe(true);
+    expect(testOutput.acceptedIds).toEqual([CHAT_ID]);
+    expect(testOutput.messages).toEqual([['Done']]);
   });
 
   test('validates resume overrides against the persisted agent catalog', async () => {

--- a/cli/__tests__/garcon-client.test.ts
+++ b/cli/__tests__/garcon-client.test.ts
@@ -57,6 +57,29 @@ describe('GarconClient', () => {
     expect(redirect).toBe('error');
   });
 
+  test('updates a chat title through the existing workspace API', async () => {
+    let request: { url: string; method: string | undefined; body: string } | undefined;
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (input, init) => {
+        request = {
+          url: String(input),
+          method: init?.method,
+          body: String(init?.body),
+        };
+        return Response.json({ success: true });
+      },
+    });
+
+    await client.updateChatTitle({ chatId: runRequest.chatId, title: 'Delegated review' });
+
+    expect(request).toEqual({
+      url: `${connection.baseUrl}/api/v1/app/session-name`,
+      method: 'PUT',
+      body: JSON.stringify({ chatId: runRequest.chatId, title: 'Delegated review' }),
+    });
+  });
+
   test('retries an ambiguous submission with the identical request body', async () => {
     const bodies: string[] = [];
     let attempts = 0;

--- a/cli/__tests__/main.test.ts
+++ b/cli/__tests__/main.test.ts
@@ -12,6 +12,7 @@ function capturedOutput(): { output: CliOutput; diagnostics: string[] } {
     output: {
       accepted() {},
       completed() {},
+      listing() {},
       diagnostic(message) { diagnostics.push(message); },
     },
   };

--- a/cli/__tests__/output.test.ts
+++ b/cli/__tests__/output.test.ts
@@ -32,4 +32,27 @@ describe('createCliOutput', () => {
     expect(stdout.chunks).toEqual([]);
     expect(stderr.chunks.join('')).toBe('submission: unavailable\n');
   });
+
+  test('prints nothing after the chat line for an empty assistant result', () => {
+    const stdout = writer();
+    const stderr = writer();
+    const output = createCliOutput(stdout, stderr);
+
+    output.accepted('1785337200123456');
+    output.completed(['', '   ']);
+
+    expect(stdout.chunks.join('')).toBe('chat id: 1785337200123456\n');
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  test('terminates catalog listings with exactly one newline', () => {
+    const stdout = writer();
+    const stderr = writer();
+    const output = createCliOutput(stdout, stderr);
+
+    output.listing('AGENT\n------\n');
+
+    expect(stdout.chunks).toEqual(['AGENT\n------\n']);
+    expect(stderr.chunks).toEqual([]);
+  });
 });

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -10,31 +10,45 @@ import {
   type ThinkingMode,
 } from '@garcon/common/chat-modes';
 import { parseChatId, type ChatId } from '@garcon/common/chat-id';
+import { normalizeTags, normalizeTagSlug } from '@garcon/common/tags';
 import { argumentError } from './errors.js';
 
 export const CLI_HELP = `Usage:
   garcon-cli [options] <prompt>
   garcon-cli [options] --resume <chat-id> <prompt>
+  garcon-cli [options] list <resource>
 
 Starts or resumes a visible chat through an already-running Garcon server.
 The selected permission mode may allow the agent to edit files and run tools.
+
+List resources:
+  agents
+  providers                 Optionally filter with --agent or --provider
+  endpoints                 Requires --provider; optionally filter with --agent or --endpoint
+  models                    Requires --agent; optionally filter with --provider and --endpoint
+  permissions               Requires --agent
+  reasoning-efforts         Requires --agent
 
 Options:
   --workspace <name>           Named Garcon data workspace (default: default)
   --config-dir <path>          Garcon config root (default: ~/.garcon)
   --server <url>               Assert the workspace descriptor's exact URL
   --cwd <path>                 Project directory for a new chat (default: current directory)
-  --agent <id>                 Agent ID; required for a new chat
+  --agent <id>                 Agent ID; required for a new chat and agent-scoped lists
   --provider <id>              Configured API provider ID
   --endpoint <id>              Endpoint ID within --provider
   --model <id>                 Model value or raw model; required for a new chat
   --permissions <mode>         Permission mode: ${PERMISSION_MODE_VALUES.join(', ')}
   --reasoning-effort <mode>    Reasoning effort: ${THINKING_MODE_VALUES.join(', ')}
+  --title <title>              Set the chat title after the turn is accepted
+  --tag <name>                 Add a tag in addition to cli; repeatable
   --resume <chat-id>           Resume an existing chat
+  --json                       Print list results as JSON
   --help                       Show this help
   --version                    Show the Garcon version
 
-Use a single - as the prompt to read UTF-8 text from stdin.`;
+Use a single - as the prompt to read UTF-8 text from stdin.
+Use -- before a positional prompt whose first word is list.`;
 
 export interface CliEnvironment {
   GARCON_CONFIG_DIR?: string;
@@ -51,11 +65,16 @@ interface CliSelectionOptions {
   thinkingMode?: ThinkingMode;
 }
 
-interface CliInvocationBase extends CliSelectionOptions {
-  kind: 'start' | 'resume';
+interface CliConnectionOptions {
   workspace: string;
   configDir: string;
   serverUrl?: string;
+}
+
+interface CliInvocationBase extends CliSelectionOptions, CliConnectionOptions {
+  kind: 'start' | 'resume';
+  title?: string;
+  additionalTags?: string[];
   prompt: string | null;
   readsPromptFromStdin: boolean;
 }
@@ -74,12 +93,33 @@ export interface ResumeCliInvocation extends CliInvocationBase {
 
 export type CliInvocation = StartCliInvocation | ResumeCliInvocation;
 
+export const LIST_RESOURCE_VALUES = [
+  'agents',
+  'providers',
+  'endpoints',
+  'models',
+  'permissions',
+  'reasoning-efforts',
+] as const;
+
+export type ListResource = (typeof LIST_RESOURCE_VALUES)[number];
+
+export interface ListCliCommand extends CliConnectionOptions {
+  kind: 'list';
+  resource: ListResource;
+  json: boolean;
+  agentId?: string;
+  providerId?: string;
+  endpointId?: string;
+}
+
 export type ParsedCliCommand =
   | { kind: 'help' }
   | { kind: 'version' }
+  | ListCliCommand
   | CliInvocation;
 
-const STRING_OPTIONS = [
+const SINGLE_STRING_OPTIONS = [
   'workspace',
   'config-dir',
   'server',
@@ -90,8 +130,11 @@ const STRING_OPTIONS = [
   'model',
   'permissions',
   'reasoning-effort',
+  'title',
   'resume',
 ] as const;
+
+type ParsedOptionValue = boolean | string | string[] | undefined;
 
 function nonEmptyOption(value: string | undefined, flag: string): string | undefined {
   if (value === undefined) return undefined;
@@ -111,15 +154,15 @@ function validateWorkspace(value: string): string {
   return value;
 }
 
-function parseModeOptions(values: Record<string, boolean | string | undefined>): {
+function parseModeOptions(values: Record<string, ParsedOptionValue>): {
   permissionMode?: PermissionMode;
   thinkingMode?: ThinkingMode;
 } {
-  const permission = values.permissions;
+  const permission = values.permissions as string | undefined;
   if (permission !== undefined && !isPermissionMode(permission)) {
     throw argumentError(`--permissions must be one of: ${PERMISSION_MODE_VALUES.join(', ')}`);
   }
-  const thinking = values['reasoning-effort'];
+  const thinking = values['reasoning-effort'] as string | undefined;
   if (thinking !== undefined && !isThinkingMode(thinking)) {
     throw argumentError(`--reasoning-effort must be one of: ${THINKING_MODE_VALUES.join(', ')}`);
   }
@@ -127,6 +170,24 @@ function parseModeOptions(values: Record<string, boolean | string | undefined>):
     ...(permission === undefined ? {} : { permissionMode: permission }),
     ...(thinking === undefined ? {} : { thinkingMode: thinking }),
   };
+}
+
+function parseAdditionalTags(value: ParsedOptionValue): string[] | undefined {
+  if (value === undefined) return undefined;
+  const rawTags = value as string[];
+  for (const tag of rawTags) {
+    if (!normalizeTagSlug(tag)) throw argumentError('--tag must contain letters or numbers');
+  }
+  const tags = normalizeTags(rawTags).filter((tag) => tag !== 'cli');
+  return tags.length > 0 ? tags : undefined;
+}
+
+function isListResource(value: string): value is ListResource {
+  return (LIST_RESOURCE_VALUES as readonly string[]).includes(value);
+}
+
+function rejectListOption(value: unknown, flag: string): void {
+  if (value !== undefined) throw argumentError(`${flag} cannot be used with list`);
 }
 
 export function parseCliArgs(
@@ -151,7 +212,10 @@ export function parseCliArgs(
         model: { type: 'string' },
         permissions: { type: 'string' },
         'reasoning-effort': { type: 'string' },
+        title: { type: 'string' },
+        tag: { type: 'string', multiple: true },
         resume: { type: 'string' },
+        json: { type: 'boolean' },
         help: { type: 'boolean' },
         version: { type: 'boolean' },
       },
@@ -165,7 +229,10 @@ export function parseCliArgs(
   const repeated = new Set<string>();
   const observed = new Set<string>();
   for (const token of parsed.tokens ?? []) {
-    if (token.kind !== 'option' || !STRING_OPTIONS.includes(token.name as typeof STRING_OPTIONS[number])) {
+    if (
+      token.kind !== 'option'
+      || !SINGLE_STRING_OPTIONS.includes(token.name as typeof SINGLE_STRING_OPTIONS[number])
+    ) {
       continue;
     }
     if (observed.has(token.name)) repeated.add(token.name);
@@ -175,7 +242,7 @@ export function parseCliArgs(
     throw argumentError(`option may be specified only once: --${[...repeated][0]}`);
   }
 
-  const values = parsed.values as Record<string, boolean | string | undefined>;
+  const values = parsed.values as Record<string, ParsedOptionValue>;
   if (values.help === true) return { kind: 'help' };
   if (values.version === true) return { kind: 'version' };
 
@@ -197,6 +264,60 @@ export function parseCliArgs(
   const model = nonEmptyOption(values.model as string | undefined, '--model');
   const cwd = nonEmptyOption(values.cwd as string | undefined, '--cwd');
   const resume = nonEmptyOption(values.resume as string | undefined, '--resume');
+  const title = nonEmptyOption(values.title as string | undefined, '--title')?.trim();
+  const additionalTags = parseAdditionalTags(values.tag);
+  const explicitPromptBoundary = parsed.tokens?.some(
+    (token) => token.kind === 'option-terminator',
+  ) ?? false;
+
+  if (parsed.positionals[0] === 'list' && !explicitPromptBoundary) {
+    const resource = parsed.positionals[1] ?? '';
+    if (parsed.positionals.length !== 2 || !isListResource(resource)) {
+      throw argumentError(`list requires one resource: ${LIST_RESOURCE_VALUES.join(', ')}`);
+    }
+    rejectListOption(cwd, '--cwd');
+    rejectListOption(values.model, '--model');
+    rejectListOption(values.permissions, '--permissions');
+    rejectListOption(values['reasoning-effort'], '--reasoning-effort');
+    rejectListOption(values.title, '--title');
+    rejectListOption(values.tag, '--tag');
+    rejectListOption(resume, '--resume');
+    if (endpointId !== undefined && providerId === undefined) {
+      throw argumentError('--endpoint requires --provider');
+    }
+    if (resource === 'agents') {
+      rejectListOption(agentId, '--agent');
+      rejectListOption(providerId, '--provider');
+      rejectListOption(endpointId, '--endpoint');
+    }
+    if (resource === 'providers') rejectListOption(endpointId, '--endpoint');
+    if (resource === 'endpoints' && providerId === undefined) {
+      throw argumentError('list endpoints requires --provider');
+    }
+    if (
+      (resource === 'models' || resource === 'permissions' || resource === 'reasoning-efforts')
+      && agentId === undefined
+    ) {
+      throw argumentError(`list ${resource} requires --agent`);
+    }
+    if (resource === 'permissions' || resource === 'reasoning-efforts') {
+      rejectListOption(providerId, '--provider');
+      rejectListOption(endpointId, '--endpoint');
+    }
+    return {
+      kind: 'list',
+      resource,
+      workspace,
+      configDir,
+      json: values.json === true,
+      ...(serverUrl === undefined ? {} : { serverUrl }),
+      ...(agentId === undefined ? {} : { agentId }),
+      ...(providerId === undefined ? {} : { providerId }),
+      ...(endpointId === undefined ? {} : { endpointId }),
+    };
+  }
+
+  if (values.json !== undefined) throw argumentError('--json can only be used with list');
   const modes = parseModeOptions(values);
 
   if (endpointId !== undefined && providerId === undefined) {
@@ -222,6 +343,8 @@ export function parseCliArgs(
     ...(providerId === undefined ? {} : { providerId }),
     ...(endpointId === undefined ? {} : { endpointId }),
     ...(model === undefined ? {} : { model }),
+    ...(title === undefined ? {} : { title }),
+    ...(additionalTags === undefined ? {} : { additionalTags }),
     ...modes,
     prompt,
     readsPromptFromStdin,

--- a/cli/catalog-output.ts
+++ b/cli/catalog-output.ts
@@ -1,0 +1,144 @@
+import type { ApiProtocol } from '@garcon/common/api-providers';
+
+export type CatalogQueryResult =
+  | {
+      resource: 'agents';
+      agents: Array<{
+        id: string;
+        label: string;
+        description: string | null;
+        defaultModel: string;
+        acceptsApiProviders: boolean;
+        supportedProtocols: ApiProtocol[];
+        permissions: string[];
+        reasoningEfforts: string[];
+      }>;
+    }
+  | {
+      resource: 'providers';
+      agentId: string | null;
+      providers: Array<{ id: string; label: string; endpoints: string[] }>;
+    }
+  | {
+      resource: 'endpoints';
+      agentId: string | null;
+      endpoints: Array<{
+        providerId: string;
+        id: string;
+        protocol: ApiProtocol;
+        defaultModel: string;
+        supportsImages: boolean;
+        hasApiKey: boolean;
+      }>;
+    }
+  | {
+      resource: 'models';
+      agentId: string;
+      defaultModel: string;
+      models: Array<{
+        value: string;
+        label: string;
+        rawModel: string;
+        providerId: string | null;
+        endpointId: string | null;
+        protocol: ApiProtocol | null;
+        isDefault: boolean;
+        supportsImages: boolean;
+        isLocal: boolean;
+      }>;
+    }
+  | {
+      resource: 'permissions';
+      agentId: string;
+      defaultPermission: string;
+      permissions: string[];
+    }
+  | {
+      resource: 'reasoning-efforts';
+      agentId: string;
+      defaultReasoningEffort: string;
+      reasoningEfforts: string[];
+    };
+
+function cleanCell(value: string): string {
+  return value.replace(/\s+/g, ' ').trim() || '-';
+}
+
+function table(headers: readonly string[], rows: readonly (readonly string[])[]): string {
+  const cleanHeaders = headers.map(cleanCell);
+  const cleanRows = rows.map((row) => row.map(cleanCell));
+  const widths = cleanHeaders.map((header, column) => Math.max(
+    header.length,
+    ...cleanRows.map((row) => row[column]?.length ?? 0),
+  ));
+  const render = (row: readonly string[]) => row
+    .map((cell, column) => column === row.length - 1 ? cell : cell.padEnd(widths[column] ?? 0))
+    .join('  ');
+  return [
+    render(cleanHeaders),
+    render(widths.map((width) => '-'.repeat(width))),
+    ...cleanRows.map(render),
+  ].join('\n');
+}
+
+function humanListing(result: CatalogQueryResult): string {
+  switch (result.resource) {
+    case 'agents':
+      return table(
+        ['AGENT', 'LABEL', 'DEFAULT MODEL'],
+        result.agents.map((agent) => [agent.id, agent.label, agent.defaultModel]),
+      );
+    case 'providers':
+      return table(
+        ['PROVIDER', 'LABEL', 'ENDPOINTS'],
+        result.providers.map((provider) => [
+          provider.id,
+          provider.label,
+          provider.endpoints.join(', '),
+        ]),
+      );
+    case 'endpoints':
+      return table(
+        ['PROVIDER', 'ENDPOINT', 'PROTOCOL', 'DEFAULT MODEL'],
+        result.endpoints.map((endpoint) => [
+          endpoint.providerId,
+          endpoint.id,
+          endpoint.protocol,
+          endpoint.defaultModel,
+        ]),
+      );
+    case 'models':
+      return table(
+        ['MODEL', 'LABEL', 'PROVIDER', 'ENDPOINT', 'DEFAULT'],
+        result.models.map((model) => [
+          model.value,
+          model.label,
+          model.providerId ?? 'native',
+          model.endpointId ?? '',
+          model.isDefault ? 'yes' : '',
+        ]),
+      );
+    case 'permissions':
+      return table(
+        ['PERMISSION', 'DEFAULT'],
+        result.permissions.map((value) => [
+          value,
+          value === result.defaultPermission ? 'yes' : '',
+        ]),
+      );
+    case 'reasoning-efforts':
+      return table(
+        ['REASONING EFFORT', 'DEFAULT'],
+        result.reasoningEfforts.map((value) => [
+          value,
+          value === result.defaultReasoningEffort ? 'yes' : '',
+        ]),
+      );
+  }
+}
+
+export function formatCatalogQueryResult(result: CatalogQueryResult, json: boolean): string {
+  if (!json) return humanListing(result);
+  const { resource: _resource, ...payload } = result;
+  return JSON.stringify(payload, null, 2);
+}

--- a/cli/catalog-query.ts
+++ b/cli/catalog-query.ts
@@ -1,0 +1,346 @@
+import type { AgentCatalogEntry, AgentModelOption } from '@garcon/common/agents';
+import type {
+  ApiProviderCatalogEntry,
+  ApiProviderEndpointCatalogEntry,
+  ApiProtocol,
+} from '@garcon/common/api-providers';
+import {
+  executionDefaultsForAgent,
+  normalizeSupportedPermissionMode,
+  normalizeSupportedThinkingMode,
+} from '@garcon/common/execution-defaults';
+import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
+import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
+import type { ListCliCommand } from './args.js';
+import {
+  formatCatalogQueryResult,
+  type CatalogQueryResult,
+} from './catalog-output.js';
+import {
+  requireCatalogAgent,
+  requireCatalogModels,
+  resolveCatalogModelSelection,
+} from './catalog-selection.js';
+import { CliError } from './errors.js';
+import type { CliOutput } from './output.js';
+
+export interface CatalogQueryClient {
+  getModelCatalog(agentId?: string, signal?: AbortSignal): Promise<ModelCatalogResponse>;
+  getSettings(signal?: AbortSignal): Promise<RemoteSettingsSnapshot>;
+}
+
+type QueryResult<Resource extends CatalogQueryResult['resource']> = Extract<
+  CatalogQueryResult,
+  { resource: Resource }
+>;
+
+function catalogError(message: string): CliError {
+  return new CliError('catalog resolution', message, 2);
+}
+
+function requireQueryAgent(
+  agent: AgentCatalogEntry | undefined,
+  resource: string,
+): AgentCatalogEntry {
+  if (!agent) throw catalogError(`list ${resource} requires --agent`);
+  return agent;
+}
+
+function requireSettings(settings: RemoteSettingsSnapshot | null): RemoteSettingsSnapshot {
+  if (!settings) throw new CliError('catalog resolution', 'settings were not loaded', 3);
+  return settings;
+}
+
+function protocol(value: unknown): value is ApiProtocol {
+  return value === 'anthropic-messages' || value === 'openai-compatible';
+}
+
+function catalogProviders(catalog: ModelCatalogResponse): ApiProviderCatalogEntry[] {
+  const valid = catalog.catalog.apiProviders.every((provider) => (
+    provider
+    && typeof provider.id === 'string'
+    && provider.id.length > 0
+    && typeof provider.label === 'string'
+    && Array.isArray(provider.endpoints)
+    && provider.endpoints.every((endpoint) => (
+      endpoint
+      && typeof endpoint.id === 'string'
+      && endpoint.id.length > 0
+      && protocol(endpoint.protocol)
+      && typeof endpoint.defaultModel === 'string'
+      && typeof endpoint.supportsImages === 'boolean'
+      && typeof endpoint.hasApiKey === 'boolean'
+    ))
+  ));
+  if (!valid) throw new CliError('catalog resolution', 'API provider catalog is invalid', 3);
+  return catalog.catalog.apiProviders;
+}
+
+function available(label: string, values: readonly string[]): string {
+  return `${label}: ${values.length > 0 ? values.join(', ') : 'none'}`;
+}
+
+function requireProvider(
+  providers: readonly ApiProviderCatalogEntry[],
+  providerId: string,
+): ApiProviderCatalogEntry {
+  const provider = providers.find((entry) => entry.id === providerId);
+  if (!provider) {
+    throw catalogError(
+      `unknown API provider: ${providerId}; ${available('available providers', providers.map((entry) => entry.id))}`,
+    );
+  }
+  return provider;
+}
+
+function requireEndpoint(
+  provider: ApiProviderCatalogEntry,
+  endpointId: string,
+): ApiProviderEndpointCatalogEntry {
+  const endpoint = provider.endpoints.find((entry) => entry.id === endpointId);
+  if (!endpoint) {
+    throw catalogError(
+      `unknown endpoint ${endpointId} in provider ${provider.id}; ${available(
+        'available endpoints',
+        provider.endpoints.map((entry) => entry.id),
+      )}`,
+    );
+  }
+  return endpoint;
+}
+
+function compatibleEndpoints(
+  provider: ApiProviderCatalogEntry,
+  agent: AgentCatalogEntry | undefined,
+): ApiProviderEndpointCatalogEntry[] {
+  if (!agent) return provider.endpoints;
+  if (!agent.acceptsApiProviderEndpoints) return [];
+  return provider.endpoints.filter((endpoint) => agent.supportedProtocols.includes(endpoint.protocol));
+}
+
+function requireCompatibleEndpoints(
+  provider: ApiProviderCatalogEntry,
+  agent: AgentCatalogEntry,
+  endpoints: ApiProviderEndpointCatalogEntry[],
+): void {
+  if (endpoints.length === 0) {
+    throw catalogError(`provider ${provider.id} has no endpoints compatible with agent ${agent.id}`);
+  }
+}
+
+function agentListing(catalog: ModelCatalogResponse): QueryResult<'agents'> {
+  const agents = catalog.catalog.agents.map((entry) => requireCatalogAgent(catalog, entry.id));
+  return {
+    resource: 'agents',
+    agents: agents.map((agent) => ({
+      id: agent.id,
+      label: agent.label,
+      description: agent.description ?? null,
+      defaultModel: agent.defaultModel,
+      acceptsApiProviders: agent.acceptsApiProviderEndpoints,
+      supportedProtocols: agent.supportedProtocols,
+      permissions: agent.supportedPermissionModes,
+      reasoningEfforts: agent.supportedThinkingModes,
+    })),
+  };
+}
+
+function providerListing(
+  catalog: ModelCatalogResponse,
+  command: ListCliCommand,
+  agent: AgentCatalogEntry | undefined,
+): QueryResult<'providers'> {
+  const allProviders = catalogProviders(catalog);
+  const providers = command.providerId === undefined
+    ? allProviders
+    : [requireProvider(allProviders, command.providerId)];
+  const listed = providers.flatMap((provider) => {
+    const endpoints = compatibleEndpoints(provider, agent);
+    if (command.providerId !== undefined && agent) {
+      requireCompatibleEndpoints(provider, agent, endpoints);
+    }
+    return endpoints.length === 0 && agent
+      ? []
+      : [{
+          id: provider.id,
+          label: provider.label,
+          endpoints: endpoints.map((endpoint) => endpoint.id),
+        }];
+  });
+  return {
+    resource: 'providers',
+    agentId: agent?.id ?? null,
+    providers: listed,
+  };
+}
+
+function endpointListing(
+  catalog: ModelCatalogResponse,
+  command: ListCliCommand,
+  agent: AgentCatalogEntry | undefined,
+): QueryResult<'endpoints'> {
+  if (!command.providerId) throw catalogError('list endpoints requires --provider');
+  const provider = requireProvider(catalogProviders(catalog), command.providerId);
+  const compatible = compatibleEndpoints(provider, agent);
+  if (agent) requireCompatibleEndpoints(provider, agent, compatible);
+  let endpoints = compatible;
+  if (command.endpointId !== undefined) {
+    const endpoint = requireEndpoint(provider, command.endpointId);
+    if (agent && !compatible.includes(endpoint)) {
+      throw catalogError(`endpoint ${endpoint.id} is not compatible with agent ${agent.id}`);
+    }
+    endpoints = [endpoint];
+  }
+  const listed = endpoints.map((endpoint) => ({
+    providerId: provider.id,
+    id: endpoint.id,
+    protocol: endpoint.protocol,
+    defaultModel: endpoint.defaultModel,
+    supportsImages: endpoint.supportsImages,
+    hasApiKey: endpoint.hasApiKey,
+  }));
+  return {
+    resource: 'endpoints',
+    agentId: agent?.id ?? null,
+    endpoints: listed,
+  };
+}
+
+function modelListing(
+  catalog: ModelCatalogResponse,
+  command: ListCliCommand,
+  agent: AgentCatalogEntry,
+): QueryResult<'models'> {
+  if (command.providerId !== undefined) {
+    if (!agent.acceptsApiProviderEndpoints) {
+      throw catalogError(`agent ${agent.id} does not accept API provider endpoints`);
+    }
+    const provider = requireProvider(catalogProviders(catalog), command.providerId);
+    if (command.endpointId !== undefined) {
+      const endpoint = requireEndpoint(provider, command.endpointId);
+      if (!agent.supportedProtocols.includes(endpoint.protocol)) {
+        throw catalogError(`endpoint ${endpoint.id} is not compatible with agent ${agent.id}`);
+      }
+    }
+  }
+  const models = requireCatalogModels(agent).filter((model) => (
+    (command.providerId === undefined || model.apiProviderId === command.providerId)
+    && (command.endpointId === undefined || model.endpointId === command.endpointId)
+  ));
+  const listed = models.map((model) => modelDetails(catalog, agent, model));
+  return {
+    resource: 'models',
+    agentId: agent.id,
+    defaultModel: agent.defaultModel,
+    models: listed,
+  };
+}
+
+function modelDetails(
+  catalog: ModelCatalogResponse,
+  agent: AgentCatalogEntry,
+  model: AgentModelOption,
+): {
+  value: string;
+  label: string;
+  rawModel: string;
+  providerId: string | null;
+  endpointId: string | null;
+  protocol: ApiProtocol | null;
+  isDefault: boolean;
+  supportsImages: boolean;
+  isLocal: boolean;
+} {
+  const selection = resolveCatalogModelSelection(catalog, agent, model);
+  return {
+    value: model.value,
+    label: model.label,
+    rawModel: selection.model,
+    providerId: selection.apiProviderId,
+    endpointId: selection.modelEndpointId,
+    protocol: selection.modelProtocol,
+    isDefault: model.value === agent.defaultModel,
+    supportsImages: model.supportsImages ?? agent.supportsImages,
+    isLocal: model.isLocal ?? false,
+  };
+}
+
+function permissionListing(
+  agent: AgentCatalogEntry,
+  settings: RemoteSettingsSnapshot,
+): QueryResult<'permissions'> {
+  const defaults = executionDefaultsForAgent(settings.executionDefaults, agent.id);
+  const defaultPermission = normalizeSupportedPermissionMode(
+    defaults.permissionMode,
+    agent.supportedPermissionModes,
+  );
+  return {
+    resource: 'permissions',
+    agentId: agent.id,
+    defaultPermission,
+    permissions: agent.supportedPermissionModes,
+  };
+}
+
+function reasoningEffortListing(
+  agent: AgentCatalogEntry,
+  settings: RemoteSettingsSnapshot,
+): QueryResult<'reasoning-efforts'> {
+  const defaults = executionDefaultsForAgent(settings.executionDefaults, agent.id);
+  const defaultReasoningEffort = normalizeSupportedThinkingMode(
+    defaults.thinkingMode,
+    agent.supportedThinkingModes,
+  );
+  return {
+    resource: 'reasoning-efforts',
+    agentId: agent.id,
+    defaultReasoningEffort,
+    reasoningEfforts: agent.supportedThinkingModes,
+  };
+}
+
+export async function runCatalogQuery(
+  command: ListCliCommand,
+  client: CatalogQueryClient,
+  output: CliOutput,
+  signal?: AbortSignal,
+): Promise<void> {
+  const needsSettings = command.resource === 'permissions'
+    || command.resource === 'reasoning-efforts';
+  const [catalog, settings] = await Promise.all([
+    client.getModelCatalog(command.resource === 'models' ? command.agentId : undefined, signal),
+    needsSettings ? client.getSettings(signal) : Promise.resolve(null),
+  ]);
+  const agent = command.agentId === undefined
+    ? undefined
+    : requireCatalogAgent(catalog, command.agentId);
+
+  let result: CatalogQueryResult;
+  switch (command.resource) {
+    case 'agents':
+      result = agentListing(catalog);
+      break;
+    case 'providers':
+      result = providerListing(catalog, command, agent);
+      break;
+    case 'endpoints':
+      result = endpointListing(catalog, command, agent);
+      break;
+    case 'models':
+      result = modelListing(catalog, command, requireQueryAgent(agent, command.resource));
+      break;
+    case 'permissions':
+      result = permissionListing(
+        requireQueryAgent(agent, command.resource),
+        requireSettings(settings),
+      );
+      break;
+    case 'reasoning-efforts':
+      result = reasoningEffortListing(
+        requireQueryAgent(agent, command.resource),
+        requireSettings(settings),
+      );
+      break;
+  }
+  output.listing(formatCatalogQueryResult(result, command.json));
+}

--- a/cli/catalog-selection.ts
+++ b/cli/catalog-selection.ts
@@ -48,7 +48,10 @@ function isApiProtocol(value: unknown): value is ApiProtocol {
   return value === 'anthropic-messages' || value === 'openai-compatible';
 }
 
-function normalizedAgent(catalog: ModelCatalogResponse, agentId: string): AgentCatalogEntry {
+export function requireCatalogAgent(
+  catalog: ModelCatalogResponse,
+  agentId: string,
+): AgentCatalogEntry {
   const raw = catalog.catalog.agents.find((entry) => entry?.id === agentId);
   if (!raw) {
     throw catalogError(
@@ -74,7 +77,7 @@ function normalizedAgent(catalog: ModelCatalogResponse, agentId: string): AgentC
   return { ...raw, defaultSettings };
 }
 
-function normalizedModels(agent: AgentCatalogEntry): AgentModelOption[] {
+export function requireCatalogModels(agent: AgentCatalogEntry): AgentModelOption[] {
   const valid = agent.models.every((model) => (
     model
     && typeof model.value === 'string'
@@ -93,7 +96,7 @@ function normalizedModels(agent: AgentCatalogEntry): AgentModelOption[] {
   return agent.models;
 }
 
-function selectedRouting(
+export function resolveCatalogModelSelection(
   catalog: ModelCatalogResponse,
   agent: AgentCatalogEntry,
   model: AgentModelOption,
@@ -190,9 +193,9 @@ export function resolveModelSelection(
   agentId: string,
   requested: RequestedModelSelection,
 ): ResolvedModelSelection {
-  const agent = normalizedAgent(catalog, agentId);
+  const agent = requireCatalogAgent(catalog, agentId);
   assertProviderAndEndpoint(catalog, agent, requested);
-  const matches = matchingModels(normalizedModels(agent), requested);
+  const matches = matchingModels(requireCatalogModels(agent), requested);
   if (matches.length > 1) {
     const routes = matches.map(describeRouting).join(', ');
     throw catalogError(`model ${requested.model} is ambiguous across: ${routes}; specify --provider and --endpoint`);
@@ -209,7 +212,7 @@ export function resolveModelSelection(
       modelProtocol: null,
     };
   }
-  return selectedRouting(catalog, agent, selected);
+  return resolveCatalogModelSelection(catalog, agent, selected);
 }
 
 function strictPermissionMode(
@@ -241,7 +244,7 @@ export function validateExplicitModes(
   agentId: string,
   requested: { permissionMode?: PermissionMode; thinkingMode?: ThinkingMode },
 ): void {
-  const agent = normalizedAgent(catalog, agentId);
+  const agent = requireCatalogAgent(catalog, agentId);
   if (requested.permissionMode !== undefined) {
     strictPermissionMode(requested.permissionMode, agent, 'default');
   }
@@ -259,7 +262,7 @@ export function resolveStartSelection(
     thinkingMode?: ThinkingMode;
   },
 ): ResolvedStartSelection {
-  const agent = normalizedAgent(catalog, requested.agentId);
+  const agent = requireCatalogAgent(catalog, requested.agentId);
   const executionDefaults = executionDefaultsForAgent(settings.executionDefaults, requested.agentId);
   const permissionMode = strictPermissionMode(
     requested.permissionMode,

--- a/cli/consultation.ts
+++ b/cli/consultation.ts
@@ -8,8 +8,10 @@ import type {
 import { createClientChatId } from '@garcon/common/client-chat-id';
 import type { ChatListEntry } from '@garcon/common/chat-list';
 import type { ChatListResponse } from '@garcon/common/chat-list';
+import type { UpdateChatTitleRequest } from '@garcon/common/chat-title-contracts';
 import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
+import { normalizeTags } from '@garcon/common/tags';
 import type { CliInvocation } from './args.js';
 import {
   resolveModelSelection,
@@ -31,6 +33,7 @@ export interface ConsultationClient extends ReceiptClient {
   listChats(signal?: AbortSignal): Promise<ChatListResponse>;
   startChat(request: StartChatCommandRequest, signal?: AbortSignal): Promise<AgentTurnCommandResponse>;
   runChat(request: AgentRunCommandRequest, signal?: AbortSignal): Promise<AgentTurnCommandResponse>;
+  updateChatTitle(request: UpdateChatTitleRequest, signal?: AbortSignal): Promise<void>;
 }
 
 export interface ConsultationDependencies {
@@ -40,6 +43,10 @@ export interface ConsultationDependencies {
 }
 
 const START_CHAT_ID_ATTEMPTS = 3;
+
+function consultationTags(invocation: CliInvocation): string[] {
+  return normalizeTags(['cli', ...(invocation.additionalTags ?? [])]);
+}
 
 function terminalResult(receipt: AgentTurnReceipt, output: CliOutput): void {
   if (receipt.state === 'completed') {
@@ -106,7 +113,7 @@ async function submitStart(
       projectPath: invocation.cwd,
       ...selection,
       command: prompt,
-      tags: ['cli'],
+      tags: consultationTags(invocation),
     };
     try {
       return await client.startChat(request, signal);
@@ -138,7 +145,7 @@ async function submitResume(
     chatId: invocation.chatId,
     command: prompt,
     ...(invocation.agentId === undefined ? {} : { expectedAgentId: invocation.agentId }),
-    tagsToAdd: ['cli'],
+    tagsToAdd: consultationTags(invocation),
     permissionFallbackPolicy: 'require-explicit-bypass',
   };
   const needsCatalog = invocation.model !== undefined
@@ -183,6 +190,14 @@ export async function runConsultation(
     ? await submitStart(invocation, prompt, client, signal, createId, createChatId)
     : await submitResume(invocation, prompt, client, signal, createId);
   output.accepted(accepted.chatId);
+  let titleError: unknown | undefined;
+  if (invocation.title !== undefined) {
+    try {
+      await client.updateChatTitle({ chatId: accepted.chatId, title: invocation.title }, signal);
+    } catch (error) {
+      titleError = error;
+    }
+  }
   const receipt = await pollTurnReceipt(
     client,
     accepted.chatId,
@@ -192,4 +207,5 @@ export async function runConsultation(
     dependencies.poller,
   );
   terminalResult(receipt, output);
+  if (titleError !== undefined) throw titleError;
 }

--- a/cli/errors.ts
+++ b/cli/errors.ts
@@ -6,6 +6,7 @@ export type CliErrorPhase =
   | 'catalog resolution'
   | 'resume admission'
   | 'submission'
+  | 'title update'
   | 'receipt polling'
   | 'transport recovery';
 

--- a/cli/garcon-client.ts
+++ b/cli/garcon-client.ts
@@ -6,6 +6,10 @@ import type {
   StartChatCommandRequest,
 } from '@garcon/common/chat-command-contracts';
 import type { ChatListResponse } from '@garcon/common/chat-list';
+import type {
+  UpdateChatTitleRequest,
+  UpdateChatTitleResponse,
+} from '@garcon/common/chat-title-contracts';
 import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
 import { normalizeRemoteSettingsSnapshot } from '@garcon/common/settings';
@@ -39,7 +43,7 @@ export class GarconHttpError extends CliError {
         || errorCode === 'UNSUPPORTED_AGENT'
         || errorCode === 'EXPECTED_AGENT_MISMATCH'
         || errorCode === 'EXPLICIT_BYPASS_REQUIRED'
-        || (phase === 'catalog resolution' && status === 400)
+        || ((phase === 'catalog resolution' || phase === 'title update') && status === 400)
         ? 2
         : 3,
     );
@@ -143,8 +147,18 @@ export class GarconClient {
     this.#submissionDelay = options.submissionDelay ?? abortableDelay;
   }
 
-  async getModelCatalog(agentId: string, signal?: AbortSignal): Promise<ModelCatalogResponse> {
-    const value = await this.#request('catalog resolution', 'GET', `/api/v1/models?agent=${encodeURIComponent(agentId)}`, undefined, signal);
+  async getModelCatalog(
+    agentId?: string,
+    signal?: AbortSignal,
+  ): Promise<ModelCatalogResponse> {
+    const query = agentId === undefined ? '' : `?agent=${encodeURIComponent(agentId)}`;
+    const value = await this.#request(
+      'catalog resolution',
+      'GET',
+      `/api/v1/models${query}`,
+      undefined,
+      signal,
+    );
     const raw = record(value);
     const catalog = record(raw?.catalog);
     if (!Array.isArray(catalog?.agents) || !Array.isArray(catalog.apiProviders)) {
@@ -175,6 +189,20 @@ export class GarconClient {
 
   runChat(request: AgentRunCommandRequest, signal?: AbortSignal): Promise<AgentTurnCommandResponse> {
     return this.#submit('/api/v1/chats/run', 'agent-run', request, signal);
+  }
+
+  async updateChatTitle(request: UpdateChatTitleRequest, signal?: AbortSignal): Promise<void> {
+    const value = await this.#request(
+      'title update',
+      'PUT',
+      '/api/v1/app/session-name',
+      request,
+      signal,
+    );
+    const response = record(value) as Partial<UpdateChatTitleResponse> | null;
+    if (response?.success !== true) {
+      throw new CliError('title update', 'server returned an invalid title update response', 3);
+    }
   }
 
   async getTurnReceipt(chatId: string, turnId: string, signal?: AbortSignal): Promise<AgentTurnReceipt> {
@@ -262,7 +290,7 @@ export class GarconClient {
 
   async #request(
     phase: CliErrorPhase,
-    method: 'GET' | 'POST',
+    method: 'GET' | 'POST' | 'PUT',
     route: string,
     body: unknown,
     signal?: AbortSignal,

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,6 +1,7 @@
 import packageJson from '../package.json' with { type: 'json' };
 import fs from 'node:fs/promises';
 import { CLI_HELP, parseCliArgs } from './args.js';
+import { runCatalogQuery } from './catalog-query.js';
 import { runConsultation } from './consultation.js';
 import { discoverRuntime } from './discovery.js';
 import { CliError } from './errors.js';
@@ -80,6 +81,17 @@ export async function main(
     }
     if (command.kind === 'version') {
       process.stdout.write(`${packageJson.version}\n`);
+      return 0;
+    }
+    if (command.kind === 'list') {
+      const connection = await discoverRuntime({
+        configDir: command.configDir,
+        workspace: command.workspace,
+        serverUrl: command.serverUrl,
+        signal: options.signal,
+      }, { fetch: options.fetch });
+      const client = new GarconClient({ ...connection, fetch: options.fetch });
+      await runCatalogQuery(command, client, output, options.signal);
       return 0;
     }
     const prompt = command.readsPromptFromStdin

--- a/cli/output.ts
+++ b/cli/output.ts
@@ -5,6 +5,7 @@ export interface CliWritable {
 export interface CliOutput {
   accepted(chatId: string): void;
   completed(messages: readonly string[]): void;
+  listing(content: string): void;
   diagnostic(message: string): void;
 }
 
@@ -18,7 +19,11 @@ export function createCliOutput(
     },
     completed(messages) {
       const nonEmpty = messages.filter((message) => message.trim().length > 0);
+      if (nonEmpty.length === 0) return;
       stdout.write(`${nonEmpty.join('\n\n')}\n`);
+    },
+    listing(content) {
+      stdout.write(`${content.replace(/\n+$/, '')}\n`);
     },
     diagnostic(message) {
       stderr.write(`${message}\n`);

--- a/common/chat-title-contracts.ts
+++ b/common/chat-title-contracts.ts
@@ -1,5 +1,14 @@
 import type { HttpErrorResponse } from './http-error.js';
 
+export interface UpdateChatTitleRequest {
+  chatId: string;
+  title: string;
+}
+
+export interface UpdateChatTitleResponse {
+  success: true;
+}
+
 export interface GenerateChatTitleRequest {
   chatId: string;
   message: string;

--- a/integration-tests/tests/server/garcon-cli.test.ts
+++ b/integration-tests/tests/server/garcon-cli.test.ts
@@ -10,12 +10,8 @@ import { GarconProcess } from '../../support/garcon-process.js';
 const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
 const WORKSPACE = 'cli-integration';
 
-function startCli(arguments_: string[]): Promise<{
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}> {
-  const child = Bun.spawn({
+function spawnCli(arguments_: string[]) {
+  return Bun.spawn({
     cmd: [process.execPath, 'cli/main.ts', ...arguments_],
     cwd: REPO_ROOT,
     env: {
@@ -26,11 +22,57 @@ function startCli(arguments_: string[]): Promise<{
     stdout: 'pipe',
     stderr: 'pipe',
   });
+}
+
+function startCli(arguments_: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const child = spawnCli(arguments_);
   return Promise.all([
     child.exited,
     new Response(child.stdout).text(),
     new Response(child.stderr).text(),
   ]).then(([exitCode, stdout, stderr]) => ({ exitCode, stdout, stderr }));
+}
+
+function startObservedCli(arguments_: string[]): {
+  acceptedChatId: Promise<string>;
+  result: ReturnType<typeof startCli>;
+} {
+  const child = spawnCli(arguments_);
+  let resolveChatId!: (chatId: string) => void;
+  let rejectChatId!: (error: Error) => void;
+  const acceptedChatId = new Promise<string>((resolve, reject) => {
+    resolveChatId = resolve;
+    rejectChatId = reject;
+  });
+  const stdout = (async () => {
+    const reader = new Response(child.stdout).body!.getReader();
+    const decoder = new TextDecoder();
+    let text = '';
+    let foundChatId = false;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      const match = text.match(/^chat id: (\d{16})$/m);
+      if (!foundChatId && match?.[1]) {
+        foundChatId = true;
+        resolveChatId(match[1]);
+      }
+    }
+    text += decoder.decode();
+    if (!foundChatId) rejectChatId(new Error('CLI exited before reporting an accepted chat ID'));
+    return text;
+  })();
+  const result = Promise.all([
+    child.exited,
+    stdout,
+    new Response(child.stderr).text(),
+  ]).then(([exitCode, stdoutText, stderr]) => ({ exitCode, stdout: stdoutText, stderr }));
+  return { acceptedChatId, result };
 }
 
 function runCli(arguments_: string[]): Promise<{
@@ -62,6 +104,36 @@ describe('garcon-cli', () => {
   test('starts and resumes a visible tagged chat through a named workspace', async () => {
     await withIntegrationFixture('garcon-cli-start-resume', async (fixture) => {
       const agent = fixture.directAgents.openAi;
+      const listedAgents = await runCli([
+        '--config-dir', fixture.dirs.config,
+        '--workspace', WORKSPACE,
+        'list', 'agents', '--json',
+      ]);
+      expect(listedAgents.exitCode).toBe(0);
+      expect(listedAgents.stderr).toBe('');
+      expect(JSON.parse(listedAgents.stdout).agents).toContainEqual(
+        expect.objectContaining({ id: agent.agentId }),
+      );
+
+      const listedModels = await runCli([
+        '--config-dir', fixture.dirs.config,
+        '--workspace', WORKSPACE,
+        'list', 'models',
+        '--agent', agent.agentId,
+        '--provider', agent.provider.providerId,
+        '--endpoint', agent.provider.endpointId,
+        '--json',
+      ]);
+      expect(listedModels.exitCode).toBe(0);
+      expect(listedModels.stderr).toBe('');
+      expect(JSON.parse(listedModels.stdout).models).toContainEqual(
+        expect.objectContaining({
+          rawModel: agent.provider.model,
+          providerId: agent.provider.providerId,
+          endpointId: agent.provider.endpointId,
+        }),
+      );
+
       const started = await runCli([
         '--config-dir', fixture.dirs.config,
         '--workspace', WORKSPACE,
@@ -70,6 +142,9 @@ describe('garcon-cli', () => {
         '--provider', agent.provider.providerId,
         '--endpoint', agent.provider.endpointId,
         '--model', agent.provider.model,
+        '--title', 'CLI delegated review',
+        '--tag', 'Review Needed',
+        '--tag', 'delegated',
         'cli-first-turn',
       ]);
       expect(started.exitCode).toBe(0);
@@ -81,13 +156,16 @@ describe('garcon-cli', () => {
       const chatsAfterStart = await fixture.client.listChats();
       expect(chatsAfterStart.sessions.find((chat) => chat.id === chatId)).toMatchObject({
         projectPath: fixture.dirs.project,
-        tags: ['cli'],
+        title: 'CLI delegated review',
+        tags: ['cli', 'delegated', 'review-needed'],
       });
 
       const resumed = await runCli([
         '--config-dir', fixture.dirs.config,
         '--workspace', WORKSPACE,
         '--resume', chatId!,
+        '--title', 'CLI follow-up review',
+        '--tag', 'Follow Up',
         'cli-second-turn',
       ]);
       expect(resumed).toEqual({
@@ -97,7 +175,13 @@ describe('garcon-cli', () => {
       });
       const chatsAfterResume = await fixture.client.listChats();
       expect(chatsAfterResume.sessions).toHaveLength(1);
-      expect(chatsAfterResume.sessions[0]?.tags).toEqual(['cli']);
+      expect(chatsAfterResume.sessions[0]?.tags).toEqual([
+        'cli',
+        'delegated',
+        'follow-up',
+        'review-needed',
+      ]);
+      expect(chatsAfterResume.sessions[0]?.title).toBe('CLI follow-up review');
     }, { namedWorkspace: WORKSPACE });
   });
 
@@ -169,19 +253,20 @@ describe('garcon-cli', () => {
     await withIntegrationFixture('garcon-cli-restart', async (fixture) => {
       const before = new Set((await fixture.client.listChats()).sessions.map((chat) => chat.id));
       const held = fixture.fakeProviders.openAi.holdNext({ lastUserText: 'cli-restart' });
-      const cli = startCli(startArguments(fixture, 'cli-restart'));
+      const cli = startObservedCli(startArguments(fixture, 'cli-restart'));
       await held.received;
       const acceptedChat = (await fixture.client.listChats()).sessions.find(
         (chat) => !before.has(chat.id),
       );
       expect(acceptedChat).toBeDefined();
+      expect(await cli.acceptedChatId).toBe(acceptedChat!.id);
       const aborted = held.expectAbort();
 
       await fixture.crashAndRestartGarcon({ reusePort: true });
       await aborted;
       held.releaseEcho();
 
-      const result = await cli;
+      const result = await cli.result;
       expect(result.exitCode).toBe(3);
       expect(result.stdout).toBe(`chat id: ${acceptedChat!.id}\n`);
       expect(result.stderr).toContain('transport recovery:');

--- a/server/chats/__tests__/title-generator.test.js
+++ b/server/chats/__tests__/title-generator.test.js
@@ -20,6 +20,7 @@ const mockAgents = {
 };
 
 const setSessionNameMock = mock(() => Promise.resolve(undefined));
+const setSessionNameIfAbsentMock = mock(() => Promise.resolve(true));
 const getChatNameMock = mock(() => null);
 const getUiSettingsMock = mock(() => Promise.resolve({
   chatTitle: { enabled: true, agentId: 'claude', model: 'opus' },
@@ -28,13 +29,14 @@ const mockSettings = {
   getUiSettings: getUiSettingsMock,
   getChatName: getChatNameMock,
   setSessionName: setSessionNameMock,
+  setSessionNameIfAbsent: setSessionNameIfAbsentMock,
 };
 const recentTitleIcons = {
   getRecentIcons: () => [],
 };
 
 const allMocks = [
-  runSingleQueryMock, setSessionNameMock,
+  runSingleQueryMock, setSessionNameMock, setSessionNameIfAbsentMock,
   getChatNameMock, getUiSettingsMock, getAgentAuthStatusMapMock,
   getAgentReadinessMapMock, getAgentCatalogEntriesMock, getModelsMock, mockAgents.getAgentCatalog,
 ];
@@ -55,6 +57,7 @@ describe('maybeGenerateChatTitle', () => {
     getModelsMock.mockImplementation(() => Promise.resolve([]));
     runSingleQueryMock.mockImplementation(() => Promise.resolve('Test Chat Title'));
     getChatNameMock.mockImplementation(() => null);
+    setSessionNameIfAbsentMock.mockImplementation(() => Promise.resolve(true));
   });
 
   it('generates and persists a title when enabled', async () => {
@@ -75,7 +78,7 @@ describe('maybeGenerateChatTitle', () => {
     expect(opts.thinkingMode).toBe('none');
     expect(opts.timeoutMs).toBe(110_000);
 
-    expect(setSessionNameMock).toHaveBeenCalledWith('100', 'Test Chat Title');
+    expect(setSessionNameIfAbsentMock).toHaveBeenCalledWith('100', 'Test Chat Title');
   });
 
   it('asks automatic generation to avoid recent icons and keep the icon first', async () => {
@@ -281,6 +284,37 @@ describe('maybeGenerateChatTitle', () => {
     expect(runSingleQueryMock).not.toHaveBeenCalled();
   });
 
+  it('preserves a manual title set while automatic generation is running', async () => {
+    let resolveGeneration;
+    let markGenerationStarted;
+    const generationStarted = new Promise((resolve) => {
+      markGenerationStarted = resolve;
+    });
+    runSingleQueryMock.mockImplementation(() => {
+      markGenerationStarted();
+      return new Promise((resolve) => {
+        resolveGeneration = resolve;
+      });
+    });
+    getChatNameMock.mockImplementation(() => null);
+    setSessionNameIfAbsentMock.mockImplementation(() => Promise.resolve(false));
+
+    const generation = maybeGenerateChatTitle({
+      chatId: '501',
+      projectPath: '/proj',
+      firstPrompt: 'Some prompt',
+      agents: mockAgents,
+      settings: mockSettings,
+      recentTitleIcons,
+    });
+    await generationStarted;
+    resolveGeneration('Generated Title');
+    await generation;
+
+    expect(setSessionNameIfAbsentMock).toHaveBeenCalledWith('501', 'Generated Title');
+    expect(setSessionNameMock).not.toHaveBeenCalled();
+  });
+
   it('strips surrounding quotes from generated title', async () => {
     runSingleQueryMock.mockImplementation(() => Promise.resolve('"Quoted Title"'));
 
@@ -293,7 +327,7 @@ describe('maybeGenerateChatTitle', () => {
       recentTitleIcons,
     });
 
-    expect(setSessionNameMock).toHaveBeenCalledWith('600', 'Quoted Title');
+    expect(setSessionNameIfAbsentMock).toHaveBeenCalledWith('600', 'Quoted Title');
   });
 
   it('does not persist an empty generated title', async () => {

--- a/server/chats/title-generator.ts
+++ b/server/chats/title-generator.ts
@@ -43,6 +43,7 @@ interface TitleGenerationSettings {
   getUiSettings(): { chatTitle?: unknown } | null | undefined;
   getChatName(chatId: string): string | null | undefined;
   setSessionName(chatId: string, title: string): Promise<unknown>;
+  setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;
 }
 
 interface MaybeGenerateChatTitleInput {
@@ -225,6 +226,10 @@ async function runTitleGeneration({
       );
     }
 
+    if (skipExistingTitle) {
+      const persisted = await settings.setSessionNameIfAbsent(chatId, title);
+      return persisted ? { chatId, title } : null;
+    }
     await settings.setSessionName(chatId, title);
     return { chatId, title };
   } catch (error) {

--- a/server/routes/workspace.ts
+++ b/server/routes/workspace.ts
@@ -23,6 +23,10 @@ import {
 import { AppTitleValidationError, sanitizeAppIdentityPatch } from '../app-title-settings.js';
 import { TranscriptSearchSettingsError } from '../chats/search/settings-coordinator.js';
 import { isGenerationTestTarget } from '../../common/generation-test-contracts.js';
+import type {
+  UpdateChatTitleRequest,
+  UpdateChatTitleResponse,
+} from '../../common/chat-title-contracts.js';
 import { testGenerationModel } from '../settings/generation-model-test.js';
 
 // Builds the canonical remote settings snapshot used by GET, PUT, and
@@ -179,7 +183,7 @@ export default function createWorkspaceRoutes(
 
   async function putSessionNameHandler(body: JsonBody): Promise<Response> {
     try {
-      const { chatId, title } = asJsonBody(body);
+      const { chatId, title } = asJsonBody(body) as Partial<UpdateChatTitleRequest>;
       if (!chatId || typeof chatId !== 'string') {
         return Response.json({ success: false, error: 'chatId is required' }, { status: 400 });
       }
@@ -192,7 +196,7 @@ export default function createWorkspaceRoutes(
       }
       // setSessionName emits 'session-name-changed' for broadcast wiring.
       await settings.setSessionName(chatId, trimmed);
-      return Response.json({ success: true });
+      return Response.json({ success: true } satisfies UpdateChatTitleResponse);
     } catch (error) {
       return Response.json({ success: false, error: errorMessage(error) }, { status: 500 });
     }

--- a/server/settings/__tests__/store.test.js
+++ b/server/settings/__tests__/store.test.js
@@ -116,6 +116,20 @@ describe('settings store', () => {
       expect(name).toBe('Trimmed Title');
     });
 
+    it('setSessionNameIfAbsent preserves an explicit title queued first', async () => {
+      const explicitWrite = store.setSessionName('abc', 'Explicit Title');
+      const generatedWrite = store.setSessionNameIfAbsent('abc', 'Generated Title');
+
+      await expect(generatedWrite).resolves.toBe(false);
+      await explicitWrite;
+      expect(store.getChatName('abc')).toBe('Explicit Title');
+    });
+
+    it('setSessionNameIfAbsent persists when no title exists', async () => {
+      await expect(store.setSessionNameIfAbsent('abc', 'Generated Title')).resolves.toBe(true);
+      expect(store.getChatName('abc')).toBe('Generated Title');
+    });
+
     it('removeSessionName deletes the entry', async () => {
       await store.setSessionName('abc', 'My Title');
       await store.removeSessionName('abc');

--- a/server/settings/domain-stores.ts
+++ b/server/settings/domain-stores.ts
@@ -200,18 +200,35 @@ export class ChatNameStore {
     return settings.chatNames[chatId] ?? null;
   }
 
+  async #persistSessionName(
+    settings: ProjectSettings,
+    chatId: string,
+    title: string,
+  ): Promise<void> {
+    if (!settings.chatNames) settings.chatNames = {};
+    const trimmed = typeof title === 'string' ? title.trim() : '';
+    if (!trimmed) {
+      delete settings.chatNames[String(chatId)];
+    } else {
+      settings.chatNames[String(chatId)] = trimmed;
+    }
+    await this.#context.save(settings);
+    this.#context.emitSessionNameChanged(chatId, trimmed || '');
+  }
+
   async setSessionName(chatId: string, title: string): Promise<void> {
     return this.#context.mutate(async () => {
       const settings = this.#context.readSettings();
-      if (!settings.chatNames) settings.chatNames = {};
-      const trimmed = typeof title === 'string' ? title.trim() : '';
-      if (!trimmed) {
-        delete settings.chatNames[String(chatId)];
-      } else {
-        settings.chatNames[String(chatId)] = trimmed;
-      }
-      await this.#context.save(settings);
-      this.#context.emitSessionNameChanged(chatId, trimmed || '');
+      await this.#persistSessionName(settings, chatId, title);
+    });
+  }
+
+  async setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean> {
+    return this.#context.mutate(async () => {
+      const settings = this.#context.readSettings();
+      if (settings.chatNames?.[String(chatId)]) return false;
+      await this.#persistSessionName(settings, chatId, title);
+      return true;
     });
   }
 

--- a/server/settings/store.ts
+++ b/server/settings/store.ts
@@ -359,6 +359,10 @@ export class SettingsStore extends EventEmitter<SettingsStoreEvents> {
     return this.#chatNames.setSessionName(chatId, title);
   }
 
+  async setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean> {
+    return this.#chatNames.setSessionNameIfAbsent(chatId, title);
+  }
+
   async removeSessionName(chatId: string): Promise<void> {
     return this.#chatNames.removeSessionName(chatId);
   }

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -10,19 +10,20 @@ import type {
 	GenerationModelTestResponse,
 	GenerationTestTarget,
 } from '$shared/generation-test-contracts';
+import type {
+	UpdateChatTitleRequest,
+	UpdateChatTitleResponse,
+} from '$shared/chat-title-contracts';
 
 const GENERATION_MODEL_TEST_TIMEOUT_MS = 120_000;
-
-export interface UpdateSessionNameResponse {
-	success: boolean;
-}
 
 /** Renames a chat session. */
 export async function updateSessionName(
 	chatId: string,
 	title: string,
-): Promise<UpdateSessionNameResponse> {
-	return apiPut<UpdateSessionNameResponse>('/api/v1/app/session-name', { chatId, title });
+): Promise<UpdateChatTitleResponse> {
+	const request: UpdateChatTitleRequest = { chatId, title };
+	return apiPut<UpdateChatTitleResponse>('/api/v1/app/session-name', request);
 }
 
 /** Fetches the current remote settings snapshot. */


### PR DESCRIPTION
Garcon CLI callers need a reliable way to discover valid live selections and organize visible delegated chats without consulting provider binaries. This adds table and JSON catalog queries for agents, providers, endpoints, models, permission modes, and reasoning efforts; supports repeatable tags and explicit titles for new or resumed chats; preserves the automatic `cli` tag and stdout contract; and makes explicit titles win atomically over background title generation.
