### PR TITLE
Prefetch earlier chat history before the boundary

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -424,6 +424,21 @@ async function signalScrollIntent(page: Page, direction: 'earlier' | 'later'): P
   }, direction);
 }
 
+async function transcriptBoundaryIntersectsViewport(
+  page: Page,
+  direction: 'earlier' | 'later',
+): Promise<boolean> {
+  return page.locator(FEED_SELECTOR).evaluate((feedElement, requestedDirection) => {
+    const boundary = feedElement.querySelector<HTMLElement>(
+      `[data-transcript-page-boundary="${requestedDirection}"]`,
+    );
+    if (!boundary) return false;
+    const viewportRect = feedElement.getBoundingClientRect();
+    const boundaryRect = boundary.getBoundingClientRect();
+    return boundaryRect.bottom > viewportRect.top && boundaryRect.top < viewportRect.bottom;
+  }, direction);
+}
+
 async function selectVisibleMessageText(page: Page): Promise<SelectionSnapshot> {
   return page.locator(FEED_SELECTOR).evaluate((feedElement) => {
     const feed = feedElement as HTMLElement;
@@ -1446,59 +1461,53 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
     await fixture.page.locator('[data-slot="chat-processing-status"]').waitFor({ state: 'visible' });
     const modelCountBeforePrefetch = await waitForStableModelCount(fixture.page, 50);
 
+    const loadAheadDistance = await fixture.page.locator(FEED_SELECTOR).evaluate((feedElement) => {
+      const feed = feedElement as HTMLElement;
+      const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
+      const start = Math.min(maximum, feed.clientHeight * 2.5);
+      if (start <= feed.clientHeight * 2) {
+        throw new Error('The transcript is too short to verify two-viewport load-ahead.');
+      }
+      feed.scrollTop = start;
+      feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+      feed.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          pointerType: 'mouse',
+        }),
+      );
+      feed.scrollTop = feed.clientHeight * 1.5;
+      feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+      return feed.scrollTop;
+    });
+    await withDiagnosticTimeout('the first held earlier-page request', firstPageRequest);
+    expect(loadAheadDistance).toBeGreaterThan(0);
+    expect(await transcriptBoundaryIntersectsViewport(fixture.page, 'earlier')).toBe(false);
+
+    releaseFirstPage();
+
+    const modelCountAfterFirstPage = await waitForStableModelCount(
+      fixture.page,
+      modelCountBeforePrefetch + 50,
+    );
+    expect(earlierRequestCount).toBe(1);
+    expect(modelCountAfterFirstPage).toBe(modelCountBeforePrefetch + 50);
+
     await fixture.page.locator(FEED_SELECTOR).evaluate((feedElement) => {
       const feed = feedElement as HTMLElement;
       feed.scrollTop = 0;
       feed.dispatchEvent(new Event('scroll', { bubbles: true }));
     });
-    // A clamped viewport emits no further scroll event for another upward gesture.
+    // A clamped viewport emits no scroll event for the subsequent upward gesture.
     await signalScrollIntent(fixture.page, 'earlier');
-    await withDiagnosticTimeout('the first held earlier-page request', firstPageRequest);
-
-    await fixture.page.locator(FEED_SELECTOR).evaluate((feedElement, previousModelCount) => {
-      const feed = feedElement as HTMLElement;
-      const sizer = feed.querySelector<HTMLElement>('[data-chat-virtual-sizer]');
-      if (!sizer) throw new Error('The virtual sizer is missing before the held page release.');
-      const browserGlobal = globalThis as typeof globalThis & {
-        __chatContinuedEarlierIntentObserved?: boolean;
-      };
-      browserGlobal.__chatContinuedEarlierIntentObserved = false;
-      const observer = new MutationObserver(() => {
-        const modelCount = Number(sizer.dataset.chatVirtualModelCount ?? 0);
-        if (modelCount <= previousModelCount) return;
-        observer.disconnect();
-        feed.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -1 }));
-        feed.scrollTop = Math.min(feed.scrollTop, feed.clientHeight / 2);
-        feed.dispatchEvent(new Event('scroll', { bubbles: true }));
-        browserGlobal.__chatContinuedEarlierIntentObserved = true;
-      });
-      observer.observe(sizer, {
-        attributes: true,
-        attributeFilter: ['data-chat-virtual-model-count'],
-      });
-    }, modelCountBeforePrefetch);
-    releaseFirstPage();
-
-    await fixture.page.waitForFunction(
-      () =>
-        Boolean(
-          (globalThis as typeof globalThis & { __chatContinuedEarlierIntentObserved?: boolean })
-            .__chatContinuedEarlierIntentObserved,
-        ),
-      undefined,
-      { timeout: 20_000 },
-    );
-    await withDiagnosticTimeout('the continued-gesture earlier-page request', secondPageRequest);
+    await withDiagnosticTimeout('the clamped-gesture earlier-page request', secondPageRequest);
     const modelCountAfterPrefetch = await waitForModelCount(
       fixture.page,
-      modelCountBeforePrefetch + 51,
+      modelCountBeforePrefetch + 100,
     );
     expect(earlierRequestCount).toBe(2);
