### PR TITLE
Support steering in OpenCode

### DIFF
--- a/integration-tests/tests/server/scripted-steering-conformance.test.ts
+++ b/integration-tests/tests/server/scripted-steering-conformance.test.ts
@@ -3,9 +3,13 @@ import type {
   AgentRunCommandRequest,
   StartChatCommandRequest,
 } from '../../../common/chat-command-contracts.js';
-import type { PendingUserInputUpdatedMessage } from '../../../common/ws-events.js';
+import type {
+  ChatSessionStoppedMessage,
+  PendingUserInputUpdatedMessage,
+} from '../../../common/ws-events.js';
 import { assistantContents, userContents } from '../../support/chat-assertions.js';
 import { claudeText } from '../../support/fake-claude-model.js';
+import { chatCompletionsText } from '../../support/fake-chat-completions-model.js';
 import { codexAssistantMessage } from '../../support/fake-codex-model.js';
 import {
   type IntegrationDirectories,
@@ -27,6 +31,11 @@ import {
 } from '../../support/live-codex.js';
 import { startScriptedClaudeTestEnvironment } from '../../support/scripted-claude.js';
 import { startScriptedCodexTestEnvironment } from '../../support/scripted-codex.js';
+import {
+  scriptedOpenCodeRunRequest,
+  scriptedOpenCodeStartRequest,
+  startScriptedOpenCodeTestEnvironment,
+} from '../../support/scripted-opencode.js';
 
 interface HeldModelTurn {
   readonly requested: Promise<unknown>;
@@ -35,8 +44,16 @@ interface HeldModelTurn {
 
 interface SteeringContractDriver {
   readonly id: string;
-  readonly serverEnvironment: Record<string, string>;
+  readonly serverEnvironment?: Record<string, string>;
+  readonly resolveServerEnvironment?: (
+    directories: IntegrationDirectories,
+  ) => Record<string, string>;
   readonly prepareWorkspace?: (directories: IntegrationDirectories) => Promise<void>;
+  readonly afterGarconStop?: (directories: IntegrationDirectories) => Promise<void>;
+  readonly extraDiagnostics?: (
+    directories: IntegrationDirectories,
+  ) => Record<string, unknown>;
+  readonly emitsTurnTerminalOnStop?: boolean;
   startRequest(input: {
     chatId: string;
     projectPath: string;
@@ -170,7 +187,10 @@ function defineSteeringConformance(
           driver.assertSettled();
         }, {
           serverEnvironment: driver.serverEnvironment,
+          resolveServerEnvironment: driver.resolveServerEnvironment,
           prepareWorkspace: driver.prepareWorkspace,
+          afterGarconStop: driver.afterGarconStop,
+          extraDiagnostics: driver.extraDiagnostics,
         });
       } finally {
         held.release();
@@ -216,15 +236,26 @@ function defineSteeringConformance(
             afterIndex: stopCursor,
             timeoutMs: LIVE_TURN_TIMEOUT_MS,
           });
-          await fixture.client.waitForTurnTerminal(chatId, active.turnId, {
-            afterIndex: stopCursor,
-            timeoutMs: LIVE_TURN_TIMEOUT_MS,
-          });
-          expectStoppedTurnEventOrder(
-            fixture.client.eventsSince(stopCursor),
-            chatId,
-            active.turnId,
-          );
+          if (driver.emitsTurnTerminalOnStop === false) {
+            await fixture.client.waitForEvent(
+              (event): event is ChatSessionStoppedMessage =>
+                event.type === 'chat-session-stopped'
+                && event.chatId === chatId
+                && event.intent === 'stop',
+              `${providerName} stop confirmation`,
+              { afterIndex: stopCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+            );
+          } else {
+            await fixture.client.waitForTurnTerminal(chatId, active.turnId, {
+              afterIndex: stopCursor,
+              timeoutMs: LIVE_TURN_TIMEOUT_MS,
+            });
+            expectStoppedTurnEventOrder(
+              fixture.client.eventsSince(stopCursor),
+              chatId,
+              active.turnId,
+            );
+          }
 
           held.release();
           driver.scriptReply(recoveryReply);
@@ -248,7 +279,10 @@ function defineSteeringConformance(
           driver.assertSettled();
         }, {
           serverEnvironment: driver.serverEnvironment,
+          resolveServerEnvironment: driver.resolveServerEnvironment,
           prepareWorkspace: driver.prepareWorkspace,
+          afterGarconStop: driver.afterGarconStop,
+          extraDiagnostics: driver.extraDiagnostics,
         });
       } finally {
         held.release();
@@ -298,6 +332,32 @@ defineSteeringConformance('Codex', async () => {
     dispose: () => environment.dispose(),
   };
 });
+
+if (process.platform === 'linux') {
+  defineSteeringConformance('OpenCode', async () => {
+    const environment = startScriptedOpenCodeTestEnvironment();
+    return {
+      driver: {
+        id: 'opencode',
+        resolveServerEnvironment: environment.resolveServerEnvironment,
+        prepareWorkspace: environment.prepareWorkspace,
+        afterGarconStop: environment.afterGarconStop,
+        extraDiagnostics: environment.extraDiagnostics,
+        emitsTurnTerminalOnStop: false,
+        startRequest: scriptedOpenCodeStartRequest,
+        runRequest: scriptedOpenCodeRunRequest,
+        holdReply: (reply) => environment.model.scriptHeldTurn([chatCompletionsText(reply)]),
+        scriptReply: (reply) => environment.model.scriptTurn([chatCompletionsText(reply)]),
+        markRequests: () => environment.model.markRequests(),
+        userTextsSince: (cursor) => environment.model.requestsSince(cursor)
+          .flatMap((request) => request.userTexts),
+        assertSettled: () => environment.model.assertSettled(),
+        reset: () => environment.model.reset(),
+      },
+      dispose: () => environment.dispose(),
+    };
+  });
+}
 
 function marker(provider: string, label: string): string {
   return `SCRIPTED_${provider.toUpperCase()}_${label}_${crypto.randomUUID().replaceAll('-', '')}`;

--- a/server-agents/opencode/src/__tests__/integration.test.js
+++ b/server-agents/opencode/src/__tests__/integration.test.js
@@ -39,6 +39,10 @@ describe('OpenCodeAgentIntegration', () => {
     });
     expect(integration.auth).toBeDefined();
     expect(integration.singleQuery).toBeDefined();
+    expect(integration.steering).toMatchObject({
+      captureTarget: expect.any(Function),
+      steer: expect.any(Function),
+    });
     expect(integration.commands).toBeNull();
     expect(integration.endpoints).toBeNull();
     expect(host.environment.get).not.toHaveBeenCalled();

--- a/server-agents/opencode/src/agents/opencode/__tests__/steering.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/steering.test.js
@@ -1,0 +1,447 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { OpenCodeRuntime } from '../opencode.js';
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function connectedEnvelope() {
+  return { payload: { id: 'evt_connected', type: 'server.connected', properties: {} } };
+}
+
+function envelope(event) {
+  return { directory: '/repo', payload: event };
+}
+
+function createEventStream() {
+  const events = [connectedEnvelope()];
+  const waiters = [];
+  let closed = false;
+  return {
+    push(event) {
+      events.push(event);
+      for (const resolve of waiters.splice(0)) resolve();
+    },
+    close() {
+      closed = true;
+      for (const resolve of waiters.splice(0)) resolve();
+    },
+    async *stream() {
+      while (!closed || events.length > 0) {
+        if (events.length > 0) {
+          yield events.shift();
+          continue;
+        }
+        await new Promise((resolve) => waiters.push(resolve));
+      }
+    },
+  };
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+function createRuntime(overrides = {}) {
+  const eventStream = createEventStream();
+  const promptAsync = overrides.promptAsync ?? mock(() => Promise.resolve({}));
+  const abort = overrides.abort ?? mock(() => Promise.resolve({ data: true }));
+  const revert = overrides.revert ?? mock(() => Promise.resolve({ data: {} }));
+  const runtime = new OpenCodeRuntime({
+    requestTimeoutMs: overrides.requestTimeoutMs,
+    createInstance: mock(() => Promise.resolve({
+      client: {
+        permission: { reply: mock(() => Promise.resolve({})) },
+        global: { event: mock(() => Promise.resolve({ stream: eventStream.stream() })) },
+        session: {
+          create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
+          promptAsync,
+          abort,
+          revert,
+        },
+      },
+      server: { close: mock(() => undefined) },
+    })),
+  });
+  return { runtime, eventStream, promptAsync, abort, revert };
+}
+
+async function start(runtime, overrides = {}) {
+  await runtime.startSession({
+    command: 'hello',
+    chatId: 'chat-1',
+    projectPath: '/repo',
+    model: 'provider/model',
+    permissionMode: 'default',
+    clientRequestId: 'request-1',
+    turnId: 'turn-1',
+    ...overrides,
+  });
+}
+
+async function bindPrompt(eventStream, promptAsync, callIndex, input) {
+  const messageId = `user-${callIndex + 1}`;
+  eventStream.push(envelope({
+    id: `evt_000${callIndex * 2 + 1}`,
+    type: 'message.updated',
+    properties: {
+      sessionID: 'session-1',
+      info: { id: messageId, role: 'user' },
+    },
+  }));
+  eventStream.push(envelope({
+    id: `evt_000${callIndex * 2 + 2}`,
+    type: 'message.part.updated',
+    properties: {
+      sessionID: 'session-1',
+      part: {
+        id: promptAsync.mock.calls[callIndex][0].parts[0].id,
+        messageID: messageId,
+        type: 'text',
+        text: input,
+      },
+    },
+  }));
+  await Promise.resolve();
+  return messageId;
+}
+
+function steerRequest(target, overrides = {}) {
+  return {
+    chatId: 'chat-1',
+    projectPath: '/repo',
+    agentSessionId: 'session-1',
+    nativeSession: null,
+    target,
+    input: '/review the current approach',
+    clientMessageId: 'message-steer',
+    prepareDelivery: mock(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function pushAssistant(eventStream, {
+  messageId,
+  parentId,
+  text,
+  eventNumber,
+  finish,
+}) {
+  eventStream.push(envelope({
+    id: `evt_${String(eventNumber).padStart(4, '0')}`,
+    type: 'message.updated',
+    properties: {
+      sessionID: 'session-1',
+      info: { id: messageId, role: 'assistant', parentID: parentId, finish },
+    },
+  }));
+  eventStream.push(envelope({
+    id: `evt_${String(eventNumber + 1).padStart(4, '0')}`,
+    type: 'message.part.updated',
+    properties: {
+      sessionID: 'session-1',
+      part: { id: `part-${messageId}`, messageID: messageId, type: 'text', text },
+    },
+  }));
+}
+
+describe('OpenCodeRuntime steering', () => {
+  it('uses promptAsync as literal same-turn steering and waits for its exact provider part', async () => {
+    const { runtime, eventStream, promptAsync } = createRuntime();
+    const messages = [];
+    const finishes = [];
+    runtime.onMessages((_chatId, emitted, metadata) => messages.push({ emitted, metadata }));
+    runtime.onFinished((_chatId, _exitCode, metadata) => finishes.push(metadata));
+
+    await start(runtime);
+    expect(runtime.steering.captureTarget('session-1')).toBeNull();
+    await bindPrompt(eventStream, promptAsync, 0, 'hello');
+    const target = await waitForTarget(runtime);
+    const preparation = mock(() => Promise.resolve());
+    let settled = false;
+    const steering = runtime.steering.steer(steerRequest(target, { prepareDelivery: preparation }))
+      .finally(() => {
+        settled = true;
+      });
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+
+    expect(preparation).toHaveBeenCalledTimes(1);
+    expect(preparation.mock.invocationCallOrder[0]).toBeLessThan(
+      promptAsync.mock.invocationCallOrder[1],
+    );
+    expect(promptAsync.mock.calls[1][0]).toMatchObject({
+      sessionID: 'session-1',
+      model: { providerID: 'provider', modelID: 'model' },
+      parts: [{ type: 'text', text: '/review the current approach' }],
+    });
+
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: { id: 'prt_unrelated', messageID: 'user-unrelated', type: 'text', text: 'other' },
+      },
+    }));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    const steerPartId = promptAsync.mock.calls[1][0].parts[0].id;
+    eventStream.push(envelope({
+      id: 'evt_0004',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: steerPartId,
+          messageID: 'user-steer',
+          type: 'text',
+          text: '/review the current approach',
+        },
+      },
+    }));
+    await expect(steering).resolves.toEqual({ kind: 'accepted' });
+
+    pushAssistant(eventStream, {
+      messageId: 'assistant-initial',
+      parentId: 'user-1',
+      text: 'initial reply',
+      eventNumber: 5,
+    });
+    pushAssistant(eventStream, {
+      messageId: 'assistant-steer',
+      parentId: 'user-steer',
+      text: 'steered reply',
+      eventNumber: 7,
+      finish: 'stop',
+    });
+    eventStream.push(envelope({
+      id: 'evt_0009',
+      type: 'session.status',
+      properties: { sessionID: 'session-1', status: { type: 'idle' } },
+    }));
+    await waitFor(() => finishes.length === 1);
+
+    expect(messages.flatMap(({ emitted }) => emitted.map((message) => message.content))).toEqual([
+      'initial reply',
+      'steered reply',
+    ]);
+    expect(messages.every(({ metadata }) => metadata.turnId === 'turn-1')).toBe(true);
+    expect(finishes).toEqual([expect.objectContaining({ turnId: 'turn-1' })]);
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('defers idle settlement while delivery preparation is in flight', async () => {
+    const { runtime, eventStream, promptAsync } = createRuntime();
+    const finishes = [];
+    runtime.onFinished(() => finishes.push('finished'));
+    await start(runtime);
+    await bindPrompt(eventStream, promptAsync, 0, 'hello');
+    const target = await waitForTarget(runtime);
+    pushAssistant(eventStream, {
+      messageId: 'assistant-initial',
+      parentId: 'user-1',
+      text: 'initial reply',
+      eventNumber: 3,
+    });
+    const preparation = deferred();
+    const preparationStarted = deferred();
+    const steering = runtime.steering.steer(steerRequest(target, {
+      prepareDelivery: () => {
+        preparationStarted.resolve();
+        return preparation.promise;
+      },
+    }));
+    const steeringOutcome = steering.then(
+      () => null,
+      (error) => error,
+    );
+    await preparationStarted.promise;
+
+    eventStream.push(envelope({
+      id: 'evt_0005',
+      type: 'session.status',
+      properties: { sessionID: 'session-1', status: { type: 'idle' } },
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(finishes).toEqual([]);
+
+    preparation.reject(new Error('delivery preparation failed'));
+    expect(await steeringOutcome).toMatchObject({ message: 'delivery preparation failed' });
+    await waitFor(() => finishes.length === 1);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('reports a provider rejection after delivery preparation without accepting it', async () => {
+    let promptCount = 0;
+    const promptAsync = mock(() => {
+      promptCount += 1;
+      return Promise.resolve(promptCount === 1
+        ? {}
+        : { error: { message: 'active session is not running' } });
+    });
+    const fixture = createRuntime({ promptAsync });
+    await start(fixture.runtime);
+    await bindPrompt(fixture.eventStream, promptAsync, 0, 'hello');
+    const target = await waitForTarget(fixture.runtime);
+    const preparation = mock(() => Promise.resolve());
+
+    await expect(fixture.runtime.steering.steer(steerRequest(target, {
+      prepareDelivery: preparation,
+    }))).resolves.toEqual({
+      kind: 'rejected',
+      reason: 'no-active-turn',
+      message: 'No active OpenCode turn',
+    });
+    expect(preparation).toHaveBeenCalledTimes(1);
+    fixture.eventStream.close();
+    await fixture.runtime.shutdown();
+  });
+
+  it('rejects a target captured for a previous turn', async () => {
+    const { runtime, eventStream, promptAsync } = createRuntime();
+    await start(runtime);
+    await bindPrompt(eventStream, promptAsync, 0, 'hello');
+    const staleTarget = await waitForTarget(runtime);
+    pushAssistant(eventStream, {
+      messageId: 'assistant-initial',
+      parentId: 'user-1',
+      text: 'initial reply',
+      eventNumber: 3,
+    });
+    eventStream.push(envelope({
+      id: 'evt_0005',
+      type: 'session.status',
+      properties: { sessionID: 'session-1', status: { type: 'idle' } },
+    }));
+    await waitFor(() => !runtime.isRunning('session-1'));
+
+    const successor = runtime.runTurn({
+      command: 'successor',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      model: 'provider/model',
+      permissionMode: 'default',
+      clientRequestId: 'request-2',
+      turnId: 'turn-2',
+    });
+    const successorOutcome = successor.catch((error) => error);
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+    await bindPrompt(eventStream, promptAsync, 1, 'successor');
+
+    await expect(runtime.steering.steer(steerRequest(staleTarget))).resolves.toEqual({
+      kind: 'rejected',
+      reason: 'turn-changed',
+      message: 'The active OpenCode turn changed',
+    });
+    await expect(runtime.abort('session-1')).resolves.toBe(true);
+    expect(await successorOutcome).toMatchObject({ message: 'OpenCode session aborted' });
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('reverts accepted but unconsumed steering before a post-stop turn', async () => {
+    const { runtime, eventStream, promptAsync, revert } = createRuntime();
+    await start(runtime);
+    await bindPrompt(eventStream, promptAsync, 0, 'hello');
+    const target = await waitForTarget(runtime);
+    const steering = runtime.steering.steer(steerRequest(target));
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+    const steerPartId = promptAsync.mock.calls[1][0].parts[0].id;
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: steerPartId,
+          messageID: 'user-steer',
+          type: 'text',
+          text: '/review the current approach',
+        },
+      },
+    }));
+    await expect(steering).resolves.toEqual({ kind: 'accepted' });
+    await expect(runtime.abort('session-1')).resolves.toBe(true);
+
+    const recovery = runtime.runTurn({
+      command: 'recover',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      model: 'provider/model',
+      permissionMode: 'default',
+      clientRequestId: 'request-2',
+      turnId: 'turn-2',
+    });
+    await waitFor(() => promptAsync.mock.calls.length === 3);
+    expect(revert).toHaveBeenCalledWith(expect.objectContaining({
+      sessionID: 'session-1',
+      messageID: 'user-steer',
+      directory: '/repo',
+    }), expect.any(Object));
+    expect(revert.mock.invocationCallOrder[0]).toBeLessThan(
+      promptAsync.mock.invocationCallOrder[2],
+    );
+
+    eventStream.push(envelope({
+      id: 'evt_0004',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: { id: 'user-recovery', role: 'user' },
+      },
+    }));
+    eventStream.push(envelope({
+      id: 'evt_0005',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[2][0].parts[0].id,
+          messageID: 'user-recovery',
+          type: 'text',
+          text: 'recover',
+        },
+      },
+    }));
+    pushAssistant(eventStream, {
+      messageId: 'assistant-recovery',
+      parentId: 'user-recovery',
+      text: 'recovered',
+      eventNumber: 6,
+    });
+    eventStream.push(envelope({
+      id: 'evt_0008',
+      type: 'session.status',
+      properties: { sessionID: 'session-1', status: { type: 'idle' } },
+    }));
+    await expect(recovery).resolves.toBeUndefined();
+    eventStream.close();
+    await runtime.shutdown();
+  });
+});
+
+async function waitForTarget(runtime) {
+  let target = null;
+  await waitFor(() => {
+    target = runtime.steering.captureTarget('session-1');
+    return target !== null;
+  });
+  return target;
+}

--- a/server-agents/opencode/src/agents/opencode/event-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/event-converter.ts
@@ -1,0 +1,114 @@
+import {
+  AssistantMessage,
+  ThinkingMessage,
+  ToolResultMessage,
+  type ChatMessage,
+} from '@garcon/common/chat-types';
+import { normalizeToolResultContent } from '@garcon/server-agent-common/shared/normalize-util';
+import type { AgentLogger } from '@garcon/server-agent-interface';
+import type { SSEEvent } from './sse-events.js';
+import { convertOpenCodeToolUse } from './tool-use-converter.js';
+import type { OpenCodeTurnContext } from './turn-events.js';
+
+export function convertOpenCodeEventToChatMessages(
+  event: SSEEvent,
+  turn: OpenCodeTurnContext,
+  logger: AgentLogger,
+): ChatMessage[] | undefined {
+  const chatMessages: ChatMessage[] = [];
+  const now = new Date().toISOString();
+  const props = event.properties || {};
+  const roleFromEvent = (
+    props.info?.role
+    || props.part?.role
+    || props.part?.snapshot?.role
+    || props.message?.role
+    || null
+  );
+
+  const { assistantPartTypes, messageRoles } = turn;
+
+  switch (event.type) {
+    case 'message.updated': {
+      const info = props.info || {};
+      const messageId = info.id;
+      if (!messageId) {
+        logger.warn('OpenCode event is missing a message ID', { eventType: event.type });
+        return;
+      }
+      // The final message frame can precede its final part on the global stream.
+      if (info.role && info.role !== 'user') messageRoles.set(messageId, info.role);
+      break;
+    }
+
+    case 'message.part.updated': {
+      const part = props.part || {};
+      if (!part.id) {
+        logger.warn('OpenCode event is missing a part ID', { eventType: event.type });
+        return;
+      }
+
+      const messageId = part.messageID;
+      if (!messageId) {
+        logger.warn('OpenCode event is missing a message ID', { eventType: event.type });
+        return;
+      }
+
+      const messageRole = roleFromEvent || messageRoles.get(messageId) || null;
+      if (!messageRole) return;
+
+      if (part.type === 'tool') {
+        if (part.state?.status === 'completed') {
+          const toolUse = convertOpenCodeToolUse(now, part);
+          chatMessages.push(toolUse);
+          chatMessages.push(new ToolResultMessage(
+            now,
+            toolUse.toolId,
+            normalizeToolResultContent(part.state.output),
+            false,
+          ));
+        } else if (part.state?.status === 'error') {
+          const toolUse = convertOpenCodeToolUse(now, part);
+          chatMessages.push(toolUse);
+          chatMessages.push(new ToolResultMessage(
+            now,
+            toolUse.toolId,
+            normalizeToolResultContent(part.state.error || 'Error'),
+            true,
+          ));
+        }
+        break;
+      }
+
+      if (part.type === 'text' || part.type === 'reasoning') {
+        assistantPartTypes.set(part.id, part.type);
+      }
+
+      if (part.text) {
+        const partType = assistantPartTypes.get(part.id);
+        if (!partType) {
+          logger.warn('OpenCode final text part was not observed earlier', {
+            eventType: event.type,
+          });
+          return;
+        }
+        assistantPartTypes.delete(part.id);
+
+        if (partType === 'text') {
+          chatMessages.push(new AssistantMessage(now, part.text));
+        } else {
+          chatMessages.push(new ThinkingMessage(now, part.text));
+        }
+      }
+      break;
+    }
+
+    case 'message.part.delta':
+      break;
+
+    default:
+      break;
+  }
+
+  return chatMessages;
+}

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -12,13 +12,10 @@ import {
   createOpenCodeTurnContext,
   openCodeEventBelongsToTurn,
   type OpenCodeSession,
-  type OpenCodeTurnContext,
 } from './turn-events.js';
-import { normalizeToolResultContent }  from '@garcon/server-agent-common/shared/normalize-util';
-import { AssistantMessage, ThinkingMessage, ToolResultMessage, ErrorMessage, PermissionRequestMessage, PermissionResolvedMessage, PermissionCancelledMessage } from '@garcon/common/chat-types';
+import { ErrorMessage, PermissionRequestMessage, PermissionResolvedMessage, PermissionCancelledMessage } from '@garcon/common/chat-types';
 import type { ChatMessage } from '@garcon/common/chat-types';
 import { convertOpencodePermissionTool } from "./permission-tool-converter.js";
-import { convertOpenCodeToolUse } from "./tool-use-converter.js";
 import { AgentEventEmitterRuntime } from '@garcon/server-agent-common/shared/event-emitter-runtime';
 import { IdleSessionPurger } from '@garcon/server-agent-common/shared/idle-session-purger';
 import type { OpenCodeConfig } from '../../config.js';
@@ -56,6 +53,8 @@ import {
   OpenCodeTimeoutError,
   withAbortableTimeout,
 } from './request-control.js';
+import { convertOpenCodeEventToChatMessages } from './event-converter.js';
+import { OpenCodeSteeringController } from './steering.js';
 
 const SILENT_LOGGER: AgentLogger = Object.freeze({
   debug() {},
@@ -377,6 +376,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
   #sessions = new Map<string, OpenCodeSession>();
   #pendingTurnWaiters = new Map<string, PendingTurnWaiter>();
   #pendingPermissions = new Map<string, PendingPermission>();
+  readonly steering: OpenCodeSteeringController;
   readonly #endpointCoordinator: OpenCodeEndpointCoordinator;
   readonly #globalEventListener: OpenCodeGlobalEventListener;
   #modelCache: OpenCodeModelCache | null = null;
@@ -425,6 +425,17 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
         ? (input) => this.#confirmGlobalEventDelivery(input)
         : async () => undefined,
       handleEvent: (client, event) => this.#handleGlobalSSEEvent(client, event),
+    });
+    this.steering = new OpenCodeSteeringController({
+      requestTimeoutMs: this.#options.requestTimeoutMs,
+      getSession: (agentSessionId) => this.#sessions.get(agentSessionId),
+      getClient: () => this.getClient(),
+      runScopedRequest: (label, scope, operation) => (
+        this.#runScopedSessionRequest(label, scope, operation)
+      ),
+      settleIdle: (agentSessionId, session, idleEventId) => (
+        this.#settleIdleSession(agentSessionId, session, idleEventId)
+      ),
     });
   }
 
@@ -566,6 +577,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     const failure = error instanceof Error ? error : new Error(String(error));
     for (const [agentSessionId, session] of this.#sessions) {
       if (session.status !== 'running') continue;
+      this.steering.stagePendingCleanup(session);
       const eventMetadata = session.turn.eventMetadata;
       session.providerWorkRequiresQuiescence = true;
       session.status = 'completed';
@@ -581,6 +593,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
   }
 
   #failTurnForProviderError(agentSessionId: string, session: OpenCodeSession, message: string): void {
+    this.steering.stagePendingCleanup(session);
     const metadata = session.turn.eventMetadata;
     session.providerWorkRequiresQuiescence = true;
     session.status = 'completed';
@@ -596,6 +609,14 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     if (session.status !== 'running' || !session.turn.providerObservedEventId || !idleEventId
       || idleEventId <= session.turn.providerObservedEventId
       || session.turn.assistantMessageIds.size === 0) return;
+    if (session.turn.pendingSteeringMessageIds.size > 0) {
+      this.#failTurnForProviderError(
+        agentSessionId,
+        session,
+        'OpenCode stopped before processing accepted steering input',
+      );
+      return;
+    }
     const contextOverflow = session.turn.pendingContextOverflowError;
     if (contextOverflow) {
       this.#failTurnForProviderError(agentSessionId, session, contextOverflow);
@@ -676,117 +697,8 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     return this.#initPromise;
   }
 
-  #convertOpenCodeEventToChatMessages(
-    event: SSEEvent,
-    turn: OpenCodeTurnContext,
-  ): ChatMessage[] | undefined {
-    const chatMessages: ChatMessage[] = [];
-    const now = new Date().toISOString();
-    const props = event.properties || {};
-    const roleFromEvent = (
-      props.info?.role
-      || props.part?.role
-      || props.part?.snapshot?.role
-      || props.message?.role
-      || null
-    );
-
-    const { assistantPartTypes, messageRoles } = turn;
-
-    switch (event.type) {
-      case 'message.updated': {
-        const info = props.info || {};
-        const messageId = info.id;
-        if (!messageId) {
-          this.#logger.warn('OpenCode event is missing a message ID', { eventType: event.type });
-          return;
-        }
-        if (info.finish !== 'stop') {
-          if (info.role && info.role !== 'user') {
-            messageRoles.set(messageId, info.role);
-          }
-        } else {
-          messageRoles.delete(messageId);
-        }
-        break;
-      }
-
-      case 'message.part.updated': {
-        const part = props.part || {};
-        if (!part.id) {
-          this.#logger.warn('OpenCode event is missing a part ID', { eventType: event.type });
-          return;
-        }
-
-        const messageId = part.messageID;
-        if (!messageId) {
-          this.#logger.warn('OpenCode event is missing a message ID', { eventType: event.type });
-          return;
-        }
-
-        const messageRole = roleFromEvent || messageRoles.get(messageId) || null;
-        if (!messageRole) {
-          return;
-        }
-
-        if (part.type === 'tool') {
-          if (part.state?.status === 'completed') {
-            const toolUse = convertOpenCodeToolUse(now, part);
-            chatMessages.push(toolUse);
-            chatMessages.push(new ToolResultMessage(
-              now,
-              toolUse.toolId,
-              normalizeToolResultContent(part.state.output),
-              false,
-            ));
-          } else if (part.state?.status === 'error') {
-            const toolUse = convertOpenCodeToolUse(now, part);
-            chatMessages.push(toolUse);
-            chatMessages.push(new ToolResultMessage(
-              now,
-              toolUse.toolId,
-              normalizeToolResultContent(part.state.error || 'Error'),
-              true,
-            ));
-          }
-          break;
-        }
-
-        if (part.type === 'text' || part.type === 'reasoning') {
-          assistantPartTypes.set(part.id, part.type);
-        }
-
-        if (part.text) {
-          const partType = assistantPartTypes.get(part.id);
-          if (!partType) {
-            this.#logger.warn('OpenCode final text part was not observed earlier', {
-              eventType: event.type,
-            });
-            return;
-          }
-          assistantPartTypes.delete(part.id);
-
-          if (partType === 'text') {
-            chatMessages.push(new AssistantMessage(now, part.text));
-          } else {
-            chatMessages.push(new ThinkingMessage(now, part.text));
-          }
-        }
-        break;
-      }
-
-      case 'message.part.delta':
-        break;
-
-      default:
-        break;
-    }
-
-    return chatMessages;
-  }
-
   #dispatchOpenCodeEvent(event: SSEEvent, session: OpenCodeSession): void {
