### PR TITLE
Keep automatic chat history continuous

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -1485,12 +1485,108 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
     expect(loadAheadDistance).toBeGreaterThan(0);
     expect(await transcriptBoundaryIntersectsViewport(fixture.page, 'earlier')).toBe(false);
 
+    expect(
+      await fixture.page.locator('[data-transcript-page-boundary="earlier"]').count(),
+    ).toBe(0);
+    const boundarySweep = await fixture.page.locator(FEED_SELECTOR).evaluate(async (feedElement) => {
+        const feed = feedElement as HTMLElement;
+        const offsets: number[] = [];
+        const frame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        for (let attempt = 0; attempt < 32 && feed.scrollTop > 0; attempt += 1) {
+          offsets.push(feed.scrollTop);
+          feed.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -80 }));
+          feed.scrollTop = Math.max(0, feed.scrollTop - feed.clientHeight / 4);
+          feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+          await frame();
+        }
+        return { offsets, scrollTop: feed.scrollTop };
+      });
+    expect(boundarySweep.scrollTop, JSON.stringify(boundarySweep, null, 2)).toBe(0);
+    expect(
+      await fixture.page.locator('[data-transcript-page-boundary="earlier"]').count(),
+    ).toBe(0);
+    const prependAnchor = await readingAnchor(fixture.page);
+    await startReadingAnchorFrameSampler(fixture.page, prependAnchor);
+    await fixture.page.locator(FEED_SELECTOR).evaluate(
+      (feedElement, input) => {
+        const feed = feedElement as HTMLElement;
+        const browserGlobal = globalThis as typeof globalThis & {
+          __chatClampedEarlierIntentPump?: {
+            complete: boolean;
+            frames: number;
+            growthFrame: number | null;
+            observedModelCount: number;
+          };
+        };
+        const pumpState = {
+          complete: false,
+          frames: 0,
+          growthFrame: null as number | null,
+          observedModelCount: input.initialModelCount,
+        };
+        browserGlobal.__chatClampedEarlierIntentPump = pumpState;
+        const pump = () => {
+          feed.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -80 }));
+          pumpState.frames += 1;
+          const sizer = feed.querySelector<HTMLElement>(input.sizerSelector);
+          pumpState.observedModelCount = Number(
+            sizer?.dataset.chatVirtualModelCount ?? Number.NaN,
+          );
+          if (pumpState.observedModelCount > input.initialModelCount) {
+            pumpState.growthFrame = pumpState.frames;
+            pumpState.complete = true;
+          } else if (pumpState.frames >= 180) {
+            pumpState.complete = true;
+          } else {
+            requestAnimationFrame(pump);
+          }
+        };
+        requestAnimationFrame(pump);
+      },
+      { initialModelCount: modelCountBeforePrefetch, sizerSelector: SIZER_SELECTOR },
+    );
+
     releaseFirstPage();
 
+    await fixture.page.waitForFunction(
+      () =>
+        (
+          globalThis as typeof globalThis & {
+            __chatClampedEarlierIntentPump?: { complete: boolean };
+          }
+        ).__chatClampedEarlierIntentPump?.complete === true,
+    );
+    const intentPump = await fixture.page.evaluate(() => {
+      const browserGlobal = globalThis as typeof globalThis & {
+        __chatClampedEarlierIntentPump?: {
+          complete: boolean;
+          frames: number;
+          growthFrame: number | null;
+          observedModelCount: number;
+        };
+      };
+      const result = browserGlobal.__chatClampedEarlierIntentPump;
+      delete browserGlobal.__chatClampedEarlierIntentPump;
+      return result;
+    });
+    expect(intentPump?.growthFrame, JSON.stringify(intentPump, null, 2)).not.toBeNull();
+    expect(intentPump?.growthFrame).toBe(intentPump?.frames);
+    expect(intentPump?.observedModelCount).toBeGreaterThan(modelCountBeforePrefetch);
     const modelCountAfterFirstPage = await waitForStableModelCount(
       fixture.page,
       modelCountBeforePrefetch + 50,
     );
+    const prependFrames = await finishReadingAnchorFrameSampler(fixture.page);
+    expect(
+      Math.max(
+        ...prependFrames.map((sample) =>
+          sample.offset === null
+            ? Number.POSITIVE_INFINITY
+            : Math.abs(sample.offset - prependAnchor.offset),
+        ),
+      ),
+      JSON.stringify({ prependAnchor, prependFrames }, null, 2),
+    ).toBeLessThanOrEqual(1);
     expect(earlierRequestCount).toBe(1);
     expect(modelCountAfterFirstPage).toBe(modelCountBeforePrefetch + 50);
 
@@ -1560,18 +1656,23 @@ async function revealEarlierTranscript(
       const prefetchPosition = await page.locator(FEED_SELECTOR).evaluate(async (feedElement) => {
         const feed = feedElement as HTMLElement;
         const settle = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-        const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
-        const target = Math.min(maximum, Math.max(101, feed.clientHeight * 0.75));
-        feed.scrollTop = target;
-        feed.dispatchEvent(new Event('scroll', { bubbles: true }));
-        await settle();
-        await settle();
-        return {
-          scrollTop: feed.scrollTop,
-          viewportHeight: feed.clientHeight,
-        };
+        const attempts: Array<{ maximum: number; target: number; scrollTop: number }> = [];
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+          const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
+          const target = Math.min(maximum, Math.max(101, feed.clientHeight * 0.75));
+          feed.scrollTop = target;
+          feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+          await settle();
+          await settle();
+          attempts.push({ maximum, target, scrollTop: feed.scrollTop });
+          // First measurements may correct the offset; the anchor sampler starts after they settle.
+          if (feed.scrollTop > 100 && feed.scrollTop <= feed.clientHeight) {
+            return { attempts, scrollTop: feed.scrollTop, viewportHeight: feed.clientHeight };
+          }
+        }
+        throw new Error(`The earlier prefetch position did not settle: ${JSON.stringify(attempts)}`);
       });
-      expect(prefetchPosition.scrollTop).toBeGreaterThan(100);
+      expect(prefetchPosition.scrollTop, JSON.stringify(prefetchPosition)).toBeGreaterThan(100);
       expect(prefetchPosition.scrollTop).toBeLessThanOrEqual(prefetchPosition.viewportHeight);
       const anchor = await readingAnchor(page);
       await startReadingAnchorFrameSampler(page, anchor);

--- a/integration-tests/tests/e2e/transcript-scrolling.test.ts
+++ b/integration-tests/tests/e2e/transcript-scrolling.test.ts
@@ -112,6 +112,27 @@ async function pageRequestCount(page: Page): Promise<number> {
   );
 }
 
+async function requestEarlierPageByScroll(page: Page): Promise<void> {
+  await page.$eval(FEED_SELECTOR, (feedElement) => {
+    const feed = feedElement as HTMLElement;
+    const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
+    const target = Math.min(maximum, feed.clientHeight * 1.5);
+    if (target <= 0) throw new Error("Transcript cannot enter the earlier load-ahead zone");
+    feed.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "PageUp" }));
+    feed.scrollTop = target;
+    feed.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await page.waitForFunction(
+    () =>
+      (
+        globalThis as typeof globalThis & {
+          __transcriptPageRequestGate?: { requestCount: number };
+        }
+      ).__transcriptPageRequestGate?.requestCount === 1,
+    { timeout: 20_000 },
+  );
+}
+
 async function waitForTranscriptIdle(page: Page): Promise<void> {
   await page.waitForFunction(
     ({ selector }) =>
@@ -142,17 +163,6 @@ async function virtualTranscriptSnapshot(page: Page): Promise<VirtualTranscriptS
   }), { sizer: SIZER_SELECTOR, item: ITEM_SELECTOR });
 }
 
