### PR TITLE
Keep Codex transcripts exact-once after Stop

### DIFF
--- a/integration-tests/bun.lock
+++ b/integration-tests/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-code": "2.1.220",
         "@earendil-works/pi-coding-agent": "0.83.0",
-        "@openai/codex": "0.144.6",
+        "@openai/codex": "0.146.0",
         "@types/bun": "1.3.14",
         "opencode-ai": "1.18.4",
         "playwright": "1.61.1",
@@ -121,19 +121,19 @@
 
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
-    "@openai/codex": ["@openai/codex@0.144.6", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw=="],
+    "@openai/codex": ["@openai/codex@0.146.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.144.6-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.146.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.144.6-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.146.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.144.6-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.146.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.144.6-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.146.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.144.6-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.146.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.144.6-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.146.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@anthropic-ai/claude-code": "2.1.220",
     "@earendil-works/pi-coding-agent": "0.83.0",
-    "@openai/codex": "0.144.6",
+    "@openai/codex": "0.146.0",
     "@types/bun": "1.3.14",
     "opencode-ai": "1.18.4",
     "playwright": "1.61.1",

--- a/integration-tests/support/fake-codex-model.ts
+++ b/integration-tests/support/fake-codex-model.ts
@@ -55,6 +55,16 @@ export function codexExecCommandCall(
   };
 }
 
+export function codexCodeModeCall(callId: string, input: string): CodexScriptedItem {
+  return {
+    type: 'custom_tool_call',
+    name: 'exec',
+    input,
+    call_id: callId,
+    status: 'completed',
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/integration-tests/support/live-codex.ts
+++ b/integration-tests/support/live-codex.ts
@@ -17,6 +17,7 @@ import { withTimeout } from './deferred.js';
 
 export const LIVE_CODEX_MODEL = 'gpt-5.4-nano';
 export const LIVE_CODEX_THINKING_MODE = 'low';
+export type CodexTestToolMode = 'direct' | 'code_mode' | 'code_mode_only';
 
 const CODEX_BINARY = fileURLToPath(
   new URL('../node_modules/.bin/codex', import.meta.url),
@@ -89,6 +90,7 @@ interface LiveCodexTestEnvironmentOptions {
   // Scripted-model environments proxy to a local fake, so any placeholder key works and no
   // credential needs to exist in the environment.
   testingKey?: string;
+  toolMode?: CodexTestToolMode;
 }
 
 type CodexProxyProcess = Bun.Subprocess<'pipe', 'ignore', 'ignore'>;
@@ -229,7 +231,14 @@ export async function startLiveCodexTestEnvironment(
       const codexHome = join(directories.home, '.codex');
       const catalogPath = join(codexHome, 'live-models.json');
       await mkdir(codexHome, { recursive: true, mode: 0o700 });
-      await writeFile(catalogPath, JSON.stringify(LIVE_MODEL_CATALOG), { mode: 0o600 });
+      const modelCatalog = {
+        ...LIVE_MODEL_CATALOG,
+        models: LIVE_MODEL_CATALOG.models.map((model) => ({
+          ...model,
+          tool_mode: options.toolMode ?? model.tool_mode,
+        })),
+      };
+      await writeFile(catalogPath, JSON.stringify(modelCatalog), { mode: 0o600 });
       await writeFile(join(codexHome, 'config.toml'), [
         'model_provider = "garcon-live-openai"',
         `model_catalog_json = ${JSON.stringify(catalogPath)}`,

--- a/integration-tests/support/scripted-codex.ts
+++ b/integration-tests/support/scripted-codex.ts
@@ -6,6 +6,7 @@
 import { FakeCodexModel } from './fake-codex-model.js';
 import {
   startLiveCodexTestEnvironment,
+  type CodexTestToolMode,
   type LiveCodexTestEnvironment,
 } from './live-codex.js';
 
@@ -13,13 +14,16 @@ export interface ScriptedCodexTestEnvironment extends LiveCodexTestEnvironment {
   readonly model: FakeCodexModel;
 }
 
-export async function startScriptedCodexTestEnvironment(): Promise<ScriptedCodexTestEnvironment> {
+export async function startScriptedCodexTestEnvironment(options: {
+  readonly toolMode?: CodexTestToolMode;
+} = {}): Promise<ScriptedCodexTestEnvironment> {
   const model = FakeCodexModel.start();
   let environment: LiveCodexTestEnvironment;
   try {
     environment = await startLiveCodexTestEnvironment({
       upstreamUrl: model.responsesUrl,
       testingKey: `garcon-scripted-codex-${crypto.randomUUID()}`,
+      toolMode: options.toolMode,
     });
   } catch (error) {
     model.stop();

--- a/integration-tests/tests/server/codex-scripted-interrupt.test.ts
+++ b/integration-tests/tests/server/codex-scripted-interrupt.test.ts
@@ -1,9 +1,10 @@
 import { access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { assistantContents } from '../../support/chat-assertions.js';
+import { assistantContents, messagesOfType } from '../../support/chat-assertions.js';
 import {
   codexAssistantMessage,
+  codexCodeModeCall,
   codexExecCommandCall,
 } from '../../support/fake-codex-model.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
@@ -25,7 +26,7 @@ describe('scripted Codex interrupt lifecycle', () => {
   let environment: ScriptedCodexTestEnvironment | undefined;
 
   beforeAll(async () => {
-    environment = await startScriptedCodexTestEnvironment();
+    environment = await startScriptedCodexTestEnvironment({ toolMode: 'code_mode' });
   });
 
   afterAll(async () => {
@@ -72,6 +73,12 @@ describe('scripted Codex interrupt lifecycle', () => {
       expect(assistantContents((await fixture.client.getMessages(chatId)).messages).join('\n'))
         .not.toContain(stoppedReply);
 
+      const recoveryCommandMarker = marker('RECOVERY_COMMAND');
+      const recoveryCommand = `printf ${JSON.stringify(recoveryCommandMarker)}`;
+      testEnvironment.model.scriptTurn([codexCodeModeCall(
+        'call_recovery_code_mode',
+        `const result = await tools.exec_command({cmd: ${JSON.stringify(recoveryCommand)}}); text(result.output);`,
+      )]);
       testEnvironment.model.scriptTurn([codexAssistantMessage(recoveryReply)]);
       const recoveryCursor = fixture.client.markEvents();
       const recovery = await fixture.client.runChat(liveCodexRunRequest({
@@ -86,6 +93,31 @@ describe('scripted Codex interrupt lifecycle', () => {
         marker: recoveryReply,
         afterIndex: recoveryCursor,
       });
+      const liveMessages = fixture.client.eventsSince(recoveryCursor).flatMap((event) =>
+        event.type === 'chat-messages'
+          && event.chatId === chatId
+          ? event.messages
+          : []);
+      expect(assistantContents(liveMessages).filter((content) => content === recoveryReply))
+        .toEqual([recoveryReply]);
+      const liveRecoveryCommands = messagesOfType(liveMessages, 'bash-tool-use')
+        .filter((message) => message.command.includes(recoveryCommandMarker));
+      expect(liveRecoveryCommands).toHaveLength(1);
+      expect(
+        messagesOfType(liveMessages, 'tool-result')
+          .filter((message) => message.toolId === liveRecoveryCommands[0]?.toolId),
+      ).toHaveLength(1);
+
+      const messages = (await fixture.client.getMessages(chatId)).messages;
+      expect(assistantContents(messages).filter((content) => content === recoveryReply))
+        .toEqual([recoveryReply]);
+      const recoveryCommands = messagesOfType(messages, 'bash-tool-use')
+        .filter((message) => message.command.includes(recoveryCommandMarker));
+      expect(recoveryCommands).toHaveLength(1);
+      expect(
+        messagesOfType(messages, 'tool-result')
+          .filter((message) => message.toolId === recoveryCommands[0]?.toolId),
+      ).toHaveLength(1);
       testEnvironment.model.assertSettled();
     }, {
       serverEnvironment: testEnvironment.serverEnvironment,

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -4,6 +4,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { BashToolUseMessage, CodexSubagentToolUseMessage, ExecToolUseMessage, PermissionRequestMessage, PermissionResolvedMessage, ToolResultMessage, WaitToolUseMessage, codexSubagentSourceFingerprint } from '@garcon/common/chat-types';
+import { getNativeMessageRevisionSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { buildApprovalResponse, createPendingApproval } from '../approvals.ts';
 import {
   CodexAppServerClient,
@@ -6120,6 +6121,10 @@ describe('CodexAppServerRuntime', () => {
     await finished;
 
     expect(emitted.map((message) => message.content)).toEqual(['Already emitted']);
+    expect(getNativeMessageRevisionSource(emitted[0])).toEqual({
+      entryId: 'turn:turn-1:item:a1',
+      withinSourceOrdinal: 0,
+    });
   });
 
   it('uses the terminal agent summary when its item completion notification is absent', async () => {

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -1331,7 +1331,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
   #handleItemCompleted(client: CodexAppServerClient, params: ItemCompletedNotification): void {
     const session = this.#sessionForClientTurn(client, params.threadId, params.turnId);
     if (!session) return;
-    session.turnItems.emit(params.item);
+    session.turnItems.emit(params.turnId, params.item);
   }
 
   #handleRawResponseItemCompleted(client: CodexAppServerClient, params: RawResponseItemCompletedNotification): void {
@@ -1385,7 +1385,7 @@ export class CodexAppServerRuntime extends AgentEventEmitterRuntime {
       return;
     }
     const aborted = params.turn.status === 'interrupted' || session.status === 'interrupting';
-    for (const item of params.turn.items) session.turnItems.emit(item);
+    for (const item of params.turn.items) session.turnItems.emit(params.turn.id, item);
     if (aborted) await session.turnItems.reconcileInterrupted(session.nativePath);
     session.capacityRetryCount = 0;
     session.pendingCapacityFailure = null;

--- a/server-agents/codex/src/agents/codex/app-server/turn-item-ledger.ts
+++ b/server-agents/codex/src/agents/codex/app-server/turn-item-ledger.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage } from '@garcon/common/chat-types';
 import type { AgentLogger } from '@garcon/server-agent-interface';
+import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { loadCodexChatMessages } from '../history-loader.js';
 import { convertCodexAppServerLiveItem } from './converter.js';
 import type { CodexThreadItem } from './protocol.js';
@@ -28,7 +29,7 @@ export class CodexTurnItemLedger {
     this.#manualCompactionPending = true;
   }
 
-  emit(item: CodexThreadItem): void {
+  emit(turnId: string, item: CodexThreadItem): void {
     if (this.#seenIds.has(item.id)) return;
     this.#seenIds.add(item.id);
     const compactionTrigger = item.type === 'contextCompaction'
@@ -36,6 +37,12 @@ export class CodexTurnItemLedger {
       : undefined;
     if (item.type === 'contextCompaction') this.#manualCompactionPending = false;
     const messages = convertCodexAppServerLiveItem(item, undefined, compactionTrigger);
+    messages.forEach((message, withinSourceOrdinal) => {
+      attachNativeMessageSource(message, {
+        entryId: `turn:${turnId}:item:${item.id}`,
+        withinSourceOrdinal,
+      });
+    });
     if (messages.length) this.#emit(messages);
   }
 

--- a/server/chat-execution/__tests__/chat-execution-coordinator.test.js
+++ b/server/chat-execution/__tests__/chat-execution-coordinator.test.js
@@ -1161,6 +1161,7 @@ describe('orchestration', () => {
           content: 'hello',
           metadata: expect.objectContaining({
             clientRequestId: 'req-1',
+            upstreamRequestId: 'msg-1',
             turnId: 'turn-1',
             deliveryStatus: 'accepted',
           }),

--- a/server/chat-execution/accepted-input-transcript.ts
+++ b/server/chat-execution/accepted-input-transcript.ts
@@ -56,6 +56,7 @@ export class AcceptedInputTranscript {
       appended = await this.chatMessages.appendMessages(chatId, [
         new UserMessage(new Date().toISOString(), content, images, {
           clientRequestId,
+          upstreamRequestId: options.clientMessageId,
           turnId: options.turnId,
           deliveryStatus,
         }),

--- a/server/chats/__tests__/chat-view-store.test.js
+++ b/server/chats/__tests__/chat-view-store.test.js
@@ -6,6 +6,7 @@ import {
   ErrorMessage,
   UserMessage,
 } from '../../../common/chat-types.js';
+import { attachNativeMessageSource } from '../../agents/shared/native-message-source.js';
 import { transcriptRevision } from '../../lib/transcript-revision.js';
 
 const TS = '2026-06-01T00:00:00.000Z';
@@ -140,6 +141,102 @@ describe('ChatViewStore', () => {
 
     expect(messages.map((message) => message.content)).toEqual(['provider content']);
     expect(contents(store.readPage('chat-1', 20))).toEqual(['provider content']);
+  });
+
+  it('reconciles shifted native echoes by exact provider identities', async () => {
+    const store = new ChatViewStore(() => false);
+    const initialHistory = [
+      user('old user one'),
+      assistant('old assistant one'),
+      user('old user two'),
+      assistant('old assistant two'),
+    ];
+    const liveUser = user('live user content', {
+      clientRequestId: 'client-request-1',
+      turnId: 'turn-1',
+      upstreamRequestId: 'provider-request-1',
+      deliveryStatus: 'accepted',
+    });
+    const liveAssistant = attachNativeMessageSource(assistant('live assistant content'), {
+      entryId: 'turn:provider-turn-1:item:provider-item-1',
+      withinSourceOrdinal: 0,
+    });
+    await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => initialHistory,
+      [liveUser, liveAssistant],
+    );
+
+    const nativeUser = user('provider user content', {
+      upstreamRequestId: 'provider-request-1',
+    });
+    const nativeAssistant = attachNativeMessageSource(assistant('provider assistant content'), {
+      entryId: 'turn:provider-turn-1:item:provider-item-1',
+      withinSourceOrdinal: 0,
+    });
+    await store.reconcileNativeSnapshot('chat-1', [
+      ...initialHistory.slice(0, 2),
+      nativeUser,
+      nativeAssistant,
+    ]);
+
+    const messages = store.readPage('chat-1', 20).messages.map((entry) => entry.message);
+    expect(messages.map((message) => message.content)).toEqual([
+      'old user one',
+      'old assistant one',
+      'provider user content',
+      'provider assistant content',
+    ]);
+    expect(messages[2].metadata).toEqual({
+      clientRequestId: 'client-request-1',
+      turnId: 'turn-1',
+      upstreamRequestId: 'provider-request-1',
+      deliveryStatus: 'accepted',
+    });
+  });
+
+  it('keeps identical native and live text without a shared identity', async () => {
+    const store = new ChatViewStore(() => false);
+    const initialHistory = [
+      user('old user one'),
+      assistant('old assistant one'),
+      user('old user two'),
+      assistant('old assistant two'),
+    ];
+    const liveUser = user('same user text', {
+      upstreamRequestId: 'live-provider-request',
+    });
+    const liveAssistant = attachNativeMessageSource(assistant('same assistant text'), {
+      entryId: 'turn:shared-turn:item:shared-item',
+      withinSourceOrdinal: 0,
+    });
+    await store.appendAfterEnsuringGeneration(
+      'chat-1',
+      async () => initialHistory,
+      [liveUser, liveAssistant],
+    );
+
+    const nativeUser = user('same user text', {
+      upstreamRequestId: 'native-provider-request',
+    });
+    const nativeAssistant = attachNativeMessageSource(assistant('same assistant text'), {
+      entryId: 'turn:shared-turn:item:shared-item',
+      withinSourceOrdinal: 1,
+    });
+    await store.reconcileNativeSnapshot('chat-1', [
+      ...initialHistory.slice(0, 2),
+      nativeUser,
+      nativeAssistant,
+    ]);
+
+    expect(contents(store.readPage('chat-1', 20))).toEqual([
+      'old user one',
+      'old assistant one',
+      'same user text',
+      'same assistant text',
+      'same user text',
+      'same assistant text',
+    ]);
   });
 
   it('rejects a restored native snapshot after execution becomes active', async () => {

--- a/server/chats/__tests__/pending-user-input-service.test.js
+++ b/server/chats/__tests__/pending-user-input-service.test.js
@@ -760,6 +760,7 @@ describe('PendingUserInputService', () => {
     const service = new PendingUserInputService(reader);
     await service.register('chat-1', 'persisted', {
       clientRequestId: 'req-1',
+      clientMessageId: 'upstream-1',
       turnId: 'turn-1',
       createdAt: '2026-06-01T00:00:00.000Z',
     });
@@ -770,7 +771,12 @@ describe('PendingUserInputService', () => {
         '2026-06-01T00:00:00.000Z',
         'persisted',
         undefined,
-        { clientRequestId: 'req-1', turnId: 'turn-1', deliveryStatus: 'accepted' },
+        {
+          clientRequestId: 'req-1',
+          upstreamRequestId: 'upstream-1',
+          turnId: 'turn-1',
+          deliveryStatus: 'accepted',
+        },
       )],
     );
     nativeMessages = [

--- a/server/chats/chat-message-reconciliation.ts
+++ b/server/chats/chat-message-reconciliation.ts
@@ -1,0 +1,110 @@
+import { UserMessage, type ChatMessage } from '../../common/chat-types.js';
+import type { ChatViewMessage } from '../../common/chat-view.js';
+import {
+  attachNativeMessageSource,
+  getNativeMessageRevisionSource,
+} from '../agents/shared/native-message-source.js';
+
+export function exactMessageIdentityKeys(message: ChatMessage): string[] {
+  const identities: string[] = [];
+  if (message instanceof UserMessage && message.metadata?.upstreamRequestId) {
+    identities.push(JSON.stringify(['upstream-request', message.metadata.upstreamRequestId]));
+  }
+  if (message instanceof UserMessage && message.metadata?.clientRequestId) {
+    identities.push(JSON.stringify(['client-request', message.metadata.clientRequestId]));
+  }
+  const source = getNativeMessageRevisionSource(message);
+  if (source?.entryId && source.withinSourceOrdinal !== undefined) {
+    identities.push(JSON.stringify(['native-source', source.entryId, source.withinSourceOrdinal]));
+  }
+  return identities;
+}
+
+export function preserveRetainedUserIdentities(
+  retainedMessages: ChatViewMessage[],
+  nativeMessages: ChatMessage[],
+): ChatMessage[] {
+  const nativeIndexByIdentity = new Map<string, number>();
+  nativeMessages.forEach((message, index) => {
+    for (const identity of exactMessageIdentityKeys(message)) {
+      if (!nativeIndexByIdentity.has(identity)) nativeIndexByIdentity.set(identity, index);
+    }
+  });
+  let reconciled = nativeMessages;
+  for (const entry of retainedMessages) {
+    const nativeIndex = exactMessageIdentityKeys(entry.message)
+      .map((identity) => nativeIndexByIdentity.get(identity))
+      .find((index) => index !== undefined);
+    if (nativeIndex === undefined) continue;
+    const nativeMessage = nativeMessages[nativeIndex];
+    const withIdentity = preserveLiveUserIdentity(entry.message, nativeMessage);
+    if (withIdentity === nativeMessage) continue;
+    if (reconciled === nativeMessages) reconciled = [...nativeMessages];
+    reconciled[nativeIndex] = withIdentity;
+  }
+  return reconciled;
+}
+
+export function retainedMessageMatchesNative(
+  retainedMessage: ChatMessage,
+  nativeMessage: ChatMessage | undefined,
+): boolean {
+  return wireMessagesEqual(retainedMessage, nativeMessage)
+    || nativeMessage !== undefined
+      && messagesShareExactIdentity(retainedMessage, nativeMessage);
+}
+
+export function userDeliveryPayloadsAreCompatible(
+  left: UserMessage,
+  right: UserMessage,
+): boolean {
+  return wireMessagesEqual(
+    withoutMetadata(left, right.timestamp),
+    withoutMetadata(right, right.timestamp),
+  ) && metadataIsCompatible(left.metadata, right.metadata);
+}
+
+function preserveLiveUserIdentity(
+  liveMessage: ChatMessage,
+  nativeMessage: ChatMessage,
+): ChatMessage {
+  if (
+    !(liveMessage instanceof UserMessage)
+    || !(nativeMessage instanceof UserMessage)
+    || !liveMessage.metadata?.clientRequestId
+    || !messagesShareExactIdentity(liveMessage, nativeMessage)
+  ) {
+    return nativeMessage;
+  }
+  return attachNativeMessageSource(new UserMessage(
+    nativeMessage.timestamp,
+    nativeMessage.content,
+    nativeMessage.images,
+    { ...nativeMessage.metadata, ...liveMessage.metadata },
+  ), getNativeMessageRevisionSource(nativeMessage));
+}
+
+function messagesShareExactIdentity(left: ChatMessage, right: ChatMessage): boolean {
+  const rightIdentities = new Set(exactMessageIdentityKeys(right));
+  return exactMessageIdentityKeys(left).some((identity) => rightIdentities.has(identity));
+}
+
+function wireMessagesEqual(left: ChatMessage, right: ChatMessage | undefined): boolean {
+  return right !== undefined && JSON.stringify(left) === JSON.stringify(right);
+}
+
+function withoutMetadata(message: UserMessage, timestamp: string): UserMessage {
+  return new UserMessage(timestamp, message.content, message.images);
+}
+
+function metadataIsCompatible(
+  leftMetadata: UserMessage['metadata'],
+  rightMetadata: UserMessage['metadata'],
+): boolean {
+  const left = leftMetadata as Record<string, unknown> | undefined;
+  for (const [key, rightValue] of Object.entries(rightMetadata ?? {})) {
+    const leftValue = left?.[key];
+    if (leftValue !== undefined && leftValue !== rightValue) return false;
+  }
+  return true;
+}

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -9,6 +9,12 @@ import {
   transcriptRevision,
   transcriptRevisions,
 } from '../lib/transcript-revision.js';
+import {
+  exactMessageIdentityKeys,
+  preserveRetainedUserIdentities,
+  retainedMessageMatchesNative,
+  userDeliveryPayloadsAreCompatible,
+} from './chat-message-reconciliation.js';
 import { ChatRunningError } from './errors.js';
 
 const logger = createLogger('chat-view');
@@ -568,9 +574,16 @@ export class ChatViewStore {
       generationId: preservesGeneration ? previous?.generationId : undefined,
       nativeRevision: revisions.full,
     });
+    const nativeIdentities = new Set(
+      reconciledNativeMessages.flatMap(exactMessageIdentityKeys),
+    );
     const unpersistedLiveMessages = previous
-      ? retainedLiveEntries
-        .filter((entry) => entry.seq > reconciledNativeMessages.length)
+        ? retainedLiveEntries
+        .filter((entry) => {
+          const identities = exactMessageIdentityKeys(entry.message);
+          return entry.seq > reconciledNativeMessages.length
+            && !identities.some((identity) => nativeIdentities.has(identity));
+        })
         .map((entry) => entry.message)
       : [];
     let fullMessages = reconciledNativeMessages;
@@ -672,7 +685,7 @@ export class ChatViewStore {
       const requestId = message.metadata.clientRequestId;
       const existing = existingByRequestId.get(requestId);
       if (existing) {
-        if (!userEchoesAreCompatible(existing, message)) {
+        if (!userDeliveryPayloadsAreCompatible(existing, message)) {
           if (conflictPolicy === 'native-wins') {
             logger.warn(`dropped conflicting retained user message during native reconciliation requestId=${requestId}`);
             continue;
@@ -914,85 +927,6 @@ function assertValidChatMessage(message: ChatMessage): void {
   if (!message || typeof message !== 'object' || typeof message.type !== 'string') {
     throw new Error('Invalid chat message');
   }
-}
-
-function wireMessagesEqual(left: ChatMessage, right: ChatMessage | undefined): boolean {
-  return right !== undefined && JSON.stringify(left) === JSON.stringify(right);
-}
-
-function preserveRetainedUserIdentities(
-  retainedMessages: ChatViewMessage[],
-  nativeMessages: ChatMessage[],
-): ChatMessage[] {
-  let reconciled = nativeMessages;
-  for (const entry of retainedMessages) {
-    const nativeIndex = entry.seq - 1;
-    if (nativeIndex >= nativeMessages.length) break;
-    const nativeMessage = nativeMessages[nativeIndex];
-    const withIdentity = preserveLiveUserIdentity(entry.message, nativeMessage);
-    if (withIdentity === nativeMessage) continue;
-    if (reconciled === nativeMessages) reconciled = [...nativeMessages];
-    reconciled[nativeIndex] = withIdentity;
-  }
-  return reconciled;
-}
-
-function preserveLiveUserIdentity(liveMessage: ChatMessage, nativeMessage: ChatMessage): ChatMessage {
-  if (
-    !(liveMessage instanceof UserMessage)
-    || !(nativeMessage instanceof UserMessage)
-    || !liveMessage.metadata?.clientRequestId
-    || !userEchoesAreCompatible(liveMessage, nativeMessage)
-  ) {
-    return nativeMessage;
-  }
-  return new UserMessage(
-    liveMessage.timestamp,
-    liveMessage.content,
-    liveMessage.images,
-    { ...nativeMessage.metadata, ...liveMessage.metadata },
-  );
-}
-
-function retainedMessageMatchesNative(
-  retainedMessage: ChatMessage,
-  nativeMessage: ChatMessage | undefined,
-): boolean {
-  return wireMessagesEqual(retainedMessage, nativeMessage)
-    || retainedMessage instanceof UserMessage
-      && nativeMessage instanceof UserMessage
-      && Boolean(retainedMessage.metadata?.clientRequestId)
-      && userEchoesAreCompatible(retainedMessage, nativeMessage);
-}
-
-function userEchoesAreCompatible(
-  liveMessage: UserMessage,
-  nativeMessage: UserMessage,
-): boolean {
-  return wireMessagesEqual(
-    withoutMetadata(liveMessage, nativeMessage.timestamp),
-    withoutMetadata(nativeMessage, nativeMessage.timestamp),
-  ) && metadataIsCompatible(liveMessage.metadata, nativeMessage.metadata);
-}
-
-function withoutMetadata(message: UserMessage, timestamp: string): UserMessage {
-  return new UserMessage(
-    timestamp,
-    message.content,
-    message.images,
-  );
-}
-
-function metadataIsCompatible(
-  liveMetadata: UserMessage['metadata'],
-  nativeMetadata: UserMessage['metadata'],
-): boolean {
-  const live = liveMetadata as Record<string, unknown> | undefined;
-  for (const [key, nativeValue] of Object.entries(nativeMetadata ?? {})) {
-    const liveValue = live?.[key];
-    if (liveValue !== undefined && liveValue !== nativeValue) return false;
-  }
-  return true;
 }
 
 function revisionsMatch(previous: string | undefined, current: string | undefined): boolean {


### PR DESCRIPTION
Codex Stop followed by a new message could leave both provider-native and retained-live copies of the same turn in the canonical transcript. This aligns recovery coverage with Codex 0.146.0 and carries exact request and turn-item identities across live delivery so native reconciliation replaces matching retained rows without ever treating equal message text as identity; no migration is required because the wire shape is unchanged.