### PR TITLE
Accept Pi provider-clamped thinking levels

### DIFF
--- a/integration-tests/support/scripted-pi.ts
+++ b/integration-tests/support/scripted-pi.ts
@@ -19,6 +19,9 @@ import type { IntegrationDirectories } from './integration-fixture.js';
 export const PI_TEST_PROVIDER = 'garcon-fake';
 export const PI_TEST_MODEL_ID = 'fake-model';
 export const PI_TEST_MODEL = `${PI_TEST_PROVIDER}/${PI_TEST_MODEL_ID}`;
+export const PI_TEST_CLAMPED_THINKING_MODEL_ID = 'fake-model-without-off';
+export const PI_TEST_CLAMPED_THINKING_MODEL =
+  `${PI_TEST_PROVIDER}/${PI_TEST_CLAMPED_THINKING_MODEL_ID}`;
 export const PI_TEST_THINKING_MODE = 'none';
 
 const SYSTEM_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
@@ -65,6 +68,15 @@ export function startScriptedPiTestEnvironment(): ScriptedPiTestEnvironment {
               id: PI_TEST_MODEL_ID,
               name: 'Garcon Fake Model',
               reasoning: false,
+              input: ['text'],
+              contextWindow: 128000,
+              maxTokens: 8192,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            }, {
+              id: PI_TEST_CLAMPED_THINKING_MODEL_ID,
+              name: 'Garcon Fake Model Without Off',
+              reasoning: true,
+              thinkingLevelMap: { off: null, minimal: 'low' },
               input: ['text'],
               contextWindow: 128000,
               maxTokens: 8192,

--- a/integration-tests/tests/server/pi-scripted-model.test.ts
+++ b/integration-tests/tests/server/pi-scripted-model.test.ts
@@ -17,6 +17,7 @@ import {
   waitForVisibleResponse,
 } from '../../support/live-agent.js';
 import {
+  PI_TEST_CLAMPED_THINKING_MODEL,
   PI_TEST_MODEL,
   piNativeSession,
   scriptedPiStartRequest,
@@ -89,6 +90,32 @@ describe('Pi against a scripted model', () => {
         ? fixture.dirs.home
         : `${fixture.dirs.home}/`;
       expect(native.path.startsWith(sessionDir)).toBe(true);
+      testEnvironment.model.assertSettled();
+    }, withScriptedPi());
+  }, 120_000);
+
+  test('accepts Pi-clamped thinking for a model without an off level', async () => {
+    const testEnvironment = requireEnvironment();
+    const reply = marker('CLAMPED_THINKING_REPLY');
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+
+    await withIntegrationFixture('pi-scripted-clamped-thinking', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedPiStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: marker('CLAMPED_THINKING_PROMPT'),
+        model: PI_TEST_CLAMPED_THINKING_MODEL,
+        thinkingMode: 'none',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
       testEnvironment.model.assertSettled();
     }, withScriptedPi());
   }, 120_000);

--- a/server-agents/pi/src/agents/pi/__tests__/pi-rpc-runtime.test.ts
+++ b/server-agents/pi/src/agents/pi/__tests__/pi-rpc-runtime.test.ts
@@ -40,6 +40,8 @@ function createFakePiProcess(options = {}) {
       ?? path.join(tempRoot, 'sessions', 'pi-session-1.jsonl'),
     modelProvider: options.modelProvider ?? 'github-copilot',
     modelId: options.modelId ?? 'gpt-5.4',
+    modelReasoning: options.modelReasoning ?? true,
+    thinkingLevelMap: options.thinkingLevelMap ?? { xhigh: 'xhigh' },
     thinkingLevel: options.thinkingLevel ?? 'off',
     steering: [],
   };
@@ -136,7 +138,12 @@ function createFakePiProcess(options = {}) {
             sessionFile: state.sessionFile,
             steeringMode: 'all',
             thinkingLevel: state.thinkingLevel,
-            model: { provider: state.modelProvider, id: state.modelId },
+            model: {
+              provider: state.modelProvider,
+              id: state.modelId,
+              reasoning: state.modelReasoning,
+              thinkingLevelMap: state.thinkingLevelMap,
+            },
           },
         });
         return;
@@ -351,6 +358,25 @@ describe('PiRpcRuntime', () => {
     await expect(runtime.startSession(baseStartRequest())).rejects.toThrow(
       /resolved model/,
     );
+    await runtime.shutdown();
+  });
+
+  it('accepts a requested thinking level that Pi clamps for the resolved model', async () => {
+    spawnOptions.push({
+      modelProvider: 'fireworks',
+      modelId: 'accounts/fireworks/models/kimi-k3',
+      thinkingLevel: 'minimal',
+      thinkingLevelMap: { off: null, minimal: 'low' },
+    });
+    const runtime = createRuntime();
+    const started = await runtime.startSession(baseStartRequest({
+      model: 'fireworks/accounts/fireworks/models/kimi-k3',
+      thinkingMode: 'none',
+    }));
+
+    expect(started.agentSessionId).toBe('pi-session-1');
+    fakes[0].pushEvent({ type: 'agent_settled' });
+    await settleIo();
     await runtime.shutdown();
   });
 

