### PR TITLE
Remember Git comparison ranges per chat

### DIFF
--- a/integration-tests/tests/e2e/git-comparison.test.ts
+++ b/integration-tests/tests/e2e/git-comparison.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { Page } from 'puppeteer-core';
 import { withE2eFixture } from '../../support/e2e-fixture.js';
 import { SpaDriver } from '../../support/spa-driver.js';
+
+const COMPARE_PANEL = '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+  + '[aria-hidden="false"]';
 
 async function runGit(projectPath: string, args: string[]): Promise<void> {
   const process = Bun.spawn(['git', ...args], {
@@ -18,7 +22,118 @@ async function runGit(projectPath: string, args: string[]): Promise<void> {
   if (exitCode !== 0) throw new Error(`git ${args[0]} failed: ${stderr.trim()}`);
 }
 
+async function waitForComparisonMarkers(
+  page: Page,
+  present: string[],
+  absent: string[],
+): Promise<void> {
+  await page.waitForFunction(
+    ({ panelSelector, expected, excluded }) => {
+      const panel = document.querySelector(panelSelector);
+      const text = panel?.textContent ?? '';
+      return panel?.querySelector('[data-git-diff-document]') !== null
+        && !text.includes('Loading comparison')
+        && expected.every((marker) => text.includes(marker))
+        && excluded.every((marker) => !text.includes(marker));
+    },
+    { timeout: 20_000 },
+    { panelSelector: COMPARE_PANEL, expected: present, excluded: absent },
+  );
+}
+
 describe('Lightpanda Git comparison', () => {
+  test('restores each chat comparison range and resets it for a new client', async () => {
+    await withE2eFixture('git-comparison-session-memory', async (fixture) => {
+      const project = fixture.integration.dirs.project;
+      await runGit(project, ['init', '-b', 'main']);
+      await runGit(project, ['config', 'user.email', 'test@example.com']);
+      await runGit(project, ['config', 'user.name', 'E2E Test']);
+      await writeFile(join(project, 'base.txt'), 'base marker\n', 'utf8');
+      await runGit(project, ['add', '.']);
+      await runGit(project, ['commit', '-m', 'base']);
+      await runGit(project, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+      await writeFile(join(project, 'head-only.txt'), 'head comparison marker\n', 'utf8');
+      await runGit(project, ['add', '.']);
+      await runGit(project, ['commit', '-m', 'head change']);
+      await writeFile(join(project, 'worktree-only.txt'), 'working tree marker\n', 'utf8');
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.setViewport(1_440, 900);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat('git-comparison-chat-a', { projectPath: project });
+      await app.waitForText('echo:git-comparison-chat-a');
+      await app.startOpenAiDirectChat('git-comparison-chat-b', { projectPath: project });
+      await app.waitForText('echo:git-comparison-chat-b');
+
+      const chats = (await fixture.integration.client.listChats()).sessions;
+      const chatA = chats.find((chat) => chat.preview.firstMessage === 'git-comparison-chat-a');
+      const chatB = chats.find((chat) => chat.preview.firstMessage === 'git-comparison-chat-b');
+      if (!chatA || !chatB) throw new Error('Both comparison chats must be listed.');
+
+      await app.clickSidebarChatContaining('git-comparison-chat-a');
+      await app.waitForSelectedChat(chatA.id);
+      await app.selectMainWorkspaceSurface('Open Git Compare');
+      await fixture.page.waitForSelector(COMPARE_PANEL);
+      await waitForComparisonMarkers(fixture.page, ['working tree marker'], [
+        'head comparison marker',
+      ]);
+      await app.clickResponsiveAction('Edit');
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      await app.fill('#git-comparison-from', 'origin/main');
+      await app.clickDialogButton('Revision');
+      await app.fill('#git-comparison-to', 'HEAD');
+      await app.clickDialogButton('Compare');
+      await waitForComparisonMarkers(fixture.page, ['head comparison marker'], [
+        'working tree marker',
+      ]);
+
+      await app.clickSidebarChatContaining('git-comparison-chat-b');
+      await app.waitForSelectedChat(chatB.id);
+      await app.selectMainWorkspaceSurface('Compare');
+      await waitForComparisonMarkers(fixture.page, ['working tree marker'], [
+        'head comparison marker',
+      ]);
+
+      await app.clickSidebarChatContaining('git-comparison-chat-a');
+      await app.waitForSelectedChat(chatA.id);
+      await app.selectMainWorkspaceSurface('Compare');
+      await waitForComparisonMarkers(fixture.page, ['head comparison marker'], [
+        'working tree marker',
+      ]);
+      await app.clickResponsiveAction('Edit');
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      expect(await fixture.page.$eval(
+        '#git-comparison-from',
+        (element) => (element as HTMLInputElement).value,
+      )).toBe('origin/main');
+      expect(await fixture.page.$eval(
+        '#git-comparison-to',
+        (element) => (element as HTMLInputElement).value,
+      )).toBe('HEAD');
+      expect(await fixture.page.$eval(
+        '[role="dialog"] button[aria-pressed="true"]',
+        (element) => element.textContent?.trim(),
+      )).toBe('Revision');
+      await app.clickDialogButton('Cancel');
+
+      await fixture.page.waitForFunction(
+        () => localStorage.getItem('workspace_layout_v1')?.includes('git-compare') === true,
+        { timeout: 20_000 },
+      );
+      const beforeReloadConnections = await fixture.spaWebSocketConnectionCount();
+      await fixture.page.reload({ waitUntil: [] });
+      await fixture.waitForSpaWebSocket({ afterConnectionCount: beforeReloadConnections });
+      await app.waitForSelectedChat(chatA.id);
+      await fixture.page.waitForSelector('[id="main-panel-singleton:git-compare"]');
+      await app.selectMainWorkspaceSurface('Compare');
+      await waitForComparisonMarkers(fixture.page, ['working tree marker'], [
+        'head comparison marker',
+      ]);
+      fixture.assertNoBrowserErrors();
+    });
+  });
+
   test('keeps a large comparison virtualized and appends a line comment without sending', async () => {
     await withE2eFixture('git-comparison-comment', async (fixture) => {
       const project = fixture.integration.dirs.project;

--- a/integration-tests/tests/e2e/git-view-surfaces.test.ts
+++ b/integration-tests/tests/e2e/git-view-surfaces.test.ts
@@ -476,6 +476,76 @@ describe('Lightpanda standalone Git views', () => {
       expect(await app.hasButton('Close view')).toBe(true);
       expect(await app.hasButton('Back')).toBe(false);
 
+      await fixture.page.waitForFunction(
+        () => {
+          const panel = document.querySelector(
+            '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+              + '[aria-hidden="false"]',
+          );
+          return panel?.textContent?.includes('working tree revision') === true
+            && !panel.textContent.includes('Loading comparison');
+        },
+        { timeout: 20_000 },
+      );
+      await app.clickResponsiveAction('Edit');
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      await app.fill('#git-comparison-from', 'HEAD~1');
+      await app.clickDialogButton('Revision');
+      await app.fill('#git-comparison-to', 'HEAD');
+      await app.clickDialogButton('Compare');
+      await fixture.page.waitForFunction(
+        () => {
+          const panel = document.querySelector(
+            '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+              + '[aria-hidden="false"]',
+          );
+          return panel?.textContent?.includes('second revision') === true
+            && !panel.textContent.includes('working tree revision')
+            && !panel.textContent.includes('Loading comparison');
+        },
+        { timeout: 20_000 },
+      );
+
+      await app.clickButton('Close view');
+      await fixture.page.waitForSelector(
+        '[role="tabpanel"][data-workspace-surface-id="singleton:chat"]'
+          + '[aria-hidden="false"]',
+      );
+      expect(await fixture.page.$(
+        '[data-workspace-surface-id="singleton:git-compare"]',
+      )).toBeNull();
+
+      await app.clickButton('Settings');
+      await app.waitForMenuItemEnabled('Open Git Compare');
+      await app.clickMenuItem('Open Git Compare');
+      await fixture.page.waitForSelector(
+        '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+          + '[aria-hidden="false"]',
+      );
+      await fixture.page.waitForFunction(
+        () => {
+          const panel = document.querySelector(
+            '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+              + '[aria-hidden="false"]',
+          );
+          return panel?.textContent?.includes('second revision') === true
+            && !panel.textContent.includes('working tree revision')
+            && !panel.textContent.includes('Loading comparison');
+        },
+        { timeout: 20_000 },
+      );
+      await app.clickResponsiveAction('Edit');
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      expect(await fixture.page.$eval(
+        '#git-comparison-from',
+        (element) => (element as HTMLInputElement).value,
+      )).toBe('HEAD~1');
+      expect(await fixture.page.$eval(
+        '#git-comparison-to',
+        (element) => (element as HTMLInputElement).value,
+      )).toBe('HEAD');
+      await app.clickDialogButton('Cancel');
+
       await app.setViewport(1_440, 900);
       await fixture.page.waitForSelector('[data-floating-workspace-toolbar]');
       await fixture.page.waitForFunction(

--- a/web/src/lib/components/git/GitComparePanel.svelte
+++ b/web/src/lib/components/git/GitComparePanel.svelte
@@ -120,10 +120,8 @@
 			onSearchRefs={(query) => {
 				if (projectPath) return controller.target.branches.fetchRefs(projectPath, query);
 			}}
-			onCompare={() => {
-				if (projectPath) void comparison.compare(projectPath);
-			}}
-			onClose={() => comparison.closeDialog()}
+			onCompare={() => void controller.compareCurrentSpecification()}
+			onClose={() => controller.closeComparisonDialog()}
 		/>
 	{/if}
 </div>

--- a/web/src/lib/git/__tests__/git-surface-test-deps.ts
+++ b/web/src/lib/git/__tests__/git-surface-test-deps.ts
@@ -2,9 +2,14 @@ import { GitBranchSelectorState } from '$lib/git/targets/git-branch-selector-sta
 import { GitMutationCoordinator } from '$lib/git/surface/git-mutations.svelte.js';
 import { GitProjectInvalidationStore } from '$lib/git/surface/git-project-invalidation.svelte.js';
 import { GitReviewDisplaySettingsStore } from '$lib/git/review/git-review-display-settings.svelte.js';
+import { GitComparisonSessionStore } from '$lib/git/review/git-comparison-session-store.js';
 import type { GitSurfaceControllerDeps } from '$lib/git/surface/git-surface-controller-deps.js';
 
-export function createGitSurfaceTestDeps(): GitSurfaceControllerDeps {
+export interface GitSurfaceTestDeps extends GitSurfaceControllerDeps {
+	comparisonSessions: GitComparisonSessionStore;
+}
+
+export function createGitSurfaceTestDeps(): GitSurfaceTestDeps {
 	const invalidations = new GitProjectInvalidationStore();
 	return {
 		createGitBranchSelector: () => new GitBranchSelectorState(),
@@ -13,5 +18,6 @@ export function createGitSurfaceTestDeps(): GitSurfaceControllerDeps {
 		}),
 		invalidationVersion: (effectiveProjectKey) => invalidations.version(effectiveProjectKey),
 		reviewDisplay: new GitReviewDisplaySettingsStore(),
+		comparisonSessions: new GitComparisonSessionStore(),
 	};
 }

--- a/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
+++ b/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitCompareSurfaceController } from '$lib/git/review/git-compare-surface.svelte.js';
 import { createGitSurfaceTestDeps } from '$lib/git/__tests__/git-surface-test-deps.js';
 import type { GitTargetCandidate } from '$lib/api/git.js';
+import type { GitComparisonSpecification } from '$lib/git/review/git-comparison.svelte.js';
+import type { GitComparisonSessionIdentity } from '$lib/git/review/git-comparison-session-store.js';
+import { gitTargetIdentity } from '$lib/git/targets/git-target.js';
 
 vi.mock('$lib/api/git.js', () => ({
 	getGitTargetCandidates: vi.fn(),
@@ -37,16 +40,46 @@ function candidate(
 	};
 }
 
-function setProject(controller: GitCompareSurfaceController): void {
+function setProject(
+	controller: GitCompareSurfaceController,
+	chatId = 'chat',
+	projectPath = '/project',
+	effectiveProjectKey = '/canonical/project',
+): void {
 	controller.setProjectState({
 		kind: 'available',
 		project: {
-			chatId: 'chat',
-			projectPath: '/project',
-			effectiveProjectKey: 'chat',
+			chatId,
+			projectPath,
+			effectiveProjectKey,
 		},
 	});
 }
+
+function comparisonIdentity(
+	chatId: string,
+	target = candidate(),
+	effectiveProjectKey = '/canonical/project',
+): GitComparisonSessionIdentity {
+	return {
+		chatId,
+		targetIdentity: gitTargetIdentity(effectiveProjectKey, target),
+	};
+}
+
+const revisionComparison: GitComparisonSpecification = {
+	fromRevision: 'origin/main',
+	toKind: 'revision',
+	toRevision: 'HEAD',
+	mode: 'direct',
+};
+
+const mergeBaseComparison: GitComparisonSpecification = {
+	fromRevision: 'origin/main',
+	toKind: 'revision',
+	toRevision: 'feature',
+	mode: 'merge-base',
+};
 
 describe('GitCompareSurfaceController', () => {
 	beforeEach(() => {
@@ -70,6 +103,457 @@ describe('GitCompareSurfaceController', () => {
 		expect(controller.comparison.toKind).toBe('working-tree');
 		expect(controller.comparison.mode).toBe('direct');
 		expect(controller.comparison.dialogOpen).toBe(false);
+	});
+
+	it('does not load without a selected chat', async () => {
+		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+
+		expect(compare).not.toHaveBeenCalled();
+	});
+
+	it('restores independent ranges for chats sharing the same target', async () => {
+		const deps = createGitSurfaceTestDeps();
+		const workingTreeComparison: GitComparisonSpecification = {
+			fromRevision: 'release',
+			toKind: 'working-tree',
+			mode: 'direct',
+		};
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		deps.comparisonSessions.remember(comparisonIdentity('chat-b'), workingTreeComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(1));
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toKind).toBe('revision');
+		expect(controller.comparison.toRevision).toBe('HEAD');
+
+		setProject(controller, 'chat-b');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		expect(controller.comparison.fromRevision).toBe('release');
+		expect(controller.comparison.toKind).toBe('working-tree');
+
+		setProject(controller, 'chat-a');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(3));
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toKind).toBe('revision');
+		expect(controller.comparison.toRevision).toBe('HEAD');
+	});
+
+	it('restores merge-base mode with revision endpoints', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), mergeBaseComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toKind).toBe('revision');
+		expect(controller.comparison.toRevision).toBe('feature');
+		expect(controller.comparison.mode).toBe('merge-base');
+	});
+
+	it('keeps comparison ranges independent across selected targets', async () => {
+		const projectTarget = candidate();
+		const otherTarget = candidate('/other', {
+			repoRoot: '/other-repo',
+			worktreePath: '/other',
+			label: 'other',
+			branch: 'feature',
+			isCurrent: false,
+		});
+		api.getGitTargetCandidates.mockResolvedValue({ targets: [projectTarget, otherTarget] });
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(
+			comparisonIdentity('chat-a', projectTarget),
+			revisionComparison,
+		);
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a', otherTarget), {
+			fromRevision: 'feature',
+			toKind: 'working-tree',
+			mode: 'direct',
+		});
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(1));
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+
+		await controller.target.selectTarget(otherTarget);
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		expect(controller.comparison.fromRevision).toBe('feature');
+		expect(controller.comparison.toKind).toBe('working-tree');
+
+		await controller.target.selectTarget(projectTarget);
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(3));
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toRevision).toBe('HEAD');
+	});
+
+	it('remembers confirmed state under the previous target before switching', async () => {
+		const projectTarget = candidate();
+		const otherTarget = candidate('/other', {
+			repoRoot: '/other-repo',
+			worktreePath: '/other',
+			label: 'other',
+			branch: 'feature',
+			isCurrent: false,
+		});
+		api.getGitTargetCandidates.mockResolvedValue({ targets: [projectTarget, otherTarget] });
+		const deps = createGitSurfaceTestDeps();
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi
+			.spyOn(controller.comparison, 'compare')
+			.mockResolvedValueOnce(true)
+			.mockResolvedValueOnce(false);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockReturnValue(
+			revisionComparison,
+		);
+
+		await controller.target.selectTarget(otherTarget);
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a', projectTarget))).toEqual(
+			revisionComparison,
+		);
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a', otherTarget))).toBeNull();
+	});
+
+	it('remembers only a successful user comparison for the active session', async () => {
+		const deps = createGitSurfaceTestDeps();
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockReturnValue(
+			revisionComparison,
+		);
+		controller.comparison.setSpecification(revisionComparison);
+
+		expect(await controller.compareCurrentSpecification()).toBe(true);
+
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+	});
+
+	it('does not replace remembered success after a failed user comparison', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		const failedSpecification: GitComparisonSpecification = {
+			fromRevision: 'missing',
+			toKind: 'working-tree',
+			mode: 'direct',
+		};
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockReturnValue(
+			failedSpecification,
+		);
+		controller.comparison.setSpecification(failedSpecification);
+		compare.mockResolvedValueOnce(false);
+
+		expect(await controller.compareCurrentSpecification()).toBe(false);
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+	});
+
+	it('does not remember unsubmitted dialog fields', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		controller.comparison.openDialog({
+			fromRevision: 'unfinished',
+			toKind: 'working-tree',
+		});
+		setProject(controller, 'chat-b');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+	});
+
+	it('restores a remembered range after controller disposal and recreation', async () => {
+		const deps = createGitSurfaceTestDeps();
+		const first = new GitCompareSurfaceController(deps);
+		const firstCompare = vi.spyOn(first.comparison, 'compare').mockResolvedValue(true);
+		setProject(first, 'chat-a');
+		first.setPresentationVisible(true);
+		await first.target.activate();
+		await vi.waitFor(() => expect(firstCompare).toHaveBeenCalledOnce());
+		vi.spyOn(first.comparison, 'confirmedSpecification', 'get').mockReturnValue(revisionComparison);
+
+		first.dispose();
+
+		const second = new GitCompareSurfaceController(deps);
+		const secondCompare = vi.spyOn(second.comparison, 'compare').mockResolvedValue(true);
+		setProject(second, 'chat-a');
+		second.setPresentationVisible(true);
+		await second.target.activate();
+		await vi.waitFor(() => expect(secondCompare).toHaveBeenCalledOnce());
+		expect(second.comparison.fromRevision).toBe('origin/main');
+		expect(second.comparison.toKind).toBe('revision');
+		expect(second.comparison.toRevision).toBe('HEAD');
+	});
+
+	it('does not share remembered ranges across client stores', async () => {
+		const firstClient = createGitSurfaceTestDeps();
+		firstClient.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const secondClient = createGitSurfaceTestDeps();
+		const controller = new GitCompareSurfaceController(secondClient);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		expect(controller.comparison.fromRevision).toBe('HEAD');
+		expect(controller.comparison.toKind).toBe('working-tree');
+	});
+
+	it('defers restoration while the project identity is resolving', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		controller.setProjectState({
+			kind: 'resolving',
+			context: {
+				chatId: 'chat-a',
+				projectPath: '/project',
+				effectiveProjectKey: null,
+			},
+		});
+
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		expect(compare).not.toHaveBeenCalled();
+
+		setProject(controller, 'chat-a');
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toRevision).toBe('HEAD');
+	});
+
+	it('does not load a restored chat while Compare is hidden', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-b'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		controller.setPresentationVisible(false);
+		setProject(controller, 'chat-b');
+		await controller.target.activate();
+		expect(compare).toHaveBeenCalledOnce();
+
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toKind).toBe('revision');
+	});
+
+	it('retries a failed automatic restore without deleting remembered intent', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi
+			.spyOn(controller.comparison, 'compare')
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+
+		controller.setPresentationVisible(false);
+		controller.setPresentationVisible(true);
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toRevision).toBe('HEAD');
+	});
+
+	it('does not retry a failed restore or discard a repair on project-state republish', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(false);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		controller.comparison.openDialog({
+			fromRevision: 'origin/repaired',
+			toKind: 'working-tree',
+		});
+
+		setProject(controller, 'chat-a');
+		await controller.target.activate();
+		await Promise.resolve();
+
+		expect(compare).toHaveBeenCalledOnce();
+		expect(controller.comparison.dialogOpen).toBe(true);
+		expect(controller.comparison.fromRevision).toBe('origin/repaired');
+	});
+
+	it('keeps a cancelled repair without a snapshot retryable', async () => {
+		const cancelled = deferred<boolean>();
+		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
+		const compare = vi
+			.spyOn(controller.comparison, 'compare')
+			.mockResolvedValueOnce(false)
+			.mockReturnValueOnce(cancelled.promise)
+			.mockResolvedValueOnce(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		controller.comparison.editComparison();
+		const submission = controller.compareCurrentSpecification();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		controller.closeComparisonDialog();
+		cancelled.resolve(false);
+		expect(await submission).toBe(false);
+
+		controller.setPresentationVisible(false);
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(3));
+	});
+
+	it('ignores a late comparison result after switching chats', async () => {
+		const deps = createGitSurfaceTestDeps();
+		const chatBComparison: GitComparisonSpecification = {
+			fromRevision: 'release',
+			toKind: 'working-tree',
+			mode: 'direct',
+		};
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		deps.comparisonSessions.remember(comparisonIdentity('chat-b'), chatBComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const first = deferred<boolean>();
+		const second = deferred<boolean>();
+		const compare = vi
+			.spyOn(controller.comparison, 'compare')
+			.mockReturnValueOnce(first.promise)
+			.mockReturnValueOnce(second.promise);
+		let confirmed: GitComparisonSpecification | null = null;
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockImplementation(
+			() => confirmed,
+		);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		setProject(controller, 'chat-b');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		confirmed = chatBComparison;
+		first.resolve(true);
+		await first.promise;
+		await Promise.resolve();
+
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+		second.resolve(true);
+		await second.promise;
+	});
+
+	it('ignores an old A continuation after switching A to B to A', async () => {
+		const deps = createGitSurfaceTestDeps();
+		const chatBComparison: GitComparisonSpecification = {
+			fromRevision: 'release',
+			toKind: 'working-tree',
+			mode: 'direct',
+		};
+		const staleSpecification: GitComparisonSpecification = {
+			fromRevision: 'stale-result',
+			toKind: 'working-tree',
+			mode: 'direct',
+		};
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		deps.comparisonSessions.remember(comparisonIdentity('chat-b'), chatBComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const firstA = deferred<boolean>();
+		const pendingB = deferred<boolean>();
+		const finalA = deferred<boolean>();
+		const compare = vi
+			.spyOn(controller.comparison, 'compare')
+			.mockReturnValueOnce(firstA.promise)
+			.mockReturnValueOnce(pendingB.promise)
+			.mockReturnValueOnce(finalA.promise);
+		let confirmed: GitComparisonSpecification | null = null;
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockImplementation(
+			() => confirmed,
+		);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(1));
+		setProject(controller, 'chat-b');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		setProject(controller, 'chat-a');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(3));
+
+		confirmed = staleSpecification;
+		firstA.resolve(true);
+		await firstA.promise;
+		await Promise.resolve();
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+
+		confirmed = revisionComparison;
+		finalA.resolve(true);
+		pendingB.resolve(false);
+		await Promise.all([finalA.promise, pendingB.promise]);
+
+		controller.setPresentationVisible(false);
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		expect(compare).toHaveBeenCalledTimes(3);
 	});
 
 	it('reports loading while target discovery delays the initial comparison', async () => {
@@ -129,22 +613,51 @@ describe('GitCompareSurfaceController', () => {
 			toRevision: 'feature',
 		});
 
-		await controller.refreshForInvalidation('chat', 1);
+		await controller.refreshForInvalidation('/canonical/project', 1);
 		await vi.waitFor(() => expect(freshness).toHaveBeenCalledOnce());
-		await controller.refreshForInvalidation('chat', 1);
+		await controller.refreshForInvalidation('/canonical/project', 1);
 
 		expect(controller.comparison.fromRevision).toBe('main');
 		expect(controller.comparison.toRevision).toBe('feature');
 		expect(freshness).toHaveBeenCalledOnce();
 	});
 