-    const chatMessages = this.#convertOpenCodeEventToChatMessages(event, session.turn);
+    const chatMessages = convertOpenCodeEventToChatMessages(event, session.turn, this.#logger);
     if (!chatMessages || !chatMessages.length) {
       return;
     }
@@ -911,12 +823,17 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
       this.#handlePermissionEvent(client, event, sessionId, session, chatId);
       return;
     }
+    this.steering.observeAcknowledgement(session, event);
     if (!openCodeEventBelongsToTurn(session, event)) return;
     this.#dispatchOpenCodeEvent(event, session);
 
     if (event.type !== 'session.status' || event.properties?.status?.type !== 'idle') return;
     if (session.aborting) {
       session.skippedIdleEventId = event.id ?? null;
+      return;
+    }
+    if (session.activeSteeringDeliveries > 0) {
+      this.steering.deferIdle(session, event.id ?? null);
       return;
     }
     this.#settleIdleSession(sessionId, session, event.id ?? null);
@@ -1197,6 +1114,9 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
       recentEventIds: new Set(),
       providerWorkRequiresQuiescence: false,
       terminalEventsFencedUntilPrompt: false,
+      activeSteeringDeliveries: 0,
+      deferredIdleEventId: null,
+      pendingSteeringRevertMessageId: null,
       turn,
     });
     this.emitSessionCreated(chatId);
