### PR TITLE
Preserve Pi extension provider configuration

### DIFF
--- a/server-agents/pi/src/agents/pi/__tests__/pi-rpc-runtime.test.ts
+++ b/server-agents/pi/src/agents/pi/__tests__/pi-rpc-runtime.test.ts
@@ -322,10 +322,11 @@ describe('PiRpcRuntime', () => {
     await runtime.shutdown();
   });
 
-  it('scrubs nested Pi session environment and keeps the offline flags', async () => {
+  it('scrubs nested Pi session environment and preserves extension configuration', async () => {
     process.env.PI_SESSION_FILE = '/home/someone/session.jsonl';
     process.env.PI_SESSION_ID = 'outer-session';
     process.env.PI_CODING_AGENT_SESSION_DIR = path.join(tempRoot, 'sessions');
+    process.env.PI_MODELS_DEV_OVERRIDE_PROVIDERS = 'all';
     process.env.GARCON_EMBEDDED_PI_PACKAGE_DIR = '/tmp/embedded-pi';
     process.env.PI_PACKAGE_DIR = '/tmp/embedded-pi';
     const runtime = createRuntime();
@@ -340,6 +341,7 @@ describe('PiRpcRuntime', () => {
     expect(env.PI_OFFLINE).toBe('1');
     expect(env.PI_SKIP_VERSION_CHECK).toBe('1');
     expect(env.PI_TELEMETRY).toBe('0');
+    expect(env.PI_MODELS_DEV_OVERRIDE_PROVIDERS).toBe('all');
     await runtime.shutdown();
   });
 

--- a/server-agents/pi/src/agents/pi/__tests__/runtime.test.js
+++ b/server-agents/pi/src/agents/pi/__tests__/runtime.test.js
@@ -130,7 +130,7 @@ describe('Pi single-query and spawn helpers', () => {
     }, testPiConfig)).rejects.toThrow('Pi command failed with code 3: no session found');
   });
 
-  it('scrubs nested Pi session environment and keeps Garcon offline flags', async () => {
+  it('scrubs nested Pi session environment and preserves extension configuration', async () => {
     process.env.PI_CODING_AGENT = '1';
     process.env.PI_SESSION_FILE = '/home/someone/session.jsonl';
     process.env.PI_SESSION_ID = 'outer-session';
@@ -159,7 +159,6 @@ describe('Pi single-query and spawn helpers', () => {
       'PI_MODEL',
       'PI_REASONING_LEVEL',
       'PI_CODING_AGENT_SESSION_DIR',
-      'PI_MODELS_DEV_OVERRIDE_PROVIDERS',
       'PI_PACKAGE_DIR',
       'GARCON_EMBEDDED_PI_PACKAGE_DIR',
     ]) {
@@ -169,6 +168,7 @@ describe('Pi single-query and spawn helpers', () => {
     expect(env.PI_OFFLINE).toBe('1');
     expect(env.PI_SKIP_VERSION_CHECK).toBe('1');
     expect(env.PI_TELEMETRY).toBe('0');
+    expect(env.PI_MODELS_DEV_OVERRIDE_PROVIDERS).toBe('all');
   });
 
   it('prefixes plan-mode prompts and leaves other modes untouched', async () => {

--- a/server-agents/pi/src/agents/pi/pi-cli.ts
+++ b/server-agents/pi/src/agents/pi/pi-cli.ts
@@ -26,7 +26,6 @@ const PI_NESTED_SESSION_ENV = [
   'PI_MODEL',
   'PI_REASONING_LEVEL',
   'PI_CODING_AGENT_SESSION_DIR',
-  'PI_MODELS_DEV_OVERRIDE_PROVIDERS',
 ] as const;
 
 // Pi --thinking tops out at xhigh, so Garcon's larger modes clamp down.


### PR DESCRIPTION
Pi extension configuration must reach spawned CLI processes so installation-specific provider overrides remain active. This change stops scrubbing `PI_MODELS_DEV_OVERRIDE_PROVIDERS` while continuing to remove nested session state, restoring /pi-models-dev provider mappings such as `fireworks-ai` to `fireworks` for both RPC sessions and one-shot queries.