-async function earlierBoundaryPrecedesTranscript(page: Page): Promise<boolean> {
-  return page.$eval(FEED_SELECTOR, (feed) => {
-    const boundary = feed.querySelector('[data-transcript-page-boundary="earlier"]');
-    const transcript = feed.querySelector("[data-chat-row-id]");
-    if (!boundary || !transcript) throw new Error("Earlier transcript boundary is not mounted");
-    return Boolean(
-      boundary.compareDocumentPosition(transcript) & Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-  });
-}
-
 describe("Lightpanda transcript scrolling", () => {
   test("pages earlier history while keeping the virtual DOM bounded", async () => {
     await withE2eFixture("transcript-scrolling", async (fixture) => {
@@ -178,12 +188,18 @@ describe("Lightpanda transcript scrolling", () => {
       expect(initial.mountedCount).toBeLessThan(initial.modelCount);
       expect(initial.mountedCount).toBeLessThan(60);
       expect(await app.hasButton("Load more")).toBe(false);
+      expect(await app.hasButton("Load earlier messages")).toBe(false);
 
       await setPageRequestGate(fixture.page, true);
-      await app.clickButton("Load earlier messages");
-      await app.waitForText("Loading earlier messages...");
+      await requestEarlierPageByScroll(fixture.page);
+      await fixture.page.waitForFunction(
+        ({ selector }) =>
+          document.querySelector<HTMLElement>(selector)?.getAttribute("aria-busy") === "true",
+        { timeout: 20_000 },
+        { selector: FEED_SELECTOR },
+      );
       expect((await virtualTranscriptSnapshot(fixture.page)).busy).toBe(true);
-      expect(await earlierBoundaryPrecedesTranscript(fixture.page)).toBe(true);
+      expect(await app.hasButton("Load earlier messages")).toBe(false);
       await releasePageRequest(fixture.page);
       await waitForModelCount(fixture.page, initial.modelCount + 50);
 

--- a/integration-tests/tests/e2e/transcript-scrolling.test.ts
+++ b/integration-tests/tests/e2e/transcript-scrolling.test.ts
@@ -115,9 +115,9 @@ async function pageRequestCount(page: Page): Promise<number> {
 async function requestEarlierPageByScroll(page: Page): Promise<void> {
   await page.$eval(FEED_SELECTOR, (feedElement) => {
     const feed = feedElement as HTMLElement;
-    const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
-    const target = Math.min(maximum, feed.clientHeight * 1.5);
-    if (target <= 0) throw new Error("Transcript cannot enter the earlier load-ahead zone");
+    // Reports keyboard intent before applying its scroll; Lightpanda clamps the
+    // desired offset to its reported top edge instead of exposing native extent.
+    const target = feed.clientHeight * 1.5;
     feed.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "PageUp" }));
     feed.scrollTop = target;
     feed.dispatchEvent(new Event("scroll", { bubbles: true }));

--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -287,6 +287,43 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.hasEarlierMessages).toBe(true);
 	});
 
+	it('retains an earlier failure while its explicit retry is loading', async () => {
+		const chat = new ActiveTranscriptState();
+		chat.replaceGeneration('chat-1', 'generation-1', [entry(51, assistant('message-51'))], {
+			lastSeq: 100,
+			pageOldestSeq: 51,
+			hasMore: true,
+		});
+		vi.mocked(getChatMessages).mockRejectedValueOnce(new Error('network unavailable'));
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		await expect(chat.loadEarlierPage('chat-1')).resolves.toBe('failed');
+		let resolveRetry!: (value: Awaited<ReturnType<typeof getChatMessages>>) => void;
+		vi.mocked(getChatMessages).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveRetry = resolve;
+			}),
+		);
+		const retry = chat.loadEarlierPage('chat-1');
+
+		expect(chat.pageStates.earlier).toEqual({
+			status: 'loading',
+			error: 'network unavailable',
+		});
+		resolveRetry({
+			chatId: 'chat-1',
+			limit: 50,
+			...page({
+				messages: [entry(50, assistant('message-50'))],
+				lastSeq: 100,
+				pageOldestSeq: 50,
+				hasMore: false,
+			}),
+		});
+		await expect(retry).resolves.toBe('loaded');
+		expect(chat.pageStates.earlier).toEqual({ status: 'idle', error: null });
+	});
+
 	it('invalidates an earlier page when gap recovery replaces the loaded window', async () => {
 		const chat = new ActiveTranscriptState();
 		chat.replaceGeneration(

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -73,7 +73,7 @@ interface FakeViewport extends ConversationViewportPort {
 		typeof vi.fn<ConversationViewportPort['restoreHiddenReadingPosition']>
 	>;
 	cancelPendingLayoutMutation: ReturnType<typeof vi.fn<() => void>>;
-	cancelForUserIntent: ReturnType<typeof vi.fn<() => void>>;
+	cancelForUserIntent: ReturnType<typeof vi.fn<ConversationViewportPort['cancelForUserIntent']>>;
 	scrollToTarget: ReturnType<typeof vi.fn<ConversationViewportPort['scrollToTarget']>>;
 }
 
@@ -81,6 +81,7 @@ function fakeViewport(overrides: Partial<ConversationViewportPort> = {}): FakeVi
 	return {
 		isReady: vi.fn(() => true),
 		isAtEnd: vi.fn(() => false),
+		ownsScrollPosition: vi.fn(() => false),
 		scrollToStart: vi.fn(),
 		scrollToEnd: vi.fn(),
 		restoreInitialEnd: vi.fn(),
@@ -182,7 +183,7 @@ describe('ConversationScrollController', () => {
 	it('cancels pending layout work before recording every user gesture', () => {
 		const { controller, viewport } = controllerFixture();
 		controller.noteUserScrollIntent('earlier');
-		expect(viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+		expect(viewport.cancelForUserIntent).toHaveBeenCalledWith('earlier');
 	});
 
 	it('requires fresh downward intent to repin inside the later threshold', () => {
@@ -268,6 +269,93 @@ describe('ConversationScrollController', () => {
 		fixture.controller.handleScroll();
 
 		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenNthCalledWith(1, null);
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenNthCalledWith(2, 'earlier');
+	});
+
+	it('keeps earlier prefetch armed across a slow pointer-originated scroll', async () => {
+		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 900 },
+		});
+
+		fixture.controller.noteUserScrollIntent();
+		fixture.scroller.scrollTop = 850;
+		fixture.controller.handleScroll();
+		now.mockReturnValue(1_500);
+		fixture.scroller.scrollTop = 820;
+		fixture.controller.handleScroll();
+		now.mockReturnValue(2_200);
+		fixture.scroller.scrollTop = 750;
+		fixture.controller.handleScroll();
+
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
+		now.mockRestore();
+	});
+
+	it('does not page after stale earlier intent enters the zone without input', async () => {
+		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 2_000 },
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		await Promise.resolve();
+		fixture.scroller.scrollTop = 1_900;
+		fixture.controller.handleScroll();
+		now.mockReturnValue(1_000_000);
+		fixture.scroller.scrollTop = 700;
+		fixture.controller.handleScroll();
+		await Promise.resolve();
+
+		expect(loadEarlierPage).not.toHaveBeenCalled();
+		now.mockRestore();
+	});
+
+	it('does not page from a viewport-owned scroll inside the intent window', async () => {
+		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 2_000 },
+			viewport: fakeViewport({ ownsScrollPosition: vi.fn(() => true) }),
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		await Promise.resolve();
+		fixture.scroller.scrollTop = 700;
+		fixture.controller.handleScroll();
+		await Promise.resolve();
+
+		expect(loadEarlierPage).not.toHaveBeenCalled();
+		now.mockRestore();
+	});
+
+	it('pages after viewport scroll ownership releases inside the intent window', async () => {
+		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const ownsScrollPosition = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 900 },
+			viewport: fakeViewport({ ownsScrollPosition }),
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		await Promise.resolve();
+		fixture.scroller.scrollTop = 775;
+		fixture.controller.handleScroll();
+		expect(loadEarlierPage).not.toHaveBeenCalled();
+		fixture.scroller.scrollTop = 750;
+		fixture.controller.handleScroll();
+
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
+		expect(ownsScrollPosition).toHaveBeenCalledTimes(2);
+		now.mockRestore();
 	});
 
 	it('prefetches later history without widening the live-end repin zone', async () => {
@@ -309,6 +397,46 @@ describe('ConversationScrollController', () => {
 		controller.handleScroll();
 
 		expect(loadEarlierPage).not.toHaveBeenCalled();
+	});
+
+	it('does not carry earlier intent across a paging-context reset', async () => {
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 900 },
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		await Promise.resolve();
+		fixture.sessions.selectedChatId = 'chat-2';
+		fixture.controller.prepareInitialBottomRestore('chat-2');
+		fixture.scroller.scrollTop = 750;
+		fixture.controller.handleScroll();
+		await Promise.resolve();
+
+		expect(loadEarlierPage).not.toHaveBeenCalled();
+	});
+
+	it('requires fresh earlier intent after leaving and re-entering the load-ahead zone', async () => {
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 900 },
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		await Promise.resolve();
+		fixture.scroller.scrollTop = 750;
+		await expect(fixture.controller.requestPage('earlier', 'scroll')).resolves.toBe('exhausted');
+		expect(loadEarlierPage).toHaveBeenCalledOnce();
+
+		fixture.scroller.scrollTop = 900;
+		fixture.controller.handleScroll();
+		fixture.scroller.scrollTop = 750;
+		fixture.controller.handleScroll();
+		await Promise.resolve();
+
+		expect(loadEarlierPage).toHaveBeenCalledOnce();
 	});
 
 	it('rearms an advanced earlier cursor after its geometry settle is superseded', async () => {
@@ -382,6 +510,31 @@ describe('ConversationScrollController', () => {
 		resolveFirstPage('loaded');
 
 		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));
+	});
+
+	it('fills the earlier load-ahead zone after a slow page advances its cursor', async () => {
+		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
+		let resolveFirstPage!: (result: 'loaded') => void;
+		const firstPage = new Promise<'loaded'>((resolve) => (resolveFirstPage = resolve));
+		const loadEarlierPage = vi
+			.fn<ConversationScrollState['loadEarlierPage']>()
+			.mockImplementationOnce(() => firstPage)
+			.mockResolvedValueOnce('exhausted');
+		const fixture = controllerFixture({
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 400, scrollTop: 350 },
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		fixture.controller.handleScroll();
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledOnce());
+
+		now.mockReturnValue(2_200);
+		fixture.state.feedMutationClock = mutationClock(1, 1);
+		resolveFirstPage('loaded');
+
+		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));
+		now.mockRestore();
 	});
 
 	it('detaches on fresh upward intent inside the later threshold', () => {
@@ -847,6 +1000,43 @@ describe('ConversationScrollController', () => {
 		controller.setViewportVisible(true);
 		await vi.waitFor(() => expect(viewport.restoreHiddenReadingPosition).toHaveBeenCalledOnce());
 		expect(viewport.scrollToEnd).not.toHaveBeenCalled();
+	});
+
+	it('rebaselines inferred gesture direction across viewport visibility changes', () => {
+		vi.spyOn(performance, 'now').mockReturnValue(100);
+		const fixture = controllerFixture({ scroller: { scrollTop: 900 } });
+		fixture.controller.noteUserScrollIntent();
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+
+		fixture.controller.setViewportVisible(false);
+		fixture.scroller.scrollTop = 100;
+		fixture.controller.handleScroll();
+		fixture.controller.setViewportVisible(true);
+		fixture.controller.handleScroll();
+
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledTimes(1);
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledWith(null);
+	});
+
+	it('does not page from an owned hidden-offset clamp after a directionless press', async () => {
+		vi.spyOn(performance, 'now').mockReturnValue(100);
+		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
+		const viewport = fakeViewport({ ownsScrollPosition: vi.fn(() => true) });
+		const fixture = controllerFixture({
+			viewport,
+			state: { canLoadEarlier: true, loadEarlierPage },
+			scroller: { clientHeight: 700, scrollTop: 5_000 },
+		});
+		fixture.controller.noteUserScrollIntent();
+		fixture.controller.setViewportVisible(false);
+		fixture.scroller.scrollTop = 1_200;
+		fixture.controller.setViewportVisible(true);
+
+		fixture.controller.handleScroll();
+		await Promise.resolve();
+
+		expect(loadEarlierPage).not.toHaveBeenCalled();
+		expect(viewport.cancelForUserIntent.mock.calls).toEqual([[null]]);
 	});
 
 	it('cancels a queued hidden-position restore when explicit navigation starts', async () => {

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-gesture.logic.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-gesture.logic.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+	ConversationTouchScrollGesture,
+	conversationScrollbarScrollDirection,
+	conversationScrollbarTrackDirection,
+	conversationTouchScrollDirection,
+	conversationWheelScrollDirection,
+} from '../conversation-scroll-gesture.js';
+
+describe('conversation scroll gesture direction', () => {
+	it('maps finger movement to the inverse content direction', () => {
+		expect(conversationTouchScrollDirection(100, 120)).toBe('earlier');
+		expect(conversationTouchScrollDirection(100, 80)).toBe('later');
+		expect(conversationTouchScrollDirection(100, 100)).toBeNull();
+	});
+
+	it('keeps the tracked finger stable when another touch starts or ends', () => {
+		const gesture = new ConversationTouchScrollGesture();
+		expect(gesture.begin([{ identifier: 1, clientY: 100 }])).toBe(true);
+		expect(
+			gesture.begin([
+				{ identifier: 1, clientY: 100 },
+				{ identifier: 2, clientY: 300 },
+			]),
+		).toBe(false);
+		expect(
+			gesture.move([
+				{ identifier: 1, clientY: 120 },
+				{ identifier: 2, clientY: 300 },
+			]),
+		).toBe('earlier');
+		gesture.end([{ identifier: 2, clientY: 300 }]);
+		expect(gesture.move([{ identifier: 2, clientY: 320 }])).toBe('earlier');
+	});
+
+	it('maps scrollbar-thumb movement to the matching content direction', () => {
+		expect(conversationScrollbarScrollDirection(100, 80)).toBe('earlier');
+		expect(conversationScrollbarScrollDirection(100, 120)).toBe('later');
+		expect(conversationScrollbarScrollDirection(100, 100)).toBeNull();
+	});
+
+	it('maps a track press relative to the committed thumb', () => {
+		expect(conversationScrollbarTrackDirection(40, 80, 120)).toBe('earlier');
+		expect(conversationScrollbarTrackDirection(90, 80, 120)).toBe('earlier');
+		expect(conversationScrollbarTrackDirection(110, 80, 120)).toBe('later');
+		expect(conversationScrollbarTrackDirection(160, 80, 120)).toBe('later');
+		expect(conversationScrollbarTrackDirection(100, 80, 120)).toBeNull();
+	});
+
+	it('maps wheel and trackpad deltas consistently', () => {
+		expect(conversationWheelScrollDirection(-1)).toBe('earlier');
+		expect(conversationWheelScrollDirection(1)).toBe('later');
+		expect(conversationWheelScrollDirection(0)).toBeNull();
+	});
+});

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-gesture.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-gesture.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { observeConversationViewportScrollGestures } from '../conversation-scroll-gesture.js';
+
+function dispatchTouch(
+	node: HTMLElement,
+	type: 'touchstart' | 'touchmove' | 'touchend',
+	touches: readonly { identifier: number; clientY: number }[],
+): void {
+	const event = new Event(type, { bubbles: true });
+	Object.defineProperty(event, 'touches', { value: touches });
+	node.dispatchEvent(event);
+}
+
+describe('conversation viewport scroll gestures', () => {
+	it('continues with the remaining finger after the tracked touch ends', () => {
+		const node = document.createElement('div');
+		const report = vi.fn();
+		const cleanup = observeConversationViewportScrollGestures(node, report);
+
+		dispatchTouch(node, 'touchstart', [{ identifier: 1, clientY: 100 }]);
+		dispatchTouch(node, 'touchstart', [
+			{ identifier: 1, clientY: 100 },
+			{ identifier: 2, clientY: 300 },
+		]);
+		dispatchTouch(node, 'touchmove', [
+			{ identifier: 1, clientY: 120 },
+			{ identifier: 2, clientY: 300 },
+		]);
+		dispatchTouch(node, 'touchend', [{ identifier: 2, clientY: 300 }]);
+		dispatchTouch(node, 'touchmove', [{ identifier: 2, clientY: 280 }]);
+
+		expect(report.mock.calls).toEqual([[null], ['earlier'], ['later']]);
+		cleanup();
+		node.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+		expect(report).toHaveBeenCalledTimes(3);
+	});
+});

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -534,7 +534,9 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		const generationId = this.generationId;
 		const operationEpoch = this.#pageLoadOperationEpoch;
 		const newestSeq = this.newestLoadedSeq;
-		this.pageStates[direction] = { status: 'loading', error: null };
+		const retryError =
+			this.pageStates[direction].status === 'error' ? this.pageStates[direction].error : null;
+		this.pageStates[direction] = { status: 'loading', error: retryError };
 		const loadPromise = this.#performPageLoad(
 			direction,
 			chatId,

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -137,7 +137,7 @@ export class ConversationScrollController {
 	}
 
 	noteUserScrollIntent(direction: TranscriptPageDirection | null = null): void {
-		this.deps.getViewport()?.cancelForUserIntent();
+		this.deps.getViewport()?.cancelForUserIntent(direction);
 		// Continued scrolling owns the page's viewport position without cancelling its
 		// data request. Explicit navigation still advances the shared operation epoch.
 		if (this.#isPageMutationInProgress) {
@@ -229,11 +229,12 @@ export class ConversationScrollController {
 		const node = this.deps.getScrollContainer();
 		if (!node || !this.#isViewportVisible || node.clientHeight <= 0) return;
 		const inferredDirection = this.#inferScrollDirection(node.scrollTop);
-		this.#applyInferredIntentDirection(inferredDirection);
 		if (this.#isPageMutationInProgress) {
 			this.#preserveHistoryBrowsing();
 			return;
 		}
+		if (this.deps.getViewport()?.ownsScrollPosition()) return;
+		this.#applyInferredIntentDirection(inferredDirection);
 		const nearBottom = this.isNearBottom();
 		const hasRecentUserScrollIntent = this.#hasRecentUserScrollIntent();
 		if (this.deps.chatState.hasLaterMessages) {
@@ -330,8 +331,12 @@ export class ConversationScrollController {
 			direction === 'earlier' &&
 			requestBoundarySignature !== null &&
 			this.#earlierBoundarySignature() !== requestBoundarySignature;
+		const shouldContinueEarlierPrefetch =
+			direction === 'earlier' &&
+			earlierBoundaryAdvanced &&
+			this.#userScrollIntent.direction === 'earlier';
 		if (
-			continuedPageIntent &&
+			(continuedPageIntent || shouldContinueEarlierPrefetch) &&
 			this.#isNearPageBoundary(direction) &&
 			(result === 'loaded' || earlierBoundaryAdvanced)
 		) {
@@ -533,6 +538,7 @@ export class ConversationScrollController {
 		if (isVisible === this.#isViewportVisible) return;
 		this.#isViewportVisible = isVisible;
 		this.#cancelViewportOperations();
+		this.#previousScrollTop = this.deps.getScrollContainer()?.scrollTop ?? null;
 		if (!isVisible) return;
 		void this.#restoreVisibleViewport();
 	}
@@ -599,14 +605,14 @@ export class ConversationScrollController {
 	}
 
 	#applyInferredIntentDirection(direction: TranscriptPageDirection | null): void {
-		if (
-			!direction ||
-			this.#userScrollIntent.direction !== null ||
-			!this.#hasRecentUserScrollIntent()
-		) {
-			return;
+		if (!direction || !this.#hasRecentUserScrollIntent()) return;
+		if (this.#userScrollIntent.direction === null) {
+			this.deps.getViewport()?.cancelForUserIntent(direction);
+			this.#userScrollIntent = { ...this.#userScrollIntent, direction };
 		}
-		this.#userScrollIntent = { ...this.#userScrollIntent, direction };
+		if (this.#userScrollIntent.direction === direction) {
+			this.#userScrollIntent = { ...this.#userScrollIntent, receivedAt: performance.now() };
+		}
 	}
 
 	#handleBoundaryProximity(direction: TranscriptPageDirection, isNearBoundary: boolean): void {
@@ -621,14 +627,20 @@ export class ConversationScrollController {
 		} else if (!this.#laterBoundaryArmed) {
 			return;
 		}
-		// Accepts only fresh directional input for an unrequested cursor. Restores and
-		// ResizeObserver scroll events have no gesture epoch and cannot page history.
+		// Earlier browsing remains armed across a slow drag or momentum scroll and
+		// advances only with the cursor. Later paging still requires fresh input.
 		const intent = this.#userScrollIntent;
-		if (
-			intent.epoch <= this.#consumedIntentEpoch[direction] ||
-			intent.direction !== direction ||
-			!this.#hasRecentUserScrollIntent()
-		) {
+		const hasEligibleIntent =
+			direction === 'earlier'
+				? intent.direction === 'earlier' &&
+					((intent.epoch > this.#consumedIntentEpoch.earlier &&
+						this.#hasRecentUserScrollIntent()) ||
+						(this.#earlierBoundaryRequestSignature !== null &&
+							this.#earlierBoundaryRequestSignature !== this.#earlierBoundarySignature()))
+				: intent.epoch > this.#consumedIntentEpoch.later &&
+					intent.direction === 'later' &&
+					this.#hasRecentUserScrollIntent();
+		if (!hasEligibleIntent) {
 			return;
 		}
 		if (direction === 'later') this.#laterBoundaryArmed = false;

--- a/web/src/lib/chat/transcript/conversation-scroll-gesture.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-gesture.ts
@@ -1,0 +1,127 @@
+import type { TranscriptPageDirection } from './active-transcript-state.svelte.js';
+
+export interface ConversationTouchPoint {
+	identifier: number;
+	clientY: number;
+}
+
+export type ConversationScrollIntentReporter = (direction: TranscriptPageDirection | null) => void;
+
+export class ConversationTouchScrollGesture {
+	#identifier: number | null = null;
+	#clientY: number | null = null;
+
+	begin(touches: readonly ConversationTouchPoint[]): boolean {
+		if (touches.some((touch) => touch.identifier === this.#identifier)) return false;
+		const touch = touches[0];
+		this.#identifier = touch?.identifier ?? null;
+		this.#clientY = touch?.clientY ?? null;
+		return touch !== undefined;
+	}
+
+	move(touches: readonly ConversationTouchPoint[]): TranscriptPageDirection | null {
+		const touch = touches.find((candidate) => candidate.identifier === this.#identifier);
+		if (!touch || this.#clientY === null) {
+			this.begin(touches);
+			return null;
+		}
+		const direction = conversationTouchScrollDirection(this.#clientY, touch.clientY);
+		this.#clientY = touch.clientY;
+		return direction;
+	}
+
+	end(touches: readonly ConversationTouchPoint[]): void {
+		const touch =
+			touches.find((candidate) => candidate.identifier === this.#identifier) ?? touches[0];
+		this.#identifier = touch?.identifier ?? null;
+		this.#clientY = touch?.clientY ?? null;
+	}
+}
+
+export function conversationTouchScrollDirection(
+	previousClientY: number,
+	currentClientY: number,
+): TranscriptPageDirection | null {
+	if (currentClientY === previousClientY) return null;
+	return currentClientY > previousClientY ? 'earlier' : 'later';
+}
+
+export function conversationScrollbarScrollDirection(
+	previousClientY: number,
+	currentClientY: number,
+): TranscriptPageDirection | null {
+	if (currentClientY === previousClientY) return null;
+	return currentClientY < previousClientY ? 'earlier' : 'later';
+}
+
+export function conversationScrollbarTrackDirection(
+	pointerClientY: number,
+	thumbTop: number,
+	thumbBottom: number,
+): TranscriptPageDirection | null {
+	const thumbCenter = (thumbTop + thumbBottom) / 2;
+	if (pointerClientY < thumbCenter) return 'earlier';
+	if (pointerClientY > thumbCenter) return 'later';
+	return null;
+}
+
+export function conversationWheelScrollDirection(deltaY: number): TranscriptPageDirection | null {
+	if (deltaY === 0) return null;
+	return deltaY < 0 ? 'earlier' : 'later';
+}
+
+export function observeConversationViewportScrollGestures(
+	node: HTMLElement,
+	report: ConversationScrollIntentReporter,
+): () => void {
+	const touchGesture = new ConversationTouchScrollGesture();
+	const touchPoints = (event: TouchEvent): ConversationTouchPoint[] =>
+		Array.from(event.touches, (touch) => ({
+			identifier: touch.identifier,
+			clientY: touch.clientY,
+		}));
+	const handleWheel = (event: WheelEvent) => {
+		const direction = conversationWheelScrollDirection(event.deltaY);
+		if (direction) report(direction);
+	};
+	const handleTouchStart = (event: TouchEvent) => {
+		if (touchGesture.begin(touchPoints(event))) report(null);
+	};
+	const handleTouchMove = (event: TouchEvent) => {
+		const direction = touchGesture.move(touchPoints(event));
+		if (direction) report(direction);
+	};
+	const handleTouchEnd = (event: TouchEvent) => {
+		touchGesture.end(touchPoints(event));
+	};
+	const handlePointerDown = (event: PointerEvent) => {
+		if (event.button === 0 && event.pointerType !== 'touch') report(null);
+	};
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
+			report('earlier');
+		} else if (event.key === ' ') {
+			report(event.shiftKey ? 'earlier' : 'later');
+		} else if (event.key === 'ArrowDown' || event.key === 'PageDown' || event.key === 'End') {
+			report('later');
+		}
+	};
+
+	node.addEventListener('wheel', handleWheel, { capture: true, passive: true });
+	node.addEventListener('touchstart', handleTouchStart, { capture: true, passive: true });
+	node.addEventListener('touchmove', handleTouchMove, { capture: true, passive: true });
+	node.addEventListener('touchend', handleTouchEnd, { capture: true, passive: true });
+	node.addEventListener('touchcancel', handleTouchEnd, { capture: true, passive: true });
+	node.addEventListener('pointerdown', handlePointerDown, { capture: true, passive: true });
+	node.addEventListener('keydown', handleKeydown, { capture: true });
+
+	return () => {
+		node.removeEventListener('wheel', handleWheel, { capture: true });
+		node.removeEventListener('touchstart', handleTouchStart, { capture: true });
+		node.removeEventListener('touchmove', handleTouchMove, { capture: true });
+		node.removeEventListener('touchend', handleTouchEnd, { capture: true });
+		node.removeEventListener('touchcancel', handleTouchEnd, { capture: true });
+		node.removeEventListener('pointerdown', handlePointerDown, { capture: true });
+		node.removeEventListener('keydown', handleKeydown, { capture: true });
+	};
+}

--- a/web/src/lib/chat/transcript/conversation-viewport-port.ts
+++ b/web/src/lib/chat/transcript/conversation-viewport-port.ts
@@ -10,6 +10,7 @@ export type ConversationViewportTargetResult =
 export interface ConversationViewportPort {
 	isReady(): boolean;
 	isAtEnd(threshold?: number): boolean;
+	ownsScrollPosition(): boolean;
 	scrollToStart(): void;
 	scrollToEnd(): void;
 	restoreInitialEnd(): void;
@@ -18,7 +19,7 @@ export interface ConversationViewportPort {
 	measureViewportFill(): Promise<ConversationViewportFillResult>;
 	restoreHiddenReadingPosition(): Promise<HiddenReadingRestoreResult>;
 	cancelPendingLayoutMutation(): void;
-	cancelForUserIntent(): void;
+	cancelForUserIntent(direction: 'earlier' | 'later' | null): void;
 	scrollToTarget(
 		target: ConversationViewportTarget,
 		options?: { align?: 'center' | 'start' | 'end' },

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -28,6 +28,11 @@
 		canUseForkAtMessageAction,
 	} from '$lib/chat/actions/fork-at-message-action.js';
 	import { visiblePendingPermissionRequests } from '$lib/chat/transcript/conversation-feed-items.js';
+	import {
+		conversationScrollbarScrollDirection,
+		conversationScrollbarTrackDirection,
+		conversationWheelScrollDirection,
+	} from '$lib/chat/transcript/conversation-scroll-gesture.js';
 	import { ConversationFeedProjectionState } from './ConversationFeedProjectionState.svelte.js';
 	import { ConversationFeedRetentionState } from './ConversationFeedRetentionState.svelte.js';
 	import { ConversationFeedVirtualController } from './ConversationFeedVirtualController.svelte.js';
@@ -43,7 +48,7 @@
 	interface Props {
 		scrollContainer?: HTMLDivElement | null;
 		onscroll?: () => void;
-		onUserScrollIntent?: () => void;
+		onUserScrollIntent?: (direction: 'earlier' | 'later' | null) => void;
 		onPermissionDecision?: (
 			permissionRequestId: string,
 			decision: PermissionDecisionPayload & { message?: string },
@@ -117,6 +122,42 @@
 		appShell.requestSidebarRecenterToSelected();
 	}
 
+	let scrollbarPointerY: number | null = null;
+
+	function handleScrollbarPointerDownCapture(event: PointerEvent): void {
+		if (event.button !== 0 || !(event.currentTarget instanceof HTMLElement)) return;
+		const target = event.target instanceof Element ? event.target : null;
+		const isThumbPickup = Boolean(target?.closest('[data-slot="scroll-area-thumb"]'));
+		scrollbarPointerY = event.clientY;
+		if (isThumbPickup) {
+			onUserScrollIntent?.(null);
+			return;
+		}
+		const thumbRect = event.currentTarget
+			.querySelector<HTMLElement>('[data-slot="scroll-area-thumb"]')
+			?.getBoundingClientRect();
+		const direction = thumbRect
+			? conversationScrollbarTrackDirection(event.clientY, thumbRect.top, thumbRect.bottom)
+			: null;
+		onUserScrollIntent?.(direction);
+	}
+
+	function handleScrollbarPointerMove(event: PointerEvent): void {
+		if (scrollbarPointerY === null || (event.buttons & 1) === 0) return;
+		const direction = conversationScrollbarScrollDirection(scrollbarPointerY, event.clientY);
+		scrollbarPointerY = event.clientY;
+		if (direction) onUserScrollIntent?.(direction);
+	}
+
+	function handleScrollbarWheel(event: WheelEvent): void {
+		const direction = conversationWheelScrollDirection(event.deltaY);
+		if (direction) onUserScrollIntent?.(direction);
+	}
+
+	function finishScrollbarPointerIntent(): void {
+		scrollbarPointerY = null;
+	}
+
 	const feedScrollAreaClass = 'h-full overflow-hidden relative';
 	const feedViewportClass = $derived(
 		cn(
@@ -159,7 +200,10 @@
 		isLiveWindow: !chatState.hasLaterMessages,
 		showTopToolbarSpacer: reserveTopFloatingToolbar,
 		showRefreshError: chatState.loadStatus === 'error' && chatState.displayMessageCount > 0,
-		showEarlierBoundary: chatState.canLoadEarlier || chatState.pageStates.earlier.status !== 'idle',
+		showEarlierBoundary:
+			chatState.pageStates.earlier.status === 'error' ||
+			(chatState.pageStates.earlier.status === 'loading' &&
+				chatState.pageStates.earlier.error !== null),
 		showLaterBoundary: chatState.canLoadLater || chatState.pageStates.later.status !== 'idle',
 		reserveComposerTraySpace,
 		floatingPermissions:
@@ -394,7 +438,12 @@
 		orientation="vertical"
 		class={cn('w-1.5', isPreparingInitialScroll && 'invisible')}
 		data-chat-feed-scrollbar
-		onpointerdown={onUserScrollIntent}
+		onpointerdowncapture={handleScrollbarPointerDownCapture}
+		onwheel={handleScrollbarWheel}
+		onpointermove={handleScrollbarPointerMove}
+		onpointerup={finishScrollbarPointerIntent}
+		onpointercancel={finishScrollbarPointerIntent}
+		onlostpointercapture={finishScrollbarPointerIntent}
 	/>
 	<ScrollAreaPrimitive.Corner />
 	<div

--- a/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
@@ -23,15 +23,17 @@ import type { ConversationVirtualFeedModel } from './conversation-feed-virtual-i
 import {
 	captureConversationVirtualAnchor,
 	type ConversationVirtualAnchor,
+	ConversationEarlierPrependAnchorOwnership,
 	createConversationElementRectObserver,
 	ConversationMountedVirtualItems,
 	ConversationPreCommitAnchorBuffer,
 	nextConversationLayoutFrame,
 	observeConversationRootOffset,
+	performConversationOwnedScroll,
+	positionPendingConversationAnchor,
 	sameConversationNumberArrays,
 	settleConversationVirtualAnchor,
 	settleConversationEndRestore,
-	settleConversationScroll,
 	settleConversationTarget,
 	scrollConversationToPhysicalEnd,
 } from './conversation-feed-virtual-runtime.js';
@@ -68,19 +70,15 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 	#configuredPinned: boolean;
 	#appliedDataRevision: number;
 	#configuredVisible: boolean;
-	// Cancellation ownership stays field-specific. Structural publication, visibility, targets, user
-	// intent, replacement, and teardown advance the layout token to invalidate deferred anchor/end writes.
-	// New targets, user intent, replacement, and teardown advance the target token. Programmatic epochs
-	// supersede TanStack scroll operations; user intent advances both epochs and may supersede core's active
-	// target. The initial-end epoch owns only the deferred initial/latest restore. The user-intent epoch
-	// prevents older scale/end work from restoring after a genuine gesture. Active targets suppress passive
-	// writes until their balanced finally block exits. Pending and hidden anchors carry one keyed reading
-	// position; pending end and measure-on-show carry one deferred viewport operation for the current surface.
+	// Structural changes advance layout and target tokens; programmatic epochs own TanStack and attachment writes.
+	// Preserved prepend intent keeps that ownership. User intent supersedes older restores, while active targets
+	// suppress passive writes. Pending anchors and deferred viewport operations belong to the current surface.
 	#layoutMutationToken = 0;
 	#targetToken = 0;
 	#hiddenAnchor: ConversationVirtualAnchor | null = null;
 	#hiddenScrollOffset: number | null = null;
 	#pendingReadingAnchor: ConversationVirtualAnchor | null = null;
+	#earlierPrependAnchor = new ConversationEarlierPrependAnchorOwnership();
 	#readingRestoreGeneration = 0;
 	#preCommitAnchorBuffer = new ConversationPreCommitAnchorBuffer();
 	#measureOnShow = false;
@@ -181,6 +179,19 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		};
 	};
 
+	// The pending anchor exists only while its settle loop owns the programmatic scroll epoch.
+	positionReadingAnchor(virtualItem: { key: unknown; index: number }): Attachment<HTMLDivElement> {
+		return (element) =>
+			positionPendingConversationAnchor({
+				anchor: this.#pendingReadingAnchor,
+				element,
+				virtualItem,
+				indexByKey: this.options.model.indexByKey,
+				viewport: this.isReady() ? this.options.viewport : null,
+				scrollToOffset: (offset) => this.#instance().scrollToOffset(offset, { behavior: 'auto' }),
+			});
+	}
+
 	destroy(): void {
 		if (this.#destroyed) return;
 		this.#destroyed = true;
@@ -231,14 +242,14 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		);
 	}
 
+	readonly ownsScrollPosition = (): boolean => this.#programmaticScrollActive;
+
 	scrollToStart(): void {
 		if (!this.isReady()) return;
 		this.#initialEndRestoreEpoch += 1;
 		this.#cancelTargetScroll();
 		this.cancelPendingLayoutMutation();
-		const operationEpoch = this.#beginProgrammaticScrollOperation();
-		this.#instance().scrollToOffset(0, { behavior: 'auto' });
-		void this.#completeSimpleScroll(operationEpoch, this.#layoutMutationToken);
+		void this.#writeSimpleScroll(() => this.#instance().scrollToOffset(0, { behavior: 'auto' }));
 	}
 
 	scrollToEnd(): void {
@@ -283,9 +294,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		this.#initialEndRestoreEpoch += 1;
 		this.#cancelTargetScroll();
 		this.cancelPendingLayoutMutation();
-		const operationEpoch = this.#beginProgrammaticScrollOperation();
-		this.#instance().scrollBy(delta, { behavior: 'auto' });
-		void this.#completeSimpleScroll(operationEpoch, this.#layoutMutationToken);
+		void this.#writeSimpleScroll(() => this.#instance().scrollBy(delta, { behavior: 'auto' }));
 	}
 
 	async waitForLayout(
@@ -390,13 +399,15 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 				const measured = await this.#measureAfterCommit(surfaceIdentity);
 				if (!measured) return this.isReady() ? 'missing-anchor' : 'not-ready';
 			}
-			if (scrollOffset === null) return 'missing-anchor';
-			// Nothing on this path advances the layout token itself, so a moved token means a
-			// structural publication landed mid-restore and now owns the viewport position.
-			if (!offsetWriteStillValid() || layoutToken !== this.#layoutMutationToken) {
+			if (
+				scrollOffset === null ||
+				!(await this.#writeSimpleScroll(
+					() => this.#instance().scrollToOffset(scrollOffset, { behavior: 'auto' }),
+					() => offsetWriteStillValid() && layoutToken === this.#layoutMutationToken,
+				))
+			) {
 				return 'missing-anchor';
 			}
-			this.#instance().scrollToOffset(scrollOffset, { behavior: 'auto' });
 			return 'restored';
 		}
 		// Carries the hide-time key through a same-surface geometry publication that
@@ -419,10 +430,15 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 			return 'restored';
 		}
 		this.#pendingReadingAnchor = null;
-		// The anchor restore advances the layout token internally, so identity, readiness, and
-		// the user-intent epoch are the coherent guards for its raw offset fallback.
-		if (scrollOffset === null || !offsetWriteStillValid()) return 'missing-anchor';
-		this.#instance().scrollToOffset(scrollOffset, { behavior: 'auto' });
+		if (
+			scrollOffset === null ||
+			!(await this.#writeSimpleScroll(
+				() => this.#instance().scrollToOffset(scrollOffset, { behavior: 'auto' }),
+				offsetWriteStillValid,
+			))
+		) {
+			return 'missing-anchor';
+		}
 		return 'restored';
 	}
 
@@ -430,16 +446,27 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		this.#layoutMutationToken += 1;
 		this.#readingRestoreGeneration += 1;
 		this.#pendingReadingAnchor = null;
+		this.#earlierPrependAnchor.clear();
 		this.#programmaticScrollActive = false;
 		this.#programmaticScrollEpoch += 1;
 	}
 
-	cancelForUserIntent(): void {
+	cancelForUserIntent(direction: 'earlier' | 'later' | null): void {
 		this.#userIntentEpoch += 1;
 		this.#initialEndRestoreEpoch += 1;
 		this.#cancelTargetScroll();
-		const shouldSupersedeCore = this.#programmaticScrollActive;
 		const viewport = this.options.viewport;
+		const pendingAnchor = this.#pendingReadingAnchor;
+		const preservesEarlierPrepend = this.#earlierPrependAnchor.preserves(
+			direction,
+			pendingAnchor,
+			viewport?.scrollTop ?? Number.POSITIVE_INFINITY,
+		);
+		if (preservesEarlierPrepend) {
+			this.options.onInitialEndRestored?.();
+			return;
+		}
+		const shouldSupersedeCore = this.#programmaticScrollActive;
 		this.cancelPendingLayoutMutation();
 		if (shouldSupersedeCore && viewport && this.isReady()) {
 			this.#instance().scrollToOffset(viewport.scrollTop, { behavior: 'auto' });
@@ -555,6 +582,10 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		} else {
 			this.#pendingReadingAnchor = null;
 		}
+		this.#earlierPrependAnchor.carry(
+			this.#pendingReadingAnchor,
+			snapshot.mutationKinds.has('history-earlier'),
+		);
 
 		if (identityChanged) this.#detachAndResetOldSurface();
 		const indexByKey = new Map(keys.map((key, index) => [key, index] as const));
@@ -786,6 +817,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 			// The latest attempt consumes its anchor even when layout never settles. Only a
 			// newer scheduled attempt may carry the same anchor across a passive supersession.
 			this.#pendingReadingAnchor = null;
+			this.#earlierPrependAnchor.complete(anchor);
 		});
 	}
 
@@ -911,15 +943,16 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		);
 	}
 
-	async #completeSimpleScroll(operationEpoch: number, token: number): Promise<void> {
-		try {
-			await settleConversationScroll({
-				isCurrent: () => this.#isCurrentLayoutOperation(token, operationEpoch),
-				readOffset: () => this.options.viewport?.scrollTop ?? null,
-			});
-		} finally {
-			this.#finishProgrammaticScrollOperation(operationEpoch);
-		}
+	async #writeSimpleScroll(write: () => void, isValid = () => true): Promise<boolean> {
+		const token = this.#layoutMutationToken;
+		return performConversationOwnedScroll({
+			begin: () => this.#beginProgrammaticScrollOperation(),
+			finish: (epoch) => this.#finishProgrammaticScrollOperation(epoch),
+			isCurrent: (epoch) => this.#isCurrentLayoutOperation(token, epoch),
+			isValid,
+			readOffset: () => this.options.viewport?.scrollTop ?? null,
+			write,
+		});
 	}
 
 	#beginProgrammaticScrollOperation(): number {
@@ -930,6 +963,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 	#isCurrentProgrammaticScrollOperation(epoch: number): boolean {
 		return epoch === this.#programmaticScrollEpoch;
 	}
+
 	#isCurrentLayoutOperation(token: number, epoch: number): boolean {
 		return (
 			token === this.#layoutMutationToken &&

--- a/web/src/lib/components/chat/ConversationFeedVirtualRow.svelte
+++ b/web/src/lib/components/chat/ConversationFeedVirtualRow.svelte
@@ -100,6 +100,7 @@
 	onfocusin={handleFocusIn}
 	onfocusout={handleFocusOut}
 	{@attach controller.measureItem}
+	{@attach controller.positionReadingAnchor(virtualItem)}
 >
 	<svelte:boundary>
 		<ConversationFeedVirtualItem

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -33,6 +33,7 @@
 	import { selectPreviewFromBatch } from '$lib/events/router.svelte';
 	import { ConversationSessionController } from '$lib/chat/conversation/conversation-session-controller.svelte.js';
 	import { ConversationScrollController } from '$lib/chat/transcript/conversation-scroll-controller.svelte.js';
+	import { observeConversationViewportScrollGestures } from '$lib/chat/transcript/conversation-scroll-gesture.js';
 	import type { ConversationViewportPort } from '$lib/chat/transcript/conversation-viewport-port.js';
 	import {
 		UserMessageNavigatorController,
@@ -440,46 +441,13 @@
 		scroll.setViewportVisible(isVisible);
 	});
 
-	// Marks real scroll gestures on the actual viewport element. This avoids
-	// depending on wrapper component event forwarding for wheel, touch, and scrollbar input.
+	// Marks real scroll gestures on the actual viewport element without wrapper event forwarding.
 	$effect(() => {
 		const node = scrollContainer;
 		if (!node) return;
-
-		const handleWheel = (event: WheelEvent) => {
-			if (event.deltaY === 0) return;
-			scroll.noteUserScrollIntent(event.deltaY < 0 ? 'earlier' : 'later');
-		};
-		const handleTouchStart = () => scroll.noteUserScrollIntent();
-		const handlePointerDown = (event: PointerEvent) => {
-			if (event.button !== 0 || event.pointerType === 'touch') return;
-			scroll.noteUserScrollIntent();
-		};
-		const handleKeydown = (event: KeyboardEvent) => {
-			if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
-				scroll.noteUserScrollIntent('earlier');
-				return;
-			}
-			if (event.key === ' ') {
-				scroll.noteUserScrollIntent(event.shiftKey ? 'earlier' : 'later');
-				return;
-			}
-			if (event.key === 'ArrowDown' || event.key === 'PageDown' || event.key === 'End') {
-				scroll.noteUserScrollIntent('later');
-			}
-		};
-
-		node.addEventListener('wheel', handleWheel, { capture: true, passive: true });
-		node.addEventListener('touchstart', handleTouchStart, { capture: true, passive: true });
-		node.addEventListener('pointerdown', handlePointerDown, { capture: true, passive: true });
-		node.addEventListener('keydown', handleKeydown, { capture: true });
-
-		return () => {
-			node.removeEventListener('wheel', handleWheel, { capture: true });
-			node.removeEventListener('touchstart', handleTouchStart, { capture: true });
-			node.removeEventListener('pointerdown', handlePointerDown, { capture: true });
-			node.removeEventListener('keydown', handleKeydown, { capture: true });
-		};
+		return observeConversationViewportScrollGestures(node, (direction) =>
+			scroll.noteUserScrollIntent(direction),
+		);
 	});
 
 	// Scrolls to bottom when the scroll container becomes available.
@@ -629,7 +597,7 @@
 			<ConversationFeed
 				bind:scrollContainer
 				onscroll={() => scroll.handleScroll()}
-				onUserScrollIntent={() => scroll.noteUserScrollIntent()}
+				onUserScrollIntent={(direction) => scroll.noteUserScrollIntent(direction)}
 				onLoadEarlier={() => void scroll.requestPage('earlier', 'button')}
 				onLoadLater={() => void scroll.requestPage('later', 'button')}
 				onPermissionDecision={(id, d) => controller.handlePermissionDecision(id, d)}

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -8,6 +8,46 @@ import {
 	ResizeObserverHarness,
 } from '$lib/components/shared/__tests__/resize-observer-harness.js';
 
+async function showFeedScrollbar(container: HTMLElement): Promise<{
+	scrollbar: HTMLElement;
+	thumb: HTMLElement;
+	viewport: HTMLElement;
+}> {
+	const root = container.querySelector<HTMLElement>('[data-scroll-area-root]');
+	const viewport = container.querySelector<HTMLElement>('[data-chat-scroll-viewport]');
+	const content = container.querySelector<HTMLElement>('[data-scroll-area-content]');
+	if (!root || !viewport || !content) throw new Error('Expected the feed scroll-area elements');
+	Object.defineProperties(viewport, {
+		offsetHeight: { configurable: true, value: 720 },
+		offsetWidth: { configurable: true, value: 900 },
+		scrollHeight: { configurable: true, value: 4_000 },
+		scrollWidth: { configurable: true, value: 900 },
+	});
+	await waitFor(() => {
+		expect(
+			ResizeObserverHarness.instances.some((observer) => observer.observed.has(viewport)),
+		).toBe(true);
+		expect(ResizeObserverHarness.instances.some((observer) => observer.observed.has(content))).toBe(
+			true,
+		);
+	});
+	for (const observer of ResizeObserverHarness.instances) {
+		if (observer.observed.has(viewport)) {
+			ResizeObserverHarness.emitFrom(observer, viewport, 900, 720);
+		}
+		if (observer.observed.has(content)) {
+			ResizeObserverHarness.emitFrom(observer, content, 900, 4_000);
+		}
+	}
+	await fireEvent.pointerEnter(root);
+	await waitFor(() => expect(container.querySelector('[data-chat-feed-scrollbar]')).not.toBeNull());
+	const scrollbar = container.querySelector<HTMLElement>('[data-chat-feed-scrollbar]');
+	const thumb = container.querySelector<HTMLElement>('[data-slot="scroll-area-thumb"]');
+	if (!scrollbar || !thumb) throw new Error('Expected the feed scrollbar and thumb');
+	await tick();
+	return { scrollbar, thumb, viewport };
+}
+
 describe('ConversationFeed', () => {
 	const originalOffsetHeight = Object.getOwnPropertyDescriptor(
 		HTMLElement.prototype,
@@ -129,11 +169,90 @@ describe('ConversationFeed', () => {
 		}
 	});
 
-	it('shows a directional earlier boundary after the automatic reveal window', async () => {
-		render(ConversationFeedTestHost, { transcriptScenario: 'local-truncation' });
+	it('reports an immediate scrollbar track jump from its committed offset', async () => {
+		const restoreResizeObserver = installResizeObserverHarness();
+		let feedViewport: HTMLElement | null = null;
+		const observedScrollTops: number[] = [];
+		const onUserScrollIntent = vi.fn(() => observedScrollTops.push(feedViewport?.scrollTop ?? -1));
+		try {
+			const { container } = render(ConversationFeedTestHost, {
+				onUserScrollIntent,
+				transcriptScenario: 'twenty-thousand',
+			});
+			const { scrollbar, thumb, viewport } = await showFeedScrollbar(container);
+			feedViewport = viewport;
+			viewport.scrollTop = 500;
+			vi.spyOn(thumb, 'getBoundingClientRect').mockReturnValue({ top: 80, bottom: 120 } as DOMRect);
+			document.addEventListener('pointerdown', () => (viewport.scrollTop = 0), { once: true });
 
-		expect(await screen.findByRole('button', { name: 'Load earlier messages' })).toBeTruthy();
-		expect(screen.queryByText('Load more')).toBeNull();
+			await fireEvent.pointerDown(scrollbar, { button: 0, clientY: 90, pointerId: 1 });
+
+			expect(onUserScrollIntent.mock.calls).toEqual([['earlier']]);
+			expect(observedScrollTops).toEqual([500]);
+			expect(viewport.scrollTop).toBe(0);
+		} finally {
+			restoreResizeObserver();
+		}
+	});
+
+	it('reports wheel direction over the custom scrollbar before it scrolls', async () => {
+		const restoreResizeObserver = installResizeObserverHarness();
+		let feedViewport: HTMLElement | null = null;
+		const observedScrollTops: number[] = [];
+		const onUserScrollIntent = vi.fn(() => observedScrollTops.push(feedViewport?.scrollTop ?? -1));
+		try {
+			const { container } = render(ConversationFeedTestHost, {
+				onUserScrollIntent,
+				transcriptScenario: 'twenty-thousand',
+			});
+			const { scrollbar, viewport } = await showFeedScrollbar(container);
+			feedViewport = viewport;
+			viewport.scrollTop = 500;
+			document.addEventListener('wheel', () => (viewport.scrollTop = 0), { once: true });
+
+			await fireEvent.wheel(scrollbar, { deltaY: -40 });
+			expect(viewport.scrollTop).toBe(0);
+			viewport.scrollTop = 500;
+			await fireEvent.wheel(scrollbar, { deltaY: 40 });
+
+			expect(onUserScrollIntent.mock.calls).toEqual([['earlier'], ['later']]);
+			expect(observedScrollTops).toEqual([500, 500]);
+		} finally {
+			restoreResizeObserver();
+		}
+	});
+
+	it('defers thumb pickup until pointer movement establishes direction', async () => {
+		const restoreResizeObserver = installResizeObserverHarness();
+		const onUserScrollIntent = vi.fn();
+		try {
+			const { container } = render(ConversationFeedTestHost, {
+				onUserScrollIntent,
+				transcriptScenario: 'twenty-thousand',
+			});
+			const { thumb, viewport } = await showFeedScrollbar(container);
+			viewport.scrollTop = 500;
+			thumb.addEventListener('pointerdown', () => (viewport.scrollTop = 499.5), { once: true });
+
+			await fireEvent.pointerDown(thumb, { button: 0, clientY: 100, pointerId: 2 });
+			expect(onUserScrollIntent.mock.calls).toEqual([[null]]);
+			await fireEvent.pointerMove(thumb, { buttons: 1, clientY: 80, pointerId: 2 });
+			await fireEvent.pointerMove(thumb, { buttons: 1, clientY: 120, pointerId: 2 });
+			await fireEvent.pointerUp(thumb, { button: 0, clientY: 120, pointerId: 2 });
+
+			expect(onUserScrollIntent.mock.calls).toEqual([[null], ['earlier'], ['later']]);
+		} finally {
+			restoreResizeObserver();
+		}
+	});
+
+	it('keeps the automatic earlier-history boundary out of the transcript', () => {
+		const { container } = render(ConversationFeedTestHost, {
+			transcriptScenario: 'local-truncation',
+		});
+
+		expect(screen.queryByRole('button', { name: 'Load earlier messages' })).toBeNull();
+		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBeNull();
 	});
 
 	it('renders later loading below the transcript without a native bottom anchor', async () => {
@@ -154,9 +273,20 @@ describe('ConversationFeed', () => {
 	});
 
 	it('keeps an earlier failure in flow as a directional retry', async () => {
-		render(ConversationFeedTestHost, { transcriptScenario: 'error-earlier' });
+		const { container } = render(ConversationFeedTestHost, {
+			transcriptScenario: 'error-earlier',
+		});
+		const retry = await screen.findByRole('button', { name: 'Retry earlier messages' });
+		const boundary = container.querySelector('[data-transcript-page-boundary="earlier"]');
+		const transcript = container.querySelector('[data-chat-row-id]');
+		if (!boundary || !transcript) throw new Error('Expected the earlier boundary and transcript');
 
-		expect(await screen.findByRole('button', { name: 'Retry earlier messages' })).toBeTruthy();
+		expect(boundary.compareDocumentPosition(transcript)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+		await fireEvent.click(retry);
+
+		const loading = await screen.findByRole('button', { name: 'Loading earlier messages...' });
+		expect(loading.getAttribute('aria-busy')).toBe('true');
+		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBe(boundary);
 	});
 
 	it('passes durable and pending row identities to mounted virtual rows', async () => {

--- a/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
@@ -20,6 +20,7 @@
 	} from '$lib/context';
 
 	interface Props {
+		onUserScrollIntent?: (direction: 'earlier' | 'later' | null) => void;
 		reserveTopFloatingToolbar?: boolean;
 		isPreparingInitialScroll?: boolean;
 		showAnnouncementTrigger?: boolean;
@@ -35,6 +36,7 @@
 	}
 
 	const {
+		onUserScrollIntent,
 		reserveTopFloatingToolbar = false,
 		isPreparingInitialScroll = false,
 		showAnnouncementTrigger = false,
@@ -72,8 +74,8 @@
 			initialTranscriptScenario === 'twenty-thousand'
 				? 20_000
 				: initialTranscriptScenario === 'loading-later'
-						? 5
-						: 120;
+					? 5
+					: 120;
 		const messages = Array.from({ length: messageCount }, (_, index) => ({
 			seq: index + 1,
 			message: new AssistantMessage('2026-07-01T00:00:00.000Z', `message ${index + 1}`),
@@ -127,6 +129,13 @@
 	function showInterleavedEarlierError(): void {
 		chatState.pageStates.earlier = { status: 'error', error: 'Interleaved failure' };
 	}
+
+	function retryEarlierPage(): void {
+		chatState.pageStates.earlier = {
+			status: 'loading',
+			error: chatState.pageStates.earlier.error,
+		};
+	}
 	setActiveTranscriptState(chatState);
 	setAgentState(new AgentState());
 	const localSettings = createLocalSettingsStore();
@@ -156,8 +165,10 @@
 </script>
 
 <ConversationFeed
+	{onUserScrollIntent}
 	{reserveTopFloatingToolbar}
 	{isPreparingInitialScroll}
+	onLoadEarlier={retryEarlierPage}
 	isVisible={true}
 	pinnedToBottom={true}
 	surfaceIdentity={`${chatState.activeChatId ?? 'none'}:${chatState.generationId}`}

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
@@ -43,7 +43,10 @@ import {
 import {
 	conversationAnchorScrollOffset,
 	conversationAnchorViewportOffset,
+	ConversationEarlierPrependAnchorOwnership,
 	ConversationPreCommitAnchorBuffer,
+	positionCommittedConversationAnchor,
+	positionPendingConversationAnchor,
 } from '../conversation-feed-virtual-runtime';
 import ConversationFeedVirtualControllerTestHost from './ConversationFeedVirtualControllerTestHost.svelte';
 
@@ -65,6 +68,67 @@ describe('ConversationFeedVirtualController helpers', () => {
 
 		expect(viewportOffset).toBe(429);
 		expect(conversationAnchorScrollOffset(1_808, 59.8, viewportOffset)).toBeCloseTo(1_319.2);
+	});
+
+	it('does not carry directionless press origins into later gestures', () => {
+		const ownership = new ConversationEarlierPrependAnchorOwnership();
+		const anchor = { key: 'anchor', viewportOffset: 0, fallbackKeys: [] };
+		ownership.carry(anchor, true);
+
+		expect(ownership.preserves(null, anchor, 80)).toBe(true);
+		expect(ownership.preserves('earlier', anchor, 0)).toBe(true);
+		ownership.clear();
+		ownership.carry(anchor, true);
+		expect(ownership.preserves(null, anchor, 0)).toBe(true);
+		expect(ownership.preserves('earlier', anchor, 80)).toBe(false);
+	});
+
+	it('positions a committed anchor before its next animation frame', () => {
+		const viewport = document.createElement('div');
+		const element = document.createElement('div');
+		viewport.scrollTop = 120;
+		vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue({ top: 40 } as DOMRect);
+		vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({ top: 390 } as DOMRect);
+		const scrollToOffset = vi.fn();
+
+		positionCommittedConversationAnchor({
+			element,
+			viewport,
+			viewportOffset: 50,
+			scrollToOffset,
+		});
+
+		expect(scrollToOffset).toHaveBeenCalledWith(420);
+	});
+
+	it('positions only the connected wrapper for the pending keyed index', () => {
+		const viewport = document.createElement('div');
+		const element = document.createElement('div');
+		viewport.append(element);
+		document.body.append(viewport);
+		element.dataset.chatVirtualItem = 'anchor';
+		element.dataset.index = '4';
+		viewport.scrollTop = 120;
+		vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue({ top: 40 } as DOMRect);
+		vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({ top: 390 } as DOMRect);
+		const scrollToOffset = vi.fn();
+		const input = {
+			anchor: { key: 'anchor', viewportOffset: 50, fallbackKeys: [] },
+			element,
+			virtualItem: { key: 'anchor', index: 4 },
+			indexByKey: new Map([['anchor', 4]]),
+			viewport,
+			scrollToOffset,
+		};
+
+		positionPendingConversationAnchor(input);
+		expect(scrollToOffset).toHaveBeenCalledWith(420);
+
+		scrollToOffset.mockClear();
+		element.dataset.index = '3';
+		positionPendingConversationAnchor(input);
+		expect(scrollToOffset).not.toHaveBeenCalled();
+		viewport.remove();
 	});
 
 	it('classifies identity, edge, estimate-only, and no-op changes', () => {
@@ -351,9 +415,13 @@ interface ControllerExposure {
 	controller: ConversationFeedVirtualController;
 	instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>;
 	initialEndRestoredCount(): number;
+	prepareHiddenOffsetWithMissingAnchor(): Promise<void>;
+	prepareHiddenOffsetWithoutAnchor(): Promise<void>;
 	prependWithRetainedWithheldAnchor(index: number): Promise<void>;
 	releaseWithheldEndItem(): Promise<void>;
 	restoreHiddenWithConcurrentGeometry(): Promise<void>;
+	stageEarlierPrependWithTail(index: number): Promise<void>;
+	stageLatchedEarlierPrependWithTail(index: number): Promise<void>;
 	withholdEndItem(): Promise<void>;
 	withholdItem(index: number): Promise<void>;
 }
@@ -379,6 +447,44 @@ async function renderController(): Promise<{
 	return { exposure, unmount: rendered.unmount };
 }
 
+async function preparePendingEarlierPrepend(
+	publish: (exposure: ControllerExposure, index: number) => Promise<void>,
+) {
+	const { exposure } = await renderController();
+	const viewport = document.querySelector<HTMLDivElement>('[data-controller-viewport]');
+	if (!viewport) throw new Error('Expected the controller viewport');
+	await fireEvent.click(screen.getByRole('button', { name: 'Toggle pinned' }));
+	viewport.scrollTop = 86;
+	viewport.dispatchEvent(new Event('scroll'));
+	await nextFrame();
+	const readingItem = exposure.instance.getVirtualItemForOffset(viewport.scrollTop);
+	if (!readingItem) throw new Error('Expected a virtual reading item');
+	const readingOffset = conversationAnchorViewportOffset(
+		readingItem.start,
+		exposure.instance.options.scrollMargin,
+		viewport.scrollTop,
+	);
+	const scrollToIndex = vi.spyOn(exposure.instance, 'scrollToIndex');
+	const scrollToOffset = vi.spyOn(exposure.instance, 'scrollToOffset');
+
+	await publish(exposure, readingItem.index);
+	expect(
+		Array.from(document.querySelectorAll<HTMLElement>('[data-chat-virtual-item]')).some(
+			(element) => element.dataset.chatVirtualItem === String(readingItem.key),
+		),
+	).toBe(false);
+	const repositionedItem = exposure.instance
+		.getVirtualItems()
+		.find((item) => item.key === readingItem.key);
+	if (!repositionedItem) throw new Error('Expected the reading item after the prepend');
+	const expectedScrollOffset = conversationAnchorScrollOffset(
+		repositionedItem.start,
+		exposure.instance.options.scrollMargin,
+		readingOffset,
+	);
+	return { exposure, viewport, scrollToIndex, scrollToOffset, expectedScrollOffset };
+}
+
 describe('ConversationFeedVirtualController', () => {
 	let restoreResizeObserver: () => void;
 
@@ -390,6 +496,7 @@ describe('ConversationFeedVirtualController', () => {
 	afterEach(() => {
 		cleanup();
 		restoreResizeObserver();
+		vi.restoreAllMocks();
 	});
 
 	it('keeps content and retention publications separate from structural measurement', async () => {
@@ -446,6 +553,34 @@ describe('ConversationFeedVirtualController', () => {
 		expect(scrollToIndex).not.toHaveBeenCalled();
 	});
 
+	it('releases viewport ownership after a simple programmatic scroll settles', async () => {
+		const { exposure } = await renderController();
+
+		exposure.controller.scrollBy(10);
+		expect(exposure.controller.ownsScrollPosition()).toBe(true);
+
+		await waitFor(() => expect(exposure.controller.ownsScrollPosition()).toBe(false));
+	});
+
+	it.each([
+		['a hidden offset without a reading anchor', 'prepareHiddenOffsetWithoutAnchor'],
+		['a hidden offset whose reading anchor disappeared', 'prepareHiddenOffsetWithMissingAnchor'],
+	] as const)('owns %s until its fallback restore settles', async (_label, prepare) => {
+		const { exposure } = await renderController();
+		await fireEvent.click(screen.getByRole('button', { name: 'Toggle pinned' }));
+		await exposure[prepare]();
+		const scrollToOffset = exposure.instance.scrollToOffset.bind(exposure.instance);
+		const ownedDuringWrite: boolean[] = [];
+		vi.spyOn(exposure.instance, 'scrollToOffset').mockImplementation((offset, options) => {
+			ownedDuringWrite.push(exposure.controller.ownsScrollPosition());
+			scrollToOffset(offset, options);
+		});
+
+		await expect(exposure.controller.restoreHiddenReadingPosition()).resolves.toBe('restored');
+		expect(ownedDuringWrite).toEqual([true]);
+		expect(exposure.controller.ownsScrollPosition()).toBe(false);
+	});
+
 	it('positions a mounted edge anchor directly without first aligning it to the top', async () => {
 		const { exposure } = await renderController();
 		const viewport = document.querySelector<HTMLDivElement>('[data-controller-viewport]');
@@ -479,6 +614,57 @@ describe('ConversationFeedVirtualController', () => {
 			readingOffset,
 		);
 		expect(scrollToOffset.mock.calls[0]?.[0]).toBeCloseTo(expectedScrollOffset);
+	});
+
+	it('keeps a clamped prepend latched through a tail publication', async () => {
+		const { exposure, viewport, scrollToIndex, scrollToOffset, expectedScrollOffset } =
+			await preparePendingEarlierPrepend((current, index) =>
+				current.stageLatchedEarlierPrependWithTail(index),
+			);
+		scrollToIndex.mockClear();
+		scrollToOffset.mockClear();
+		viewport.scrollTop = 80;
+		exposure.controller.cancelForUserIntent('earlier');
+		await exposure.releaseWithheldEndItem();
+
+		await waitFor(() =>
+			expect(scrollToOffset).toHaveBeenCalledWith(expectedScrollOffset, { behavior: 'auto' }),
+		);
+	});
+
+	it('keeps an unlatched earlier prepend through a tail publication at the clamped edge', async () => {
+		const { exposure, viewport, scrollToIndex, scrollToOffset, expectedScrollOffset } =
+			await preparePendingEarlierPrepend((current, index) =>
+				current.stageEarlierPrependWithTail(index),
+			);
+		scrollToIndex.mockClear();
+		scrollToOffset.mockClear();
+		viewport.scrollTop = 0;
+		exposure.controller.cancelForUserIntent('earlier');
+		await exposure.releaseWithheldEndItem();
+
+		await waitFor(() =>
+			expect(scrollToOffset).toHaveBeenCalledWith(expectedScrollOffset, { behavior: 'auto' }),
+		);
+	});
+
+	it('cancels a pending earlier prepend after a tail publication away from the edge', async () => {
+		const { exposure, viewport, scrollToIndex, scrollToOffset } =
+			await preparePendingEarlierPrepend((current, index) =>
+				current.stageEarlierPrependWithTail(index),
+			);
+		scrollToIndex.mockClear();
+		scrollToOffset.mockClear();
+		viewport.scrollTop = 80;
+		exposure.controller.cancelForUserIntent(null);
+		exposure.controller.cancelForUserIntent('earlier');
+		scrollToIndex.mockClear();
+		scrollToOffset.mockClear();
+		await exposure.releaseWithheldEndItem();
+		for (let frame = 0; frame < 10; frame += 1) await nextFrame();
+
+		expect(scrollToIndex).not.toHaveBeenCalled();
+		expect(scrollToOffset).not.toHaveBeenCalled();
 	});
 
 	it('uses an index target when a retained virtual anchor has no committed wrapper', async () => {
@@ -607,7 +793,7 @@ describe('ConversationFeedVirtualController', () => {
 		const scrollToIndex = vi.spyOn(exposure.instance, 'scrollToIndex');
 
 		exposure.controller.restoreInitialEnd();
-		exposure.controller.cancelForUserIntent();
+		exposure.controller.cancelForUserIntent(null);
 		await nextFrame();
 		await nextFrame();
 		await nextFrame();

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
@@ -14,9 +14,13 @@
 		controller: ConversationFeedVirtualController;
 		instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>;
 		initialEndRestoredCount(): number;
+		prepareHiddenOffsetWithMissingAnchor(): Promise<void>;
+		prepareHiddenOffsetWithoutAnchor(): Promise<void>;
 		releaseWithheldEndItem(): Promise<void>;
 		restoreHiddenWithConcurrentGeometry(): Promise<void>;
 		prependWithRetainedWithheldAnchor(index: number): Promise<void>;
+		stageEarlierPrependWithTail(index: number): Promise<void>;
+		stageLatchedEarlierPrependWithTail(index: number): Promise<void>;
 		withholdEndItem(): Promise<void>;
 		withholdItem(index: number): Promise<void>;
 	}
@@ -28,6 +32,7 @@
 	let { onReady }: Props = $props();
 	let itemCount = $state(12);
 	let firstItemNumber = $state(0);
+	let historyEarlierMutation = $state(false);
 	let contentRevision = $state(0);
 	let geometryRevision = $state(1);
 	let measurementReset = $state<ConversationVirtualGeometrySnapshot['measurementReset']>('none');
@@ -40,6 +45,7 @@
 	let releaseRetention: (() => void) | null = null;
 	let initialEndRestoredCount = 0;
 	let withheldKey: string | null = $state(null);
+	let transcriptEligible = $state(true);
 
 	const keys = $derived(
 		Array.from({ length: itemCount }, (_, index) =>
@@ -49,27 +55,31 @@
 	const model = $derived.by((): ConversationVirtualFeedModel => {
 		void contentRevision;
 		// Transcript-kind items keep reading-anchor capture eligible, matching production feeds.
-		const items: ConversationVirtualFeedItem[] = keys.map((key, index) => ({
-			kind: 'transcript',
-			key,
-			item: {
-				kind: 'message',
-				id: `row-${index}`,
-				rowIds: [`row-${index}`],
-				virtualKey: `row-${index}`,
-				message: new UserMessage('2026-08-03T00:00:00.000Z', `prompt ${index}`),
-				index,
-				prevMessage: null,
-			},
-			spacingAfter: 'none',
-		}));
+		const items: ConversationVirtualFeedItem[] = keys.map((key, index) =>
+			transcriptEligible
+				? {
+						kind: 'transcript',
+						key,
+						item: {
+							kind: 'message',
+							id: `row-${index}`,
+							rowIds: [`row-${index}`],
+							virtualKey: `row-${index}`,
+							message: new UserMessage('2026-08-03T00:00:00.000Z', `prompt ${index}`),
+							index,
+							prevMessage: null,
+						},
+						spacingAfter: 'none',
+					}
+				: { kind: 'viewport-start-spacer', key, spacingAfter: 'none' },
+		);
 		return {
 			items,
 			indexByKey: new Map(keys.map((key, index) => [key, index])),
 			indexByRowId: new Map(),
 			targetByDomAnchorId: new Map(),
 			transcriptStartIndex: 0,
-			transcriptEndIndex: items.length,
+			transcriptEndIndex: transcriptEligible ? items.length : 0,
 		};
 	});
 	const geometry = $derived.by((): ConversationVirtualGeometrySnapshot => ({
@@ -78,7 +88,7 @@
 		keys,
 		estimates: keys.map(() => 40 * textScale),
 		measurementReset,
-		mutationKinds: new Set(),
+		mutationKinds: new Set(historyEarlierMutation ? ['history-earlier' as const] : []),
 		endBehavior: 'restore-if-pinned',
 	}));
 	const retention = new ConversationFeedRetentionState();
@@ -124,9 +134,13 @@
 			controller,
 			instance,
 			initialEndRestoredCount: () => initialEndRestoredCount,
+			prepareHiddenOffsetWithMissingAnchor,
+			prepareHiddenOffsetWithoutAnchor,
 			releaseWithheldEndItem,
 			restoreHiddenWithConcurrentGeometry,
 			prependWithRetainedWithheldAnchor,
+			stageEarlierPrependWithTail,
+			stageLatchedEarlierPrependWithTail,
 			withholdEndItem,
 			withholdItem,
 		});
@@ -160,15 +174,33 @@
 		releaseRetention = retention.acquire(key, 'focus');
 		withheldKey = key;
 		await tick();
+		historyEarlierMutation = true;
 		firstItemNumber -= 4;
 		itemCount += 4;
 		measurementReset = 'none';
 		geometryRevision += 1;
 		await tick();
+		await tick();
+	}
+
+	async function stageEarlierPrependWithTail(index: number): Promise<void> {
+		await prependWithRetainedWithheldAnchor(index);
+		appendItem();
+		await tick();
+	}
+
+	async function stageLatchedEarlierPrependWithTail(index: number): Promise<void> {
+		await prependWithRetainedWithheldAnchor(index);
+		if (viewport) viewport.scrollTop = 0;
+		controller.cancelForUserIntent(null);
+		controller.cancelForUserIntent('earlier');
+		appendItem();
+		await tick();
 	}
 
 	function appendItem(): void {
 		controller.prepareForGeometryPublication(geometryRevision + 1);
+		historyEarlierMutation = false;
 		itemCount += 1;
 		measurementReset = 'none';
 		geometryRevision += 1;
@@ -176,6 +208,7 @@
 
 	function prependItems(): void {
 		controller.prepareForGeometryPublication(geometryRevision + 1);
+		historyEarlierMutation = true;
 		firstItemNumber -= 4;
 		itemCount += 4;
 		measurementReset = 'none';
@@ -217,6 +250,30 @@
 		await restore;
 	}
 
+	async function prepareHiddenOffsetWithoutAnchor(): Promise<void> {
+		controller.prepareForGeometryPublication(geometryRevision + 1);
+		transcriptEligible = false;
+		geometryRevision += 1;
+		await tick();
+		if (viewport) viewport.scrollTop = 86;
+		visible = false;
+		await tick();
+		visible = true;
+		await tick();
+	}
+
+	async function prepareHiddenOffsetWithMissingAnchor(): Promise<void> {
+		if (viewport) viewport.scrollTop = 86;
+		visible = false;
+		await tick();
+		controller.prepareForGeometryPublication(geometryRevision + 1);
+		firstItemNumber += 100;
+		geometryRevision += 1;
+		await tick();
+		visible = true;
+		await tick();
+	}
+
 	async function withholdEndItem(): Promise<void> {
 		await withholdItem($virtualizer.getVirtualItems().at(-1)?.index ?? -1);
 	}
@@ -249,6 +306,7 @@
 	>
 		{#each $virtualizer.getVirtualItems() as virtualItem (virtualItem.key)}
 			{#if String(virtualItem.key) !== withheldKey}
+				<!-- Real browser geometry covers positionReadingAnchor; zero-valued test rects would invent corrections. -->
 				<div
 					data-index={virtualItem.index}
 					data-chat-virtual-item={String(virtualItem.key)}

--- a/web/src/lib/components/chat/conversation-feed-virtual-runtime.ts
+++ b/web/src/lib/components/chat/conversation-feed-virtual-runtime.ts
@@ -29,6 +29,54 @@ export interface ConversationVirtualAnchor {
 	fallbackKeys: readonly string[];
 }
 
+// Keeps prepend provenance with the keyed restore instead of the latest geometry snapshot. The clamped
+// latch lasts only for the bounded eight-iteration anchor restore, so coasting survives its offset writes.
+// Source-aware intent can later let a discrete track jump override the latch without weakening coasting.
+export class ConversationEarlierPrependAnchorOwnership {
+	#anchor: ConversationVirtualAnchor | null = null;
+	#clamped = false;
+
+	clear(): void {
+		this.#anchor = null;
+		this.#clamped = false;
+	}
+
+	carry(anchor: ConversationVirtualAnchor | null, isEarlierPublication: boolean): void {
+		if (!anchor) {
+			this.clear();
+			return;
+		}
+		if (isEarlierPublication) {
+			if (this.#anchor !== anchor) {
+				this.#clamped = false;
+			}
+			this.#anchor = anchor;
+		} else if (this.#anchor !== anchor) {
+			this.clear();
+		}
+	}
+
+	preserves(
+		direction: 'earlier' | 'later' | null,
+		anchor: ConversationVirtualAnchor | null,
+		scrollTop: number,
+	): boolean {
+		if (!anchor || this.#anchor !== anchor) return false;
+		// A directionless press is stateless; its movement is classified before scrolling.
+		if (direction === null) return true;
+		if (direction !== 'earlier') return false;
+		if (!this.#clamped && scrollTop > CHAT_GEOMETRY_END_THRESHOLD_PX) {
+			return false;
+		}
+		this.#clamped = true;
+		return true;
+	}
+
+	complete(anchor: ConversationVirtualAnchor): void {
+		if (this.#anchor === anchor) this.clear();
+	}
+}
+
 // TanStack includes scrollMargin in item.start while the rendered row transform removes it.
 export function conversationAnchorViewportOffset(
 	itemStart: number,
@@ -44,6 +92,48 @@ export function conversationAnchorScrollOffset(
 	viewportOffset: number,
 ): number {
 	return itemStart - scrollMargin - viewportOffset;
+}
+
+export function positionCommittedConversationAnchor(input: {
+	element: HTMLElement;
+	viewport: HTMLElement;
+	viewportOffset: number;
+	scrollToOffset(offset: number): void;
+}): void {
+	const elementOffset =
+		input.element.getBoundingClientRect().top - input.viewport.getBoundingClientRect().top;
+	const correction = elementOffset - input.viewportOffset;
+	if (Math.abs(correction) <= GEOMETRY_TOLERANCE_PX) return;
+	input.scrollToOffset(Math.max(0, input.viewport.scrollTop + correction));
+}
+
+export function positionPendingConversationAnchor(input: {
+	anchor: ConversationVirtualAnchor | null;
+	element: HTMLElement;
+	virtualItem: { key: unknown; index: number };
+	indexByKey: ReadonlyMap<string, number>;
+	viewport: HTMLElement | null;
+	scrollToOffset(offset: number): void;
+}): void {
+	if (!input.anchor || !input.viewport) return;
+	const key = [input.anchor.key, ...input.anchor.fallbackKeys].find((candidate) =>
+		input.indexByKey.has(candidate),
+	);
+	if (
+		!input.element.isConnected ||
+		key !== String(input.virtualItem.key) ||
+		input.indexByKey.get(key) !== input.virtualItem.index ||
+		input.element.dataset.chatVirtualItem !== key ||
+		Number(input.element.dataset.index) !== input.virtualItem.index
+	) {
+		return;
+	}
+	positionCommittedConversationAnchor({
+		element: input.element,
+		viewport: input.viewport,
+		viewportOffset: key === input.anchor.key ? input.anchor.viewportOffset : 0,
+		scrollToOffset: input.scrollToOffset,
+	});
 }
 
 export class ConversationPreCommitAnchorBuffer {
@@ -379,6 +469,29 @@ export async function settleConversationScroll(input: {
 			return;
 		}
 		previousOffset = offset;
+	}
+}
+
+export async function performConversationOwnedScroll(input: {
+	begin(): number;
+	finish(epoch: number): void;
+	isCurrent(epoch: number): boolean;
+	isValid(): boolean;
+	readOffset(): number | null;
+	write(): void;
+}): Promise<boolean> {
+	if (!input.isValid()) return false;
+	const epoch = input.begin();
+	try {
+		if (!input.isValid() || !input.isCurrent(epoch)) return false;
+		input.write();
+		await settleConversationScroll({
+			isCurrent: () => input.isValid() && input.isCurrent(epoch),
+			readOffset: input.readOffset,
+		});
+		return true;
+	} finally {
+		input.finish(epoch);
 	}
 }
 


### PR DESCRIPTION
Removes the normal manual history boundary and keeps automatic earlier-history paging responsive during sustained upward scrolling while preserving the reader's exact keyed viewport position across asynchronous prepends. Scroll intent and restore ownership are now explicit across wheel, touch, keyboard, and custom-scrollbar input so real navigation cancels correctly without adding content-based message deduplication.