@@ -1244,6 +1164,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
         || sess.turn !== turn
       ) return;
       this.#logger.error('OpenCode prompt failed', { agentSessionId, error: err.message });
+      this.steering.stagePendingCleanup(sess);
       sess.providerWorkRequiresQuiescence = true;
       sess.status = 'completed';
       sess.lastActivityAt = Date.now();
@@ -1290,13 +1211,17 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
     const client = await this.getClient();
     if (session) {
       await this.#quiesceRetiredProviderWork(client, agentSessionId, session, scope);
+      await this.steering.removeUnconsumed(client, agentSessionId, session, scope);
     }
     const waiter = this.#createTurnWaiter(agentSessionId);
     if (session) {
       session.status = 'running';
       session.aborting = false;
       session.skippedIdleEventId = null;
+      session.activeSteeringDeliveries = 0;
+      session.deferredIdleEventId = null;
       session.chatId = chatId;
+      session.model = model;
       session.permissionMode = permissionMode;
       session.directory = scope.directory;
       session.lastActivityAt = Date.now();
@@ -1313,6 +1238,9 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
         recentEventIds: new Set(),
         providerWorkRequiresQuiescence: false,
         terminalEventsFencedUntilPrompt: false,
+        activeSteeringDeliveries: 0,
+        deferredIdleEventId: null,
+        pendingSteeringRevertMessageId: null,
         turn,
       });
     }
