### PR TITLE
Stabilize virtual transcript scrolling and reveal

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -24,6 +24,12 @@ interface ReadingAnchor {
   offset: number;
 }
 
+interface ReadingAnchorFrameSample {
+  frame: number;
+  offset: number | null;
+  scrollTop: number;
+}
+
 interface SelectionSnapshot {
   key: string;
   rowId: string;
@@ -565,6 +571,65 @@ async function readingAnchor(page: Page): Promise<ReadingAnchor> {
     if (!anchor || !key) throw new Error('No visible transcript item is available as an anchor.');
     return { key, offset: anchor.rect.top - viewport.top };
   }, ITEM_SELECTOR);
+}
+
+async function startReadingAnchorFrameSampler(page: Page, anchor: ReadingAnchor): Promise<void> {
+  await page.locator(FEED_SELECTOR).evaluate(
+    async (feedElement, input) => {
+      const feed = feedElement as HTMLElement;
+      const browserGlobal = globalThis as typeof globalThis & {
+        __chatReadingAnchorSampler?: {
+          active: boolean;
+          frame: number;
+          key: string;
+          samples: ReadingAnchorFrameSample[];
+        };
+      };
+      const sampler = {
+        active: true,
+        frame: 0,
+        key: input.key,
+        samples: [] as ReadingAnchorFrameSample[],
+      };
+      browserGlobal.__chatReadingAnchorSampler = sampler;
+      const sample = () => {
+        if (!sampler.active) return;
+        const viewport = feed.getBoundingClientRect();
+        const item = [...feed.querySelectorAll<HTMLElement>(input.itemSelector)].find(
+          (candidate) => candidate.dataset.chatVirtualItem === sampler.key,
+        );
+        sampler.samples.push({
+          frame: sampler.frame,
+          offset: item ? item.getBoundingClientRect().top - viewport.top : null,
+          scrollTop: feed.scrollTop,
+        });
+        sampler.frame += 1;
+        requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    },
+    { itemSelector: ITEM_SELECTOR, key: anchor.key },
+  );
+}
+
+async function finishReadingAnchorFrameSampler(page: Page): Promise<ReadingAnchorFrameSample[]> {
+  return page.evaluate(async () => {
+    const browserGlobal = globalThis as typeof globalThis & {
+      __chatReadingAnchorSampler?: {
+        active: boolean;
+        samples: ReadingAnchorFrameSample[];
+      };
+    };
+    const sampler = browserGlobal.__chatReadingAnchorSampler;
+    if (!sampler) throw new Error('The reading-anchor frame sampler is missing.');
+    for (let frame = 0; frame < 6; frame += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    }
+    sampler.active = false;
+    delete browserGlobal.__chatReadingAnchorSampler;
+    return sampler.samples;
+  });
 }
 
 async function anchorByKey(
@@ -1381,12 +1446,13 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
     await fixture.page.locator('[data-slot="chat-processing-status"]').waitFor({ state: 'visible' });
     const modelCountBeforePrefetch = await waitForStableModelCount(fixture.page, 50);
 
-    await signalScrollIntent(fixture.page, 'earlier');
     await fixture.page.locator(FEED_SELECTOR).evaluate((feedElement) => {
       const feed = feedElement as HTMLElement;
-      feed.scrollTop = Math.min(feed.clientHeight / 2, Math.max(0, feed.scrollHeight - feed.clientHeight));
+      feed.scrollTop = 0;
       feed.dispatchEvent(new Event('scroll', { bubbles: true }));
     });
+    // A clamped viewport emits no further scroll event for another upward gesture.
+    await signalScrollIntent(fixture.page, 'earlier');
     await withDiagnosticTimeout('the first held earlier-page request', firstPageRequest);
 
     await fixture.page.locator(FEED_SELECTOR).evaluate((feedElement, previousModelCount) => {
@@ -1709,9 +1775,26 @@ async function verifyAppendGeometry(fixture: ChromiumFixture, chatId: string): P
 
   await scrollToPosition(fixture.page, 'middle');
   const detachedAnchor = await readingAnchor(fixture.page);
+  await startReadingAnchorFrameSampler(fixture.page, detachedAnchor);
   await appendTurn(fixture.integration, chatId, 'chromium-detached-append');
   await fixture.page.getByRole('status').filter({ hasText: 'New response available' }).waitFor();
   const restoredDetachedAnchor = await anchorByKey(fixture.page, detachedAnchor.key);
+  const detachedAppendFrames = await finishReadingAnchorFrameSampler(fixture.page);
+  expect(detachedAppendFrames.length).toBeGreaterThan(2);
+  expect(
+    detachedAppendFrames.filter((sample) => sample.offset === null),
+    JSON.stringify({ detachedAnchor, detachedAppendFrames }, null, 2),
+  ).toEqual([]);
+  expect(
+    Math.max(
+      ...detachedAppendFrames.map((sample) =>
+        sample.offset === null
+          ? Number.POSITIVE_INFINITY
+          : Math.abs(sample.offset - detachedAnchor.offset),
+      ),
+    ),
+    JSON.stringify({ detachedAnchor, detachedAppendFrames }, null, 2),
+  ).toBeLessThanOrEqual(1);
   expect(
     Math.abs(restoredDetachedAnchor.offset - detachedAnchor.offset),
     JSON.stringify({ detachedAnchor, restoredDetachedAnchor }),

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -228,6 +228,18 @@ describe('ConversationScrollController', () => {
 		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
 	});
 
+	it('prefetches from an upward gesture when the top edge cannot emit another scroll event', async () => {
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const { controller } = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 0 },
+		});
+
+		controller.noteUserScrollIntent('earlier');
+
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
+	});
+
 	it('does not prefetch earlier history outside the viewport-ahead zone', () => {
 		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
 		const { controller } = controllerFixture({

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -144,11 +144,27 @@ export class ConversationScrollController {
 		}
 		this.#clearInitialBottomRestore();
 		this.#previousScrollTop = this.deps.getScrollContainer()?.scrollTop ?? this.#previousScrollTop;
+		const intentEpoch = this.#userScrollIntent.epoch + 1;
 		this.#userScrollIntent = {
-			epoch: this.#userScrollIntent.epoch + 1,
+			epoch: intentEpoch,
 			direction,
 			receivedAt: performance.now(),
 		};
+		// Evaluates a clamped edge after the gesture because another wheel or key input
+		// at that edge may not produce the usual scroll event.
+		if (direction) {
+			const chatId = this.deps.sessions.selectedChatId;
+			queueMicrotask(() => {
+				if (
+					this.#userScrollIntent.epoch !== intentEpoch ||
+					this.#userScrollIntent.direction !== direction ||
+					this.deps.sessions.selectedChatId !== chatId
+				) {
+					return;
+				}
+				this.#handleBoundaryProximity(direction, this.#isNearPageBoundary(direction));
+			});
+		}
 	}
 
 	prepareInitialBottomRestore(chatId: string | null): void {

--- a/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
@@ -936,11 +936,12 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 	}
 
 	#committedVirtualRangeSignature(): string | null {
-		// Delayed measurements can expand the range until TanStack closes its scroll cycle.
+		// The paint gate waits for TanStack to settle and committed rows to cover the viewport.
 		if (this.#instance().isScrolling) return null;
-		return this.#mountedItems.committedRangeSignature(
-			this.#instance().getVirtualItems(),
+		return this.#mountedItems.committedViewportRangeSignature(
+			this.#instance(),
 			this.#configuredKeys,
+			this.options.viewport,
 		);
 	}
 

--- a/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
@@ -15,6 +15,7 @@ import {
 	CHAT_GEOMETRY_END_THRESHOLD_PX,
 	classifyConversationVirtualStructure,
 	classifyMeasuredConversationViewportFill,
+	conversationVirtualGeometryChangesBeforeAnchor,
 	createRetainedConversationRangeExtractor,
 	shouldPreserveConversationVirtualEdge,
 } from './conversation-feed-viewport-geometry.js';
@@ -530,7 +531,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 			endBehavior: snapshot.endBehavior,
 			restorePolicyEnd,
 		});
-		const shouldCaptureReadingPosition =
+		const readingPositionPolicyApplies =
 			this.options.visible &&
 			this.#activeTargetScrolls === 0 &&
 			(structure === 'interior-only' || resetMeasurements || preserveEdgeReadingPosition) &&
@@ -541,14 +542,28 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 			snapshot.geometryRevision,
 			preferTranscriptAnchor,
 		);
