### PR TITLE
Add /st alias for /steer

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1322,6 +1322,8 @@
 	"settings_slash_command_rename": "Rename the current chat",
 	"settings_slash_command_move": "Move the current chat to the top or bottom of its section in Manual order",
 	"settings_slash_command_tag": "Add or remove tags on the current chat",
+	"settings_slash_command_steer": "Send guidance to the active turn",
+	"settings_slash_command_steer_short": "Short alias for /steer",
 	"settings_slash_command_snippet": "Expand a saved snippet into the composer for review",
 	"settings_slash_command_snippet_short": "Short alias for /snippet",
 	"settings_providers_description": "Provider configuration for Claude Code, Codex, and Direct Chat.",

--- a/web/src/lib/chat/composer/__tests__/slash-commands.logic.test.ts
+++ b/web/src/lib/chat/composer/__tests__/slash-commands.logic.test.ts
@@ -64,6 +64,7 @@ describe('BUILTIN_SLASH_COMMANDS', () => {
 		const goal = BUILTIN_SLASH_COMMANDS.find((command) => command.name === 'goal');
 		const scheduleIn = BUILTIN_SLASH_COMMANDS.find((command) => command.name === 'in');
 		const steer = BUILTIN_SLASH_COMMANDS.find((command) => command.name === 'steer');
+		const steerShort = BUILTIN_SLASH_COMMANDS.find((command) => command.name === 'st');
 		const rename = BUILTIN_SLASH_COMMANDS.find((command) => command.name === 'rename');
 		const move = BUILTIN_SLASH_COMMANDS.filter((command) => command.name === 'move');
 		const tag = BUILTIN_SLASH_COMMANDS.filter((command) => command.name === 'tag');
@@ -80,6 +81,8 @@ describe('BUILTIN_SLASH_COMMANDS', () => {
 		expect(scheduleIn?.description).toBeTruthy();
 		expect(steer?.source).toBe('command');
 		expect(steer?.description).toBeTruthy();
+		expect(steerShort?.source).toBe('command');
+		expect(steerShort?.description).toBeTruthy();
 		expect(rename?.source).toBe('command');
 		expect(rename?.description).toBeTruthy();
 		expect(move).toHaveLength(1);
@@ -224,11 +227,17 @@ describe('parseSteerCommand', () => {
 			kind: 'valid',
 			prompt: 'Check the test\nthen continue',
 		});
+		expect(parseSteerCommand('/ST Check the test\nthen continue')).toEqual({
+			kind: 'valid',
+			prompt: 'Check the test\nthen continue',
+		});
 	});
 
 	it('requires guidance and ignores similar commands', () => {
 		expect(parseSteerCommand('/steer')).toEqual({ kind: 'invalid' });
+		expect(parseSteerCommand('/st')).toEqual({ kind: 'invalid' });
 		expect(parseSteerCommand('/steering continue')).toEqual({ kind: 'not-command' });
+		expect(parseSteerCommand('/status continue')).toEqual({ kind: 'not-command' });
 	});
 });
 