@@ -1350,6 +1278,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
       }
       this.#logger.error('OpenCode query failed', { agentSessionId, error: err.message });
       if (!sess || sess.status !== 'running' || sess.turn !== turn) throw err;
+      this.steering.stagePendingCleanup(sess);
       sess.providerWorkRequiresQuiescence = true;
       sess.status = 'completed';
       sess.lastActivityAt = Date.now();
@@ -1415,6 +1344,7 @@ export class OpenCodeRuntime extends AgentEventEmitterRuntime {
       || session.status !== 'running'
       || session.turn !== turn
     ) return false;
+    this.steering.stagePendingCleanup(session);
     session.status = 'aborted';
     session.lastActivityAt = Date.now();
     this.#rejectTurnWaiter(agentSessionId, new Error('OpenCode session aborted'));

--- a/server-agents/opencode/src/agents/opencode/steering.ts
+++ b/server-agents/opencode/src/agents/opencode/steering.ts
@@ -1,0 +1,250 @@
+import type {
+  AgentSteerRequest,
+  AgentSteerResult,
+  AgentSteerTarget,
+} from '@garcon/server-agent-interface';
+import { buildPromptBody } from './prompt.js';
+import { withAbortableTimeout } from './request-control.js';
+import type { SSEEvent } from './sse-events.js';
+import {
+  hasOpenCodeResultError,
+  openCodeResultErrorMessage,
+  throwOpenCodeResultError,
+  withOpenCodeRequestScope,
+  type OpenCodeRequestScope,
+} from './sdk-result.js';
+import {
+  createOpenCodePromptPartId,
+  observeOpenCodeSteeringPart,
+  type OpenCodeSession,
+  type OpenCodeTurnContext,
+} from './turn-events.js';
+
+interface CapturedOpenCodeSteerTarget {
+  session: OpenCodeSession;
+  turn: OpenCodeTurnContext;
+}
+
+interface PendingOpenCodeSteeringAcknowledgement extends CapturedOpenCodeSteerTarget {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+interface OpenCodeSteeringOptions {
+  requestTimeoutMs: number;
+  getSession(agentSessionId: string): OpenCodeSession | undefined;
+  getClient(): Promise<any>;
+  runScopedRequest<T>(
+    label: string,
+    scope: OpenCodeRequestScope,
+    operation: (signal: AbortSignal, scope: OpenCodeRequestScope) => Promise<T>,
+  ): Promise<T>;
+  settleIdle(
+    agentSessionId: string,
+    session: OpenCodeSession,
+    idleEventId: string | null,
+  ): void;
+}
+
+export class OpenCodeSteeringController {
+  readonly #targets = new WeakMap<AgentSteerTarget, CapturedOpenCodeSteerTarget>();
+  readonly #acknowledgements = new Map<string, PendingOpenCodeSteeringAcknowledgement>();
+
+  constructor(private readonly options: OpenCodeSteeringOptions) {}
+
+  captureTarget(agentSessionId: string): AgentSteerTarget | null {
+    const session = this.options.getSession(agentSessionId);
+    if (
+      !session
+      || session.status !== 'running'
+      || session.aborting
+      || !session.turn.providerMessageId
+    ) return null;
+    const target = Object.freeze({});
+    this.#targets.set(target, { session, turn: session.turn });
+    return target;
+  }
+
+  async steer(request: AgentSteerRequest): Promise<AgentSteerResult> {
+    const captured = request.target ? this.#targets.get(request.target) : undefined;
+    if (!captured) return rejectedSteer('no-active-turn', 'No active OpenCode turn');
+    this.#targets.delete(request.target!);
+
+    const session = this.options.getSession(request.agentSessionId);
+    if (session !== captured.session || session?.turn !== captured.turn) {
+      return rejectedSteer('turn-changed', 'The active OpenCode turn changed');
+    }
+    if (
+      session.status !== 'running'
+      || session.aborting
+      || session.chatId !== request.chatId
+    ) return rejectedSteer('no-active-turn', 'No active OpenCode turn');
+    if (!request.input.trim()) {
+      return rejectedSteer('invalid-input', 'OpenCode rejected the steering input');
+    }
+
+    const client = await this.options.getClient();
+    if (
+      this.options.getSession(request.agentSessionId) !== session
+      || session.status !== 'running'
+      || session.aborting
+      || session.turn !== captured.turn
+    ) return rejectedSteer('turn-changed', 'The active OpenCode turn changed');
+
+    const turn = captured.turn;
+    const partId = createOpenCodePromptPartId();
+    const promptBody = buildPromptBody(request.input, session.model, partId);
+    let acknowledge!: () => void;
+    const acknowledgement = new Promise<void>((resolve) => {
+      acknowledge = resolve;
+    });
+    const pending = {
+      session,
+      turn,
+      promise: acknowledgement,
+      resolve: acknowledge,
+    } satisfies PendingOpenCodeSteeringAcknowledgement;
+    turn.providerSteeringPartIds.add(partId);
+    this.#acknowledgements.set(partId, pending);
+    session.activeSteeringDeliveries += 1;
+    let attempted = false;
+    let preserveCorrelation = false;
+
+    try {
+      await request.prepareDelivery();
+      attempted = true;
+      let result: unknown;
+      try {
+        // OpenCode's own app submits promptAsync while a session is busy to steer its active
+        // loop; the caller-owned part ID supplies the durable delivery acknowledgement.
+        // https://github.com/anomalyco/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts#L311-L328
+        result = await this.options.runScopedRequest(
+          'OpenCode steering submit',
+          { directory: session.directory },
+          (signal, requestScope) => client.session.promptAsync(withOpenCodeRequestScope({
+            sessionID: request.agentSessionId,
+            ...promptBody,
+          }, requestScope), { signal }),
+        );
+      } catch {
+        preserveCorrelation = true;
+        session.providerWorkRequiresQuiescence = true;
+        return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
+      }
+
+      if (hasOpenCodeResultError(result)) return classifySteerRejection(result);
+      preserveCorrelation = true;
+      try {
+        await withAbortableTimeout(
+          () => pending.promise,
+          this.options.requestTimeoutMs,
+          'OpenCode steering acknowledgement',
+        );
+      } catch {
+        session.providerWorkRequiresQuiescence = true;
+        return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
+      }
+      return { kind: 'accepted' };
+    } catch (error) {
+      if (!attempted) throw error;
+      preserveCorrelation = true;
+      session.providerWorkRequiresQuiescence = true;
+      return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
+    } finally {
+      if (this.#acknowledgements.get(partId) === pending) {
+        this.#acknowledgements.delete(partId);
+      }
+      if (!preserveCorrelation) turn.providerSteeringPartIds.delete(partId);
+      this.#releaseDelivery(request.agentSessionId, session, turn);
+    }
+  }
+
+  observeAcknowledgement(session: OpenCodeSession, event: SSEEvent): void {
+    const partId = observeOpenCodeSteeringPart(session, event);
+    if (!partId) return;
+    const pending = this.#acknowledgements.get(partId);
+    if (!pending || pending.session !== session || pending.turn !== session.turn) return;
+    this.#acknowledgements.delete(partId);
+    pending.resolve();
+  }
+
+  deferIdle(session: OpenCodeSession, idleEventId: string | null): void {
+    if (!idleEventId) return;
+    if (!session.deferredIdleEventId || idleEventId > session.deferredIdleEventId) {
+      session.deferredIdleEventId = idleEventId;
+    }
+  }
+
+  stagePendingCleanup(session: OpenCodeSession): void {
+    const earliest = [...session.turn.pendingSteeringMessageIds].sort()[0];
+    if (
+      earliest
+      && (!session.pendingSteeringRevertMessageId
+        || earliest < session.pendingSteeringRevertMessageId)
+    ) session.pendingSteeringRevertMessageId = earliest;
+  }
+
+  async removeUnconsumed(
+    client: any,
+    agentSessionId: string,
+    session: OpenCodeSession,
+    scope: OpenCodeRequestScope,
+  ): Promise<void> {
+    const messageId = session.pendingSteeringRevertMessageId;
+    if (!messageId) return;
+    const result = await this.options.runScopedRequest(
+      'OpenCode unconsumed steering revert',
+      scope,
+      (signal, requestScope) => client.session.revert(
+        withOpenCodeRequestScope({ sessionID: agentSessionId, messageID: messageId }, requestScope),
+        { signal },
+      ),
+    );
+    throwOpenCodeResultError(result, 'OpenCode unconsumed steering revert failed');
+    session.pendingSteeringRevertMessageId = null;
+  }
+
+  #releaseDelivery(
+    agentSessionId: string,
+    session: OpenCodeSession,
+    turn: OpenCodeTurnContext,
+  ): void {
+    session.activeSteeringDeliveries = Math.max(0, session.activeSteeringDeliveries - 1);
+    if (session.activeSteeringDeliveries > 0 || session.turn !== turn) return;
+    const deferredIdleEventId = session.deferredIdleEventId;
+    session.deferredIdleEventId = null;
+    if (session.aborting) {
+      if (
+        deferredIdleEventId
+        && (!session.skippedIdleEventId || deferredIdleEventId > session.skippedIdleEventId)
+      ) session.skippedIdleEventId = deferredIdleEventId;
+      return;
+    }
+    this.options.settleIdle(agentSessionId, session, deferredIdleEventId);
+  }
+}
+
+function rejectedSteer(
+  reason: Extract<AgentSteerResult, { kind: 'rejected' }>['reason'],
+  message: string,
+): AgentSteerResult {
+  return { kind: 'rejected', reason, message };
+}
+
+function failedSteer(
+  outcome: Extract<AgentSteerResult, { kind: 'failed' }>['outcome'],
+  message: string,
+): AgentSteerResult {
+  return { kind: 'failed', outcome, message };
+}
+
+function classifySteerRejection(result: unknown): AgentSteerResult {
+  const message = openCodeResultErrorMessage(result, 'OpenCode rejected the steering input');
+  if (/empty input|input.*(?:too large|limit|maximum)|invalid input/i.test(message)) {
+    return rejectedSteer('invalid-input', 'OpenCode rejected the steering input');
+  }
+  if (/no active|not running|session.*(?:idle|not found)/i.test(message)) {
+    return rejectedSteer('no-active-turn', 'No active OpenCode turn');
+  }
+  return rejectedSteer('provider-rejected', 'OpenCode rejected the steering input');
+}

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -12,6 +12,8 @@ export interface OpenCodeTurnContext {
   providerPromptText: string;
   providerObservedEventId: string | null;
   providerContinuationMessageIds: Set<string>;
+  providerSteeringPartIds: Set<string>;
+  pendingSteeringMessageIds: Set<string>;
   observedUserMessageIds: Set<string>;
   autoCompactionActive: boolean;
   pendingContextOverflowError: string | null;
@@ -39,6 +41,11 @@ export interface OpenCodeSession {
   // Terminal session events have no prompt identity. Recovery drops the abort backlog until
   // OpenCode publishes the exact caller-owned part for the successor prompt.
   terminalEventsFencedUntilPrompt: boolean;
+  activeSteeringDeliveries: number;
+  deferredIdleEventId: string | null;
+  // A stopped turn leaves accepted follow-up messages in OpenCode's transcript. The next
+  // prompt reverts the earliest unconsumed one before OpenCode can include it in model input.
+  pendingSteeringRevertMessageId: string | null;
   turn: OpenCodeTurnContext;
 }
 
@@ -55,10 +62,12 @@ export function createOpenCodeTurnContext(
   return {
     eventMetadata,
     providerMessageId: null,
-    providerPromptPartId: `prt_${crypto.randomUUID().replaceAll('-', '')}`,
+    providerPromptPartId: createOpenCodePromptPartId(),
     providerPromptText: promptText,
     providerObservedEventId: null,
     providerContinuationMessageIds: new Set(),
+    providerSteeringPartIds: new Set(),
+    pendingSteeringMessageIds: new Set(),
     observedUserMessageIds: new Set(),
     autoCompactionActive: false,
     pendingContextOverflowError: null,
@@ -66,6 +75,26 @@ export function createOpenCodeTurnContext(
     messageRoles: new Map(),
     assistantPartTypes: new Map(),
   };
+}
+
+export function createOpenCodePromptPartId(): string {
+  return `prt_${crypto.randomUUID().replaceAll('-', '')}`;
+}
+
+export function observeOpenCodeSteeringPart(
+  session: OpenCodeSession,
+  event: SSEEvent,
+): string | null {
+  if (event.type !== 'message.part.updated') return null;
+  const part = event.properties?.part;
+  const partId = typeof part?.id === 'string' ? part.id : '';
+  const messageId = typeof part?.messageID === 'string' ? part.messageID : '';
+  if (!partId || !messageId || !session.turn.providerSteeringPartIds.has(partId)) return null;
+
+  session.turn.providerContinuationMessageIds.add(messageId);
+  session.turn.pendingSteeringMessageIds.add(messageId);
+  session.turn.providerObservedEventId = event.id ?? null;
+  return partId;
 }
 
 export function acceptUniqueOpenCodeTurnEvent(
@@ -131,6 +160,7 @@ export function openCodeEventBelongsToTurn(
     }
     turn.providerObservedEventId = event.id ?? null;
     turn.assistantMessageIds.add(messageId);
+    turn.pendingSteeringMessageIds.delete(info.parentID);
     return true;
   }
   if (event.type === 'message.part.updated') {

--- a/server-agents/opencode/src/index.ts
+++ b/server-agents/opencode/src/index.ts
@@ -66,7 +66,7 @@ export default class OpenCodeAgentIntegration implements AgentIntegration {
   readonly auth: NonNullable<AgentIntegration['auth']>;
   readonly commands = null;
   readonly forking: NonNullable<AgentIntegration['forking']>;
-  readonly steering = null;
+  readonly steering: NonNullable<AgentIntegration['steering']>;
   readonly goals = null;
   readonly endpoints = null;
   readonly singleQuery: NonNullable<AgentIntegration['singleQuery']>;
@@ -85,6 +85,10 @@ export default class OpenCodeAgentIntegration implements AgentIntegration {
       descriptors: [],
     });
     this.execution = new OpenCodeExecution(runtime, nativeSessions);
+    this.steering = {
+      captureTarget: (request) => runtime.steering.captureTarget(request.agentSessionId),
+      steer: (request) => runtime.steering.steer(request),
+    };
     this.transcript = createOpenCodeTranscript(runtime, nativeSessions, sessionId, logger);
     this.catalog = createModelCatalog({
       logger: host.logger,


### PR DESCRIPTION
OpenCode sessions now expose same-turn steering through the provider's asynchronous prompt path, with exact turn and delivery correlation, idle-race fencing, and stopped-input cleanup so accepted guidance is applied once without leaking into later turns; existing OpenCode chats can use the standard Garcon steering commands without any client migration.