-		const preservationAnchor = shouldCaptureReadingPosition
+		const candidateAnchor = readingPositionPolicyApplies
 			? (this.#pendingReadingAnchor ??
 				preCommitAnchor ??
 				this.#captureVirtualAnchor(preferTranscriptAnchor))
 			: null;
+		// TanStack already anchors an unaffected trailing publication. A second keyed
+		// restore would align the row to the start for a frame before restoring its offset.
+		const shouldRestoreReadingPosition = Boolean(
+			candidateAnchor &&
+			(this.#pendingReadingAnchor !== null ||
+				conversationVirtualGeometryChangesBeforeAnchor({
+					previousKeys: this.#configuredKeys,
+					previousEstimates: this.#configuredEstimates,
+					nextKeys: keys,
+					nextEstimates: estimates,
+					anchorKey: candidateAnchor.key,
+				})),
+		);
+		const preservationAnchor = shouldRestoreReadingPosition ? candidateAnchor : null;
 		if (preservationAnchor && !restorePolicyEnd) {
 			this.#pendingReadingAnchor = preservationAnchor;
-		} else if (!shouldCaptureReadingPosition || restorePolicyEnd) {
+		} else if (!shouldRestoreReadingPosition || restorePolicyEnd) {
 			this.#pendingReadingAnchor = null;
 		}
 

--- a/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
@@ -15,8 +15,8 @@ import {
 	CHAT_GEOMETRY_END_THRESHOLD_PX,
 	classifyConversationVirtualStructure,
 	classifyMeasuredConversationViewportFill,
-	conversationVirtualGeometryChangesBeforeAnchor,
 	createRetainedConversationRangeExtractor,
+	selectConversationReadingRestoreAnchor,
 	shouldPreserveConversationVirtualEdge,
 } from './conversation-feed-viewport-geometry.js';
 import type { ConversationVirtualFeedModel } from './conversation-feed-virtual-items.js';
@@ -521,11 +521,9 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		});
 		const restorePolicyEnd =
 			snapshot.endBehavior === 'restore-if-pinned' && untrack(() => this.options.pinned);