--- a/web/src/lib/chat/composer/slash-commands.ts
+++ b/web/src/lib/chat/composer/slash-commands.ts
@@ -54,6 +54,11 @@ export const BUILTIN_SLASH_COMMANDS: readonly SlashCommand[] = [
 		description: 'Send guidance to the active turn',
 	},
 	{
+		name: 'st',
+		source: 'command',
+		description: 'Short alias for /steer',
+	},
+	{
 		name: 's',
 		source: 'command',
 		description: 'Short alias for /snippet',
@@ -119,7 +124,7 @@ export type SteerCommandParseResult =
 	| { kind: 'invalid' }
 	| { kind: 'valid'; prompt: string };
 
-const STEER_COMMAND_RE = /^\s*\/steer(?=\s|$)(?:\s+([\s\S]*))?$/i;
+const STEER_COMMAND_RE = /^\s*\/(?:steer|st)(?=\s|$)(?:\s+([\s\S]*))?$/i;
 
 export function parseSteerCommand(input: string): SteerCommandParseResult {
 	const match = STEER_COMMAND_RE.exec(input);

--- a/web/src/lib/components/chat/SlashCommandMenu.svelte
+++ b/web/src/lib/components/chat/SlashCommandMenu.svelte
@@ -97,7 +97,7 @@
 		const builtins = BUILTIN_SLASH_COMMANDS.filter((command) => {
 			if (command.name === 'fork') return supportsFork;
 			if (command.name === 'in') return canScheduleIn;
-			if (command.name === 'steer') return supportsSteering;
+			if (command.name === 'steer' || command.name === 'st') return supportsSteering;
 			if (command.name === 'goal') return supportsGoals;
 			return true;
 		});

--- a/web/src/lib/components/chat/__tests__/SlashCommandMenu.test.ts
+++ b/web/src/lib/components/chat/__tests__/SlashCommandMenu.test.ts
@@ -184,7 +184,7 @@ describe('SlashCommandMenu', () => {
 		expect(screen.queryByText('/goal')).toBeNull();
 	});
 
-	it('lists the steer command from capability data', () => {
+	it('lists the steer commands from capability data', () => {
 		const { unmount } = render(SlashCommandMenuTestHost, {
 			...baseProps,
 			supportsSteering: true,
@@ -198,14 +198,27 @@ describe('SlashCommandMenu', () => {
 		expect(screen.getByText('Send guidance to the active turn')).toBeTruthy();
 		unmount();
 
+		const alias = render(SlashCommandMenuTestHost, {
+			...baseProps,
+			supportsSteering: true,
+			isVisible: true,
+			query: 'st',
+			onSelect: vi.fn(),
+			onClose: vi.fn(),
+		});
+		expect(screen.getByText('/st')).toBeTruthy();
+		expect(screen.getByText('Short alias for /steer')).toBeTruthy();
+		alias.unmount();
+
 		render(SlashCommandMenuTestHost, {
 			...baseProps,
 			isVisible: true,
-			query: 'steer',
+			query: 'st',
 			onSelect: vi.fn(),
 			onClose: vi.fn(),
 		});
 		expect(screen.queryByText('/steer')).toBeNull();
+		expect(screen.queryByText('/st')).toBeNull();
 	});
 
 	it('hides the fork command when not supported', () => {

--- a/web/src/lib/components/settings/__tests__/Settings.test.ts
+++ b/web/src/lib/components/settings/__tests__/Settings.test.ts
@@ -264,6 +264,8 @@ describe('Settings', () => {
 			expect(screen.getByText('/rename <title>')).toBeTruthy();
 			expect(screen.getByText('/move <top|bottom>')).toBeTruthy();
 			expect(screen.getByText('/tag <add|rm> <tag> [tag...]')).toBeTruthy();
+			expect(screen.getByText('/steer <prompt>')).toBeTruthy();
+			expect(screen.getByText('/st <prompt>')).toBeTruthy();
 			expect(screen.getByText('/snippet <short-name> [arguments]')).toBeTruthy();
 			expect(screen.getByText('/s <short-name> [arguments]')).toBeTruthy();
 		} finally {

--- a/web/src/lib/components/settings/__tests__/keyboard-shortcut-entries.logic.test.ts
+++ b/web/src/lib/components/settings/__tests__/keyboard-shortcut-entries.logic.test.ts
@@ -50,6 +50,15 @@ describe('keyboard shortcut entries', () => {
 		);
 	});
 
+	it('documents both steer command spellings', () => {
+		expect(SLASH_COMMANDS).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ command: '/steer <prompt>' }),
+				expect.objectContaining({ command: '/st <prompt>' }),
+			]),
+		);
+	});
+
 	it('documents both snippet command spellings', () => {
 		expect(SLASH_COMMANDS).toEqual(
 			expect.arrayContaining([

--- a/web/src/lib/components/settings/keyboard-shortcut-entries.ts
+++ b/web/src/lib/components/settings/keyboard-shortcut-entries.ts
@@ -40,6 +40,8 @@ export const SLASH_COMMANDS: readonly SlashCommandEntry[] = [
 	{ command: '/rename <title>', description: m.settings_slash_command_rename },
 	{ command: '/move <top|bottom>', description: m.settings_slash_command_move },
 	{ command: '/tag <add|rm> <tag> [tag...]', description: m.settings_slash_command_tag },
+	{ command: '/steer <prompt>', description: m.settings_slash_command_steer },
+	{ command: '/st <prompt>', description: m.settings_slash_command_steer_short },
 	{
 		command: '/snippet <short-name> [arguments]',
 		description: m.settings_slash_command_snippet,


### PR DESCRIPTION
Adds `/st` as a short alias for `/steer` so steering can be invoked more quickly, while preserving agent capability gating and documenting both spellings in the Settings command legend.