### PR TITLE
Support symlinked CLI workspaces

### DIFF
--- a/cli/__tests__/discovery.test.ts
+++ b/cli/__tests__/discovery.test.ts
@@ -177,6 +177,40 @@ describe('discoverRuntime', () => {
     })).rejects.toThrow('upgrade Garcon and garcon-cli together');
   });
 
+  test('follows a named workspace symlink to a sibling workspace directory', async () => {
+    if (process.platform === 'win32') return;
+    const testFixture = await fixture();
+    const targetWorkspaceDir = `${testFixture.workspaceDir}-target`;
+    await fs.rename(testFixture.workspaceDir, targetWorkspaceDir);
+    await fs.symlink(path.basename(targetWorkspaceDir), testFixture.workspaceDir, 'dir');
+    const descriptor = {
+      ...testFixture.descriptor,
+      workspaceDir: targetWorkspaceDir,
+    };
+    await fs.writeFile(
+      path.join(targetWorkspaceDir, SERVER_RUNTIME_FILENAME),
+      JSON.stringify(descriptor),
+      { mode: 0o600 },
+    );
+
+    const connection = await discoverRuntime({
+      configDir: testFixture.configDir,
+      workspace: 'review',
+    }, {
+      fetch: async (input) => Response.json({
+        schemaVersion: SERVER_RUNTIME_SCHEMA_VERSION,
+        instanceId: descriptor.instanceId,
+        proof: runtimeProof(
+          String(descriptor.localCapability),
+          String(descriptor.instanceId),
+          input,
+        ),
+      }),
+    });
+
+    expect(connection.workspaceDir).toBe(targetWorkspaceDir);
+  });
+
   test('rejects a workspace symlink that escapes the config directory', async () => {
     if (process.platform === 'win32') return;
     const configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-cli-config-'));

--- a/cli/discovery.ts
+++ b/cli/discovery.ts
@@ -72,8 +72,8 @@ async function canonicalWorkspace(configDir: string, workspace: string): Promise
       throw new Error('workspace is not a direct child of the config directory');
     }
     const canonicalWorkspaceDir = await fsPromises.realpath(namedWorkspace);
-    if (canonicalWorkspaceDir !== namedWorkspace || path.dirname(canonicalWorkspaceDir) !== canonicalConfigDir) {
-      throw new Error('workspace directory must be a direct, non-symlink child of the config directory');
+    if (path.dirname(canonicalWorkspaceDir) !== canonicalConfigDir) {
+      throw new Error('workspace directory must resolve to a direct child of the config directory');
     }
     return canonicalWorkspaceDir;
   } catch (error) {

--- a/integration-tests/tests/server/garcon-cli.test.ts
+++ b/integration-tests/tests/server/garcon-cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { PendingUserInputUpdatedMessage } from '../../../common/ws-events.js';
 import { userContents } from '../../support/chat-assertions.js';
@@ -120,6 +121,29 @@ function controlArguments(fixture: IntegrationFixture, command: string[]): strin
 }
 
 describe('garcon-cli', () => {
+  test('discovers a running named workspace through a sibling symlink', async () => {
+    await withIntegrationFixture('garcon-cli-workspace-symlink', async (fixture) => {
+      const listedAgents = await runCli([
+        '--config-dir', fixture.dirs.config,
+        '--workspace', WORKSPACE,
+        'list', 'agents', '--json',
+      ]);
+
+      expect(listedAgents.exitCode).toBe(0);
+      expect(listedAgents.stderr).toBe('');
+      expect(JSON.parse(listedAgents.stdout).agents).toContainEqual(
+        expect.objectContaining({ id: fixture.directAgents.openAi.agentId }),
+      );
+    }, {
+      namedWorkspace: WORKSPACE,
+      prepareWorkspace: async (dirs) => {
+        const targetWorkspace = `${dirs.workspace}-target`;
+        await fs.rename(dirs.workspace, targetWorkspace);
+        await fs.symlink(path.basename(targetWorkspace), dirs.workspace, 'dir');
+      },
+    });
+  });
+
   test('starts and resumes a visible tagged chat through a named workspace', async () => {
     await withIntegrationFixture('garcon-cli-start-resume', async (fixture) => {
       const agent = fixture.directAgents.openAi;


### PR DESCRIPTION
Garcon servers already canonicalize named workspace symlinks, but garcon-cli rejected them during discovery. This change allows named workspace links that resolve to another direct child of the config directory, continues rejecting links that escape the config root, and adds unit and black-box coverage for a running symlinked workspace.
