### PR TITLE
Serialize direct chat admission

### DIFF
--- a/integration-tests/tests/e2e/queue-workflow.test.ts
+++ b/integration-tests/tests/e2e/queue-workflow.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { Page } from 'puppeteer-core';
 import { withE2eFixture } from '../../support/e2e-fixture.js';
 import { SpaDriver } from '../../support/spa-driver.js';
 import {
@@ -6,7 +7,148 @@ import {
   waitForAcceptedResponseRequestBodies,
 } from '../../support/accepted-response-loss.js';
 
+interface BrowserRequestGate {
+	path: string;
+	requestCount: number;
+	release: (() => void) | null;
+}
+
+type RequestGateGlobal = typeof globalThis & {
+	__garconBrowserRequestGate?: BrowserRequestGate;
+};
+
+async function holdFirstBrowserRequest(page: Page, path: string): Promise<void> {
+	await page.evaluate((targetPath) => {
+		const originalFetch = globalThis.fetch.bind(globalThis);
+		const testGlobal = globalThis as RequestGateGlobal;
+		testGlobal.__garconBrowserRequestGate = {
+			path: targetPath,
+			requestCount: 0,
+			release: null,
+		};
+		const gatedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+			const inputUrl = typeof input === 'string'
+				? input
+				: input instanceof URL
+					? input.href
+					: input.url;
+			const gate = testGlobal.__garconBrowserRequestGate;
+			if (gate && new URL(inputUrl, globalThis.location.href).pathname === gate.path) {
+				gate.requestCount += 1;
+				if (gate.requestCount === 1) {
+					await new Promise<void>((resolve) => {
+						gate.release = resolve;
+					});
+				}
+			}
+			return originalFetch(input, init);
+		};
+		Object.defineProperty(globalThis, 'fetch', {
+			configurable: true,
+			writable: true,
+			value: gatedFetch,
+		});
+	}, path);
+}
+
+async function waitForHeldBrowserRequest(page: Page): Promise<void> {
+	await page.waitForFunction(
+		() => (globalThis as RequestGateGlobal).__garconBrowserRequestGate?.requestCount === 1,
+		{ timeout: 10_000 },
+	);
+}
+
+async function browserRequestCount(page: Page): Promise<number> {
+	return page.evaluate(() => (
+		(globalThis as RequestGateGlobal).__garconBrowserRequestGate?.requestCount ?? 0
+	));
+}
+
+async function releaseHeldBrowserRequest(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		const gate = (globalThis as RequestGateGlobal).__garconBrowserRequestGate;
+		if (!gate?.release) throw new Error('No browser request is waiting for release.');
+		const release = gate.release;
+		gate.release = null;
+		release();
+	});
+}
+
 describe('Lightpanda queue workflow', () => {
+	test('keeps a second message as a draft until direct admission is confirmed', async () => {
+		await withE2eFixture('queue-direct-admission', async (fixture) => {
+			const app = new SpaDriver(fixture.page, fixture.integration);
+			await app.open();
+			await fixture.waitForSpaWebSocket();
+			await app.startOpenAiDirectChat('ui-admission-seed');
+			await app.waitForText('echo:ui-admission-seed');
+			const chat = (await fixture.integration.client.listChats()).sessions.find(
+				(entry) => entry.preview.firstMessage === 'ui-admission-seed',
+			);
+			if (!chat) throw new Error('Admission-race chat was not listed.');
+
+			await holdFirstBrowserRequest(fixture.page, '/api/v1/chats/run');
+			const active = fixture.integration.fakeProviders.openAi.holdNext({
+				lastUserText: 'ui-admission-first',
+			});
+			await app.sendComposer('ui-admission-first');
+			await waitForHeldBrowserRequest(fixture.page);
+			await app.fill('textarea[placeholder="Reply..."]', 'ui-admission-second');
+
+			const composer = await fixture.page.evaluate(() => {
+				const textarea = document.querySelector<HTMLTextAreaElement>(
+					'textarea[placeholder="Reply..."]',
+				);
+				const send = [...document.querySelectorAll('button')].find((element) => (
+					!element.closest('[aria-hidden="true"]')
+					&& element.getAttribute('aria-label') === 'Send message'
+				)) as HTMLButtonElement | undefined;
+				return {
+					text: textarea?.value,
+					textareaDisabled: textarea?.disabled,
+					sendDisabled: send?.disabled,
+				};
+			});
+			expect(composer).toEqual({
+				text: 'ui-admission-second',
+				textareaDisabled: false,
+				sendDisabled: true,
+			});
+			await fixture.page.$eval('textarea[placeholder="Reply..."]', (element) => {
+				element.dispatchEvent(new KeyboardEvent('keydown', {
+					key: 'Enter',
+					bubbles: true,
+					cancelable: true,
+				}));
+			});
+			expect(await browserRequestCount(fixture.page)).toBe(1);
+			expect(await app.exactTextCount('ui-admission-second')).toBe(0);
+
+			await releaseHeldBrowserRequest(fixture.page);
+			await active.received;
+			await app.submitComposerWithEnter('ui-admission-second', 'Queue message');
+			await app.waitForQueuedPreview('ui-admission-second');
+			const control = await fixture.integration.client.getExecutionControl(chat.id);
+			expect(control.queue.entries.map((entry) => entry.content)).toEqual([
+				'ui-admission-second',
+			]);
+
+			active.releaseEcho();
+			await fixture.integration.fakeProviders.openAi.waitForRequest({
+				lastUserText: 'ui-admission-second',
+			});
+			await app.waitForText('echo:ui-admission-second');
+			expect(fixture.integration.fakeProviders.openAi.requests()
+				.map((request) => request.lastUserText)
+				.filter((text) => text.startsWith('ui-admission-'))).toEqual([
+				'ui-admission-seed',
+				'ui-admission-first',
+				'ui-admission-second',
+			]);
+			fixture.assertNoBrowserErrors();
+		});
+	});
+
 	test('clears stale controls and shows an Enter-queued message after restart', async () => {
 		await withE2eFixture('queue-controls-after-restart', async (fixture) => {
 			const app = new SpaDriver(fixture.page, fixture.integration);

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -1288,6 +1288,107 @@ describe('ConversationSessionController', () => {
 		expect(deps.lifecycle.beginTurn).toHaveBeenCalledWith('chat-1');
 	});
 
+	it('blocks a second direct submission until the first admission can enter queue mode', async () => {
+		const firstRequest = deferred<Awaited<ReturnType<typeof runChat>>>();
+		const processingSnapshot = deferred<unknown>();
+		const processingSnapshotRequested = deferred<void>();
+		mockRunChat.mockReturnValueOnce(firstRequest.promise);
+		const { deps } = createDeps();
+		deps.requestProcessingSnapshot.mockImplementationOnce(() => {
+			processingSnapshotRequested.resolve(undefined);
+			return processingSnapshot.promise;
+		});
+		deps.composerState.inputText = 'first message';
+		const controller = new ConversationSessionController(deps);
+
+		const firstSubmission = controller.submitForChat('chat-1');
+		await flushPromises();
+		expect(controller.isDirectAdmissionPending('chat-1')).toBe(true);
+
+		deps.composerState.inputText = 'second message';
+		await expect(controller.submitForChat('chat-1')).resolves.toBe('no-op');
+		expect(mockRunChat).toHaveBeenCalledTimes(1);
+		expect(mockCreateQueuedInput).not.toHaveBeenCalled();
+		expect(deps.composerState.inputText).toBe('second message');
+
+		firstRequest.resolve({
+			success: true,
+			commandType: 'agent-run',
+			clientRequestId: 'req-first',
+			chatId: 'chat-1',
+			turnId: 'turn-first',
+			status: 'accepted',
+			acceptedAt: '2026-08-04T00:00:00.000Z',
+		});
+		await processingSnapshotRequested.promise;
+		expect(controller.isDirectAdmissionPending('chat-1')).toBe(true);
+		expect(deps.requestProcessingSnapshot).toHaveBeenCalledOnce();
+
+		processingSnapshot.resolve({ outcome: 'snapshot', chats: [] });
+		await expect(firstSubmission).resolves.toBe('accepted');
+		expect(controller.isDirectAdmissionPending('chat-1')).toBe(false);
+
+		deps.sessions.byId['chat-1'].isProcessing = true;
+		deps.sessions.byId['chat-1'].processingPhase = 'running';
+		mockCreateQueuedInput.mockResolvedValueOnce({
+			success: true,
+			commandType: 'queue-entry-create',
+			clientRequestId: 'req-second',
+			chatId: 'chat-1',
+			status: 'accepted',
+			acceptedAt: '2026-08-04T00:00:01.000Z',
+			entryId: 'entry-second',
+			control: emptyControl(),
+		});
+
+		await expect(controller.submitForChat('chat-1')).resolves.toBe('accepted');
+		expect(mockRunChat).toHaveBeenCalledTimes(1);
+		expect(mockCreateQueuedInput).toHaveBeenCalledWith(
+			expect.objectContaining({ chatId: 'chat-1', content: 'second message' }),
+		);
+	});
+
+	it('claims direct admission before a pending control refresh settles', async () => {
+		const controlRefresh = deferred<Awaited<ReturnType<typeof getChatExecutionControl>>>();
+		mockGetChatExecutionControl.mockReturnValueOnce(controlRefresh.promise);
+		mockRunChat.mockResolvedValueOnce({
+			success: true,
+			commandType: 'agent-run',
+			clientRequestId: 'req-first',
+			chatId: 'chat-1',
+			turnId: 'turn-first',
+			status: 'accepted',
+			acceptedAt: '2026-08-04T00:00:00.000Z',
+		});
+		const { deps } = createDeps();
+		const controller = new ConversationSessionController(deps);
+		controller.handleChatSwitch('chat-1');
+		deps.composerState.inputText = 'first message';
+		deps.composerState.contentRevision = 1;
+
+		const firstSubmission = controller.submitForChat('chat-1');
+		expect(controller.isDirectAdmissionPending('chat-1')).toBe(true);
+		deps.composerState.inputText = 'second message';
+		deps.composerState.contentRevision = 2;
+
+		await expect(controller.submitForChat('chat-1')).resolves.toBe('no-op');
+		controlRefresh.resolve({
+			success: true,
+			chatId: 'chat-1',
+			control: emptyControl(),
+		});
+		await expect(firstSubmission).resolves.toBe('accepted');
+
+		expect(mockRunChat).toHaveBeenCalledOnce();
+		expect(mockRunChat).toHaveBeenCalledWith(
+			expect.objectContaining({ chatId: 'chat-1', command: 'first message' }),
+		);
+		expect(mockCreateQueuedInput).not.toHaveBeenCalled();
+		expect(deps.composerState.clearAfterSubmit).not.toHaveBeenCalled();
+		expect(deps.composerState.inputText).toBe('second message');
+		expect(controller.isDirectAdmissionPending('chat-1')).toBe(false);
+	});
+
 	it('submits follow-up messages with the current integration settings', async () => {
 		mockRunChat.mockResolvedValueOnce({
 			success: true,

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -878,7 +878,7 @@ describe('ConversationSessionController', () => {
 			control,
 		);
 		expect(deps.lifecycle.beginStopping).toHaveBeenCalledWith('chat-1', expect.any(String));
-		expect(deps.requestProcessingSnapshot).toHaveBeenCalledOnce();
+		expect(deps.requestProcessingSnapshot).toHaveBeenCalledWith('stop-probe');
 		expect(deps.lifecycle.clearTurnStatus).not.toHaveBeenCalled();
 	});
 
@@ -904,7 +904,7 @@ describe('ConversationSessionController', () => {
 			}),
 		);
 		expect(mockStopChat).not.toHaveBeenCalled();
-		expect(deps.requestProcessingSnapshot).toHaveBeenCalledOnce();
+		expect(deps.requestProcessingSnapshot).toHaveBeenCalledWith('stop-probe');
 		expect(deps.lifecycle.clearTurnStatus).not.toHaveBeenCalled();
 	});
 
@@ -923,7 +923,7 @@ describe('ConversationSessionController', () => {
 
 		await controller.handleAbort();
 
-		expect(deps.requestProcessingSnapshot).toHaveBeenCalledOnce();
+		expect(deps.requestProcessingSnapshot).toHaveBeenCalledWith('stop-probe');
 		expect(deps.lifecycle.restoreStopping).not.toHaveBeenCalled();
 		expect(deps.chatState.localNotices).toEqual([]);
 	});
@@ -1322,7 +1322,7 @@ describe('ConversationSessionController', () => {
 		});
 		await processingSnapshotRequested.promise;
 		expect(controller.isDirectAdmissionPending('chat-1')).toBe(true);
-		expect(deps.requestProcessingSnapshot).toHaveBeenCalledOnce();
+		expect(deps.requestProcessingSnapshot).toHaveBeenCalledWith('admission');
 
 		processingSnapshot.resolve({ outcome: 'snapshot', chats: [] });
 		await expect(firstSubmission).resolves.toBe('accepted');
@@ -1361,6 +1361,11 @@ describe('ConversationSessionController', () => {
 			acceptedAt: '2026-08-04T00:00:00.000Z',
 		});
 		const { deps } = createDeps();
+		deps.composerState.clearAfterSubmit.mockImplementation(() => {
+			deps.composerState.inputText = '';
+			deps.composerState.images = [];
+			deps.composerState.contentRevision += 2;
+		});
 		const controller = new ConversationSessionController(deps);
 		controller.handleChatSwitch('chat-1');
 		deps.composerState.inputText = 'first message';
@@ -1368,8 +1373,10 @@ describe('ConversationSessionController', () => {
 
 		const firstSubmission = controller.submitForChat('chat-1');
 		expect(controller.isDirectAdmissionPending('chat-1')).toBe(true);
+		expect(deps.composerState.clearAfterSubmit).toHaveBeenCalledOnce();
+		expect(deps.composerState.inputText).toBe('');
 		deps.composerState.inputText = 'second message';
-		deps.composerState.contentRevision = 2;
+		deps.composerState.contentRevision += 1;
 
 		await expect(controller.submitForChat('chat-1')).resolves.toBe('no-op');
 		controlRefresh.resolve({
@@ -1384,9 +1391,62 @@ describe('ConversationSessionController', () => {
 			expect.objectContaining({ chatId: 'chat-1', command: 'first message' }),
 		);
 		expect(mockCreateQueuedInput).not.toHaveBeenCalled();
-		expect(deps.composerState.clearAfterSubmit).not.toHaveBeenCalled();
+		expect(deps.composerState.clearAfterSubmit).toHaveBeenCalledOnce();
 		expect(deps.composerState.inputText).toBe('second message');
 		expect(controller.isDirectAdmissionPending('chat-1')).toBe(false);
+	});
+
+	it('waits programmatic submissions for direct admission instead of dropping them', async () => {
+		const firstRequest = deferred<Awaited<ReturnType<typeof runChat>>>();
+		mockRunChat.mockReturnValueOnce(firstRequest.promise);
+		mockCreateQueuedInput.mockResolvedValueOnce({
+			success: true,
+			commandType: 'queue-entry-create',
+			clientRequestId: 'req-review',
+			chatId: 'chat-1',
+			status: 'accepted',
+			acceptedAt: '2026-08-04T00:00:01.000Z',
+			entryId: 'entry-review',
+			control: emptyControl(),
+		});
+		const { deps } = createDeps();
+		deps.composerState.inputText = 'first message';
+		deps.requestProcessingSnapshot.mockImplementationOnce(async () => {
+			deps.sessions.byId['chat-1'].isProcessing = true;
+			deps.sessions.byId['chat-1'].processingPhase = 'running';
+			return { outcome: 'snapshot', chats: [] };
+		});
+		const controller = new ConversationSessionController(deps);
+
+		const firstSubmission = controller.submitForChat('chat-1');
+		await flushPromises();
+		const reviewSubmission = controller.submitForChat('chat-1', 'review this pull request');
+		let reviewSettled = false;
+		void reviewSubmission.then(() => {
+			reviewSettled = true;
+		});
+		await flushPromises();
+
+		expect(reviewSettled).toBe(false);
+		expect(mockRunChat).toHaveBeenCalledOnce();
+		expect(mockCreateQueuedInput).not.toHaveBeenCalled();
+
+		firstRequest.resolve({
+			success: true,
+			commandType: 'agent-run',
+			clientRequestId: 'req-first',
+			chatId: 'chat-1',
+			turnId: 'turn-first',
+			status: 'accepted',
+			acceptedAt: '2026-08-04T00:00:00.000Z',
+		});
+		await expect(firstSubmission).resolves.toBe('accepted');
+		await expect(reviewSubmission).resolves.toBe('accepted');
+
+		expect(mockRunChat).toHaveBeenCalledOnce();
+		expect(mockCreateQueuedInput).toHaveBeenCalledWith(
+			expect.objectContaining({ chatId: 'chat-1', content: 'review this pull request' }),
+		);
 	});
 
 	it('submits follow-up messages with the current integration settings', async () => {
@@ -1547,6 +1607,12 @@ describe('ConversationSessionController', () => {
 		deps.sessions.isDraft = vi.fn(() => true);
 		deps.composerState.inputText = 'start from draft';
 		deps.composerState.images = [new File(['hello'], 'hello.txt', { type: 'text/plain' })];
+		deps.composerState.contentRevision = 1;
+		deps.composerState.clearAfterSubmit.mockImplementation(() => {
+			deps.composerState.inputText = '';
+			deps.composerState.images = [];
+			deps.composerState.contentRevision += 2;
+		});
 		mockStartChat.mockResolvedValueOnce({
 			success: true,
 			commandType: 'chat-start',
@@ -1580,6 +1646,9 @@ describe('ConversationSessionController', () => {
 
 			expect(readers).toHaveLength(1);
 			expect(deps.composerState.isSubmitting).toBe(true);
+			expect(deps.composerState.inputText).toBe('');
+			deps.composerState.inputText = 'next message';
+			deps.composerState.contentRevision += 1;
 
 			await controller.submitForChat('draft-1');
 
@@ -1600,6 +1669,8 @@ describe('ConversationSessionController', () => {
 				}),
 			);
 			expect(mockStartChat.mock.calls[0][0]).not.toHaveProperty('options');
+			expect(deps.composerState.clearAfterSubmit).toHaveBeenCalledOnce();
+			expect(deps.composerState.inputText).toBe('next message');
 			expect(deps.composerState.isSubmitting).toBe(false);
 		} finally {
 			vi.stubGlobal('FileReader', originalFileReader);

--- a/web/src/lib/chat/conversation/__tests__/submission-settlement.logic.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/submission-settlement.logic.test.ts
@@ -52,8 +52,8 @@ const failures = [
 
 describe('settleSubmissionFailure', () => {
 	for (const failure of failures) {
-		for (const restoreComposerOnFailure of [true, false]) {
-			it(`${failure.kind} with restore=${restoreComposerOnFailure}`, async () => {
+		for (const ownsComposer of [true, false]) {
+			it(`${failure.kind} with composer ownership=${ownsComposer}`, async () => {
 				const deps = createDeps();
 				const refreshControl = vi.fn(async () => undefined);
 				const onRejected = vi.fn();
@@ -63,7 +63,7 @@ describe('settleSubmissionFailure', () => {
 						chatId: 'chat-1',
 						previousText: 'previous',
 						previousImages: [],
-						restoreComposerOnFailure,
+						ownsComposer,
 					},
 					failure.error(),
 					{
@@ -89,7 +89,7 @@ describe('settleSubmissionFailure', () => {
 					expect(deps.chatState.updatePendingUserInputDeliveryStatus).not.toHaveBeenCalled();
 				}
 				expect(refreshControl).toHaveBeenCalledTimes(failure.refreshes ? 1 : 0);
-				const restores = restoreComposerOnFailure && failure.outcome === 'rejected';
+				const restores = ownsComposer && failure.outcome === 'rejected';
 				expect(deps.composerState.inputText).toBe(restores ? 'previous' : 'current');
 				expect(deps.composerState.saveDraft).toHaveBeenCalledTimes(restores ? 1 : 0);
 				expect(onRejected).toHaveBeenCalledTimes(failure.outcome === 'rejected' ? 1 : 0);
@@ -111,7 +111,7 @@ describe('settleSubmissionFailure', () => {
 				chatId: 'chat-1',
 				previousText: 'queued text',
 				previousImages: [],
-				restoreComposerOnFailure: true,
+				ownsComposer: true,
 			},
 			new Error('queue failed'),
 			{
@@ -137,7 +137,7 @@ describe('settleSubmissionFailure', () => {
 				chatId: 'chat-1',
 				previousText: 'submitted text',
 				previousImages: [],
-				restoreComposerOnFailure: true,
+				ownsComposer: true,
 			},
 			new Error('request rejected'),
 			{

--- a/web/src/lib/chat/conversation/__tests__/submission-settlement.logic.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/submission-settlement.logic.test.ts
@@ -16,6 +16,7 @@ function createDeps() {
 		composerState: {
 			inputText: 'current',
 			images: [] as File[],
+			contentRevision: 1,
 			saveDraft: vi.fn(),
 		},
 	} satisfies SubmissionSettlementDeps;
@@ -122,6 +123,31 @@ describe('settleSubmissionFailure', () => {
 
 		expect(restoreRejected).toHaveBeenCalledOnce();
 		expect(deps.composerState.inputText).toBe('current');
+		expect(deps.composerState.saveDraft).not.toHaveBeenCalled();
+	});
+
+	it('preserves a newer draft when a cleared submission is rejected', async () => {
+		const deps = createDeps();
+		deps.composerState.inputText = 'new draft';
+		deps.composerState.contentRevision = 2;
+
+		await settleSubmissionFailure(
+			deps,
+			{
+				chatId: 'chat-1',
+				previousText: 'submitted text',
+				previousImages: [],
+				restoreComposerOnFailure: true,
+			},
+			new Error('request rejected'),
+			{
+				unknownNotice: 'unknown',
+				rejectedNotice: () => 'rejected',
+				composerRevisionAfterClear: 1,
+			},
+		);
+
+		expect(deps.composerState.inputText).toBe('new draft');
 		expect(deps.composerState.saveDraft).not.toHaveBeenCalled();
 	});
 });

--- a/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
@@ -138,6 +138,19 @@ type SessionConversationUiState = Pick<
 
 type SessionStartupCoordinator = Pick<StartupCoordinator, 'beginLocalStartup' | 'completeStartup'>;
 
+interface DirectAdmissionBarrier {
+	settled: Promise<void>;
+	release: () => void;
+}
+
+function createDirectAdmissionBarrier(): DirectAdmissionBarrier {
+	let release!: () => void;
+	const settled = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	return { settled, release };
+}
+
 export interface SessionControllerDeps {
 	sessions: Pick<
 		ChatSessionsPort,
@@ -201,7 +214,7 @@ export interface SessionControllerDeps {
 	navigation: { navigateToChat?: (chatId: string) => void };
 	/** Rebuilds the chat transcript from native history (e.g. after an agent switch). */
 	reloadTranscript?: (chatId: string) => Promise<void>;
-	requestProcessingSnapshot: () => Promise<unknown>;
+	requestProcessingSnapshot: (source: 'admission' | 'stop-probe') => Promise<unknown>;
 	setIsViewportPinnedToBottom: (v: boolean) => void;
 	setInitialBottomRestorePending: (chatId: string | null) => void;
 	scrollToBottom: () => void;
@@ -217,7 +230,7 @@ function isExecutionControlAdmissionConflict(error: unknown): boolean {
 
 export class ConversationSessionController {
 	#lastChatId: string | null = null;
-	#pendingDirectAdmissions = $state.raw<ReadonlySet<string>>(new Set());
+	#pendingDirectAdmissions = $state.raw<ReadonlyMap<string, DirectAdmissionBarrier>>(new Map());
 	readonly #slashCommands: ConversationSlashCommandService;
 	readonly #agentSwitch: ConversationAgentSwitchService;
 	readonly #acceptedInputs: AcceptedInputSubmissionService;
@@ -469,35 +482,68 @@ export class ConversationSessionController {
 		return chatId !== null && this.#pendingDirectAdmissions.has(chatId);
 	}
 
-	#setDirectAdmissionPending(chatId: string, pending: boolean): void {
-		if (this.#pendingDirectAdmissions.has(chatId) === pending) return;
-		const next = new Set(this.#pendingDirectAdmissions);
-		if (pending) next.add(chatId);
-		else next.delete(chatId);
+	#claimDirectAdmission(chatId: string): DirectAdmissionBarrier | null {
+		if (this.#pendingDirectAdmissions.has(chatId)) return null;
+		const barrier = createDirectAdmissionBarrier();
+		const next = new Map(this.#pendingDirectAdmissions);
+		next.set(chatId, barrier);
 		this.#pendingDirectAdmissions = next;
+		return barrier;
+	}
+
+	#releaseDirectAdmission(chatId: string, barrier: DirectAdmissionBarrier): void {
+		if (this.#pendingDirectAdmissions.get(chatId) !== barrier) return;
+		const next = new Map(this.#pendingDirectAdmissions);
+		next.delete(chatId);
+		this.#pendingDirectAdmissions = next;
+		barrier.release();
+	}
+
+	#restorePreflightSubmission(
+		chatId: string,
+		text: string,
+		images: File[],
+		composerRevisionAfterClear: number | null,
+	): void {
+		const { composerState, sessions } = this.deps;
+		if (
+			composerRevisionAfterClear === null ||
+			sessions.selectedChatId !== chatId ||
+			composerState.contentRevision !== composerRevisionAfterClear
+		)
+			return;
+		composerState.inputText = text;
+		composerState.images = images;
+		composerState.saveDraft(chatId);
 	}
 
 	// Accepts an explicit chat ID so draft startup cannot race selection changes.
-	async submitForChat(chatId: string, messageOverride?: string, imageOverride?: File[]): Promise<ConversationSubmissionOutcome> {
+	async submitForChat(
+		chatId: string,
+		messageOverride?: string,
+		imageOverride?: File[],
+	): Promise<ConversationSubmissionOutcome> {
 		const { deps } = this;
+		const ownsComposer = messageOverride === undefined && imageOverride === undefined;
+		while (this.isDirectAdmissionPending(chatId)) {
+			if (ownsComposer) return 'no-op';
+			await this.#pendingDirectAdmissions.get(chatId)?.settled;
+		}
 		const selected = deps.sessions.byId[chatId];
 		if (!selected?.projectPath) return 'no-op';
-		if (this.isDirectAdmissionPending(chatId)) return 'no-op';
 		if (selected.status === 'draft' && deps.composerState.isSubmitting) return 'no-op';
 		const text = messageOverride ?? deps.composerState.inputText.trim();
 		const submissionImages = imageOverride ?? deps.composerState.images;
 		if (!text && submissionImages.length === 0) return 'no-op';
 
-		const restoreComposerOnFailure = messageOverride === undefined && imageOverride === undefined;
 		const previousText = deps.composerState.inputText;
 		const previousImages = [...deps.composerState.images];
-		const composerRevision = deps.composerState.contentRevision;
 		const slash = this.#slashCommands.dispatchSubmission({
 			chatId,
 			chat: selected,
 			text,
 			images: [...submissionImages],
-			ownsComposer: restoreComposerOnFailure,
+			ownsComposer,
 		});
 		if (slash.kind === 'handled') return slash.outcome;
 
@@ -510,7 +556,8 @@ export class ConversationSessionController {
 			images: [] as ChatImage[],
 			previousText,
 			previousImages,
-			restoreComposerOnFailure,
+			ownsComposer,
+			composerRevisionAfterClear: null,
 		};
 		if (slash.kind === 'steer') {
 			return submitSteerRoute(deps, this.#acceptedInputs, specializedContext);
@@ -521,65 +568,82 @@ export class ConversationSessionController {
 
 		const isDraft = selected.status === 'draft';
 		const activeTurn = selected.status === 'running' && selected.isProcessing;
-		let directAdmissionClaimed = false;
+		let directAdmission: DirectAdmissionBarrier | null = null;
 		if (!isDraft && !activeTurn) {
-			this.#setDirectAdmissionPending(chatId, true);
-			directAdmissionClaimed = true;
-		}
-		const pendingControlRefresh = this.#queue.pendingControlRefresh(chatId);
-		if (!isDraft && !activeTurn && pendingControlRefresh) {
-			await this.#queue.settleControlRefresh(pendingControlRefresh);
-		}
-		const route = classifySubmission({
-			isDraft,
-			isProcessing: activeTurn,
-			control: deps.conversationUi.getExecutionControl(chatId),
-			hasAttachments: submissionImages.length > 0,
-		});
-		if (route === 'queue-attachments-unsupported') {
-			deps.chatState.appendLocalNotice('error', m.chat_notice_queue_attachments_unavailable());
-			if (directAdmissionClaimed) this.#setDirectAdmissionPending(chatId, false);
-			return 'rejected';
-		}
-		const directAdmission = route === 'direct';
-		if (!directAdmission && directAdmissionClaimed) {
-			this.#setDirectAdmissionPending(chatId, false);
-			directAdmissionClaimed = false;
+			directAdmission = this.#claimDirectAdmission(chatId);
+			if (!directAdmission) return 'no-op';
 		}
 
-		if (route === 'draft') {
-			deps.composerState.isSubmitting = true;
-		}
-		let imagePayload: ChatImage[] = [];
-		try {
-			if (submissionImages.length > 0) imagePayload = await prepareChatImages(submissionImages);
-		} catch (error) {
-			console.error('[SessionController] Failed to prepare attachment payload:', error);
-			if (route === 'draft') deps.composerState.isSubmitting = false;
-			if (directAdmissionClaimed) this.#setDirectAdmissionPending(chatId, false);
-			deps.chatState.appendLocalNotice('error', m.chat_notice_failed_prepare_attachments({
-				detail: errorDetail(error),
-			}));
-			return 'rejected';
+		let composerRevisionAfterClear: number | null = null;
+		if (ownsComposer) {
+			deps.composerState.clearAfterSubmit(chatId);
+			composerRevisionAfterClear = deps.composerState.contentRevision;
 		}
 
-		const context = {
-			chatId,
-			chat: selected,
-			startup: deps.sessions.startupByChatId[chatId],
-			text,
-			content: slash.content,
-			images: imagePayload,
-			previousText,
-			previousImages,
-			restoreComposerOnFailure:
-				restoreComposerOnFailure && deps.composerState.contentRevision === composerRevision,
-		};
-		if (route === 'queue') {
-			return submitQueueRoute(deps, this.#acceptedInputs, this.#queue, context);
-		}
-		if (route === 'draft') return submitDraftRoute(deps, this.#acceptedInputs, context);
 		try {
+			const pendingControlRefresh = this.#queue.pendingControlRefresh(chatId);
+			if (!isDraft && !activeTurn && pendingControlRefresh) {
+				await this.#queue.settleControlRefresh(pendingControlRefresh);
+			}
+			const route = classifySubmission({
+				isDraft,
+				isProcessing: activeTurn,
+				control: deps.conversationUi.getExecutionControl(chatId),
+				hasAttachments: submissionImages.length > 0,
+			});
+			if (route === 'queue-attachments-unsupported') {
+				this.#restorePreflightSubmission(
+					chatId,
+					previousText,
+					previousImages,
+					composerRevisionAfterClear,
+				);
+				deps.chatState.appendLocalNotice('error', m.chat_notice_queue_attachments_unavailable());
+				return 'rejected';
+			}
+			if (route !== 'direct' && directAdmission) {
+				this.#releaseDirectAdmission(chatId, directAdmission);
+				directAdmission = null;
+			}
+
+			if (route === 'draft') deps.composerState.isSubmitting = true;
+			let imagePayload: ChatImage[] = [];
+			try {
+				if (submissionImages.length > 0) imagePayload = await prepareChatImages(submissionImages);
+			} catch (error) {
+				console.error('[SessionController] Failed to prepare attachment payload:', error);
+				if (route === 'draft') deps.composerState.isSubmitting = false;
+				this.#restorePreflightSubmission(
+					chatId,
+					previousText,
+					previousImages,
+					composerRevisionAfterClear,
+				);
+				deps.chatState.appendLocalNotice(
+					'error',
+					m.chat_notice_failed_prepare_attachments({
+						detail: errorDetail(error),
+					}),
+				);
+				return 'rejected';
+			}
+
+			const context = {
+				chatId,
+				chat: selected,
+				startup: deps.sessions.startupByChatId[chatId],
+				text,
+				content: slash.content,
+				images: imagePayload,
+				previousText,
+				previousImages,
+				ownsComposer,
+				composerRevisionAfterClear,
+			};
+			if (route === 'queue') {
+				return submitQueueRoute(deps, this.#acceptedInputs, this.#queue, context);
+			}
+			if (route === 'draft') return submitDraftRoute(deps, this.#acceptedInputs, context);
 			const outcome = await submitRunRoute(
 				deps,
 				this.#acceptedInputs,
@@ -587,10 +651,10 @@ export class ConversationSessionController {
 				context,
 				this.#executionModelSelection(),
 			);
-			await deps.requestProcessingSnapshot().catch(() => undefined);
+			await deps.requestProcessingSnapshot('admission').catch(() => undefined);
 			return outcome;
 		} finally {
-			if (directAdmissionClaimed) this.#setDirectAdmissionPending(chatId, false);
+			if (directAdmission) this.#releaseDirectAdmission(chatId, directAdmission);
 		}
 	}
 
@@ -641,7 +705,7 @@ export class ConversationSessionController {
 		})
 			.then(async (result) => {
 				onResult?.(chatId, result);
-				await deps.requestProcessingSnapshot().catch(() => undefined);
+				await deps.requestProcessingSnapshot('stop-probe').catch(() => undefined);
 				if (isStopSatisfied(result.outcome)) return;
 				restore();
 				appendFailure(m.chat_notice_stop_request_failed());

--- a/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
@@ -201,7 +201,7 @@ export interface SessionControllerDeps {
 	navigation: { navigateToChat?: (chatId: string) => void };
 	/** Rebuilds the chat transcript from native history (e.g. after an agent switch). */
 	reloadTranscript?: (chatId: string) => Promise<void>;
-	requestProcessingSnapshot?: () => Promise<unknown>;
+	requestProcessingSnapshot: () => Promise<unknown>;
 	setIsViewportPinnedToBottom: (v: boolean) => void;
 	setInitialBottomRestorePending: (chatId: string | null) => void;
 	scrollToBottom: () => void;
@@ -217,6 +217,7 @@ function isExecutionControlAdmissionConflict(error: unknown): boolean {
 
 export class ConversationSessionController {
 	#lastChatId: string | null = null;
+	#pendingDirectAdmissions = $state.raw<ReadonlySet<string>>(new Set());
 	readonly #slashCommands: ConversationSlashCommandService;
 	readonly #agentSwitch: ConversationAgentSwitchService;
 	readonly #acceptedInputs: AcceptedInputSubmissionService;
@@ -464,11 +465,24 @@ export class ConversationSessionController {
 		});
 	}
 
+	isDirectAdmissionPending(chatId: string | null): boolean {
+		return chatId !== null && this.#pendingDirectAdmissions.has(chatId);
+	}
+
+	#setDirectAdmissionPending(chatId: string, pending: boolean): void {
+		if (this.#pendingDirectAdmissions.has(chatId) === pending) return;
+		const next = new Set(this.#pendingDirectAdmissions);
+		if (pending) next.add(chatId);
+		else next.delete(chatId);
+		this.#pendingDirectAdmissions = next;
+	}
+
 	// Accepts an explicit chat ID so draft startup cannot race selection changes.
 	async submitForChat(chatId: string, messageOverride?: string, imageOverride?: File[]): Promise<ConversationSubmissionOutcome> {
 		const { deps } = this;
 		const selected = deps.sessions.byId[chatId];
 		if (!selected?.projectPath) return 'no-op';
+		if (this.isDirectAdmissionPending(chatId)) return 'no-op';
 		if (selected.status === 'draft' && deps.composerState.isSubmitting) return 'no-op';
 		const text = messageOverride ?? deps.composerState.inputText.trim();
 		const submissionImages = imageOverride ?? deps.composerState.images;
@@ -477,6 +491,7 @@ export class ConversationSessionController {
 		const restoreComposerOnFailure = messageOverride === undefined && imageOverride === undefined;
 		const previousText = deps.composerState.inputText;
 		const previousImages = [...deps.composerState.images];
+		const composerRevision = deps.composerState.contentRevision;
 		const slash = this.#slashCommands.dispatchSubmission({
 			chatId,
 			chat: selected,
@@ -506,6 +521,11 @@ export class ConversationSessionController {
 
 		const isDraft = selected.status === 'draft';
 		const activeTurn = selected.status === 'running' && selected.isProcessing;
+		let directAdmissionClaimed = false;
+		if (!isDraft && !activeTurn) {
+			this.#setDirectAdmissionPending(chatId, true);
+			directAdmissionClaimed = true;
+		}
 		const pendingControlRefresh = this.#queue.pendingControlRefresh(chatId);
 		if (!isDraft && !activeTurn && pendingControlRefresh) {
 			await this.#queue.settleControlRefresh(pendingControlRefresh);
@@ -518,7 +538,13 @@ export class ConversationSessionController {
 		});
 		if (route === 'queue-attachments-unsupported') {
 			deps.chatState.appendLocalNotice('error', m.chat_notice_queue_attachments_unavailable());
+			if (directAdmissionClaimed) this.#setDirectAdmissionPending(chatId, false);
 			return 'rejected';
+		}
+		const directAdmission = route === 'direct';
+		if (!directAdmission && directAdmissionClaimed) {
+			this.#setDirectAdmissionPending(chatId, false);
+			directAdmissionClaimed = false;
 		}
 
 		if (route === 'draft') {
@@ -530,6 +556,7 @@ export class ConversationSessionController {
 		} catch (error) {
 			console.error('[SessionController] Failed to prepare attachment payload:', error);
 			if (route === 'draft') deps.composerState.isSubmitting = false;
+			if (directAdmissionClaimed) this.#setDirectAdmissionPending(chatId, false);
 			deps.chatState.appendLocalNotice('error', m.chat_notice_failed_prepare_attachments({
 				detail: errorDetail(error),
 			}));
@@ -545,19 +572,26 @@ export class ConversationSessionController {
 			images: imagePayload,
 			previousText,
 			previousImages,
-			restoreComposerOnFailure,
+			restoreComposerOnFailure:
+				restoreComposerOnFailure && deps.composerState.contentRevision === composerRevision,
 		};
 		if (route === 'queue') {
 			return submitQueueRoute(deps, this.#acceptedInputs, this.#queue, context);
 		}
 		if (route === 'draft') return submitDraftRoute(deps, this.#acceptedInputs, context);
-		return submitRunRoute(
-			deps,
-			this.#acceptedInputs,
-			this.#queue,
-			context,
-			this.#executionModelSelection(),
-		);
+		try {
+			const outcome = await submitRunRoute(
+				deps,
+				this.#acceptedInputs,
+				this.#queue,
+				context,
+				this.#executionModelSelection(),
+			);
+			await deps.requestProcessingSnapshot().catch(() => undefined);
+			return outcome;
+		} finally {
+			if (directAdmissionClaimed) this.#setDirectAdmissionPending(chatId, false);
+		}
 	}
 
 	// Forks a chat without sending a new message, then selects the fork. Backs
@@ -607,7 +641,7 @@ export class ConversationSessionController {
 		})
 			.then(async (result) => {
 				onResult?.(chatId, result);
-				await deps.requestProcessingSnapshot?.().catch(() => undefined);
+				await deps.requestProcessingSnapshot().catch(() => undefined);
 				if (isStopSatisfied(result.outcome)) return;
 				restore();
 				appendFailure(m.chat_notice_stop_request_failed());

--- a/web/src/lib/chat/conversation/submission-routes.ts
+++ b/web/src/lib/chat/conversation/submission-routes.ts
@@ -178,7 +178,12 @@ export async function submitDraftRoute(
 		images: context.images.length > 0 ? context.images : undefined,
 		tags: startup?.tags,
 	}));
-	beginOptimisticInput(deps, context, submission.clientRequestId, submission.clientMessageId);
+	const composerRevisionAfterClear = beginOptimisticInput(
+		deps,
+		context,
+		submission.clientRequestId,
+		submission.clientMessageId,
+	);
 	deps.startupCoordinator.beginLocalStartup(chatId);
 	try {
 		const response = await submission.submit();
@@ -192,6 +197,7 @@ export async function submitDraftRoute(
 		deps.startupCoordinator.completeStartup(chatId);
 		return settleSubmissionFailure(deps, context, error, {
 			clientRequestId: submission.clientRequestId,
+			composerRevisionAfterClear,
 			unknownNotice: m.chat_notice_delivery_outcome_unconfirmed(),
 			rejectedNotice: (failure) => m.chat_notice_failed_start_chat({ detail: errorDetail(failure) }),
 			onRejected: () => {
@@ -220,7 +226,12 @@ export async function submitRunRoute(
 		agentSettings: deps.agentState.agentSettings,
 		...selection,
 	});
-	beginOptimisticInput(deps, context, submission.clientRequestId, submission.clientMessageId);
+	const composerRevisionAfterClear = beginOptimisticInput(
+		deps,
+		context,
+		submission.clientRequestId,
+		submission.clientMessageId,
+	);
 	try {
 		await submission.submit();
 		deps.chatState.updatePendingUserInputDeliveryStatus(submission.clientRequestId, 'accepted');
@@ -229,6 +240,7 @@ export async function submitRunRoute(
 	} catch (error) {
 		return settleSubmissionFailure(deps, context, error, {
 			clientRequestId: submission.clientRequestId,
+			composerRevisionAfterClear,
 			unknownNotice: m.chat_notice_delivery_outcome_unconfirmed(),
 			rejectedNotice: (failure) => m.chat_notice_failed_send_message({ detail: errorDetail(failure) }),
 			clearPendingOnAdmissionConflict: true,
@@ -244,13 +256,18 @@ function beginOptimisticInput(
 	context: SubmissionContext,
 	clientRequestId: string,
 	clientMessageId: string,
-): void {
+): number | null {
 	deps.chatState.upsertPendingUserInput(
 		pendingUserInput(context.chatId, context.text, context.images, clientRequestId, clientMessageId),
 	);
 	if (deps.sessions.selectedChatId === context.chatId) deps.scrollToBottom();
-	if (context.restoreComposerOnFailure) deps.composerState.clearAfterSubmit(context.chatId);
+	let composerRevisionAfterClear: number | null = null;
+	if (context.restoreComposerOnFailure) {
+		deps.composerState.clearAfterSubmit(context.chatId);
+		composerRevisionAfterClear = deps.composerState.contentRevision;
+	}
 	deps.composerState.isSubmitting = true;
+	return composerRevisionAfterClear;
 }
 
 function restoreSteerComposer(

--- a/web/src/lib/chat/conversation/submission-routes.ts
+++ b/web/src/lib/chat/conversation/submission-routes.ts
@@ -32,7 +32,8 @@ export interface SubmissionContext {
 	images: ChatImage[];
 	previousText: string;
 	previousImages: File[];
-	restoreComposerOnFailure: boolean;
+	ownsComposer: boolean;
+	composerRevisionAfterClear: number | null;
 }
 
 interface ExecutionModelSelection {
@@ -50,7 +51,7 @@ export async function submitQueueRoute(
 ): Promise<ConversationSubmissionOutcome> {
 	const sequence = queue.beginSubmission(context.chatId);
 	// Clears before awaiting the network so typing during the request survives.
-	if (context.restoreComposerOnFailure) deps.composerState.clearAfterSubmit(context.chatId);
+	clearOwnedComposer(deps, context);
 	const submission = acceptedInputs.enqueue({ chatId: context.chatId, content: context.content });
 	try {
 		const result = await submission.submit();
@@ -61,7 +62,7 @@ export async function submitQueueRoute(
 			unknownNotice: m.chat_notice_queue_outcome_unconfirmed(),
 			rejectedNotice: (failure) => m.chat_notice_failed_queue_message({
 				detail: errorDetail(failure),
-				content: context.restoreComposerOnFailure ? context.previousText : context.text,
+				content: context.ownsComposer ? context.previousText : context.text,
 			}),
 			restoreRejected: () => queue.recordSubmissionFailure(context.chatId, {
 				sequence,
@@ -82,7 +83,7 @@ export async function submitGoalControlRoute(
 	context: SubmissionContext,
 ): Promise<ConversationSubmissionOutcome> {
 	const sequence = queue.beginSubmission(context.chatId);
-	if (context.restoreComposerOnFailure) deps.composerState.clearAfterSubmit(context.chatId);
+	clearOwnedComposer(deps, context);
 	const submission = acceptedInputs.goalControl({
 		chatId: context.chatId,
 		content: context.content,
@@ -96,7 +97,7 @@ export async function submitGoalControlRoute(
 			unknownNotice: m.chat_notice_queue_outcome_unconfirmed(),
 			rejectedNotice: (failure) => m.chat_notice_failed_queue_message({
 				detail: errorDetail(failure),
-				content: context.restoreComposerOnFailure ? context.previousText : context.text,
+				content: context.ownsComposer ? context.previousText : context.text,
 			}),
 			restoreRejected: () => queue.recordSubmissionFailure(context.chatId, {
 				sequence,
@@ -129,11 +130,7 @@ export async function submitSteerRoute(
 		),
 	);
 	if (deps.sessions.selectedChatId === context.chatId) deps.scrollToBottom();
-	let clearedComposerRevision: number | null = null;
-	if (context.restoreComposerOnFailure) {
-		deps.composerState.clearAfterSubmit(context.chatId);
-		clearedComposerRevision = deps.composerState.contentRevision;
-	}
+	const clearedComposerRevision = clearOwnedComposer(deps, context);
 	try {
 		await submission.submit();
 		deps.chatState.updatePendingUserInputDeliveryStatus(submission.clientRequestId, 'accepted');
@@ -261,13 +258,16 @@ function beginOptimisticInput(
 		pendingUserInput(context.chatId, context.text, context.images, clientRequestId, clientMessageId),
 	);
 	if (deps.sessions.selectedChatId === context.chatId) deps.scrollToBottom();
-	let composerRevisionAfterClear: number | null = null;
-	if (context.restoreComposerOnFailure) {
-		deps.composerState.clearAfterSubmit(context.chatId);
-		composerRevisionAfterClear = deps.composerState.contentRevision;
-	}
+	const composerRevisionAfterClear = clearOwnedComposer(deps, context);
 	deps.composerState.isSubmitting = true;
 	return composerRevisionAfterClear;
+}
+
+function clearOwnedComposer(deps: RouteDeps, context: SubmissionContext): number | null {
+	if (!context.ownsComposer) return null;
+	if (context.composerRevisionAfterClear !== null) return context.composerRevisionAfterClear;
+	deps.composerState.clearAfterSubmit(context.chatId);
+	return deps.composerState.contentRevision;
 }
 
 function restoreSteerComposer(
@@ -276,7 +276,7 @@ function restoreSteerComposer(
 	clearedComposerRevision: number | null,
 ): void {
 	if (
-		!context.restoreComposerOnFailure
+		!context.ownsComposer
 		|| deps.sessions.selectedChatId !== context.chatId
 		|| deps.composerState.contentRevision !== clearedComposerRevision
 		|| deps.composerState.inputText !== ''

--- a/web/src/lib/chat/conversation/submission-settlement.ts
+++ b/web/src/lib/chat/conversation/submission-settlement.ts
@@ -12,7 +12,7 @@ export interface SubmissionSettlementDeps {
 	>;
 	composerState: Pick<
 		SessionControllerDeps['composerState'],
-		'inputText' | 'images' | 'saveDraft'
+		'inputText' | 'images' | 'contentRevision' | 'saveDraft'
 	>;
 }
 
@@ -28,6 +28,7 @@ export interface SubmissionFailureOptions {
 	unknownNotice: string;
 	rejectedNotice(error: unknown): string;
 	clearPendingOnAdmissionConflict?: boolean;
+	composerRevisionAfterClear?: number | null;
 	refreshControl?: () => Promise<void>;
 	restoreRejected?: () => void;
 	onRejected?: () => void | Promise<void>;
@@ -56,7 +57,13 @@ export async function settleSubmissionFailure(
 	}
 
 	if (!outcomeUnknown) await options.onRejected?.();
-	if (context.restoreComposerOnFailure && !outcomeUnknown) {
+	const composerCanBeRestored =
+		options.composerRevisionAfterClear === undefined
+		|| (
+			typeof options.composerRevisionAfterClear === 'number'
+			&& deps.composerState.contentRevision === options.composerRevisionAfterClear
+		);
+	if (context.restoreComposerOnFailure && !outcomeUnknown && composerCanBeRestored) {
 		if (options.restoreRejected) {
 			options.restoreRejected();
 		} else {

--- a/web/src/lib/chat/conversation/submission-settlement.ts
+++ b/web/src/lib/chat/conversation/submission-settlement.ts
@@ -20,7 +20,7 @@ export interface SubmissionFailureContext {
 	chatId: string;
 	previousText: string;
 	previousImages: File[];
-	restoreComposerOnFailure: boolean;
+	ownsComposer: boolean;
 }
 
 export interface SubmissionFailureOptions {
@@ -63,7 +63,7 @@ export async function settleSubmissionFailure(
 			typeof options.composerRevisionAfterClear === 'number'
 			&& deps.composerState.contentRevision === options.composerRevisionAfterClear
 		);
-	if (context.restoreComposerOnFailure && !outcomeUnknown && composerCanBeRestored) {
+	if (context.ownsComposer && !outcomeUnknown && composerCanBeRestored) {
 		if (options.restoreRejected) {
 			options.restoreRejected();
 		} else {

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -362,7 +362,7 @@
 			},
 		},
 		reloadTranscript: (chatId) => reloadChatFromNative(ws, chatState, chatId),
-		requestProcessingSnapshot: () => ws.requestProcessingSnapshot(),
+		requestProcessingSnapshot: (source) => ws.requestProcessingSnapshot(source),
 		setIsViewportPinnedToBottom: (v) => {
 			scroll.setPinnedToBottom(v);
 		},

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -369,6 +369,9 @@
 		setInitialBottomRestorePending: (chatId) => scroll.prepareInitialBottomRestore(chatId),
 		scrollToBottom: scrollToBottomAndFill,
 	});
+	const directAdmissionPending = $derived(
+		controller.isDirectAdmissionPending(sessions.selectedChatId),
+	);
 	const userMessageNavigator = new UserMessageNavigatorController({
 		transcript: chatState,
 		getSelectedChatId: () => sessions.selectedChatId,
@@ -718,6 +721,7 @@
 
 	<PromptComposer
 		{isVisible}
+		{directAdmissionPending}
 		onsubmit={onSubmit}
 		onModelChange={(next) => controller.handleModelSelectionChange(next)}
 		onPermissionModeChange={(m) => controller.handlePermissionModeChange(m)}

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -95,6 +95,7 @@
 		quickCommitError?: string | null;
 		quickCommitBranchSelector?: GitQuickBranchSelectorControls | null;
 		onQuickCommit?: (() => void) | null;
+		directAdmissionPending?: boolean;
 		// False when the composer is mounted but hidden (e.g. the Git tab is
 		// active). Focus requests must not be consumed while hidden, since
 		// focusing a display:none textarea is a silent no-op.
@@ -114,6 +115,7 @@
 		quickCommitError = null,
 		quickCommitBranchSelector = null,
 		onQuickCommit = null,
+		directAdmissionPending = false,
 		isVisible = true,
 	}: Props = $props();
 
@@ -614,7 +616,7 @@
 	const isDisabled = $derived(isDraftStartupSubmitting);
 	const canSubmit = $derived(
 		canSubmitComposer(
-			isDisabled || snippetExpansion.pending,
+			isDisabled || directAdmissionPending || snippetExpansion.pending,
 			composerState.inputText,
 			composerState.images.length,
 		),

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -162,6 +162,34 @@ describe('PromptComposer focus', () => {
 		}
 	});
 
+	it('keeps the next draft editable but blocks sending during direct admission', async () => {
+		const onsubmit = vi.fn();
+		const { rerender } = render(PromptComposerTestHost, {
+			selectedChatId: 'chat-admitting',
+			selectedStatus: 'running',
+			directAdmissionPending: true,
+			onsubmit,
+		});
+		const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+		await fireEvent.input(textarea, { target: { value: 'queue this next' } });
+
+		expect(textarea.disabled).toBe(false);
+		expect(
+			(screen.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled,
+		).toBe(true);
+		await fireEvent.keyDown(textarea, { key: 'Enter' });
+		expect(onsubmit).not.toHaveBeenCalled();
+
+		await rerender({
+			directAdmissionPending: false,
+			selectedIsProcessing: true,
+		});
+		const queueButton = screen.getByRole('button', { name: 'Queue message' }) as HTMLButtonElement;
+		expect(queueButton.disabled).toBe(false);
+		await fireEvent.click(queueButton);
+		expect(onsubmit).toHaveBeenCalledOnce();
+	});
+
 	it('retries app-shell focus requests after the selected chat becomes enabled', async () => {
 		const outsideButton = document.createElement('button');
 		outsideButton.dataset.testid = 'outside-focus';

--- a/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
@@ -51,6 +51,7 @@
 		quickCommitTrayVisible?: boolean;
 		quickCommitRefreshing?: boolean;
 		quickCommitSummary?: GitQuickSummaryReady | null;
+		directAdmissionPending?: boolean;
 		onsubmit?: () => void;
 		onAbort?: () => void;
 		onQuickCommit?: () => void;
@@ -74,6 +75,7 @@
 		quickCommitTrayVisible = false,
 		quickCommitRefreshing = false,
 		quickCommitSummary = null,
+		directAdmissionPending = false,
 		onsubmit = () => {},
 		onAbort = () => {},
 		onQuickCommit = () => {},
@@ -325,6 +327,7 @@
 	{quickCommitTrayVisible}
 	{quickCommitRefreshing}
 	{quickCommitSummary}
+	{directAdmissionPending}
 	{onAbort}
 	{onQuickCommit}
 />

--- a/web/src/lib/ws/__tests__/chat-processing-reconciler.test.ts
+++ b/web/src/lib/ws/__tests__/chat-processing-reconciler.test.ts
@@ -221,7 +221,12 @@ describe('ChatProcessingReconciler', () => {
 		}
 	});
 
-	it.each(['heartbeat', 'visibility', 'stop-probe'] satisfies ChatProcessingSnapshotSource[])(
+	it.each([
+		'heartbeat',
+		'visibility',
+		'stop-probe',
+		'admission',
+	] satisfies ChatProcessingSnapshotSource[])(
 		'attributes %s snapshot repairs without logging chat IDs',
 		(source) => {
 			const socket = makeConnection();

--- a/web/src/lib/ws/connection.svelte.ts
+++ b/web/src/lib/ws/connection.svelte.ts
@@ -58,7 +58,8 @@ export interface DrainCursor {
 	current: number;
 }
 
-export type ChatProcessingSnapshotSource = 'heartbeat' | 'visibility' | 'stop-probe' | 'reconnect';
+export type ChatProcessingSnapshotSource =
+	'heartbeat' | 'visibility' | 'stop-probe' | 'admission' | 'reconnect';
 
 export interface WsMessageContext {
 	readonly processingSnapshotSource?: ChatProcessingSnapshotSource;


### PR DESCRIPTION
Prevents a second idle-chat message from bypassing the queue while the first direct run is awaiting cross-channel processing confirmation. The composer now holds a per-chat ephemeral admission gate through the authoritative processing snapshot, preserves newly typed draft content, and resumes normal queue submission once the running projection is applied.