### PR TITLE
Prefetch Git history before scroll end

### DIFF
--- a/web/src/lib/components/git/GitCommitListScreen.svelte
+++ b/web/src/lib/components/git/GitCommitListScreen.svelte
@@ -13,8 +13,6 @@
 	import GitCommitListRow from './GitCommitListRow.svelte';
 	import { GitCommitListVirtualController } from './GitCommitListVirtualController.svelte.js';
 
-	const LOAD_THRESHOLD_PX = 96;
-
 	interface GitCommitListScreenProps {
 		commits: GitHistoryCommitListItem[];
 		isLoading: boolean;
@@ -63,13 +61,15 @@
 	let lastBoundarySignature: string | null = null;
 	let boundaryRequestRevision: number | null = null;
 
-	function isNearListBottom(): boolean {
+	function isWithinLoadAheadRange(): boolean {
 		if (!listRef || listRef.clientHeight <= 0) return false;
-		return listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight < LOAD_THRESHOLD_PX;
+		const remainingDistance = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight;
+		return remainingDistance <= listRef.clientHeight;
 	}
 
 	function maybeLoadMore(): void {
-		if (isLoading || error || nextOffset === null || !isNearListBottom() || !listRef) return;
+		if (isLoading || error || nextOffset === null || !isWithinLoadAheadRange() || !listRef)
+			return;
 		const collectionSignature =
 			collectionChange.kind === 'append'
 				? collectionChange.kind

--- a/web/src/lib/components/git/__tests__/GitCommitListVirtualController.test.ts
+++ b/web/src/lib/components/git/__tests__/GitCommitListVirtualController.test.ts
@@ -375,11 +375,17 @@ describe('GitCommitListVirtualController', () => {
 		});
 	});
 
-	it('loads a physical bottom boundary once until new user intent', async () => {
+	it('loads at the one-viewport boundary once until new user intent', async () => {
 		const rendered = renderList(commits(50), { nextOffset: 50 });
 		const list = mockViewportGeometry(rendered.container, 200);
 		Object.defineProperty(list, 'scrollHeight', { configurable: true, value: 1_000 });
-		list.scrollTop = 710;
+		list.scrollTop = 590;
+
+		await fireEvent.scroll(list);
+		await nextFrame();
+		expect(rendered.onLoadMore).not.toHaveBeenCalled();
+
+		list.scrollTop = 600;
 
 		await fireEvent.scroll(list);
 		await fireEvent.scroll(list);
@@ -395,7 +401,7 @@ describe('GitCommitListVirtualController', () => {
 			collectionChange: { revision: 2, kind: 'replace' },
 		});
 		await nextFrame();
-		list.scrollTop = 710;
+		list.scrollTop = 600;
 		await fireEvent.scroll(list);
 		await waitFor(() => expect(rendered.onLoadMore).toHaveBeenCalledTimes(2));
 
@@ -412,7 +418,7 @@ describe('GitCommitListVirtualController', () => {
 		const rendered = renderList(commits(50), { nextOffset: 50 });
 		const list = mockViewportGeometry(rendered.container, 200);
 		Object.defineProperty(list, 'scrollHeight', { configurable: true, value: 1_000 });
-		list.scrollTop = 710;
+		list.scrollTop = 600;
 
 		await fireEvent.scroll(list);
 		await waitFor(() => expect(rendered.onLoadMore).toHaveBeenCalledOnce());

--- a/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
+++ b/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
@@ -276,7 +276,7 @@ describe('GitHistoryView', () => {
 		expect(history.screen).toBe('list');
 	});
 
-	it('loads the next commit page automatically near the bottom', async () => {
+	it('loads the next commit page automatically one viewport before the bottom', async () => {
 		const nextPage = deferred<Awaited<ReturnType<typeof getGitHistoryCommits>>>();
 		vi.mocked(getGitHistoryCommits)
 			.mockResolvedValueOnce({
@@ -311,11 +311,11 @@ describe('GitHistoryView', () => {
 			scrollHeight: { configurable: true, value: 1_000 },
 		});
 
-		list.scrollTop = 650;
+		list.scrollTop = 590;
 		await fireEvent.scroll(list);
 		expect(getGitHistoryCommits).toHaveBeenCalledOnce();
 
-		list.scrollTop = 710;
+		list.scrollTop = 600;
 		await fireEvent.scroll(list);
 		await fireEvent.scroll(list);
 		await waitFor(() => expect(getGitHistoryCommits).toHaveBeenCalledTimes(2));
@@ -383,7 +383,7 @@ describe('GitHistoryView', () => {
 			clientHeight: { configurable: true, value: 200 },
 			scrollHeight: { configurable: true, value: 1_000 },
 		});
-		list.scrollTop = 710;
+		list.scrollTop = 600;
 		await fireEvent.scroll(list);
 
 		const retry = await screen.findByRole('button', { name: 'Retry loading commits' });


### PR DESCRIPTION
Git History currently waits until users are almost at the end of the loaded list before requesting another page, which can expose the loading boundary during normal scrolling. This change begins loading when the remaining distance reaches one viewport while preserving the existing request, retry, and deduplication guards, with boundary coverage for the new threshold.