### PR TITLE
Show chat history loading without shifting the feed

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -1484,6 +1484,10 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
     await withDiagnosticTimeout('the first held earlier-page request', firstPageRequest);
     expect(loadAheadDistance).toBeGreaterThan(0);
     expect(await transcriptBoundaryIntersectsViewport(fixture.page, 'earlier')).toBe(false);
+    const earlierLoadingIndicator = fixture.page.locator(
+      '[data-chat-earlier-loading-indicator]',
+    );
+    await earlierLoadingIndicator.waitFor({ state: 'visible' });
 
     expect(
       await fixture.page.locator('[data-transcript-page-boundary="earlier"]').count(),
@@ -1576,6 +1580,7 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
       fixture.page,
       modelCountBeforePrefetch + 50,
     );
+    await earlierLoadingIndicator.waitFor({ state: 'detached' });
     const prependFrames = await finishReadingAnchorFrameSampler(fixture.page);
     expect(
       Math.max(

--- a/integration-tests/tests/e2e/transcript-scrolling.test.ts
+++ b/integration-tests/tests/e2e/transcript-scrolling.test.ts
@@ -199,6 +199,7 @@ describe("Lightpanda transcript scrolling", () => {
         { selector: FEED_SELECTOR },
       );
       expect((await virtualTranscriptSnapshot(fixture.page)).busy).toBe(true);
+      await app.waitForText("Loading earlier messages...");
       expect(await app.hasButton("Load earlier messages")).toBe(false);
       await releasePageRequest(fixture.page);
       await waitForModelCount(fixture.page, initial.modelCount + 50);

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -174,6 +174,12 @@
 			isPreparingInitialScroll && 'invisible',
 		),
 	);
+	const showEarlierLoadingStatus = $derived(
+		!isPreparingInitialScroll &&
+			chatState.displayMessageCount > 0 &&
+			chatState.pageStates.earlier.status === 'loading' &&
+			chatState.pageStates.earlier.error === null,
+	);
 	const activePendingPermissionRequests = $derived.by(() =>
 		pendingPermissionRequests.filter(
 			(request) => !request.chatId || request.chatId === chatState.activeChatId,
@@ -410,6 +416,20 @@
 				<Loader2 class="h-4 w-4 animate-spin" />
 				<span>{m.chat_chat_loading_chat_messages()}</span>
 			</div>
+		</div>
+	{:else if showEarlierLoadingStatus}
+		<!-- Keeps automatic loading outside TanStack geometry so prepends cannot move the reading anchor. -->
+		<div
+			class={cn(
+				'pointer-events-none absolute inset-x-0 z-10 flex h-8 items-center justify-center gap-1.5 border-b border-border bg-background text-xs text-muted-foreground',
+				reserveTopFloatingToolbar ? 'top-[var(--workspace-floating-taskbar-inset)]' : 'top-0',
+			)}
+			role="status"
+			aria-live="polite"
+			data-chat-earlier-loading-indicator
+		>
+			<Loader2 class="size-3.5 animate-spin" aria-hidden="true" />
+			<span>{m.chat_transcript_loading_earlier()}</span>
 		</div>
 	{/if}
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex -- scroll container needs programmatic focus for Ctrl+U/D; follow-up: CLEANUP_ROUND_TWO.md#a11y-suppression-register -->

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -255,6 +255,25 @@ describe('ConversationFeed', () => {
 		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBeNull();
 	});
 
+	it('shows automatic earlier loading outside virtual geometry', () => {
+		const { container } = render(ConversationFeedTestHost, {
+			reserveTopFloatingToolbar: true,
+			transcriptScenario: 'loading-earlier',
+		});
+		const viewport = screen.getByRole('region', { name: 'Chat messages' });
+		const indicator = container.querySelector<HTMLElement>('[data-chat-earlier-loading-indicator]');
+
+		expect(indicator?.textContent).toContain('Loading earlier messages...');
+		expect(indicator?.classList.contains('top-[var(--workspace-floating-taskbar-inset)]')).toBe(
+			true,
+		);
+		expect(indicator?.closest('[data-chat-virtual-sizer]')).toBeNull();
+		expect(viewport.contains(indicator)).toBe(false);
+		expect(viewport.getAttribute('aria-busy')).toBe('true');
+		expect(screen.queryByRole('button', { name: 'Load earlier messages' })).toBeNull();
+		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBeNull();
+	});
+
 	it('renders later loading below the transcript without a native bottom anchor', async () => {
 		const { container } = render(ConversationFeedTestHost, {
 			transcriptScenario: 'loading-later',
@@ -287,6 +306,7 @@ describe('ConversationFeed', () => {
 		const loading = await screen.findByRole('button', { name: 'Loading earlier messages...' });
 		expect(loading.getAttribute('aria-busy')).toBe('true');
 		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBe(boundary);
+		expect(container.querySelector('[data-chat-earlier-loading-indicator]')).toBeNull();
 	});
 
 	it('passes durable and pending row identities to mounted virtual rows', async () => {

--- a/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
@@ -27,6 +27,7 @@
 		transcriptScenario?:
 			| 'empty'
 			| 'local-truncation'
+			| 'loading-earlier'
 			| 'loading-later'
 			| 'error-earlier'
 			| 'row-ids'
@@ -87,6 +88,9 @@
 		});
 		if (initialTranscriptScenario === 'loading-later') {
 			chatState.pageStates.later = { status: 'loading', error: null };
+		}
+		if (initialTranscriptScenario === 'loading-earlier') {
+			chatState.pageStates.earlier = { status: 'loading', error: null };
 		}
 		if (initialTranscriptScenario === 'error-earlier') {
 			chatState.pageStates.earlier = { status: 'error', error: 'Network unavailable' };


### PR DESCRIPTION
Fast upward scrolling can still reach the top while an earlier transcript page is in flight, leaving no visible explanation for the pause. This adds a compact loading status above the feed as an absolute overlay outside TanStack's measured viewport and virtual sizer, preserving scroll and anchor geometry while keeping automatic paging button-free and retaining the existing in-flow control only for explicit error retries.