-    expect(modelCountAfterPrefetch).toBeGreaterThan(modelCountBeforePrefetch + 50);
-    await fixture.page.evaluate(() => {
-      delete (globalThis as typeof globalThis & { __chatContinuedEarlierIntentObserved?: boolean })
-        .__chatContinuedEarlierIntentObserved;
-    });
+    expect(modelCountAfterPrefetch).toBe(modelCountBeforePrefetch + 100);
   } finally {
     releaseFirstPage();
     heldCompletion.releaseEcho();

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -8,14 +8,17 @@ import type { ConversationFeedMutationClock } from '../conversation-feed-mutatio
 import type { ConversationViewportPort } from '../conversation-viewport-port';
 import { mountInitialBottomRestoreEffect } from './conversation-scroll-controller-effect-harness.svelte';
 
-function mutationClock(dataRevision = 0): ConversationFeedMutationClock {
+function mutationClock(
+	dataRevision = 0,
+	historyEarlierRevision = 0,
+): ConversationFeedMutationClock {
 	return {
 		dataRevision,
 		lastResponseRevisionByMessageType: {},
 		lastRevisionByKind: {
 			initial: 0,
 			'live-append': 0,
-			'history-earlier': 0,
+			'history-earlier': historyEarlierRevision,
 			'history-later': 0,
 			replacement: 0,
 			'presentation-structure': 0,
@@ -215,11 +218,11 @@ describe('ConversationScrollController', () => {
 		expect(viewport.scrollToEnd).not.toHaveBeenCalled();
 	});
 
-	it('prefetches earlier history one viewport before the top edge', async () => {
+	it('prefetches earlier history two viewports before the top edge', async () => {
 		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
 		const { controller } = controllerFixture({
 			state: { canLoadEarlier: true, loadEarlierPage },
-			scroller: { clientHeight: 400, scrollTop: 350 },
+			scroller: { clientHeight: 400, scrollTop: 750 },
 		});
 
 		controller.noteUserScrollIntent('earlier');
@@ -244,13 +247,27 @@ describe('ConversationScrollController', () => {
 		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
 		const { controller } = controllerFixture({
 			state: { canLoadEarlier: true, loadEarlierPage },
-			scroller: { clientHeight: 400, scrollTop: 401 },
+			scroller: { clientHeight: 400, scrollTop: 801 },
 		});
 
 		controller.noteUserScrollIntent('earlier');
 		controller.handleScroll();
 
 		expect(loadEarlierPage).not.toHaveBeenCalled();
+	});
+
+	it('infers earlier intent from a pointer-originated scrollbar movement', async () => {
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 900 },
+		});
+
+		fixture.controller.noteUserScrollIntent();
+		fixture.scroller.scrollTop = 750;
+		fixture.controller.handleScroll();
+
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
 	});
 
 	it('prefetches later history without widening the live-end repin zone', async () => {
@@ -294,23 +311,27 @@ describe('ConversationScrollController', () => {
 		expect(loadEarlierPage).not.toHaveBeenCalled();
 	});
 
-	it('rearms a completed page boundary only after leaving the prefetch zone', async () => {
-		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+	it('rearms an advanced earlier cursor after its geometry settle is superseded', async () => {
+		const loadEarlierPage = vi.fn<ConversationScrollState['loadEarlierPage']>();
 		const fixture = controllerFixture({
+			viewport: fakeViewport({
+				waitForLayout: vi.fn<ConversationViewportPort['waitForLayout']>(async () => 'superseded'),
+			}),
 			state: { canLoadEarlier: true, loadEarlierPage },
-			scroller: { clientHeight: 400, scrollTop: 350 },
+			scroller: { clientHeight: 400, scrollTop: 750 },
 		});
-
-		await expect(fixture.controller.requestPage('earlier', 'button')).resolves.toBe('exhausted');
+		loadEarlierPage
+			.mockImplementationOnce(async () => {
+				fixture.state.feedMutationClock = mutationClock(1, 1);
+				return 'loaded';
+			})
+			.mockResolvedValueOnce('exhausted');
 
 		fixture.controller.noteUserScrollIntent('earlier');
 		fixture.controller.handleScroll();
-		expect(loadEarlierPage).toHaveBeenCalledOnce();
+		await vi.waitFor(() => expect(fixture.viewport.waitForLayout).toHaveBeenCalledOnce());
+		await Promise.resolve();
 
-		fixture.scroller.scrollTop = 500;
-		fixture.controller.noteUserScrollIntent('later');
-		fixture.controller.handleScroll();
-		fixture.scroller.scrollTop = 350;
 		fixture.controller.noteUserScrollIntent('earlier');
 		fixture.controller.handleScroll();
 
@@ -338,6 +359,7 @@ describe('ConversationScrollController', () => {
 
 		fixture.controller.noteUserScrollIntent('earlier');
 		fixture.controller.handleScroll();
+		fixture.state.feedMutationClock = mutationClock(1, 1);
 		resolveFirstPage('loaded');
 
 		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -13,11 +13,13 @@ import type {
 
 const USER_SCROLL_INTENT_WINDOW_MS = 2_000;
 const MIN_PAGE_PREFETCH_DISTANCE_PX = 100;
+const EARLIER_PAGE_PREFETCH_VIEWPORTS = 2;
 const LIVE_END_REPIN_THRESHOLD_PX = 50;
 
-// Keeps one viewport buffered while preserving the prior boundary distance on short surfaces.
-function pagePrefetchDistance(viewportHeight: number): number {
-	return Math.max(MIN_PAGE_PREFETCH_DISTANCE_PX, viewportHeight);
+// Buffers extra earlier history while preserving one-viewport later paging.
+function pagePrefetchDistance(direction: TranscriptPageDirection, viewportHeight: number): number {
+	const viewportCount = direction === 'earlier' ? EARLIER_PAGE_PREFETCH_VIEWPORTS : 1;
+	return Math.max(MIN_PAGE_PREFETCH_DISTANCE_PX, viewportHeight * viewportCount);
 }
 
 type PageRequestReason = 'scroll' | 'button';
@@ -70,7 +72,8 @@ export class ConversationScrollController {
 	#initialBottomPaintChatId = $state<string | null>(null);
 	#userScrollIntent: UserScrollIntent = { epoch: 0, direction: null, receivedAt: 0 };
 	#consumedIntentEpoch: Record<TranscriptPageDirection, number> = { earlier: 0, later: 0 };
-	#boundaryArmed: Record<TranscriptPageDirection, boolean> = { earlier: true, later: true };
+	#laterBoundaryArmed = true;
+	#earlierBoundaryRequestSignature: string | null = null;
 	#followLiveRequiresIntentAfter = 0;
 	#previousScrollTop: number | null = null;
 	#viewportOperationEpoch = 0;
@@ -264,11 +267,15 @@ export class ConversationScrollController {
 		const chatId = this.deps.sessions.selectedChatId;
 		if (!chatId || !this.#canRequestPage(direction, reason === 'button')) return 'invalidated';
 		const requestIntentEpoch = this.#userScrollIntent.epoch;
+		const requestBoundarySignature =
+			direction === 'earlier' ? this.#earlierBoundarySignature() : null;
 
-		// Disarms the crossed boundary before awaiting data. It re-arms after the
-		// viewport leaves the edge or a newer same-direction input survives the settle,
-		// so measurement-driven scroll events cannot chain requests by themselves.
-		this.#boundaryArmed[direction] = false;
+		// Records the crossed boundary before awaiting data. Earlier history advances
+		// its signature, while later paging re-arms only after leaving or continuing.
+		if (direction === 'later') this.#laterBoundaryArmed = false;
+		if (requestBoundarySignature) {
+			this.#earlierBoundaryRequestSignature = requestBoundarySignature;
+		}
 		// Requires a fresh post-page downward gesture before near-end geometry resumes live following.
 		this.#followLiveRequiresIntentAfter = Math.max(
 			this.#followLiveRequiresIntentAfter,
@@ -300,9 +307,7 @@ export class ConversationScrollController {
 			this.#consumedIntentEpoch = {
 				earlier: Math.max(
 					this.#consumedIntentEpoch.earlier,
-					direction === 'earlier' && continuedPageIntent
-						? requestIntentEpoch
-						: latestIntentEpoch,
+					direction === 'earlier' && continuedPageIntent ? requestIntentEpoch : latestIntentEpoch,
 				),
 				later: Math.max(
 					this.#consumedIntentEpoch.later,
@@ -314,8 +319,16 @@ export class ConversationScrollController {
 		if (this.deps.sessions.selectedChatId !== chatId) return 'invalidated';
 		this.#syncBoundaryLatch(direction);
 		if (reason === 'button') this.#preserveHistoryBrowsing();
-		if (result === 'loaded' && continuedPageIntent && this.#isNearPageBoundary(direction)) {
-			this.#boundaryArmed[direction] = true;
+		const earlierBoundaryAdvanced =
+			direction === 'earlier' &&
+			requestBoundarySignature !== null &&
+			this.#earlierBoundarySignature() !== requestBoundarySignature;
+		if (
+			continuedPageIntent &&
+			this.#isNearPageBoundary(direction) &&
+			(result === 'loaded' || earlierBoundaryAdvanced)
+		) {
+			if (direction === 'later') this.#laterBoundaryArmed = true;
 			this.#handleBoundaryProximity(direction, true);
 		}
 		return result;
@@ -591,11 +604,17 @@ export class ConversationScrollController {
 
 	#handleBoundaryProximity(direction: TranscriptPageDirection, isNearBoundary: boolean): void {
 		if (!isNearBoundary) {
-			this.#boundaryArmed[direction] = true;
+			if (direction === 'earlier') this.#earlierBoundaryRequestSignature = null;
+			else this.#laterBoundaryArmed = true;
 			return;
 		}
-		if (!this.#boundaryArmed[direction] || !this.#canRequestPage(direction)) return;
-		// Accepts only a fresh directional gesture at a re-armed edge. Restores and
+		if (!this.#canRequestPage(direction)) return;
+		if (direction === 'earlier') {
+			if (this.#earlierBoundaryRequestSignature === this.#earlierBoundarySignature()) return;
+		} else if (!this.#laterBoundaryArmed) {
+			return;
+		}
+		// Accepts only fresh directional input for an unrequested cursor. Restores and
 		// ResizeObserver scroll events have no gesture epoch and cannot page history.
 		const intent = this.#userScrollIntent;
 		if (
@@ -605,7 +624,7 @@ export class ConversationScrollController {
 		) {
 			return;
 		}
-		this.#boundaryArmed[direction] = false;
+		if (direction === 'later') this.#laterBoundaryArmed = false;
 		this.#consumedIntentEpoch[direction] = intent.epoch;
 		void this.requestPage(direction, 'scroll');
 	}
@@ -625,16 +644,27 @@ export class ConversationScrollController {
 	}
 
 	#syncBoundaryLatch(direction: TranscriptPageDirection): void {
-		if (!this.#isNearPageBoundary(direction)) this.#boundaryArmed[direction] = true;
+		if (this.#isNearPageBoundary(direction)) return;
+		if (direction === 'earlier') this.#earlierBoundaryRequestSignature = null;
+		else this.#laterBoundaryArmed = true;
 	}
 
 	#isNearPageBoundary(direction: TranscriptPageDirection): boolean {
 		const scroller = this.deps.getScrollContainer();
 		if (!scroller || scroller.clientHeight <= 0) return false;
-		const distance = pagePrefetchDistance(scroller.clientHeight);
+		const distance = pagePrefetchDistance(direction, scroller.clientHeight);
 		return direction === 'earlier'
 			? scroller.scrollTop <= distance
 			: (this.deps.getViewport()?.isAtEnd(distance) ?? false);
+	}
+
+	#earlierBoundarySignature(): string {
+		return [
+			this.deps.sessions.selectedChatId ?? '',
+			this.deps.chatState.generationId,
+			this.deps.chatState.windowRevision,
+			this.deps.chatState.feedMutationClock.lastRevisionByKind['history-earlier'],
+		].join(':');
 	}
 
 	#isCurrentViewportOperation(chatId: string, operationEpoch: number): boolean {
@@ -697,7 +727,8 @@ export class ConversationScrollController {
 	#resetPagingContext(): void {
 		const epoch = this.#userScrollIntent.epoch;
 		this.#consumedIntentEpoch = { earlier: epoch, later: epoch };
-		this.#boundaryArmed = { earlier: true, later: true };
+		this.#laterBoundaryArmed = true;
+		this.#earlierBoundaryRequestSignature = null;
 		this.#followLiveRequiresIntentAfter = epoch;
 		this.#previousScrollTop = this.deps.getScrollContainer()?.scrollTop ?? null;
 	}
@@ -714,10 +745,7 @@ export class ConversationScrollController {
 		);
 	}
 
-	#hasContinuedPageIntent(
-		direction: TranscriptPageDirection,
-		requestIntentEpoch: number,
-	): boolean {
+	#hasContinuedPageIntent(direction: TranscriptPageDirection, requestIntentEpoch: number): boolean {
 		return (
 			this.#userScrollIntent.epoch > requestIntentEpoch &&
 			this.#userScrollIntent.direction === direction &&

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -441,7 +441,7 @@
 	});
 
 	// Marks real scroll gestures on the actual viewport element. This avoids
-	// depending on wrapper component event forwarding for wheel and touch input.
+	// depending on wrapper component event forwarding for wheel, touch, and scrollbar input.
 	$effect(() => {
 		const node = scrollContainer;
 		if (!node) return;
@@ -451,6 +451,10 @@
 			scroll.noteUserScrollIntent(event.deltaY < 0 ? 'earlier' : 'later');
 		};
 		const handleTouchStart = () => scroll.noteUserScrollIntent();
+		const handlePointerDown = (event: PointerEvent) => {
+			if (event.button !== 0 || event.pointerType === 'touch') return;
+			scroll.noteUserScrollIntent();
+		};
 		const handleKeydown = (event: KeyboardEvent) => {
 			if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
 				scroll.noteUserScrollIntent('earlier');
@@ -467,11 +471,13 @@
 
 		node.addEventListener('wheel', handleWheel, { capture: true, passive: true });
 		node.addEventListener('touchstart', handleTouchStart, { capture: true, passive: true });
+		node.addEventListener('pointerdown', handlePointerDown, { capture: true, passive: true });
 		node.addEventListener('keydown', handleKeydown, { capture: true });
 
 		return () => {
 			node.removeEventListener('wheel', handleWheel, { capture: true });
 			node.removeEventListener('touchstart', handleTouchStart, { capture: true });
+			node.removeEventListener('pointerdown', handlePointerDown, { capture: true });
 			node.removeEventListener('keydown', handleKeydown, { capture: true });
 		};
 	});


### PR DESCRIPTION
Long transcripts should keep earlier history buffered while the user is reading or scrolling toward the top instead of waiting for the page boundary to enter the viewport. This expands earlier-page prefetch to two viewports, recognizes scrollbar-originated upward intent, and advances paging by the exact earlier-history revision so each cursor is requested once while preserving explicit clamped-edge loading; no migration is required because this is a client-side paging policy change.