### PR TITLE
Stabilize chat history prepends

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -1551,7 +1551,7 @@ async function prepareTranscript(
 async function revealEarlierTranscript(
   page: Page,
   initialModelCount: number,
-): Promise<ReadingAnchor> {
+): Promise<{ anchor: ReadingAnchor; frames: ReadingAnchorFrameSample[] }> {
   return withDiagnosticTimeout(
     'the earlier transcript page to be revealed',
     (async () => {
@@ -1574,12 +1574,13 @@ async function revealEarlierTranscript(
       expect(prefetchPosition.scrollTop).toBeGreaterThan(100);
       expect(prefetchPosition.scrollTop).toBeLessThanOrEqual(prefetchPosition.viewportHeight);
       const anchor = await readingAnchor(page);
+      await startReadingAnchorFrameSampler(page, anchor);
       const previousRevision = await virtualDataRevision(page);
       await signalScrollIntent(page, 'earlier');
       await page.locator(FEED_SELECTOR).dispatchEvent('scroll');
       await waitForVirtualDataRevisionAfter(page, previousRevision);
       await waitForModelCount(page, initialModelCount + 1);
-      return anchor;
+      return { anchor, frames: await finishReadingAnchorFrameSampler(page) };
     })(),
   );
 }
@@ -1589,8 +1590,22 @@ async function verifyBoundedPrepend(fixture: ChromiumFixture, chatId: string): P
   await scrollToPosition(fixture.page, 'end');
   await waitForDistanceFromEnd(fixture.page, 1);
   await verifyDetachedNearEndGrowth(fixture.page);
-  const prependAnchor = await revealEarlierTranscript(fixture.page, initialModelCount);
+  const { anchor: prependAnchor, frames: prependFrames } = await revealEarlierTranscript(
+    fixture.page,
+    initialModelCount,
+  );
   const restoredPrependAnchor = await anchorByKey(fixture.page, prependAnchor.key);
+  expect(prependFrames.length).toBeGreaterThan(2);
+  expect(
+    Math.max(
+      ...prependFrames.map((sample) =>
+        sample.offset === null
+          ? Number.POSITIVE_INFINITY
+          : Math.abs(sample.offset - prependAnchor.offset),
+      ),
+    ),
+    JSON.stringify({ prependAnchor, prependFrames }, null, 2),
+  ).toBeLessThanOrEqual(1);
   expect(Math.abs(restoredPrependAnchor.offset - prependAnchor.offset)).toBeLessThanOrEqual(1);
 
   const expandedGeometry = await transcriptGeometry(fixture.page);

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -338,6 +338,25 @@ describe('ConversationScrollController', () => {
 		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));
 	});
 