-	it('disposal cancels future activation', async () => {
-		const controller = new GitCompareSurfaceController(createGitSurfaceTestDeps());
+	it('restores the same symbolic range after branch checkout', async () => {
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonSessions.remember(comparisonIdentity('chat-a'), revisionComparison);
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+		setProject(controller, 'chat-a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		expect(await controller.target.switchBranch('feature', 'local-branch')).toBe(true);
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toKind).toBe('revision');
+		expect(controller.comparison.toRevision).toBe('HEAD');
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat-a'))).toEqual(
+			revisionComparison,
+		);
+	});
+
+	it('disposal remembers confirmed state and cancels future activation', async () => {
+		const deps = createGitSurfaceTestDeps();
+		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		setProject(controller);
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockReturnValue(
+			revisionComparison,
+		);
 		controller.dispose();
 		controller.setPresentationVisible(true);
 		await controller.target.activate();
-		expect(compare).not.toHaveBeenCalled();
+		expect(compare).toHaveBeenCalledOnce();
+		expect(deps.comparisonSessions.recall(comparisonIdentity('chat'))).toEqual(revisionComparison);
 	});
 });

--- a/web/src/lib/git/review/__tests__/git-comparison-session-store.logic.test.ts
+++ b/web/src/lib/git/review/__tests__/git-comparison-session-store.logic.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+	GitComparisonSessionStore,
+	type GitComparisonSessionIdentity,
+} from '$lib/git/review/git-comparison-session-store.js';
+import type { GitComparisonSpecification } from '$lib/git/review/git-comparison.svelte.js';
+
+const revision: GitComparisonSpecification = {
+	fromRevision: 'origin/main',
+	toKind: 'revision',
+	toRevision: 'HEAD',
+	mode: 'direct',
+};
+
+const workingTree: GitComparisonSpecification = {
+	fromRevision: 'release',
+	toKind: 'working-tree',
+	mode: 'direct',
+};
+
+function identity(chatId: string, targetIdentity = 'target-a'): GitComparisonSessionIdentity {
+	return { chatId, targetIdentity };
+}
+
+describe('GitComparisonSessionStore', () => {
+	it('keeps chats and physical targets independent', () => {
+		const store = new GitComparisonSessionStore();
+		store.remember(identity('chat-a'), revision);
+		store.remember(identity('chat-b'), workingTree);
+		store.remember(identity('chat-a', 'target-b'), workingTree);
+
+		expect(store.recall(identity('chat-a'))).toEqual(revision);
+		expect(store.recall(identity('chat-b'))).toEqual(workingTree);
+		expect(store.recall(identity('chat-a', 'target-b'))).toEqual(workingTree);
+	});
+
+	it('returns copies rather than mutable retained objects', () => {
+		const store = new GitComparisonSessionStore();
+		store.remember(identity('chat-a'), revision);
+		const recalled = store.recall(identity('chat-a'));
+		if (!recalled) throw new Error('Expected a remembered comparison.');
+		recalled.fromRevision = 'mutated';
+
+		expect(store.recall(identity('chat-a'))).toEqual(revision);
+	});
+
+	it('retains a copy rather than the caller mutable object', () => {
+		const store = new GitComparisonSessionStore();
+		const specification = { ...revision };
+		store.remember(identity('chat-a'), specification);
+		specification.fromRevision = 'mutated';
+
+		expect(store.recall(identity('chat-a'))).toEqual(revision);
+	});
+
+	it('evicts the least recently used entry and touches reads', () => {
+		const store = new GitComparisonSessionStore(2);
+		store.remember(identity('chat-a'), revision);
+		store.remember(identity('chat-b'), revision);
+		expect(store.recall(identity('chat-a'))).toEqual(revision);
+
+		store.remember(identity('chat-c'), revision);
+
+		expect(store.recall(identity('chat-a'))).toEqual(revision);
+		expect(store.recall(identity('chat-b'))).toBeNull();
+		expect(store.recall(identity('chat-c'))).toEqual(revision);
+	});
+
+	it('replaces an entry and keeps the replacement most recent', () => {
+		const store = new GitComparisonSessionStore(2);
+		store.remember(identity('chat-a'), revision);
+		store.remember(identity('chat-b'), revision);
+		store.remember(identity('chat-a'), workingTree);
+		store.remember(identity('chat-c'), revision);
+
+		expect(store.recall(identity('chat-a'))).toEqual(workingTree);
+		expect(store.recall(identity('chat-b'))).toBeNull();
+		expect(store.recall(identity('chat-c'))).toEqual(revision);
+	});
+
+	it('clears all client memory at root teardown', () => {
+		const store = new GitComparisonSessionStore();
+		store.remember(identity('chat-a'), revision);
+		store.remember(identity('chat-b'), workingTree);
+
+		store.clear();
+
+		expect(store.recall(identity('chat-a'))).toBeNull();
+		expect(store.recall(identity('chat-b'))).toBeNull();
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-comparison.test.ts
+++ b/web/src/lib/git/review/__tests__/git-comparison.test.ts
@@ -134,6 +134,74 @@ describe('GitComparisonController', () => {
 		expect([comparison.fromRevision, comparison.toRevision]).toEqual(['feature', 'main']);
 	});
 
+	it('exposes requested revision names rather than resolved hashes', async () => {
+		const original = revisionSnapshotWithFile();
+		if (original.to.kind !== 'revision') throw new Error('Expected a revision snapshot.');
+		const snapshot = {
+			...original,
+			mode: 'merge-base' as const,
+			from: { ...original.from, requestedRevision: 'origin/main' },
+			to: { ...original.to, requestedRevision: 'HEAD' },
+		};
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
+		const comparison = new GitComparisonController();
+		comparison.setSpecification({
+			fromRevision: 'origin/main',
+			toKind: 'revision',
+			toRevision: 'HEAD',
+			mode: 'merge-base',
+		});
+
+		expect(await comparison.compare('/project')).toBe(true);
+		expect(comparison.confirmedSpecification).toEqual({
+			fromRevision: 'origin/main',
+			toKind: 'revision',
+			toRevision: 'HEAD',
+			mode: 'merge-base',
+		});
+		expect(comparison.confirmedSpecification?.fromRevision).not.toBe(snapshot.from.hash);
+	});
+
+	it('normalizes confirmed Working Tree comparisons and clears them on reset', async () => {
+		const snapshot = {
+			...workingTreeSnapshot(),
+			from: { ...workingTreeSnapshot().from, requestedRevision: 'origin/main' },
+		};
+		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);
+		const comparison = new GitComparisonController();
+		comparison.setSpecification({ fromRevision: 'origin/main', toKind: 'working-tree' });
+
+		expect(await comparison.compare('/project')).toBe(true);
+		expect(comparison.confirmedSpecification).toEqual({
+			fromRevision: 'origin/main',
+			toKind: 'working-tree',
+			mode: 'direct',
+		});
+
+		comparison.reset();
+		expect(comparison.confirmedSpecification).toBeNull();
+	});
+
+	it('keeps the prior confirmed specification after a failed request', async () => {
+		vi.mocked(getGitComparisonSnapshot)
+			.mockResolvedValueOnce(workingTreeSnapshot())
+			.mockResolvedValueOnce({
+				status: 'not-found',
+				project: '/project',
+				endpoint: 'from',
+				revision: 'missing',
+				message: 'Missing revision.',
+			});
+		const comparison = new GitComparisonController();
+		comparison.setSpecification({ fromRevision: 'main', toKind: 'working-tree' });
+		expect(await comparison.compare('/project')).toBe(true);
+		const confirmed = comparison.confirmedSpecification;
+
+		comparison.setSpecification({ fromRevision: 'missing', toKind: 'working-tree' });
+		expect(await comparison.compare('/project')).toBe(false);
+		expect(comparison.confirmedSpecification).toEqual(confirmed);
+	});
+
 	it('loads a frozen Working Tree comparison and detects later changes', async () => {
 		const snapshot = { ...workingTreeSnapshot(), repoRoot: '/repo' };
 		vi.mocked(getGitComparisonSnapshot).mockResolvedValue(snapshot);

--- a/web/src/lib/git/review/git-compare-surface.svelte.ts
+++ b/web/src/lib/git/review/git-compare-surface.svelte.ts
@@ -5,20 +5,35 @@ import type { GitSurfaceControllerDeps } from '$lib/git/surface/git-surface-cont
 import { GitTargetSessionController } from '$lib/git/targets/git-target-session.svelte.js';
 import {
 	GitComparisonController,
-	type GitComparisonDialogDefaults,
+	type GitComparisonSpecification,
 } from './git-comparison.svelte.js';
+import type {
+	GitComparisonSessionIdentity,
+	GitComparisonSessionStore,
+} from './git-comparison-session-store.js';
 
-export const DEFAULT_GIT_COMPARISON: GitComparisonDialogDefaults = {
+export const DEFAULT_GIT_COMPARISON: GitComparisonSpecification = {
 	fromRevision: 'HEAD',
 	toKind: 'working-tree',
+	mode: 'direct',
 };
+
+interface GitCompareSurfaceControllerDeps extends GitSurfaceControllerDeps {
+	comparisonSessions: Pick<GitComparisonSessionStore, 'recall' | 'remember'>;
+}
+
+interface ActiveGitComparisonSession {
+	identity: GitComparisonSessionIdentity;
+	projectPath: string;
+}
 
 export class GitCompareSurfaceController implements PortableSingletonController {
 	readonly comparison = new GitComparisonController();
 	readonly target: GitTargetSessionController;
 	presentationVisible = $state(false);
 
-	#loadedTargetIdentity: string | null = null;
+	#chatId: string | null = null;
+	#loadedSessionIdentity: GitComparisonSessionIdentity | null = null;
 	#unregisterReviewDisplay: () => void;
 
 	get isLoading(): boolean {
@@ -29,7 +44,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		);
 	}
 
-	constructor(private readonly deps: GitSurfaceControllerDeps) {
+	constructor(private readonly deps: GitCompareSurfaceControllerDeps) {
 		this.target = new GitTargetSessionController({
 			kind: 'git-compare',
 			createBranchSelector: deps.createGitBranchSelector,
@@ -44,32 +59,43 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 					}
 					return;
 				}
+				this.#rememberConfirmedComparison();
 				this.comparison.reset();
-				this.#loadedTargetIdentity = null;
+				this.#loadedSessionIdentity = null;
 				if (this.presentationVisible) {
 					void this.#activateComparison();
 				}
 			},
 		});
-		this.#unregisterReviewDisplay = deps.reviewDisplay.register(
-			singletonSurfaceId('git-compare'),
-			{
-				isVisible: () => this.presentationVisible,
-				hasOpenCommentComposer: () => this.comparison.document.commentComposer.open,
-				markContextChangeBlocked: () =>
-					this.comparison.document.markContextChangeBlocked(),
-				apply: (diffMode, contextLines) => {
-					const projectPath = this.target.activeProjectPath;
-					if (projectPath && this.comparison.snapshot) {
-						this.comparison.setDisplayOptions(projectPath, diffMode, contextLines);
-					}
-				},
+		this.#unregisterReviewDisplay = deps.reviewDisplay.register(singletonSurfaceId('git-compare'), {
+			isVisible: () => this.presentationVisible,
+			hasOpenCommentComposer: () => this.comparison.document.commentComposer.open,
+			markContextChangeBlocked: () => this.comparison.document.markContextChangeBlocked(),
+			apply: (diffMode, contextLines) => {
+				const projectPath = this.target.activeProjectPath;
+				if (projectPath && this.comparison.snapshot) {
+					this.comparison.setDisplayOptions(projectPath, diffMode, contextLines);
+				}
 			},
-		);
+		});
 	}
 
 	setProjectState(projectState: WorkspaceProjectState): void {
+		const nextChatId = projectStateChatId(projectState);
+		const chatChanged = nextChatId !== this.#chatId;
+		if (chatChanged) {
+			this.#rememberConfirmedComparison();
+			this.comparison.reset();
+			this.#loadedSessionIdentity = null;
+			this.#chatId = nextChatId;
+		}
+		const wasProjectIdentityPending = this.target.projectIdentityPending;
 		this.target.setProjectState(projectState);
+		const completedProjectResolution =
+			wasProjectIdentityPending && projectState.kind === 'available';
+		if (this.presentationVisible && (chatChanged || completedProjectResolution)) {
+			void this.#activateComparison();
+		}
 	}
 
 	setPresentationVisible(visible: boolean): void {
@@ -87,40 +113,96 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		return this.target.refreshForInvalidation(effectiveProjectKey, version);
 	}
 
+	async compareCurrentSpecification(): Promise<boolean> {
+		const active = this.#activeSession();
+		if (!active) return false;
+
+		const requestIdentity = active.identity;
+		this.#loadedSessionIdentity = requestIdentity;
+		const loaded = await this.comparison.compare(active.projectPath);
+		if (this.#loadedSessionIdentity !== requestIdentity) return false;
+		if (loaded) this.#rememberConfirmedComparison(requestIdentity);
+		return loaded;
+	}
+
+	closeComparisonDialog(): void {
+		this.comparison.closeDialog();
+		// Keeps an empty cancelled session retryable on the next activation.
+		if (!this.comparison.snapshot) this.#loadedSessionIdentity = null;
+	}
+
 	dispose(): void {
+		this.#rememberConfirmedComparison();
 		this.#unregisterReviewDisplay();
 		this.target.dispose();
 		this.comparison.reset();
-		this.#loadedTargetIdentity = null;
+		this.#chatId = null;
+		this.#loadedSessionIdentity = null;
 	}
 
 	async #activateComparison(): Promise<void> {
-		if (
-			!this.presentationVisible ||
-			this.target.projectIdentityPending ||
-			!this.target.activeProjectPath ||
-			!this.target.appliedIdentity ||
-			this.target.appliedIdentity !== this.target.identity
-		) {
-			return;
-		}
+		if (!this.presentationVisible) return;
+		const active = this.#activeSession();
+		if (!active) return;
+		if (sameSession(this.#loadedSessionIdentity, active.identity)) return;
 
-		const projectPath = this.target.activeProjectPath;
-		const targetIdentity = this.target.appliedIdentity;
-		if (!projectPath || !targetIdentity) return;
-		if (this.#loadedTargetIdentity === targetIdentity) return;
-		this.comparison.setSpecification(DEFAULT_GIT_COMPARISON, {
+		const specification =
+			this.deps.comparisonSessions.recall(active.identity) ?? DEFAULT_GIT_COMPARISON;
+		this.comparison.setSpecification(specification, {
 			diffMode: this.deps.reviewDisplay.diffMode,
 			contextLines: this.deps.reviewDisplay.contextLines,
 		});
 		// Marked before the await so a concurrent activation for the same
-		// identity does not start a second default load.
-		this.#loadedTargetIdentity = targetIdentity;
-		const loaded = await this.comparison.compare(projectPath);
+		// session does not start a second load.
+		const activationIdentity = active.identity;
+		this.#loadedSessionIdentity = activationIdentity;
+		const loaded = await this.comparison.compare(active.projectPath);
+		if (this.#loadedSessionIdentity !== activationIdentity) return;
 		// A failed default load must stay retryable on the next visibility or
-		// activation pass; a superseded identity keeps the newer marker.
-		if (!loaded && this.#loadedTargetIdentity === targetIdentity) {
-			this.#loadedTargetIdentity = null;
+		// activation pass; a superseded session keeps the newer marker.
+		if (!loaded) {
+			this.#loadedSessionIdentity = null;
+			return;
 		}
+		this.#rememberConfirmedComparison(activationIdentity);
 	}
+
+	#activeSession(): ActiveGitComparisonSession | null {
+		const chatId = this.#chatId;
+		const projectPath = this.target.activeProjectPath;
+		const targetIdentity = this.target.appliedIdentity;
+		if (
+			!chatId ||
+			!projectPath ||
+			!targetIdentity ||
+			this.target.projectIdentityPending ||
+			targetIdentity !== this.target.identity
+		) {
+			return null;
+		}
+		return {
+			identity: { chatId, targetIdentity },
+			projectPath,
+		};
+	}
+
+	#rememberConfirmedComparison(identity = this.#loadedSessionIdentity): void {
+		const specification = this.comparison.confirmedSpecification;
+		if (!identity || !specification) return;
+		this.deps.comparisonSessions.remember(identity, specification);
+	}
+}
+
+function projectStateChatId(projectState: WorkspaceProjectState): string | null {
+	if (projectState.kind === 'absent') return null;
+	return projectState.kind === 'resolving'
+		? projectState.context.chatId
+		: projectState.project.chatId;
+}
+
+function sameSession(
+	left: GitComparisonSessionIdentity | null,
+	right: GitComparisonSessionIdentity,
+): boolean {
+	return left?.chatId === right.chatId && left.targetIdentity === right.targetIdentity;
 }

--- a/web/src/lib/git/review/git-comparison-session-store.ts
+++ b/web/src/lib/git/review/git-comparison-session-store.ts
@@ -1,0 +1,66 @@
+import type { GitComparisonSpecification } from './git-comparison.svelte.js';
+
+export const GIT_COMPARISON_SESSION_LIMIT = 32;
+
+export interface GitComparisonSessionIdentity {
+	readonly chatId: string;
+	readonly targetIdentity: string;
+}
+
+interface GitComparisonSessionEntry {
+	readonly specification: GitComparisonSpecification;
+}
+
+export class GitComparisonSessionStore {
+	readonly #entries = new Map<string, GitComparisonSessionEntry>();
+
+	constructor(private readonly maxEntries = GIT_COMPARISON_SESSION_LIMIT) {}
+
+	recall(identity: GitComparisonSessionIdentity): GitComparisonSpecification | null {
+		const key = sessionKey(identity);
+		const entry = this.#entries.get(key);
+		if (!entry) return null;
+		this.#entries.delete(key);
+		this.#entries.set(key, entry);
+		return cloneSpecification(entry.specification);
+	}
+
+	remember(
+		identity: GitComparisonSessionIdentity,
+		specification: GitComparisonSpecification,
+	): void {
+		const key = sessionKey(identity);
+		this.#entries.delete(key);
+		this.#entries.set(key, {
+			specification: cloneSpecification(specification),
+		});
+		while (this.#entries.size > this.maxEntries) {
+			const oldest = this.#entries.keys().next().value;
+			if (oldest === undefined) break;
+			this.#entries.delete(oldest);
+		}
+	}
+
+	clear(): void {
+		this.#entries.clear();
+	}
+}
+
+function sessionKey(identity: GitComparisonSessionIdentity): string {
+	return JSON.stringify([identity.chatId, identity.targetIdentity]);
+}
+
+function cloneSpecification(specification: GitComparisonSpecification): GitComparisonSpecification {
+	return specification.toKind === 'working-tree'
+		? {
+				fromRevision: specification.fromRevision,
+				toKind: 'working-tree',
+				mode: 'direct',
+			}
+		: {
+				fromRevision: specification.fromRevision,
+				toKind: 'revision',
+				toRevision: specification.toRevision,
+				mode: specification.mode,
+			};
+}

--- a/web/src/lib/git/review/git-comparison.svelte.ts
+++ b/web/src/lib/git/review/git-comparison.svelte.ts
@@ -20,6 +20,19 @@ export interface GitComparisonDialogDefaults {
 	mode?: GitComparisonMode;
 }
 
+export type GitComparisonSpecification =
+	| {
+			fromRevision: string;
+			toKind: 'working-tree';
+			mode: 'direct';
+	  }
+	| {
+			fromRevision: string;
+			toKind: 'revision';
+			toRevision: string;
+			mode: GitComparisonMode;
+	  };
+
 export interface GitComparisonDisplayOptions {
 	diffMode: DiffMode;
 	contextLines: number;
@@ -42,6 +55,24 @@ export class GitComparisonController {
 
 	get documentError(): string | null {
 		return this.bodyError ?? (this.dialogOpen ? null : this.error);
+	}
+
+	get confirmedSpecification(): GitComparisonSpecification | null {
+		const snapshot = this.snapshot;
+		if (!snapshot) return null;
+		if (snapshot.to.kind === 'working-tree') {
+			return {
+				fromRevision: snapshot.from.requestedRevision,
+				toKind: 'working-tree',
+				mode: 'direct',
+			};
+		}
+		return {
+			fromRevision: snapshot.from.requestedRevision,
+			toKind: 'revision',
+			toRevision: snapshot.to.requestedRevision,
+			mode: snapshot.mode,
+		};
 	}
 
 	private snapshotAbort: AbortController | null = null;
@@ -350,11 +381,13 @@ export class GitComparisonController {
 	}
 
 	private restoreInputsFromSnapshot(): void {
-		const snapshot = this.snapshot;
-		if (!snapshot) return;
-		this.fromRevision = snapshot.from.requestedRevision;
-		this.toKind = snapshot.to.kind === 'working-tree' ? 'working-tree' : 'revision';
-		if (snapshot.to.kind === 'revision') this.toRevision = snapshot.to.requestedRevision;
-		this.mode = snapshot.mode;
+		const specification = this.confirmedSpecification;
+		if (!specification) return;
+		this.fromRevision = specification.fromRevision;
+		this.toKind = specification.toKind;
+		this.mode = specification.mode;
+		if (specification.toKind === 'revision') {
+			this.toRevision = specification.toRevision;
+		}
 	}
 }

--- a/web/src/lib/workspace/__tests__/singleton-surfaces.test.ts
+++ b/web/src/lib/workspace/__tests__/singleton-surfaces.test.ts
@@ -45,7 +45,12 @@ function createRegistry() {
 			return controller;
 		},
 	});
-	return { registry, commits, pullRequestsStores };
+	return {
+		registry,
+		commits,
+		pullRequestsStores,
+		comparisonSessions: gitSurfaceDeps.comparisonSessions,
+	};
 }
 
 describe('SingletonSurfaceRegistry', () => {
@@ -155,6 +160,25 @@ describe('SingletonSurfaceRegistry', () => {
 		expect(registry.gitWorkbench()).toBe(workbench);
 		expect(registry.gitHistory()).toBe(history);
 		expect(registry.gitCompare()).not.toBe(compare);
+	});
+
+	it('retains Compare memory across surface disposal and clears it at root destruction', () => {
+		const { registry, comparisonSessions } = createRegistry();
+		const identity = { chatId: 'chat-a', targetIdentity: 'target-a' };
+		const specification = {
+			fromRevision: 'origin/main',
+			toKind: 'revision' as const,
+			toRevision: 'HEAD',
+			mode: 'direct' as const,
+		};
+		comparisonSessions.remember(identity, specification);
+		registry.gitCompare();
+
+		registry.disposeSurface('git-compare');
+		expect(comparisonSessions.recall(identity)).toEqual(specification);
+
+		registry.destroy();
+		expect(comparisonSessions.recall(identity)).toBeNull();
 	});
 
 	it('routes visibility for every singleton through one lifecycle owner', () => {

--- a/web/src/lib/workspace/singleton-surfaces.svelte.ts
+++ b/web/src/lib/workspace/singleton-surfaces.svelte.ts
@@ -6,6 +6,7 @@ import type { GitSurfaceControllerDeps } from '$lib/git/surface/git-surface-cont
 import { GitWorkbenchSurfaceController } from '$lib/git/workbench/git-workbench-surface.svelte.js';
 import { GitHistorySurfaceController } from '$lib/git/history/git-history-surface.svelte.js';
 import { GitCompareSurfaceController } from '$lib/git/review/git-compare-surface.svelte.js';
+import type { GitComparisonSessionStore } from '$lib/git/review/git-comparison-session-store.js';
 import type { PullRequestsStore } from '$lib/git/pull-requests/pull-requests-store.svelte.js';
 import type { CommitController } from '$lib/git/commit/commit-controller.svelte.js';
 import type { WorkspaceProjectState } from '$lib/workspace/workspace-context.svelte.js';
@@ -13,6 +14,7 @@ import type { WorkspaceProjectState } from '$lib/workspace/workspace-context.sve
 export interface SingletonSurfaceRegistryDeps extends GitSurfaceControllerDeps {
 	createCommit(): CommitController;
 	createPullRequests(): PullRequestsStore;
+	comparisonSessions: GitComparisonSessionStore;
 }
 
 export class FilesSurfaceController implements PortableSingletonController {
@@ -147,6 +149,7 @@ export class SingletonSurfaceRegistry {
 			controller.dispose();
 		}
 		this.#controllers.clear();
+		this.deps.comparisonSessions.clear();
 	}
 
 	#controller<K extends PortableSingletonKind>(kind: K): SingletonControllerByKind[K] {

--- a/web/src/lib/workspace/workspace-services.ts
+++ b/web/src/lib/workspace/workspace-services.ts
@@ -9,6 +9,7 @@ import { gitProjectInvalidations } from '$lib/git/surface/git-project-invalidati
 import { GitMutationCoordinator } from '$lib/git/surface/git-mutations.svelte.js';
 import { GitBranchSelectorState } from '$lib/git/targets/git-branch-selector-state.svelte.js';
 import { GitReviewDisplaySettingsStore } from '$lib/git/review/git-review-display-settings.svelte.js';
+import { GitComparisonSessionStore } from '$lib/git/review/git-comparison-session-store.js';
 import { GitViewLauncher } from '$lib/git/surface/git-view-launcher.svelte.js';
 import type {
 	FileOpenPlacementPreference,
@@ -169,6 +170,7 @@ export function createWorkspaceServices(deps: WorkspaceRootDependencies): Worksp
 		});
 	const gitBranchActions = createGitBranchSelector();
 	const gitReviewDisplay = new GitReviewDisplaySettingsStore();
+	const comparisonSessions = new GitComparisonSessionStore();
 	const singletonSurfaces = new SingletonSurfaceRegistry({
 		createCommit: () =>
 			new CommitController({
@@ -192,6 +194,7 @@ export function createWorkspaceServices(deps: WorkspaceRootDependencies): Worksp
 		invalidationVersion: (effectiveProjectKey) =>
 			gitProjectInvalidations.version(effectiveProjectKey),
 		reviewDisplay: gitReviewDisplay,
+		comparisonSessions,
 	});
 	const domainBindings = new WorkspaceDomainBindings({
 		workspaceContext: context,


### PR DESCRIPTION
Git Compare now remembers the last successfully loaded symbolic range independently for each chat and selected repository or worktree during the current client session, restoring it after chat switches and view close/reopen while intentionally resetting after a page reload.