### PR TITLE
Fix mobile snippet palette and trigger dismissal

### DIFF
--- a/integration-tests/tests/e2e/snippet-palette-focus.test.ts
+++ b/integration-tests/tests/e2e/snippet-palette-focus.test.ts
@@ -22,7 +22,7 @@ describe('snippet palette focus', () => {
       });
 
       const app = new SpaDriver(fixture.page, fixture.integration);
-      await fixture.page.setViewport({ width: 844, height: 390, isMobile: true });
+      await fixture.page.setViewport({ width: 390, height: 844, isMobile: true });
       await app.open();
       await fixture.waitForSpaWebSocket();
       await app.clickButton('New Chat');
@@ -30,6 +30,15 @@ describe('snippet palette focus', () => {
       await app.fill(
         '[role="dialog"] input[aria-label="Project Path"]',
         fixture.integration.dirs.project,
+      );
+      await fixture.page.evaluate(() => {
+        const viewport = window.visualViewport;
+        if (!viewport) throw new Error('Missing visual viewport.');
+        Object.defineProperty(viewport, 'height', { configurable: true, value: 390 });
+        viewport.dispatchEvent(new Event('resize'));
+      });
+      await fixture.page.waitForFunction(
+        () => document.documentElement.style.getPropertyValue('--app-height') === '390px',
       );
 
       await fixture.page.$eval(NEW_CHAT_COMPOSER, (element) => {
@@ -53,11 +62,11 @@ describe('snippet palette focus', () => {
         );
         const list = document.querySelector<HTMLElement>('[role="listbox"]');
         return {
-          previewTabIndex: preview?.tabIndex ?? -1,
+          previewVisible: Boolean(preview?.getClientRects().length),
           listHeight: list?.getBoundingClientRect().height ?? 0,
         };
       });
-      expect(paletteLayout.previewTabIndex).toBe(0);
+      expect(paletteLayout.previewVisible).toBe(false);
       expect(paletteLayout.listHeight).toBeGreaterThan(0);
       await fixture.page.evaluate(() => {
         const option = [...document.querySelectorAll<HTMLElement>('[role="option"]')].find(

--- a/web/src/lib/chat/composer/__tests__/snippet-palette-trigger-state.test.ts
+++ b/web/src/lib/chat/composer/__tests__/snippet-palette-trigger-state.test.ts
@@ -5,11 +5,15 @@ function trigger(start = 0) {
 	return { start, end: start + 4, query: 'go' };
 }
 
+function source(start = 0, suffix = 'go') {
+	return `${'x'.repeat(start)};;${suffix}`;
+}
+
 describe('SnippetPaletteTriggerState', () => {
 	it('opens for a detected trigger and preserves it while hidden', () => {
 		const palette = new SnippetPaletteTriggerState();
 
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(trigger(3), source(3));
 		palette.hide();
 
 		expect(palette.isOpen).toBe(false);
@@ -17,27 +21,31 @@ describe('SnippetPaletteTriggerState', () => {
 		expect(palette.initialQuery).toBe('go');
 	});
 
-	it('suppresses a dismissed occurrence until detection clears', () => {
+	it('suppresses a dismissed occurrence until its prefix is removed', () => {
 		const palette = new SnippetPaletteTriggerState();
 
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(trigger(3), source(3));
 		palette.dismiss();
-		palette.updateDetectedTrigger({ ...trigger(3), end: 6, query: 'gone' });
+		palette.updateDetectedTrigger({ ...trigger(3), end: 9, query: 'gone' }, source(3, 'gone'));
 		expect(palette.isOpen).toBe(false);
 
-		palette.updateDetectedTrigger(null);
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(null, `${source(3, 'gone')} `);
+		palette.updateDetectedTrigger(trigger(3), source(3));
+		expect(palette.isOpen).toBe(false);
+
+		palette.updateDetectedTrigger(null, `${'x'.repeat(3)};`);
+		palette.updateDetectedTrigger(trigger(3), source(3));
 		expect(palette.isOpen).toBe(true);
 	});
 
 	it('does not discard an inline dismissal when a menu-opened palette closes', () => {
 		const palette = new SnippetPaletteTriggerState();
 
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(trigger(3), source(3));
 		palette.dismiss();
 		palette.openFromMenu();
 		palette.dismiss();
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(trigger(3), source(3));
 
 		expect(palette.isOpen).toBe(false);
 	});
@@ -45,10 +53,10 @@ describe('SnippetPaletteTriggerState', () => {
 	it('resets dismissals when the composer identity changes', () => {
 		const palette = new SnippetPaletteTriggerState();
 
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(trigger(3), source(3));
 		palette.dismiss();
 		palette.reset();
-		palette.updateDetectedTrigger(trigger(3));
+		palette.updateDetectedTrigger(trigger(3), source(3));
 
 		expect(palette.isOpen).toBe(true);
 	});

--- a/web/src/lib/chat/composer/snippet-palette-trigger-state.svelte.ts
+++ b/web/src/lib/chat/composer/snippet-palette-trigger-state.svelte.ts
@@ -4,19 +4,20 @@ export class SnippetPaletteTriggerState {
 	isOpen = $state(false);
 	trigger = $state<SnippetTrigger | null>(null);
 	initialQuery = $state('');
-	#dismissedTriggerStart: number | null = null;
+	#activePrefix = '';
+	#dismissedOccurrence: { start: number; prefix: string } | null = null;
 
 	openFromMenu(): void {
-		this.#open(null);
+		this.#open(null, '');
 	}
 
-	updateDetectedTrigger(trigger: SnippetTrigger | null): void {
+	updateDetectedTrigger(trigger: SnippetTrigger | null, sourceText: string): void {
+		this.#clearDismissalWhenPrefixIsRemoved(sourceText);
 		if (!trigger) {
-			this.#dismissedTriggerStart = null;
 			if (this.trigger) this.complete();
 			return;
 		}
-		this.#open(trigger);
+		this.#open(trigger, sourceText);
 	}
 
 	// Modal inertness prevents composer input or menu opens while a hidden trigger backs the argument chain.
@@ -25,7 +26,9 @@ export class SnippetPaletteTriggerState {
 	}
 
 	dismiss(): void {
-		if (this.trigger) this.#dismissedTriggerStart = this.trigger.start;
+		if (this.trigger) {
+			this.#dismissedOccurrence = { start: this.trigger.start, prefix: this.#activePrefix };
+		}
 		this.complete();
 	}
 
@@ -33,18 +36,29 @@ export class SnippetPaletteTriggerState {
 		this.isOpen = false;
 		this.trigger = null;
 		this.initialQuery = '';
+		this.#activePrefix = '';
 	}
 
 	reset(): void {
 		this.complete();
-		this.#dismissedTriggerStart = null;
+		this.#dismissedOccurrence = null;
 	}
 
-	#open(trigger: SnippetTrigger | null): void {
+	#open(trigger: SnippetTrigger | null, sourceText: string): void {
 		if (this.isOpen) return;
-		if (trigger && trigger.start === this.#dismissedTriggerStart) return;
+		if (trigger && trigger.start === this.#dismissedOccurrence?.start) return;
 		this.trigger = trigger;
+		this.#activePrefix = trigger
+			? sourceText.slice(trigger.start, trigger.end - trigger.query.length)
+			: '';
 		this.initialQuery = trigger?.query ?? '';
 		this.isOpen = true;
+	}
+
+	#clearDismissalWhenPrefixIsRemoved(sourceText: string): void {
+		const dismissed = this.#dismissedOccurrence;
+		if (!dismissed) return;
+		if (sourceText.startsWith(dismissed.prefix, dismissed.start)) return;
+		this.#dismissedOccurrence = null;
 	}
 }

--- a/web/src/lib/components/chat/ComposerSnippetPalette.svelte
+++ b/web/src/lib/components/chat/ComposerSnippetPalette.svelte
@@ -4,7 +4,7 @@
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Settings2 from '@lucide/svelte/icons/settings-2';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { getLocalSettings, getSnippets } from '$lib/context';
+	import { getAppShell, getLocalSettings, getSnippets } from '$lib/context';
 	import type { SnippetInsertionHandler } from '$lib/chat/composer/snippet-insertion.js';
 	import { normalizeSnippetTrigger } from '$lib/chat/composer/snippet-trigger.js';
 	import { snippetPreview } from '$lib/snippets/snippet-presentation.js';
@@ -41,6 +41,7 @@
 	}: Props = $props();
 
 	const snippets = getSnippets();
+	const appShell = getAppShell();
 	const localSettings = getLocalSettings();
 	const uid = $props.id();
 	const listId = `${uid}-list`;
@@ -61,6 +62,7 @@
 		onEditSnippets: () => onEditSnippets(),
 	});
 	const triggerHint = $derived(normalizeSnippetTrigger(localSettings.snippetTrigger));
+	const mobileKeyboardVisible = $derived(appShell.isMobile && appShell.keyboardHeight > 0);
 
 	$effect(() => {
 		palette.syncOpen(open, initialQuery);
@@ -190,14 +192,14 @@
 			{/if}
 		</div>
 
-		{#if palette.highlightedSnippet}
-			<div class="shrink-0 border-t border-border px-4 py-3">
+		{#if palette.highlightedSnippet && !mobileKeyboardVisible}
+			<div class="snippet-template-preview-shell shrink-0 border-t border-border px-4 py-3">
 				<!-- svelte-ignore a11y_no_noninteractive_tabindex -- overflow preview is keyboard-scrollable and exposes the complete template; follow-up: INLINE_SNIPPET_EXPANSION.md#a11y-suppression-register -->
 				<pre
 					role="region"
 					tabindex="0"
 					aria-label={m.snippets_template_preview_label()}
-					class="snippet-template-preview h-28 overflow-y-auto font-mono text-xs leading-4 whitespace-pre-wrap text-muted-foreground sm:h-40"
+					class="h-28 overflow-y-auto font-mono text-xs leading-4 whitespace-pre-wrap text-muted-foreground sm:h-40"
 				>{palette.highlightedSnippet.template}</pre>
 			</div>
 		{/if}
@@ -234,9 +236,9 @@
 />
 
 <style>
-	@media (max-height: 30rem) {
-		.snippet-template-preview {
-			height: 4rem;
+	@media (max-height: 36rem) {
+		.snippet-template-preview-shell {
+			display: none;
 		}
 	}
 </style>

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -248,6 +248,7 @@
 		const input = event.currentTarget as HTMLTextAreaElement;
 		snippetPalette.updateDetectedTrigger(
 			findSnippetTrigger(input.value, input.selectionStart, localSettings.snippetTrigger),
+			input.value,
 		);
 	}
 

--- a/web/src/lib/components/chat/__tests__/ComposerSnippetPalette.test.ts
+++ b/web/src/lib/components/chat/__tests__/ComposerSnippetPalette.test.ts
@@ -144,6 +144,13 @@ describe('ComposerSnippetPalette', () => {
 		expect(preview.textContent).toContain('Summarize item 1');
 	});
 
+	it('hides the preview while the mobile keyboard needs the palette height', async () => {
+		render(ComposerSnippetPaletteTestHost, { mobile: true, keyboardHeight: 320 });
+
+		await screen.findByRole('option', { name: /^item-0\b/ });
+		expect(screen.queryByRole('region', { name: 'Template preview' })).toBeNull();
+	});
+
 	it('badges templates that use the arguments and project path tokens', async () => {
 		render(ComposerSnippetPaletteTestHost, {
 			count: 1,

--- a/web/src/lib/components/chat/__tests__/ComposerSnippetPaletteTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ComposerSnippetPaletteTestHost.svelte
@@ -17,6 +17,8 @@
 		initialQuery?: string;
 		contextHint?: string | null;
 		insertionResult?: SnippetInsertionResult;
+		mobile?: boolean;
+		keyboardHeight?: number;
 	}
 
 	let {
@@ -26,6 +28,8 @@
 		initialQuery = '',
 		contextHint = null,
 		insertionResult = 'inserted',
+		mobile = false,
+		keyboardHeight = 0,
 	}: Props = $props();
 
 	let open = $state(true);
@@ -51,6 +55,8 @@
 	}));
 
 	const appShell = new AppShellStore();
+	appShell.isMobile = untrack(() => mobile);
+	appShell.keyboardHeight = untrack(() => keyboardHeight);
 	const transientLayers = new TransientLayerRegistry(new ChatInteractionGate());
 	const localSettings = new LocalSettingsStore();
 	localSettings.set('snippetTrigger', ';;');

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -899,8 +899,12 @@ describe('PromptComposer focus', () => {
 
 		await inputAtCaret(textarea, ';;r', 3);
 		expect(screen.queryByRole('dialog', { name: 'Insert Snippet' })).toBeNull();
+		await inputAtCaret(textarea, ';;review ', 9);
+		await inputAtCaret(textarea, ';;review', 8);
+		await inputAtCaret(textarea, ';;', 2);
+		expect(screen.queryByRole('dialog', { name: 'Insert Snippet' })).toBeNull();
 
-		await inputAtCaret(textarea, '', 0);
+		await inputAtCaret(textarea, ';', 1);
 		await inputAtCaret(textarea, ';;', 2);
 		expect(await screen.findByRole('dialog', { name: 'Insert Snippet' })).toBeTruthy();
 	});

--- a/web/src/lib/components/chat/prompt-composer-state.svelte.ts
+++ b/web/src/lib/components/chat/prompt-composer-state.svelte.ts
@@ -48,13 +48,16 @@ export class PromptComposerUiState {
 		this.setFileMentionTrigger(fileTrigger);
 		if (fileTrigger) {
 			this.setSlashCommandTrigger(null);
-			this.snippetPalette.updateDetectedTrigger(null);
+			this.snippetPalette.updateDetectedTrigger(null, value);
 			return;
 		}
 
 		this.setSlashCommandTrigger(findSlashCommandTrigger(value, caret));
 		if (isComposing) return;
-		this.snippetPalette.updateDetectedTrigger(findSnippetTrigger(value, caret, snippetTrigger));
+		this.snippetPalette.updateDetectedTrigger(
+			findSnippetTrigger(value, caret, snippetTrigger),
+			value,
+		);
 	}
 
 	/** Resets ephemeral UI on chat switch. Returns true if the chat changed. */


### PR DESCRIPTION
Hide the snippet template preview when a mobile keyboard or short viewport would crowd out the result list, and keep a dismissed inline trigger suppressed until its prefix is actually removed. This keeps snippet selection usable on phones and prevents the palette from reopening when users continue typing and backspace to the same trigger.