--- a/server-agents/pi/src/agents/pi/pi-cli.ts
+++ b/server-agents/pi/src/agents/pi/pi-cli.ts
@@ -1,5 +1,6 @@
 import { normalizeThinkingMode, type PermissionMode, type ThinkingMode } from '@garcon/common/chat-modes';
 import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
+import type { ModelThinkingLevel } from '@earendil-works/pi-ai';
 import type { PiConfig } from '../../config.js';
 
 const PI_OFFLINE_ENV = 'PI_OFFLINE';
@@ -29,7 +30,7 @@ const PI_NESTED_SESSION_ENV = [
 ] as const;
 
 // Pi --thinking tops out at xhigh, so Garcon's larger modes clamp down.
-export function mapThinkingMode(mode: ThinkingMode): string | undefined {
+export function mapThinkingMode(mode: ThinkingMode): ModelThinkingLevel | undefined {
   switch (mode) {
     case 'none':
       return 'off';

--- a/server-agents/pi/src/agents/pi/pi-rpc-protocol.ts
+++ b/server-agents/pi/src/agents/pi/pi-rpc-protocol.ts
@@ -1,5 +1,6 @@
 import type { AgentAttachment } from '@garcon/common/agent-execution';
 import { parseAttachmentDataUrl } from '@garcon/server-agent-common/shared/attachments';
+import type { ModelThinkingLevel } from '@earendil-works/pi-ai';
 import {
   AgentIntegrationError,
   type AgentSteerResult,
@@ -7,6 +8,16 @@ import {
 import { buildPiPrompt } from './pi-cli.js';
 import { PiRpcCommandError } from './pi-rpc-client.js';
 import type { PiResumeRequest, PiStartRequest } from './runtime-types.js';
+
+const PI_THINKING_LEVELS: readonly ModelThinkingLevel[] = [
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+];
 
 export interface PreparedPiRpcPrompt {
   readonly message: string;
@@ -61,6 +72,36 @@ export function occurrenceCounts(values: readonly string[]): Map<string, number>
   const counts = new Map<string, number>();
   for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
   return counts;
+}
+
+// Mirrors Pi's upward-first clamp for levels unsupported by the resolved model.
+// https://github.com/earendil-works/pi-mono/blob/845d6ff1f6643aba440341cce877ce1c43ebbc39/packages/ai/src/models.ts#L661-L692
+export function resolvePiThinkingLevel(
+  model: Readonly<Record<string, unknown>>,
+  requested: ModelThinkingLevel,
+): ModelThinkingLevel {
+  const levelMap = model.thinkingLevelMap && typeof model.thinkingLevelMap === 'object'
+    ? model.thinkingLevelMap as Readonly<Record<string, unknown>>
+    : null;
+  const supported = model.reasoning === true
+    ? PI_THINKING_LEVELS.filter((level) => {
+      const mapped = levelMap?.[level];
+      if (mapped === null) return false;
+      return (level !== 'xhigh' && level !== 'max') || mapped !== undefined;
+    })
+    : ['off'] satisfies ModelThinkingLevel[];
+  if (supported.includes(requested)) return requested;
+
+  const requestedIndex = PI_THINKING_LEVELS.indexOf(requested);
+  for (let index = requestedIndex; index < PI_THINKING_LEVELS.length; index += 1) {
+    const candidate = PI_THINKING_LEVELS[index];
+    if (supported.includes(candidate)) return candidate;
+  }
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const candidate = PI_THINKING_LEVELS[index];
+    if (supported.includes(candidate)) return candidate;
+  }
+  return supported[0] ?? 'off';
 }
 
 export function rejectedPiSteer(

--- a/server-agents/pi/src/agents/pi/pi-rpc-runtime.ts
+++ b/server-agents/pi/src/agents/pi/pi-rpc-runtime.ts
@@ -37,6 +37,7 @@ import {
   piUserMessageText,
   preparePiRpcPrompt,
   rejectedPiSteer,
+  resolvePiThinkingLevel,
   type PreparedPiRpcPrompt,
 } from './pi-rpc-protocol.js';
 import {
@@ -607,9 +608,12 @@ export class PiRpcRuntime extends AgentEventEmitterRuntime {
       throw new Error(`Pi resolved model ${resolvedModel || 'unknown'} instead of ${session.model}`);
     }
     const expectedThinking = mapThinkingMode(request.thinkingMode);
-    if (expectedThinking && data.thinkingLevel !== expectedThinking) {
+    const effectiveThinking = expectedThinking && model
+      ? resolvePiThinkingLevel(model, expectedThinking)
+      : expectedThinking;
+    if (effectiveThinking && data.thinkingLevel !== effectiveThinking) {
       throw new Error(
-        `Pi thinking level is ${String(data.thinkingLevel)} instead of ${expectedThinking}`,
+        `Pi thinking level is ${String(data.thinkingLevel)} instead of ${effectiveThinking}`,
       );
     }
     assertPiExecutionOpen(request);


### PR DESCRIPTION
Some Pi providers do not support every generic thinking level and legitimately normalize requests such as off to minimal. The RPC readiness check now validates the effective model-specific level instead of requiring literal equality, allowing extension-provided models such as Fireworks to start while retaining resolved model and thinking verification.