+	it('rearms the same earlier cursor after an invalidated prefetch', async () => {
+		const loadEarlierPage = vi
+			.fn<ConversationScrollState['loadEarlierPage']>()
+			.mockResolvedValueOnce('invalidated')
+			.mockResolvedValueOnce('exhausted');
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 750 },
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		await expect(fixture.controller.requestPage('earlier', 'scroll')).resolves.toBe('invalidated');
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		fixture.controller.handleScroll();
+
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));
+	});
+
 	it('preserves continued earlier intent while a prefetch settles', async () => {
 		let resolveFirstPage!: (result: 'loaded') => void;
 		const firstPage = new Promise<'loaded'>((resolve) => (resolveFirstPage = resolve));

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -317,6 +317,13 @@ export class ConversationScrollController {
 			this.#isPageMutationInProgress = false;
 		}
 		if (this.deps.sessions.selectedChatId !== chatId) return 'invalidated';
+		if (
+			direction === 'earlier' &&
+			result === 'invalidated' &&
+			this.#earlierBoundaryRequestSignature === requestBoundarySignature
+		) {
+			this.#earlierBoundaryRequestSignature = null;
+		}
 		this.#syncBoundaryLatch(direction);
 		if (reason === 'button') this.#preserveHistoryBrowsing();
 		const earlierBoundaryAdvanced =

--- a/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
@@ -23,14 +23,13 @@ import type { ConversationVirtualFeedModel } from './conversation-feed-virtual-i
 import {
 	captureConversationVirtualAnchor,
 	type ConversationVirtualAnchor,
-	conversationAnchorScrollOffset,
 	createConversationElementRectObserver,
 	ConversationMountedVirtualItems,
 	ConversationPreCommitAnchorBuffer,
-	nextConversationAnimationFrame as nextAnimationFrame,
 	nextConversationLayoutFrame,
 	observeConversationRootOffset,
 	sameConversationNumberArrays,
+	settleConversationVirtualAnchor,
 	settleConversationEndRestore,
 	settleConversationScroll,
 	settleConversationTarget,
@@ -753,55 +752,22 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 			if (!key) return false;
 			const index = model.indexByKey.get(key);
 			if (index === undefined) return false;
-			this.#instance().scrollToIndex(index, { align: 'start', behavior: 'auto' });
-			for (let attempt = 0; attempt < MAX_SETTLE_ITERATIONS; attempt += 1) {
-				await nextConversationLayoutFrame();
-				if (
-					token !== this.#layoutMutationToken ||
-					!this.#isCurrentProgrammaticScrollOperation(operationEpoch) ||
-					!this.isReady()
-				) {
-					return false;
-				}
-				const item = this.#instance()
-					.getVirtualItems()
-					.find((candidate) => candidate.key === key);
-				if (!item) continue;
-				const viewportOffset = key === anchor.key ? anchor.viewportOffset : 0;
-				const scrollOffset = conversationAnchorScrollOffset(
-					item.start,
-					this.#instance().options.scrollMargin,
-					viewportOffset,
-				);
-				this.#instance().scrollToOffset(scrollOffset, { behavior: 'auto' });
-				await nextAnimationFrame();
-				if (
-					token !== this.#layoutMutationToken ||
-					!this.#isCurrentProgrammaticScrollOperation(operationEpoch) ||
-					!this.isReady()
-				) {
-					return false;
-				}
-				const settledItem = this.#instance()
-					.getVirtualItems()
-					.find((candidate) => candidate.key === key);
-				const settledOffset = this.options.viewport?.scrollTop ?? this.#instance().scrollOffset;
-				if (
-					settledItem &&
-					settledOffset != null &&
-					Math.abs(
-						settledOffset -
-							conversationAnchorScrollOffset(
-								settledItem.start,
-								this.#instance().options.scrollMargin,
-								viewportOffset,
-							),
-					) <= OFFSET_TOLERANCE_PX
-				) {
-					return true;
-				}
+			if (resetMeasurements) {
+				this.#instance().scrollToIndex(index, { align: 'start', behavior: 'auto' });
 			}
-			return false;
+			return await settleConversationVirtualAnchor({
+				instance: this.#instance(),
+				mountedItems: this.#mountedItems,
+				configuredKeys: this.#configuredKeys,
+				key,
+				index,
+				viewportOffset: key === anchor.key ? anchor.viewportOffset : 0,
+				readScrollOffset: () => this.options.viewport?.scrollTop ?? this.#instance().scrollOffset,
+				isCurrent: () =>
+					token === this.#layoutMutationToken &&
+					this.#isCurrentProgrammaticScrollOperation(operationEpoch) &&
+					this.isReady(),
+			});
 		} finally {
 			release();
 			this.#finishProgrammaticScrollOperation(operationEpoch);

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
@@ -351,6 +351,7 @@ interface ControllerExposure {
 	controller: ConversationFeedVirtualController;
 	instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>;
 	initialEndRestoredCount(): number;
+	prependWithRetainedWithheldAnchor(index: number): Promise<void>;
 	releaseWithheldEndItem(): Promise<void>;
 	restoreHiddenWithConcurrentGeometry(): Promise<void>;
 	withholdEndItem(): Promise<void>;
@@ -443,6 +444,62 @@ describe('ConversationFeedVirtualController', () => {
 		await nextFrame();
 
 		expect(scrollToIndex).not.toHaveBeenCalled();
+	});
+
+	it('positions a mounted edge anchor directly without first aligning it to the top', async () => {
+		const { exposure } = await renderController();
+		const viewport = document.querySelector<HTMLDivElement>('[data-controller-viewport]');
+		if (!viewport) throw new Error('Expected the controller viewport');
+		await fireEvent.click(screen.getByRole('button', { name: 'Toggle pinned' }));
+		viewport.scrollTop = 86;
+		viewport.dispatchEvent(new Event('scroll'));
+		await nextFrame();
+		const readingItem = exposure.instance.getVirtualItemForOffset(viewport.scrollTop);
+		if (!readingItem) throw new Error('Expected a virtual reading item');
+		const readingOffset = conversationAnchorViewportOffset(
+			readingItem.start,
+			exposure.instance.options.scrollMargin,
+			viewport.scrollTop,
+		);
+		expect(readingOffset).toBeLessThan(0);
+		const scrollToIndex = vi.spyOn(exposure.instance, 'scrollToIndex');
+		const scrollToOffset = vi.spyOn(exposure.instance, 'scrollToOffset');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Prepend' }));
+		await waitFor(() => expect(scrollToOffset).toHaveBeenCalled());
+
+		expect(scrollToIndex).not.toHaveBeenCalled();
+		const repositionedItem = exposure.instance
+			.getVirtualItems()
+			.find((item) => item.key === readingItem.key);
+		if (!repositionedItem) throw new Error('Expected the reading item after the prepend');
+		const expectedScrollOffset = conversationAnchorScrollOffset(
+			repositionedItem.start,
+			exposure.instance.options.scrollMargin,
+			readingOffset,
+		);
+		expect(scrollToOffset.mock.calls[0]?.[0]).toBeCloseTo(expectedScrollOffset);
+	});
+
+	it('uses an index target when a retained virtual anchor has no committed wrapper', async () => {
+		const { exposure } = await renderController();
+		const viewport = document.querySelector<HTMLDivElement>('[data-controller-viewport]');
+		if (!viewport) throw new Error('Expected the controller viewport');
+		await fireEvent.click(screen.getByRole('button', { name: 'Toggle pinned' }));
+		viewport.scrollTop = 86;
+		viewport.dispatchEvent(new Event('scroll'));
+		await nextFrame();
+		const readingItem = exposure.instance.getVirtualItemForOffset(viewport.scrollTop);
+		if (!readingItem) throw new Error('Expected a virtual reading item');
+		const scrollToIndex = vi.spyOn(exposure.instance, 'scrollToIndex');
+
+		await exposure.prependWithRetainedWithheldAnchor(readingItem.index);
+		await waitFor(() =>
+			expect(scrollToIndex).toHaveBeenCalledWith(readingItem.index + 4, {
+				align: 'start',
+				behavior: 'auto',
+			}),
+		);
 	});
 
 	it('resets text-scale measurements immediately when visible and once on show when hidden', async () => {

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
@@ -16,6 +16,7 @@
 		initialEndRestoredCount(): number;
 		releaseWithheldEndItem(): Promise<void>;
 		restoreHiddenWithConcurrentGeometry(): Promise<void>;
+		prependWithRetainedWithheldAnchor(index: number): Promise<void>;
 		withholdEndItem(): Promise<void>;
 		withholdItem(index: number): Promise<void>;
 	}
@@ -26,6 +27,7 @@
 
 	let { onReady }: Props = $props();
 	let itemCount = $state(12);
+	let firstItemNumber = $state(0);
 	let contentRevision = $state(0);
 	let geometryRevision = $state(1);
 	let measurementReset = $state<ConversationVirtualGeometrySnapshot['measurementReset']>('none');
@@ -37,10 +39,12 @@
 	let virtualRoot: HTMLDivElement | null = $state(null);
 	let releaseRetention: (() => void) | null = null;
 	let initialEndRestoredCount = 0;
-	let withheldIndex: number | null = $state(null);
+	let withheldKey: string | null = $state(null);
 
 	const keys = $derived(
-		Array.from({ length: itemCount }, (_, index) => JSON.stringify([surfaceIdentity, index])),
+		Array.from({ length: itemCount }, (_, index) =>
+			JSON.stringify([surfaceIdentity, firstItemNumber + index]),
+		),
 	);
 	const model = $derived.by((): ConversationVirtualFeedModel => {
 		void contentRevision;
@@ -122,6 +126,7 @@
 			initialEndRestoredCount: () => initialEndRestoredCount,
 			releaseWithheldEndItem,
 			restoreHiddenWithConcurrentGeometry,
+			prependWithRetainedWithheldAnchor,
 			withholdEndItem,
 			withholdItem,
 		});
@@ -148,9 +153,31 @@
 		geometryRevision += 1;
 	}
 
+	async function prependWithRetainedWithheldAnchor(index: number): Promise<void> {
+		controller.prepareForGeometryPublication(geometryRevision + 1);
+		releaseRetention?.();
+		const key = keys[index] ?? 'missing';
+		releaseRetention = retention.acquire(key, 'focus');
+		withheldKey = key;
+		await tick();
+		firstItemNumber -= 4;
+		itemCount += 4;
+		measurementReset = 'none';
+		geometryRevision += 1;
+		await tick();
+	}
+
 	function appendItem(): void {
 		controller.prepareForGeometryPublication(geometryRevision + 1);
 		itemCount += 1;
+		measurementReset = 'none';
+		geometryRevision += 1;
+	}
+
+	function prependItems(): void {
+		controller.prepareForGeometryPublication(geometryRevision + 1);
+		firstItemNumber -= 4;
+		itemCount += 4;
 		measurementReset = 'none';
 		geometryRevision += 1;
 	}
@@ -195,12 +222,12 @@
 	}
 
 	async function withholdItem(index: number): Promise<void> {
-		withheldIndex = index >= 0 ? index : null;
+		withheldKey = index >= 0 ? (keys[index] ?? null) : null;
 		await tick();
 	}
 
 	async function releaseWithheldEndItem(): Promise<void> {
-		withheldIndex = null;
+		withheldKey = null;
 		await tick();
 	}
 </script>
@@ -221,7 +248,7 @@
 		style:position="relative"
 	>
 		{#each $virtualizer.getVirtualItems() as virtualItem (virtualItem.key)}
-			{#if virtualItem.index !== withheldIndex}
+			{#if String(virtualItem.key) !== withheldKey}
 				<div
 					data-index={virtualItem.index}
 					data-chat-virtual-item={String(virtualItem.key)}
@@ -237,6 +264,7 @@
 
 <button onclick={publishContent}>Publish content</button>
 <button onclick={appendItem}>Append</button>
+<button onclick={prependItems}>Prepend</button>
 <button onclick={retainFirst}>Retain first</button>
 <button onclick={shrink}>Shrink</button>
 <button onclick={toggleScale}>Toggle scale</button>

--- a/web/src/lib/components/chat/conversation-feed-virtual-runtime.ts
+++ b/web/src/lib/components/chat/conversation-feed-virtual-runtime.ts
@@ -3,6 +3,7 @@ import {
 	observeElementRect,
 	type Rect,
 	type SvelteVirtualizer,
+	type VirtualItem,
 	type Virtualizer,
 } from '@tanstack/svelte-virtual';
 import {
@@ -17,6 +18,7 @@ import {
 const HIDDEN_ANCHOR_FALLBACK_RADIUS = 8;
 const MAX_END_RESTORE_ITERATIONS = 60;
 const MAX_EARLY_END_RESTORE_ITERATIONS = 8;
+const MAX_ANCHOR_SETTLE_ITERATIONS = 8;
 const MAX_TARGET_SETTLE_ITERATIONS = 180;
 const REQUIRED_END_STABLE_FRAMES = 2;
 const GEOMETRY_TOLERANCE_PX = 0.5;
@@ -87,6 +89,17 @@ export class ConversationMountedVirtualItems {
 		this.#elements.clear();
 	}
 
+	committedVirtualItem(
+		instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>,
+		configuredKeys: readonly string[],
+		key: string,
+	): VirtualItem | undefined {
+		const committedByIndex = this.#keysByIndex(configuredKeys);
+		return instance
+			.getVirtualItems()
+			.find((item) => String(item.key) === key && committedByIndex.get(item.index) === key);
+	}
+
 	transcriptKeys(
 		configuredKeys: readonly string[],
 		eligibleKeys: ReadonlySet<string>,
@@ -134,6 +147,59 @@ export class ConversationMountedVirtualItems {
 		}
 		return keysByIndex;
 	}
+}
+
+export async function settleConversationVirtualAnchor(input: {
+	instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>;
+	mountedItems: ConversationMountedVirtualItems;
+	configuredKeys: readonly string[];
+	key: string;
+	index: number;
+	viewportOffset: number;
+	readScrollOffset(): number | null;
+	isCurrent(): boolean;
+}): Promise<boolean> {
+	for (let attempt = 0; attempt < MAX_ANCHOR_SETTLE_ITERATIONS; attempt += 1) {
+		await nextConversationLayoutFrame();
+		if (!input.isCurrent()) return false;
+		const item = input.mountedItems.committedVirtualItem(
+			input.instance,
+			input.configuredKeys,
+			input.key,
+		);
+		if (!item) {
+			// An index target remains valid while an offscreen or retained wrapper materializes.
+			input.instance.scrollToIndex(input.index, { align: 'start', behavior: 'auto' });
+			continue;
+		}
+		const scrollOffset = conversationAnchorScrollOffset(
+			item.start,
+			input.instance.options.scrollMargin,
+			input.viewportOffset,
+		);
+		input.instance.scrollToOffset(scrollOffset, { behavior: 'auto' });
+		await nextConversationAnimationFrame();
+		if (!input.isCurrent()) return false;
+		const settledItem = input.instance
+			.getVirtualItems()
+			.find((candidate) => candidate.key === input.key);
+		const settledOffset = input.readScrollOffset();
+		if (
+			settledItem &&
+			settledOffset != null &&
+			Math.abs(
+				settledOffset -
+					conversationAnchorScrollOffset(
+						settledItem.start,
+						input.instance.options.scrollMargin,
+						input.viewportOffset,
+					),
+			) <= GEOMETRY_TOLERANCE_PX
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 export function captureConversationVirtualAnchor(input: {


### PR DESCRIPTION
Prepending earlier transcript pages could briefly reposition a visible reading anchor, while an invalidated automatic request could leave the same cursor latched and require a manual retry. This change preserves an already-mounted anchor at its exact viewport offset without transient start alignment, retains index-based restoration for offscreen or measurement-reset rows, and re-arms only the exact invalidated paging request so earlier history remains stable and automatically retryable.