### PR TITLE
Use a circular chat history loader

### DIFF
--- a/integration-tests/tests/e2e/transcript-scrolling.test.ts
+++ b/integration-tests/tests/e2e/transcript-scrolling.test.ts
@@ -199,7 +199,7 @@ describe("Lightpanda transcript scrolling", () => {
         { selector: FEED_SELECTOR },
       );
       expect((await virtualTranscriptSnapshot(fixture.page)).busy).toBe(true);
-      await app.waitForText("Loading earlier messages...");
+      await fixture.page.waitForSelector('[data-chat-earlier-loading-indicator]');
       expect(await app.hasButton("Load earlier messages")).toBe(false);
       await releasePageRequest(fixture.page);
       await waitForModelCount(fixture.page, initial.modelCount + 50);

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -421,15 +421,17 @@
 		<!-- Keeps automatic loading outside TanStack geometry so prepends cannot move the reading anchor. -->
 		<div
 			class={cn(
-				'pointer-events-none absolute inset-x-0 z-10 flex h-8 items-center justify-center gap-1.5 border-b border-border bg-background text-xs text-muted-foreground',
-				reserveTopFloatingToolbar ? 'top-[var(--workspace-floating-taskbar-inset)]' : 'top-0',
+				'pointer-events-none absolute left-1/2 z-10 flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-none',
+				reserveTopFloatingToolbar
+					? 'top-[calc(var(--workspace-floating-taskbar-inset)+0.5rem)]'
+					: 'top-2',
 			)}
 			role="status"
 			aria-live="polite"
 			data-chat-earlier-loading-indicator
 		>
 			<Loader2 class="size-3.5 animate-spin" aria-hidden="true" />
-			<span>{m.chat_transcript_loading_earlier()}</span>
+			<span class="sr-only">{m.chat_transcript_loading_earlier()}</span>
 		</div>
 	{/if}
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex -- scroll container needs programmatic focus for Ctrl+U/D; follow-up: CLEANUP_ROUND_TWO.md#a11y-suppression-register -->

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -264,7 +264,18 @@ describe('ConversationFeed', () => {
 		const indicator = container.querySelector<HTMLElement>('[data-chat-earlier-loading-indicator]');
 
 		expect(indicator?.textContent).toContain('Loading earlier messages...');
-		expect(indicator?.classList.contains('top-[var(--workspace-floating-taskbar-inset)]')).toBe(
+		expect(
+			indicator?.classList.contains('top-[calc(var(--workspace-floating-taskbar-inset)+0.5rem)]'),
+		).toBe(true);
+		expect(indicator?.classList.contains('left-1/2')).toBe(true);
+		expect(indicator?.classList.contains('-translate-x-1/2')).toBe(true);
+		expect(indicator?.classList.contains('size-8')).toBe(true);
+		expect(indicator?.classList.contains('rounded-full')).toBe(true);
+		expect(indicator?.classList.contains('border')).toBe(true);
+		expect(indicator?.classList.contains('bg-background')).toBe(true);
+		expect(indicator?.classList.contains('shadow-none')).toBe(true);
+		expect(indicator?.classList.contains('inset-x-0')).toBe(false);
+		expect(screen.getByText('Loading earlier messages...').classList.contains('sr-only')).toBe(
 			true,
 		);
 		expect(indicator?.closest('[data-chat-virtual-sizer]')).toBeNull();


### PR DESCRIPTION
Refines automatic earlier-history loading to a compact, centered circular spinner with an opaque background, a 1px border, and no shadow, keeping progress visible without occupying the feed width or participating in TanStack's measured geometry.