-		// The pinned core carries upstream #1246, so count shrink preserves surviving keyed
-		// measurements and ignores stale connected indexes without a Garcon reset pass.
+		// Upstream #1246 preserves keyed measurements across count shrink without a Garcon reset.
 		const resetMeasurements = snapshot.measurementReset === 'all';
-		// The pre-commit anchor records old TanStack coordinates; the keyed restore applies them
-		// after Svelte commits the new sizer.
+		// The keyed restore reapplies pre-commit TanStack coordinates after Svelte commits the sizer.
 		const preserveEdgeReadingPosition = shouldPreserveConversationVirtualEdge({
 			structure,
 			endBehavior: snapshot.endBehavior,
@@ -547,23 +545,15 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 				preCommitAnchor ??
 				this.#captureVirtualAnchor(preferTranscriptAnchor))
 			: null;
-		// TanStack already anchors an unaffected trailing publication. A second keyed
-		// restore would align the row to the start for a frame before restoring its offset.
-		const shouldRestoreReadingPosition = Boolean(
-			candidateAnchor &&
-			(this.#pendingReadingAnchor !== null ||
-				conversationVirtualGeometryChangesBeforeAnchor({
-					previousKeys: this.#configuredKeys,
-					previousEstimates: this.#configuredEstimates,
-					nextKeys: keys,
-					nextEstimates: estimates,
-					anchorKey: candidateAnchor.key,
-				})),
-		);
-		const preservationAnchor = shouldRestoreReadingPosition ? candidateAnchor : null;
+		const preservationAnchor = selectConversationReadingRestoreAnchor({
+			candidateAnchor,
+			pendingAnchor: this.#pendingReadingAnchor,
+			previous: { keys: this.#configuredKeys, estimates: this.#configuredEstimates },
+			next: snapshot,
+		});
 		if (preservationAnchor && !restorePolicyEnd) {
 			this.#pendingReadingAnchor = preservationAnchor;
-		} else if (!shouldRestoreReadingPosition || restorePolicyEnd) {
+		} else {
 			this.#pendingReadingAnchor = null;
 		}
 

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
@@ -32,12 +32,12 @@ import {
 	classifyMeasuredConversationViewportFill,
 	classifyConversationVirtualStructure,
 	attainableConversationTargetOffset,
-	conversationVirtualGeometryChangesBeforeAnchor,
 	createRetainedConversationRangeExtractor,
 	isConversationTargetLayoutReady,
 	retainedConversationRange,
 	resolveConversationViewportRect,
 	selectConversationReadingAnchor,
+	selectConversationReadingRestoreAnchor,
 	shouldPreserveConversationVirtualEdge,
 } from '../conversation-feed-viewport-geometry';
 import {
@@ -156,33 +156,51 @@ describe('ConversationFeedVirtualController helpers', () => {
 	});
 
 	it('restores only geometry that can move the reading anchor start', () => {
+		const anchor = { key: 'anchor' };
 		expect(
-			conversationVirtualGeometryChangesBeforeAnchor({
-				previousKeys: ['start', 'before', 'anchor', 'end'],
-				previousEstimates: [16, 80, 120, 16],
-				nextKeys: ['start', 'before', 'anchor', 'appended', 'end'],
-				nextEstimates: [16, 80, 120, 180, 16],
-				anchorKey: 'anchor',
+			selectConversationReadingRestoreAnchor({
+				candidateAnchor: anchor,
+				pendingAnchor: null,
+				previous: {
+					keys: ['start', 'before', 'anchor', 'end'],
+					estimates: [16, 80, 120, 16],
+				},
+				next: {
+					keys: ['start', 'before', 'anchor', 'appended', 'end'],
+					estimates: [16, 80, 120, 180, 16],
+				},
 			}),
-		).toBe(false);
+		).toBeNull();
 		expect(
-			conversationVirtualGeometryChangesBeforeAnchor({
-				previousKeys: ['start', 'before', 'anchor', 'end'],
-				previousEstimates: [16, 80, 120, 16],
-				nextKeys: ['start', 'prepended', 'before', 'anchor', 'end'],
-				nextEstimates: [16, 180, 80, 120, 16],
-				anchorKey: 'anchor',
+			selectConversationReadingRestoreAnchor({
+				candidateAnchor: anchor,
+				pendingAnchor: null,
+				previous: {
+					keys: ['start', 'before', 'anchor', 'end'],
+					estimates: [16, 80, 120, 16],
+				},
+				next: {
+					keys: ['start', 'prepended', 'before', 'anchor', 'end'],
+					estimates: [16, 180, 80, 120, 16],
+				},
 			}),
-		).toBe(true);
+		).toBe(anchor);
 		expect(
-			conversationVirtualGeometryChangesBeforeAnchor({
-				previousKeys: ['start', 'before', 'anchor'],
-				previousEstimates: [16, 80, 120],
-				nextKeys: ['start', 'before', 'anchor'],
-				nextEstimates: [16, 96, 120],
-				anchorKey: 'anchor',
+			selectConversationReadingRestoreAnchor({
+				candidateAnchor: anchor,
+				pendingAnchor: null,
+				previous: { keys: ['start', 'before', 'anchor'], estimates: [16, 80, 120] },
+				next: { keys: ['start', 'before', 'anchor'], estimates: [16, 96, 120] },
 			}),
-		).toBe(true);
+		).toBe(anchor);
+		expect(
+			selectConversationReadingRestoreAnchor({
+				candidateAnchor: anchor,
+				pendingAnchor: anchor,
+				previous: { keys: ['start', 'before', 'anchor'], estimates: [16, 80, 120] },
+				next: { keys: ['start', 'before', 'anchor'], estimates: [16, 80, 120] },
+			}),
+		).toBe(anchor);
 	});
 
 	it('anchors the first meaningfully visible transcript item instead of a subpixel sliver', () => {

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
@@ -32,6 +32,7 @@ import {
 	classifyMeasuredConversationViewportFill,
 	classifyConversationVirtualStructure,
 	attainableConversationTargetOffset,
+	conversationVirtualGeometryChangesBeforeAnchor,
 	createRetainedConversationRangeExtractor,
 	isConversationTargetLayoutReady,
 	retainedConversationRange,
@@ -152,6 +153,36 @@ describe('ConversationFeedVirtualController helpers', () => {
 				restorePolicyEnd: false,
 			}),
 		).toBe(false);
+	});
+
+	it('restores only geometry that can move the reading anchor start', () => {
+		expect(
+			conversationVirtualGeometryChangesBeforeAnchor({
+				previousKeys: ['start', 'before', 'anchor', 'end'],
+				previousEstimates: [16, 80, 120, 16],
+				nextKeys: ['start', 'before', 'anchor', 'appended', 'end'],
+				nextEstimates: [16, 80, 120, 180, 16],
+				anchorKey: 'anchor',
+			}),
+		).toBe(false);
+		expect(
+			conversationVirtualGeometryChangesBeforeAnchor({
+				previousKeys: ['start', 'before', 'anchor', 'end'],
+				previousEstimates: [16, 80, 120, 16],
+				nextKeys: ['start', 'prepended', 'before', 'anchor', 'end'],
+				nextEstimates: [16, 180, 80, 120, 16],
+				anchorKey: 'anchor',
+			}),
+		).toBe(true);
+		expect(
+			conversationVirtualGeometryChangesBeforeAnchor({
+				previousKeys: ['start', 'before', 'anchor'],
+				previousEstimates: [16, 80, 120],
+				nextKeys: ['start', 'before', 'anchor'],
+				nextEstimates: [16, 96, 120],
+				anchorKey: 'anchor',
+			}),
+		).toBe(true);
 	});
 
 	it('anchors the first meaningfully visible transcript item instead of a subpixel sliver', () => {
@@ -370,6 +401,30 @@ describe('ConversationFeedVirtualController', () => {
 		await nextFrame();
 		expect(exposure.instance.options.count).toBe(4);
 		expect(measure).not.toHaveBeenCalled();
+	});
+
+	it('leaves detached tail append anchoring to TanStack without a keyed restore', async () => {
+		const { exposure } = await renderController();
+		const viewport = document.querySelector<HTMLDivElement>('[data-controller-viewport]');
+		if (!viewport) throw new Error('Expected the controller viewport');
+		await fireEvent.click(screen.getByRole('button', { name: 'Toggle pinned' }));
+		viewport.scrollTop = 80;
+		viewport.dispatchEvent(new Event('scroll'));
+		await nextFrame();
+		const scrollToIndex = vi.spyOn(exposure.instance, 'scrollToIndex');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Append' }));
+		await waitFor(() =>
+			expect(
+				document
+					.querySelector('[data-controller-sizer]')
+					?.getAttribute('data-controller-model-count'),
+			).toBe('13'),
+		);
+		await nextFrame();
+		await nextFrame();
+
+		expect(scrollToIndex).not.toHaveBeenCalled();
 	});
 
 	it('resets text-scale measurements immediately when visible and once on show when hidden', async () => {

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
@@ -148,6 +148,13 @@
 		geometryRevision += 1;
 	}
 
+	function appendItem(): void {
+		controller.prepareForGeometryPublication(geometryRevision + 1);
+		itemCount += 1;
+		measurementReset = 'none';
+		geometryRevision += 1;
+	}
+
 	function toggleScale(): void {
 		controller.prepareForGeometryPublication(geometryRevision + 1);
 		textScale = textScale === 1 ? 0.85 : 1;
@@ -229,6 +236,7 @@
 </div>
 
 <button onclick={publishContent}>Publish content</button>
+<button onclick={appendItem}>Append</button>
 <button onclick={retainFirst}>Retain first</button>
 <button onclick={shrink}>Shrink</button>
 <button onclick={toggleScale}>Toggle scale</button>

--- a/web/src/lib/components/chat/__tests__/conversation-feed-viewport-geometry.logic.test.ts
+++ b/web/src/lib/components/chat/__tests__/conversation-feed-viewport-geometry.logic.test.ts
@@ -1,0 +1,57 @@
+import type { VirtualItem } from '@tanstack/svelte-virtual';
+import { describe, expect, it } from 'vitest';
+import { isConversationVirtualViewportCovered } from '../conversation-feed-viewport-geometry';
+
+function virtualItem(key: string, index: number, start: number, size: number): VirtualItem {
+	return { key, index, start, end: start + size, size, lane: 0 };
+}
+
+describe('conversation virtual viewport geometry', () => {
+	it('keeps a switched feed concealed while its committed range leaves visible space uncovered', () => {
+		const staleRange = [
+			virtualItem('seq-29', 29, 2_136.984_375, 58),
+			virtualItem('bash-8', 30, 2_194.984_375, 68.5),
+			virtualItem('seq-32', 31, 2_263.484_375, 163.984_375),
+			virtualItem('seq-33', 32, 2_427.468_75, 58),
+			virtualItem('bash-9', 33, 2_485.468_75, 68.5),
+			virtualItem('seq-36', 34, 2_553.968_75, 164.031_25),
+			virtualItem('end-spacer', 35, 2_718, 57),
+		];
+		const viewport = {
+			scrollOffset: 2_017,
+			viewportSize: 758,
+			scrollMargin: 0,
+			totalSize: 2_775,
+		};
+
+		expect(isConversationVirtualViewportCovered(staleRange, viewport)).toBe(false);
+		expect(
+			isConversationVirtualViewportCovered(
+				[virtualItem('seq-28', 28, 1_905, 231.984_375), ...staleRange],
+				viewport,
+			),
+		).toBe(true);
+	});
+
+	it('accepts an underfilled list after all visible list content commits', () => {
+		expect(
+			isConversationVirtualViewportCovered(
+				[virtualItem('first', 0, 60, 100), virtualItem('second', 1, 160, 132)],
+				{ scrollOffset: 0, viewportSize: 758, scrollMargin: 60, totalSize: 232 },
+			),
+		).toBe(true);
+	});
+
+	it('rejects disjoint retained rows that bracket an uncovered viewport', () => {
+		expect(
+			isConversationVirtualViewportCovered(
+				[
+					virtualItem('retained-start', 0, 0, 100),
+					virtualItem('visible-start', 5, 500, 100),
+					virtualItem('retained-end', 10, 1_000, 100),
+				],
+				{ scrollOffset: 500, viewportSize: 500, scrollMargin: 0, totalSize: 1_100 },
+			),
+		).toBe(false);
+	});
+});

--- a/web/src/lib/components/chat/conversation-feed-viewport-geometry.ts
+++ b/web/src/lib/components/chat/conversation-feed-viewport-geometry.ts
@@ -99,6 +99,33 @@ export function selectConversationReadingAnchor<T extends { key: unknown; end: n
 	);
 }
 
+// Rejects a stale or disjoint range that could add a visible row after reveal.
+export function isConversationVirtualViewportCovered(
+	virtualItems: readonly { start: number; end: number }[],
+	input: {
+		scrollOffset: number;
+		viewportSize: number;
+		scrollMargin: number;
+		totalSize: number;
+	},
+): boolean {
+	const visibleStart = Math.max(input.scrollOffset, input.scrollMargin);
+	const visibleEnd = Math.min(
+		input.scrollOffset + input.viewportSize,
+		input.scrollMargin + input.totalSize,
+	);
+	if (visibleEnd <= visibleStart + CHAT_GEOMETRY_END_THRESHOLD_PX) return true;
+
+	let coveredThrough = visibleStart;
+	for (const item of virtualItems) {
+		if (item.end < coveredThrough - CHAT_GEOMETRY_END_THRESHOLD_PX) continue;
+		if (item.start > coveredThrough + CHAT_GEOMETRY_END_THRESHOLD_PX) return false;
+		coveredThrough = Math.max(coveredThrough, item.end);
+		if (coveredThrough >= visibleEnd - CHAT_GEOMETRY_END_THRESHOLD_PX) return true;
+	}
+	return false;
+}
+
 export function retainedConversationRange(
 	range: Range,
 	retainedIndexes: readonly number[],

--- a/web/src/lib/components/chat/conversation-feed-viewport-geometry.ts
+++ b/web/src/lib/components/chat/conversation-feed-viewport-geometry.ts
@@ -43,6 +43,29 @@ export function shouldPreserveConversationVirtualEdge(input: {
 	);
 }
 
+export function conversationVirtualGeometryChangesBeforeAnchor(input: {
+	previousKeys: readonly string[];
+	previousEstimates: readonly number[];
+	nextKeys: readonly string[];
+	nextEstimates: readonly number[];
+	anchorKey: string;
+}): boolean {
+	const previousAnchorIndex = input.previousKeys.indexOf(input.anchorKey);
+	const nextAnchorIndex = input.nextKeys.indexOf(input.anchorKey);
+	if (previousAnchorIndex < 0 || nextAnchorIndex < 0) return true;
+
+	return (
+		!arraysEqual(
+			input.previousKeys.slice(0, previousAnchorIndex),
+			input.nextKeys.slice(0, nextAnchorIndex),
+		) ||
+		!arraysEqual(
+			input.previousEstimates.slice(0, previousAnchorIndex),
+			input.nextEstimates.slice(0, nextAnchorIndex),
+		)
+	);
+}
+
 export function selectConversationReadingAnchor<T extends { key: unknown; end: number }>(
 	items: readonly T[],
 	scrollOffset: number,

--- a/web/src/lib/components/chat/conversation-feed-viewport-geometry.ts
+++ b/web/src/lib/components/chat/conversation-feed-viewport-geometry.ts
@@ -43,7 +43,7 @@ export function shouldPreserveConversationVirtualEdge(input: {
 	);
 }
 
-export function conversationVirtualGeometryChangesBeforeAnchor(input: {
+function conversationVirtualGeometryChangesBeforeAnchor(input: {
 	previousKeys: readonly string[];
 	previousEstimates: readonly number[];
 	nextKeys: readonly string[];
@@ -64,6 +64,27 @@ export function conversationVirtualGeometryChangesBeforeAnchor(input: {
 			input.nextEstimates.slice(0, nextAnchorIndex),
 		)
 	);
+}
+
+export function selectConversationReadingRestoreAnchor<T extends { key: string }>(input: {
+	candidateAnchor: T | null;
+	pendingAnchor: T | null;
+	previous: Pick<ConversationVirtualGeometrySnapshot, 'keys' | 'estimates'>;
+	next: Pick<ConversationVirtualGeometrySnapshot, 'keys' | 'estimates'>;
+}): T | null {
+	const anchor = input.candidateAnchor;
+	if (!anchor) return null;
+	// Avoids a redundant keyed restore when TanStack already anchors an unaffected tail append.
+	const shouldRestore =
+		input.pendingAnchor !== null ||
+		conversationVirtualGeometryChangesBeforeAnchor({
+			previousKeys: input.previous.keys,
+			previousEstimates: input.previous.estimates,
+			nextKeys: input.next.keys,
+			nextEstimates: input.next.estimates,
+			anchorKey: anchor.key,
+		});
+	return shouldRestore ? anchor : null;
 }
 
 export function selectConversationReadingAnchor<T extends { key: unknown; end: number }>(

--- a/web/src/lib/components/chat/conversation-feed-virtual-runtime.ts
+++ b/web/src/lib/components/chat/conversation-feed-virtual-runtime.ts
@@ -3,12 +3,12 @@ import {
 	observeElementRect,
 	type Rect,
 	type SvelteVirtualizer,
-	type VirtualItem,
 	type Virtualizer,
 } from '@tanstack/svelte-virtual';
 import {
 	attainableConversationTargetOffset,
 	CHAT_GEOMETRY_END_THRESHOLD_PX,
+	isConversationVirtualViewportCovered,
 	isConversationTargetLayoutReady,
 	resolveConversationViewportRect,
 	selectConversationReadingAnchor,
@@ -98,14 +98,27 @@ export class ConversationMountedVirtualItems {
 		return keys;
 	}
 
-	committedRangeSignature(
-		virtualItems: readonly VirtualItem[],
+	committedViewportRangeSignature(
+		instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>,
 		configuredKeys: readonly string[],
+		viewport: HTMLDivElement | null,
 	): string | null {
+		if (!viewport) return null;
+		const virtualItems = instance.getVirtualItems();
 		if (virtualItems.length === 0 && configuredKeys.length > 0) return null;
 		const committedByIndex = this.#keysByIndex(configuredKeys);
 		for (const item of virtualItems) {
 			if (committedByIndex.get(item.index) !== String(item.key)) return null;
+		}
+		if (
+			!isConversationVirtualViewportCovered(virtualItems, {
+				scrollOffset: viewport.scrollTop,
+				viewportSize: viewport.clientHeight,
+				scrollMargin: instance.options.scrollMargin,
+				totalSize: instance.getTotalSize(),
+			})
+		) {
+			return null;
 		}
 		return virtualItems.map((item) => `${item.index}:${String(item.key)}`).join('|');
 	}


### PR DESCRIPTION
Virtual transcripts should load at a clamped top edge, preserve the detached reading position during live tail updates, and never reveal a switched feed before committed rows cover the viewport. This evaluates directional boundary intent even when no scroll event fires, avoids redundant keyed restoration for tail-only geometry changes, and keeps the paint gate closed until the current TanStack range is mounted and continuously covers the visible span while preserving strict keyed restoration for prepends, scale changes, hidden restores, and explicit navigation.