### PR TITLE
Fix OpenCode out-of-order event handling

### DIFF
--- a/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
@@ -451,6 +451,16 @@ describe('OpenCodeRuntime abort', () => {
         info: { id: 'assistant-b', role: 'assistant', parentID: 'user-b' },
       },
     }));
+    // OpenCode allocates durable event IDs before commit, so concurrent delivery can invert
+    // two previously unseen IDs.
+    eventStream.push(envelope({
+      id: 'evt_0010',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: { id: 'user-concurrent', role: 'user', time: { created: Date.now() } },
+      },
+    }));
     eventStream.push(envelope({
       id: 'evt_0009',
       type: 'message.part.updated',
@@ -460,7 +470,7 @@ describe('OpenCodeRuntime abort', () => {
       },
     }));
     eventStream.push(envelope({
-      id: 'evt_0010',
+      id: 'evt_0011',
       type: 'session.status',
       properties: { sessionID: 'session-1', status: { type: 'idle' } },
     }));

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -8,7 +8,7 @@ import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import { buildPromptBody, parseOpenCodeModel } from './prompt.js';
 import { extractSessionId, extractTextParts, isOpenCodeAbortError, isOpenCodeContextOverflowError, openCodeSessionError, type SSEEvent } from './sse-events.js';
 import {
-  acceptSequencedOpenCodeTurnEvent,
+  acceptUniqueOpenCodeTurnEvent,
   createOpenCodeTurnContext,
   openCodeEventBelongsToTurn,
   type OpenCodeSession,
@@ -871,7 +871,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
       });
       return;
     }
-    if (!acceptSequencedOpenCodeTurnEvent(session, event, this.#logger)) return;
+    if (!acceptUniqueOpenCodeTurnEvent(session, event, this.#logger)) return;
 
     const chatId = session.chatId;
     if (!chatId) {
@@ -1194,7 +1194,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
       directory: scope.directory,
       startedAt: new Date().toISOString(),
       lastActivityAt: Date.now(),
-      lastEventId: null,
+      recentEventIds: new Set(),
       providerWorkRequiresQuiescence: false,
       terminalEventsFencedUntilPrompt: false,
       turn,
@@ -1310,7 +1310,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
         directory: scope.directory,
         startedAt: new Date().toISOString(),
         lastActivityAt: Date.now(),
-        lastEventId: null,
+        recentEventIds: new Set(),
         providerWorkRequiresQuiescence: false,
         terminalEventsFencedUntilPrompt: false,
         turn,

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -32,7 +32,7 @@ export interface OpenCodeSession {
   directory?: string;
   startedAt: string;
   lastActivityAt: number;
-  lastEventId: string | null;
+  recentEventIds: Set<string>;
   // A transport or control-plane failure can retire Garcon's turn while OpenCode still owns
   // provider work. The next turn aborts that work before submitting another prompt.
   providerWorkRequiresQuiescence: boolean;
@@ -41,6 +41,12 @@ export interface OpenCodeSession {
   terminalEventsFencedUntilPrompt: boolean;
   turn: OpenCodeTurnContext;
 }
+
+// OpenCode assigns IDs before durable commits, so concurrent publishers can deliver unseen
+// events outside lexical order. The bounded window rejects actual duplicates without making
+// ordering an arrival contract; durable sequence metadata can replace it if global replay grows.
+// https://github.com/anomalyco/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/core/src/event.ts#L419-L437
+const RECENT_EVENT_ID_LIMIT = 512;
 
 export function createOpenCodeTurnContext(
   eventMetadata: RuntimeEventMetadata,
@@ -62,7 +68,7 @@ export function createOpenCodeTurnContext(
   };
 }
 
-export function acceptSequencedOpenCodeTurnEvent(
+export function acceptUniqueOpenCodeTurnEvent(
   session: OpenCodeSession,
   event: SSEEvent,
   logger: AgentLogger,
@@ -82,14 +88,18 @@ export function acceptSequencedOpenCodeTurnEvent(
     logger.warn('Ignoring OpenCode event without an event ID', { eventType: event.type });
     return false;
   }
-  if (session.lastEventId && event.id <= session.lastEventId) {
-    logger.debug('Ignoring replayed or out-of-order OpenCode event', {
+  if (session.recentEventIds.has(event.id)) {
+    logger.debug('Ignoring replayed OpenCode event', {
       eventType: event.type,
       eventId: event.id,
     });
     return false;
   }
-  session.lastEventId = event.id;
+  session.recentEventIds.add(event.id);
+  if (session.recentEventIds.size > RECENT_EVENT_ID_LIMIT) {
+    const oldestEventId = session.recentEventIds.values().next().value;
+    if (oldestEventId) session.recentEventIds.delete(oldestEventId);
+  }
   return true;
 }
 


### PR DESCRIPTION
OpenCode assigns event IDs before durable commits, so concurrent publishers can deliver valid unseen events outside lexical order; treating IDs as a monotonic arrival cursor can discard assistant output and settle a turn without its response. This change replaces lexical high-water filtering with bounded exact-ID deduplication and covers the inverted delivery case in the OpenCode abort lifecycle.