### PR TITLE
Page large shared chat loads

### DIFF
--- a/common/share-types.ts
+++ b/common/share-types.ts
@@ -26,6 +26,16 @@ export interface ShareStatusResponse {
 
 export interface GetSharedChatResponse {
   snapshot: SharedChatSnapshot;
+  page: SharedChatMessagePage;
+}
+
+export interface SharedChatMessagePage {
+  snapshotVersion: string;
+  totalMessages: number;
+  start: number;
+  end: number;
+  nextBefore: number | null;
+  reset?: boolean;
 }
 
 export interface RevokeShareResponse {

--- a/server/chats/share-page.ts
+++ b/server/chats/share-page.ts
@@ -1,12 +1,10 @@
 // Renders the shared-chat HTML page. Enriches the SPA shell so a shared link is
 // both human-friendly (the Svelte app hydrates as usual) and agent-friendly: the
-// served HTML carries Open Graph/Twitter metadata, a machine-discoverable link to
-// the plain-text transcript, and a no-JavaScript transcript fallback that agents
-// and crawlers can read directly. The fallback is removed the instant JS runs, so
-// browser users never see it.
+// served HTML carries Open Graph/Twitter metadata and machine-discoverable links
+// to the plain-text transcript. The small no-JavaScript fallback links to the
+// transcript instead of embedding it, keeping browser parse cost bounded.
 
 import type { SharedChatSnapshot } from '../../common/share-types.ts';
-import { renderSharedChatText } from './share-transcript.ts';
 import type { PublicAppTitle } from '../app-title.js';
 import { appTitleBootstrapScript } from '../app-title.js';
 
@@ -59,7 +57,9 @@ function buildHeadTags(
     `<meta property="og:site_name" content="${siteName}" />`,
     `<meta property="og:title" content="${title}" />`,
     `<meta property="og:description" content="${description}" />`,
-    canonicalUrl ? `<meta property="og:url" content="${escapeHtml(canonicalUrl)}" />` : '',
+    canonicalUrl
+      ? `<meta property="og:url" content="${escapeHtml(canonicalUrl)}" />`
+      : '',
     `<meta name="twitter:card" content="summary" />`,
     `<meta name="twitter:title" content="${title}" />`,
     `<meta name="twitter:description" content="${description}" />`,
@@ -69,12 +69,17 @@ function buildHeadTags(
     .join('\n\t\t');
 }
 
-// Builds the no-JS transcript block. When removable, an inline script strips it
-// before the SPA mounts so browser users never see raw text; agents and crawlers
-// that do not execute JavaScript read the transcript straight from the markup.
-function buildBodyFallback(snapshot: SharedChatSnapshot, removable: boolean): string {
-  const transcript = escapeHtml(renderSharedChatText(snapshot));
-  const block = `<div id="${FALLBACK_ELEMENT_ID}"><pre>${transcript}</pre></div>`;
+// Keeps the fallback independent of transcript size. Agents can follow the
+// explicit plain-text link without forcing every browser to parse the transcript.
+function buildBodyFallback(
+  snapshot: SharedChatSnapshot,
+  token: string,
+  removable: boolean,
+): string {
+  const title = escapeHtml(shareTitle(snapshot));
+  const agent = escapeHtml(snapshot.agentId || 'agent');
+  const llmHref = escapeHtml(`/shared/llm/${encodeURIComponent(token)}`);
+  const block = `<main id="${FALLBACK_ELEMENT_ID}"><h1>${title}</h1><p>Shared ${agent} conversation with ${snapshot.messages.length} messages.</p><p><a href="${llmHref}">Read the full plain-text transcript</a></p></main>`;
   if (!removable) return block;
   return `${block}<script>document.getElementById(${JSON.stringify(FALLBACK_ELEMENT_ID)})?.remove()</script>`;
 }
@@ -90,7 +95,7 @@ export function injectSharedChatContext(
   appTitle: PublicAppTitle,
 ): string {
   const head = buildHeadTags(snapshot, token, canonicalUrl, appTitle);
-  const body = buildBodyFallback(snapshot, true);
+  const body = buildBodyFallback(snapshot, token, true);
   const bootstrap = appTitleBootstrapScript(appTitle);
 
   let html = /<title>[^<]*<\/title>/.test(shell)
@@ -106,7 +111,7 @@ export function injectSharedChatContext(
 }
 
 // Self-contained shared page used when the SPA shell is unavailable (e.g. the
-// build output is missing). Keeps the transcript visible since no SPA will mount.
+// build output is missing). Keeps the plain-text transcript link visible.
 export function renderStandaloneSharedHtml(
   snapshot: SharedChatSnapshot,
   token: string,
@@ -114,7 +119,7 @@ export function renderStandaloneSharedHtml(
   appTitle: PublicAppTitle,
 ): string {
   const head = buildHeadTags(snapshot, token, canonicalUrl, appTitle);
-  const body = buildBodyFallback(snapshot, false);
+  const body = buildBodyFallback(snapshot, token, false);
   return `<!doctype html>
 <html lang="en">
 	<head>

--- a/server/routes/__tests__/shares.test.js
+++ b/server/routes/__tests__/shares.test.js
@@ -19,7 +19,8 @@ function createSnapshot(overrides = {}) {
       {
         type: 'assistant-message',
         timestamp: '2025-01-02T03:05:05.000Z',
-        content: 'Yes. The thread discusses making the shared page readable without JavaScript.',
+        content:
+          'Yes. The thread discusses making the shared page readable without JavaScript.',
       },
       {
         type: 'bash-tool-use',
@@ -42,7 +43,9 @@ function createSnapshot(overrides = {}) {
 function createRoutes(snapshot = createSnapshot(), appTitle = null) {
   return createShareRoutes(
     {
-      getShare: mock((token) => token === snapshot.shareToken ? snapshot : null),
+      getShare: mock((token) =>
+        token === snapshot.shareToken ? snapshot : null,
+      ),
       getShareByChatId: mock(() => null),
       createShare: mock(() => Promise.resolve(snapshot)),
       updateShare: mock(() => Promise.resolve(snapshot)),
@@ -52,11 +55,23 @@ function createRoutes(snapshot = createSnapshot(), appTitle = null) {
     { getChat: mock(() => null) },
     {
       getChatName: mock(() => null),
-      getUiSettings: mock(() => appTitle ? { appIdentity: { title: appTitle } } : {}),
-      getRemoteSettingsVersion: mock(() => appTitle ? 3 : 0),
+      getUiSettings: mock(() =>
+        appTitle ? { appIdentity: { title: appTitle } } : {},
+      ),
+      getRemoteSettingsVersion: mock(() => (appTitle ? 3 : 0)),
     },
     { getChatMetadata: mock(() => null) },
-    { getOrCreatePage: mock(() => Promise.resolve({ messages: [], generationId: 'generation-1', lastSeq: 0, pageOldestSeq: 0, hasMore: false })) },
+    {
+      getOrCreatePage: mock(() =>
+        Promise.resolve({
+          messages: [],
+          generationId: 'generation-1',
+          lastSeq: 0,
+          pageOldestSeq: 0,
+          hasMore: false,
+        }),
+      ),
+    },
   );
 }
 
@@ -102,46 +117,274 @@ describe('shared transcript routes', () => {
   });
 });
 
+describe('shared chat snapshot route', () => {
+  it('returns the newest bounded page with an older-page cursor', async () => {
+    const messages = Array.from({ length: 250 }, (_, index) => ({
+      type: 'assistant-message',
+      timestamp: '2025-01-02T03:05:05.000Z',
+      content: `message-${index}`,
+    }));
+    const routes = createRoutes(createSnapshot({ messages }));
+    const response = await routes['/api/v1/shared'].GET(
+      new Request('http://localhost/api/v1/shared?token=share-token&limit=200'),
+      new URL('http://localhost/api/v1/shared?token=share-token&limit=200'),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(
+      'no-cache, no-store, must-revalidate',
+    );
+    expect(body.snapshot.messages).toHaveLength(200);
+    expect(body.snapshot.messages[0].content).toBe('message-50');
+    expect(body.snapshot.messages[199].content).toBe('message-249');
+    expect(body.page).toEqual({
+      snapshotVersion: '2025-01-02T03:04:05.000Z',
+      totalMessages: 250,
+      start: 50,
+      end: 250,
+      nextBefore: 50,
+    });
+  });
+
+  it('returns an exact older page without overlap', async () => {
+    const messages = Array.from({ length: 250 }, (_, index) => ({
+      type: 'assistant-message',
+      timestamp: '2025-01-02T03:05:05.000Z',
+      content: `message-${index}`,
+    }));
+    const routes = createRoutes(createSnapshot({ messages }));
+    const response = await routes['/api/v1/shared'].GET(
+      new Request(
+        'http://localhost/api/v1/shared?token=share-token&limit=200&before=50&version=2025-01-02T03%3A04%3A05.000Z',
+      ),
+      new URL(
+        'http://localhost/api/v1/shared?token=share-token&limit=200&before=50&version=2025-01-02T03%3A04%3A05.000Z',
+      ),
+    );
+    const body = await response.json();
+
+    expect(body.snapshot.messages).toHaveLength(50);
+    expect(body.snapshot.messages[0].content).toBe('message-0');
+    expect(body.snapshot.messages[49].content).toBe('message-49');
+    expect(body.page).toEqual({
+      snapshotVersion: '2025-01-02T03:04:05.000Z',
+      totalMessages: 250,
+      start: 0,
+      end: 50,
+      nextBefore: null,
+    });
+  });
+
+  it('resets to the newest page when a cursor targets an older snapshot version', async () => {
+    const snapshot = createSnapshot({
+      messages: Array.from({ length: 250 }, (_, index) => ({
+        type: 'assistant-message',
+        timestamp: '2025-01-02T03:05:05.000Z',
+        content: `message-${index}`,
+      })),
+    });
+    const routes = createRoutes(snapshot);
+
+    const firstResponse = await routes['/api/v1/shared'].GET(
+      new Request('http://localhost/api/v1/shared?token=share-token&limit=200'),
+      new URL('http://localhost/api/v1/shared?token=share-token&limit=200'),
+    );
+    const firstBody = await firstResponse.json();
+    expect(firstBody.page.nextBefore).toBe(50);
+
+    snapshot.sharedAt = '2025-01-02T04:04:05.000Z';
+    snapshot.messages = Array.from({ length: 270 }, (_, index) => ({
+      type: 'assistant-message',
+      timestamp: '2025-01-02T03:05:05.000Z',
+      content: `message-${index}`,
+    }));
+
+    const staleResponse = await routes['/api/v1/shared'].GET(
+      new Request(
+        `http://localhost/api/v1/shared?token=share-token&limit=200&before=${firstBody.page.nextBefore}&version=${encodeURIComponent(firstBody.page.snapshotVersion)}`,
+      ),
+      new URL(
+        `http://localhost/api/v1/shared?token=share-token&limit=200&before=${firstBody.page.nextBefore}&version=${encodeURIComponent(firstBody.page.snapshotVersion)}`,
+      ),
+    );
+    const staleBody = await staleResponse.json();
+
+    expect(staleBody.snapshot.messages).toHaveLength(200);
+    expect(staleBody.snapshot.messages[0].content).toBe('message-70');
+    expect(staleBody.snapshot.messages[199].content).toBe('message-269');
+    expect(staleBody.page).toEqual({
+      snapshotVersion: '2025-01-02T04:04:05.000Z',
+      totalMessages: 270,
+      start: 70,
+      end: 270,
+      nextBefore: 70,
+      reset: true,
+    });
+  });
+
+  it('preserves the complete snapshot when pagination is not requested', async () => {
+    const messages = Array.from({ length: 250 }, (_, index) => ({
+      type: 'assistant-message',
+      timestamp: '2025-01-02T03:05:05.000Z',
+      content: `message-${index}`,
+    }));
+    const routes = createRoutes(createSnapshot({ messages }));
+    const response = await routes['/api/v1/shared'].GET(
+      new Request('http://localhost/api/v1/shared?token=share-token'),
+      new URL('http://localhost/api/v1/shared?token=share-token'),
+    );
+    const body = await response.json();
+
+    expect(body.snapshot.messages).toHaveLength(250);
+    expect(body.page).toEqual({
+      snapshotVersion: '2025-01-02T03:04:05.000Z',
+      totalMessages: 250,
+      start: 0,
+      end: 250,
+      nextBefore: null,
+    });
+  });
+});
+
 describe('shared chat page route', () => {
-  it('serves an HTML page with share metadata, an LLM alternate link, and a no-JS transcript', async () => {
+  it('serves bounded HTML with metadata and machine-readable transcript links', async () => {
     const routes = createRoutes();
     const response = await routes['/shared/:token'].GET(
-      new Request('http://localhost/shared/share-token'),
+      new Request('http://localhost/shared/share-token', {
+        headers: { Accept: 'text/html' },
+      }),
       new URL('http://localhost/shared/share-token'),
     );
     const body = await response.text();
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('text/html');
-    expect(body).toContain('<meta property="og:title" content="Investigate flaky share rendering" />');
+    expect(body).toContain(
+      '<meta property="og:title" content="Investigate flaky share rendering" />',
+    );
     expect(body).toContain('<meta property="og:site_name" content="Garcon" />');
-    expect(body).toContain('<meta property="og:url" content="http://localhost/shared/share-token" />');
+    expect(body).toContain(
+      '<meta property="og:url" content="http://localhost/shared/share-token" />',
+    );
     expect(body).toContain('rel="alternate" type="text/plain"');
     expect(body).toContain('href="/shared/llm/share-token"');
-    // Full transcript is embedded for agents that do not run JavaScript.
-    expect(body).toContain('Title: Investigate flaky share rendering');
+    expect(response.headers.get('link')).toBe(
+      '</shared/llm/share-token>; rel="alternate"; type="text/plain"',
+    );
+    expect(response.headers.get('vary')).toBe('Accept');
+    expect(body).toContain('Read the full plain-text transcript');
+    expect(body).not.toContain('All tests passed.');
+  });
+
+  it('keeps canonical HTML size independent of transcript size', async () => {
+    const largeContent = 'large transcript content '.repeat(100_000);
+    const routes = createRoutes(
+      createSnapshot({
+        messages: [
+          {
+            type: 'assistant-message',
+            timestamp: '2025-01-02T03:05:05.000Z',
+            content: largeContent,
+          },
+        ],
+      }),
+    );
+    const response = await routes['/shared/:token'].GET(
+      new Request('http://localhost/shared/share-token', {
+        headers: { Accept: 'text/html' },
+      }),
+      new URL('http://localhost/shared/share-token'),
+    );
+    const body = await response.text();
+
+    expect(body.length).toBeLessThan(100_000);
+    expect(body).not.toContain(largeContent.slice(0, 1_000));
+  });
+
+  it('serves plain text from the canonical URL when explicitly requested', async () => {
+    const routes = createRoutes();
+    const request = new Request('http://localhost/shared/share-token', {
+      headers: { Accept: 'text/plain' },
+    });
+    const response = await routes['/shared/:token'].GET(
+      request,
+      new URL(request.url),
+    );
+    const body = await response.text();
+
+    expect(response.headers.get('content-type')).toContain('text/plain');
+    expect(response.headers.get('vary')).toBe('Accept');
     expect(body).toContain('All tests passed.');
+  });
+
+  it('negotiates weighted and generic Accept headers without serving rejected types', async () => {
+    const routes = createRoutes();
+    const cases = [
+      { accept: undefined, status: 200, type: 'text/plain' },
+      { accept: '*/*', status: 200, type: 'text/plain' },
+      { accept: 'text/plain;q=0', status: 406, type: null },
+      {
+        accept: 'text/plain;q=1, text/html;q=0',
+        status: 200,
+        type: 'text/plain',
+      },
+      {
+        accept: 'text/plain;q=0.5, text/html;q=0.9',
+        status: 200,
+        type: 'text/html',
+      },
+      { accept: 'text/html, */*;q=0.8', status: 200, type: 'text/html' },
+    ];
+
+    for (const testCase of cases) {
+      const request = new Request('http://localhost/shared/share-token', {
+        headers: testCase.accept ? { Accept: testCase.accept } : undefined,
+      });
+      const response = await routes['/shared/:token'].GET(
+        request,
+        new URL(request.url),
+      );
+
+      expect(response.status).toBe(testCase.status);
+      if (testCase.type) {
+        expect(response.headers.get('content-type')).toContain(testCase.type);
+      }
+      expect(response.headers.get('vary')).toBe('Accept');
+    }
   });
 
   it('uses the remote app title in shared-page metadata', async () => {
     const routes = createRoutes(createSnapshot(), 'Garcon - Work');
     const response = await routes['/shared/:token'].GET(
-      new Request('http://localhost/shared/share-token'),
+      new Request('http://localhost/shared/share-token', {
+        headers: { Accept: 'text/html' },
+      }),
       new URL('http://localhost/shared/share-token'),
     );
     const body = await response.text();
 
     expect(response.status).toBe(200);
-    expect(body).toContain('<title>Investigate flaky share rendering · Garcon - Work</title>');
-    expect(body).toContain('<meta property="og:site_name" content="Garcon - Work" />');
-    expect(body).toContain('<meta name="apple-mobile-web-app-title" content="Garcon - Work" />');
+    expect(body).toContain(
+      '<title>Investigate flaky share rendering · Garcon - Work</title>',
+    );
+    expect(body).toContain(
+      '<meta property="og:site_name" content="Garcon - Work" />',
+    );
+    expect(body).toContain(
+      '<meta name="apple-mobile-web-app-title" content="Garcon - Work" />',
+    );
   });
 
   it('HTML-escapes snapshot content to prevent markup injection', async () => {
-    const snapshot = createSnapshot({ title: 'Bug <img src=x onerror=alert(1)>' });
+    const snapshot = createSnapshot({
+      title: 'Bug <img src=x onerror=alert(1)>',
+    });
     const routes = createRoutes(snapshot);
     const response = await routes['/shared/:token'].GET(
-      new Request('http://localhost/shared/share-token'),
+      new Request('http://localhost/shared/share-token', {
+        headers: { Accept: 'text/html' },
+      }),
       new URL('http://localhost/shared/share-token'),
     );
     const body = await response.text();

--- a/server/routes/shares.ts
+++ b/server/routes/shares.ts
@@ -5,15 +5,27 @@ import { markRouteNoAuth } from '../lib/http-route.js';
 import { withJsonBody } from '../lib/json-route.js';
 import type { IShareStore } from '../chats/share-store.js';
 import type { IChatRegistry } from '../chats/store.js';
-import type { ShareChatResponse, ShareStatusResponse, GetSharedChatResponse, RevokeShareResponse } from '../../common/share-types.ts';
+import type {
+  GetSharedChatResponse,
+  RevokeShareResponse,
+  ShareChatResponse,
+  SharedChatSnapshot,
+  ShareStatusResponse,
+} from '../../common/share-types.ts';
 import { renderSharedChatText } from '../chats/share-transcript.ts';
-import { injectSharedChatContext, renderStandaloneSharedHtml } from '../chats/share-page.ts';
+import {
+  injectSharedChatContext,
+  renderStandaloneSharedHtml,
+} from '../chats/share-page.ts';
 import { loadStaticText } from './static.js';
 import { extractFirstLine } from '../lib/text.js';
 import type { RouteMap } from '../lib/http-route-types.js';
 import type { ChatViewPageReader } from '../chats/chat-message-reader.js';
 import type { ChatMetadata } from '../chats/metadata-store.js';
-import { injectAppTitleIntoShell, resolvePublicAppTitle } from '../app-title.js';
+import {
+  injectAppTitleIntoShell,
+  resolvePublicAppTitle,
+} from '../app-title.js';
 
 interface SettingsDep {
   getChatName(chatId: string): string | null;
@@ -49,12 +61,128 @@ function extractShareTokenFromPath(pathname: string): string | null {
   }
 }
 
-function htmlResponse(html: string): Response {
+const MAX_SHARED_CHAT_PAGE_SIZE = 200;
+const NO_STORE = 'no-cache, no-store, must-revalidate';
+
+function htmlResponse(html: string, llmPath?: string): Response {
+  const headers: Record<string, string> = {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': NO_STORE,
+    Vary: 'Accept',
+  };
+  if (llmPath) {
+    headers.Link = `<${llmPath}>; rel="alternate"; type="text/plain"`;
+  }
   return new Response(html, {
+    headers,
+  });
+}
+
+function parseMessageCursor(
+  value: string | null,
+  totalMessages: number,
+): number {
+  if (value === null) return totalMessages;
+  if (!/^\d+$/.test(value)) return totalMessages;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) return totalMessages;
+  return Math.max(0, Math.min(parsed, totalMessages));
+}
+
+function parsePageSize(value: string | null, totalMessages: number): number {
+  // Preserve the original full-snapshot API when pagination is not requested.
+  if (value === null) return totalMessages;
+  if (!/^\d+$/.test(value)) return MAX_SHARED_CHAT_PAGE_SIZE;
+  return Math.max(1, Math.min(Number(value), MAX_SHARED_CHAT_PAGE_SIZE));
+}
+
+type SharedRepresentation = 'html' | 'text';
+
+interface AcceptMatch {
+  quality: number;
+  specificity: number;
+  position: number;
+}
+
+function matchAcceptedType(
+  accept: string,
+  candidate: 'text/html' | 'text/plain',
+): AcceptMatch | null {
+  const [candidateType, candidateSubtype] = candidate.split('/');
+  let best: AcceptMatch | null = null;
+
+  for (const [position, entry] of accept.split(',').entries()) {
+    const [rawRange, ...rawParameters] = entry.split(';');
+    const [type, subtype] = rawRange.trim().toLowerCase().split('/');
+    if (!type || !subtype) continue;
+    if (type !== '*' && type !== candidateType) continue;
+    if (subtype !== '*' && subtype !== candidateSubtype) continue;
+
+    let quality = 1;
+    for (const parameter of rawParameters) {
+      const [name, value] = parameter.split('=').map((part) => part.trim());
+      if (name?.toLowerCase() !== 'q') continue;
+      const parsed = Number(value);
+      quality =
+        Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0;
+    }
+
+    const specificity = type === '*' ? 0 : subtype === '*' ? 1 : 2;
+    const match = { quality, specificity, position };
+    if (
+      !best ||
+      specificity > best.specificity ||
+      (specificity === best.specificity && quality > best.quality)
+    ) {
+      best = match;
+    }
+  }
+
+  return best;
+}
+
+function negotiateSharedRepresentation(
+  request: Request,
+): SharedRepresentation | null {
+  const accept = request.headers.get('accept')?.trim();
+  // Preserve direct readability for generic agents and crawlers. Browser
+  // navigations explicitly advertise text/html.
+  if (!accept) return 'text';
+
+  const candidates: Array<{
+    representation: SharedRepresentation;
+    match: AcceptMatch;
+  }> = [];
+  const text = matchAcceptedType(accept, 'text/plain');
+  const html = matchAcceptedType(accept, 'text/html');
+  if (text && text.quality > 0)
+    candidates.push({ representation: 'text', match: text });
+  if (html && html.quality > 0)
+    candidates.push({ representation: 'html', match: html });
+
+  candidates.sort(
+    (left, right) =>
+      right.match.quality - left.match.quality ||
+      right.match.specificity - left.match.specificity ||
+      left.match.position - right.match.position,
+  );
+  return candidates[0]?.representation ?? null;
+}
+
+function plainTextResponse(snapshot: SharedChatSnapshot): Response {
+  return new Response(renderSharedChatText(snapshot), {
     headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': NO_STORE,
+      Vary: 'Accept',
     },
+  });
+}
+
+function publicJsonResponse(body: unknown, status = 200): Response {
+  return Response.json(body, {
+    status,
+    headers: { 'Cache-Control': NO_STORE },
   });
 }
 
@@ -65,18 +193,25 @@ export default function createShareRoutes(
   metadata: MetadataDep,
   chatViews: ChatViewsDep,
 ): RouteMap {
-
   // POST /api/v1/chats/share - Creates or returns existing share.
-  async function postShareChat(body: Record<string, unknown>): Promise<Response> {
+  async function postShareChat(
+    body: Record<string, unknown>,
+  ): Promise<Response> {
     try {
       const chatId = String(body.chatId || '').trim();
       if (!chatId) {
-        return Response.json({ success: false, error: 'chatId is required' }, { status: 400 });
+        return Response.json(
+          { success: false, error: 'chatId is required' },
+          { status: 400 },
+        );
       }
 
       const session = registry.getChat(chatId);
       if (!session) {
-        return Response.json({ success: false, error: 'Session not found' }, { status: 404 });
+        return Response.json(
+          { success: false, error: 'Session not found' },
+          { status: 404 },
+        );
       }
 
       const page = await chatViews.getOrCreatePage(chatId, 100_000);
@@ -111,15 +246,24 @@ export default function createShareRoutes(
       };
       return Response.json(resp);
     } catch (error: unknown) {
-      return Response.json({ success: false, error: (error as Error).message }, { status: 500 });
+      return Response.json(
+        { success: false, error: (error as Error).message },
+        { status: 500 },
+      );
     }
   }
 
   // DELETE /api/v1/chats/share?chatId=X - Revokes a share.
-  async function deleteShareChat(_request: Request, url: URL): Promise<Response> {
+  async function deleteShareChat(
+    _request: Request,
+    url: URL,
+  ): Promise<Response> {
     const chatId = url.searchParams.get('chatId');
     if (!chatId) {
-      return Response.json({ success: false, error: 'chatId query parameter is required' }, { status: 400 });
+      return Response.json(
+        { success: false, error: 'chatId query parameter is required' },
+        { status: 400 },
+      );
     }
 
     try {
@@ -127,64 +271,110 @@ export default function createShareRoutes(
       const resp: RevokeShareResponse = { success: revoked };
       return Response.json(resp, { status: revoked ? 200 : 404 });
     } catch (error: unknown) {
-      return Response.json({ success: false, error: (error as Error).message }, { status: 500 });
+      return Response.json(
+        { success: false, error: (error as Error).message },
+        { status: 500 },
+      );
     }
   }
 
   // GET /api/v1/chats/share/status?chatId=X - Checks share status.
-  async function getShareStatus(_request: Request, url: URL): Promise<Response> {
+  async function getShareStatus(
+    _request: Request,
+    url: URL,
+  ): Promise<Response> {
     const chatId = url.searchParams.get('chatId');
     if (!chatId) {
-      return Response.json({ success: false, error: 'chatId query parameter is required' }, { status: 400 });
+      return Response.json(
+        { success: false, error: 'chatId query parameter is required' },
+        { status: 400 },
+      );
     }
 
     const existing = await shareStore.getShareByChatId(chatId);
     const resp: ShareStatusResponse = existing
-      ? { isShared: true, shareToken: existing.shareToken, shareUrl: `/shared/${existing.shareToken}`, sharedAt: existing.sharedAt }
+      ? {
+          isShared: true,
+          shareToken: existing.shareToken,
+          shareUrl: `/shared/${existing.shareToken}`,
+          sharedAt: existing.sharedAt,
+        }
       : { isShared: false };
     return Response.json(resp);
   }
 
   // GET /api/v1/shared - Public endpoint, returns snapshot by token.
-  const getSharedChat = markRouteNoAuth(async function getSharedChat(_request: Request, url: URL): Promise<Response> {
+  const getSharedChat = markRouteNoAuth(async function getSharedChat(
+    _request: Request,
+    url: URL,
+  ): Promise<Response> {
     const token = url.searchParams.get('token');
     if (!token) {
-      return Response.json({ error: 'token query parameter is required' }, { status: 400 });
+      return publicJsonResponse(
+        { error: 'token query parameter is required' },
+        400,
+      );
     }
 
     const snapshot = await shareStore.getShare(token);
     if (!snapshot) {
-      return Response.json({ error: 'Share not found' }, { status: 404 });
+      return publicJsonResponse({ error: 'Share not found' }, 404);
     }
 
-    const resp: GetSharedChatResponse = { snapshot };
-    return Response.json(resp);
+    const totalMessages = snapshot.messages.length;
+    const requestedBefore = url.searchParams.get('before');
+    const requestedVersion = url.searchParams.get('version');
+    const cursorIsStale =
+      requestedBefore !== null &&
+      requestedVersion !== null &&
+      requestedVersion !== snapshot.sharedAt;
+    const end = parseMessageCursor(
+      cursorIsStale ? null : requestedBefore,
+      totalMessages,
+    );
+    const pageSize = parsePageSize(
+      url.searchParams.get('limit'),
+      totalMessages,
+    );
+    const start = Math.max(0, end - pageSize);
+    const resp: GetSharedChatResponse = {
+      snapshot: { ...snapshot, messages: snapshot.messages.slice(start, end) },
+      page: {
+        snapshotVersion: snapshot.sharedAt,
+        totalMessages,
+        start,
+        end,
+        nextBefore: start > 0 ? start : null,
+        ...(cursorIsStale ? { reset: true } : {}),
+      },
+    };
+    return publicJsonResponse(resp);
   });
 
   // Serves a plain text transcript at /shared/llm/:token for LLM consumption.
-  const getLlmTranscript = markRouteNoAuth(async function getLlmTranscript(_request: Request, url: URL): Promise<Response> {
+  const getLlmTranscript = markRouteNoAuth(async function getLlmTranscript(
+    _request: Request,
+    url: URL,
+  ): Promise<Response> {
     const token = extractLlmTokenFromPath(url.pathname);
     if (!token) {
-      return Response.json({ error: 'Share token is required' }, { status: 400 });
+      return publicJsonResponse({ error: 'Share token is required' }, 400);
     }
 
     const snapshot = await shareStore.getShare(token);
     if (!snapshot) {
-      return Response.json({ error: 'Share not found' }, { status: 404 });
+      return publicJsonResponse({ error: 'Share not found' }, 404);
     }
 
-    return new Response(renderSharedChatText(snapshot), {
-      headers: {
-        'Content-Type': 'text/plain; charset=utf-8',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-      },
-    });
+    return plainTextResponse(snapshot);
   });
 
   // Serves the shared chat page at /shared/:token. Enriches the SPA shell with
-  // share metadata and an agent-readable transcript fallback so a shared link is
-  // both human-friendly and scrapable by agents that do not execute JavaScript.
-  const getSharedChatPage = markRouteNoAuth(async function getSharedChatPage(_request: Request, url: URL): Promise<Response> {
+  // share metadata and bounded transcript discovery so large chats stay fast.
+  const getSharedChatPage = markRouteNoAuth(async function getSharedChatPage(
+    request: Request,
+    url: URL,
+  ): Promise<Response> {
     const shell = await loadStaticText('/index.html');
     const token = extractShareTokenFromPath(url.pathname);
     const snapshot = token ? await shareStore.getShare(token) : null;
@@ -201,15 +391,28 @@ export default function createShareRoutes(
         : new Response('Not found', { status: 404 });
     }
 
+    const representation = negotiateSharedRepresentation(request);
+    if (representation === 'text') return plainTextResponse(snapshot);
+    if (!representation) {
+      return new Response('Not acceptable', {
+        status: 406,
+        headers: { 'Cache-Control': NO_STORE, Vary: 'Accept' },
+      });
+    }
+
     const canonicalUrl = `${url.origin}/shared/${encodeURIComponent(token)}`;
+    const llmPath = `/shared/llm/${encodeURIComponent(token)}`;
     const html = shell
       ? injectSharedChatContext(shell, snapshot, token, canonicalUrl, appTitle)
       : renderStandaloneSharedHtml(snapshot, token, canonicalUrl, appTitle);
-    return htmlResponse(html);
+    return htmlResponse(html, llmPath);
   });
 
   return {
-    '/api/v1/chats/share': { POST: withJsonBody(postShareChat), DELETE: deleteShareChat },
+    '/api/v1/chats/share': {
+      POST: withJsonBody(postShareChat),
+      DELETE: deleteShareChat,
+    },
     '/api/v1/chats/share/status': { GET: getShareStatus },
     '/api/v1/shared': { GET: getSharedChat },
     '/shared/:token': { GET: getSharedChatPage },

--- a/web/src/lib/api/shares.ts
+++ b/web/src/lib/api/shares.ts
@@ -25,9 +25,16 @@ export async function revokeShare(chatId: string): Promise<RevokeShareResponse> 
 	return apiDelete<RevokeShareResponse>(`/api/v1/chats/share?chatId=${encodeURIComponent(chatId)}`);
 }
 
-/** Fetches a shared chat snapshot (public, no auth). */
-export async function getSharedChat(token: string): Promise<GetSharedChatResponse> {
-	const response = await fetch(`/api/v1/shared?token=${encodeURIComponent(token)}`);
+/** Fetches a bounded page of a shared chat snapshot (public, no auth). */
+export async function getSharedChat(
+	token: string,
+	before?: number,
+	version?: string | null,
+): Promise<GetSharedChatResponse> {
+	const params = new URLSearchParams({ token, limit: '200' });
+	if (before !== undefined) params.set('before', String(before));
+	if (version) params.set('version', version);
+	const response = await fetch(`/api/v1/shared?${params.toString()}`);
 	if (!response.ok) {
 		throw new Error(response.status === 404 ? 'Share not found' : 'Failed to load shared chat');
 	}

--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -28,13 +28,36 @@
 
 	const appTitle = getAppTitle();
 
-	let messages = $state<ChatMessage[]>([]);
+	interface SharedMessageEntry {
+		index: number;
+		message: ChatMessage;
+	}
+
+	let messages = $state<SharedMessageEntry[]>([]);
 	let title = $state('');
 	let agentId = $state('');
 	let sharedAt = $state('');
 	let isLoading = $state(true);
+	let isLoadingEarlier = $state(false);
 	let errorMsg = $state<string | null>(null);
+	let olderPageError = $state(false);
+	let nextBefore = $state<number | null>(null);
+	let totalMessages = $state(0);
+	let snapshotVersion = $state<string | null>(null);
 	let thinkingStates = $state<Record<number, boolean>>({});
+
+	function parseMessages(rawMessages: unknown[], startIndex: number): SharedMessageEntry[] {
+		return rawMessages
+			.map((raw: unknown, offset): SharedMessageEntry | null => {
+				try {
+					const message = parseChatMessage(raw as Record<string, unknown>);
+					return message ? { index: startIndex + offset, message } : null;
+				} catch {
+					return null;
+				}
+			})
+			.filter((entry): entry is SharedMessageEntry => entry !== null);
+	}
 
 	onMount(() => {
 		const mql = window.matchMedia('(prefers-color-scheme: dark)');
@@ -61,15 +84,10 @@
 			title = snapshot.title;
 			agentId = snapshot.agentId;
 			sharedAt = snapshot.sharedAt;
-			messages = (snapshot.messages ?? [])
-				.map((raw: unknown) => {
-					try {
-						return parseChatMessage(raw as Record<string, unknown>);
-					} catch {
-						return null;
-					}
-				})
-				.filter((msg): msg is ChatMessage => msg !== null);
+			messages = parseMessages(snapshot.messages ?? [], resp.page.start);
+			totalMessages = resp.page.totalMessages;
+			nextBefore = resp.page.nextBefore;
+			snapshotVersion = resp.page.snapshotVersion;
 		} catch {
 			errorMsg = m.shared_view_not_found();
 		} finally {
@@ -79,6 +97,44 @@
 			window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });
 		}
 	});
+
+	async function loadEarlier(): Promise<void> {
+		if (nextBefore === null || isLoadingEarlier) return;
+		isLoadingEarlier = true;
+		olderPageError = false;
+		try {
+			const resp = await getSharedChat(token, nextBefore, snapshotVersion);
+			const olderMessages = parseMessages(resp.snapshot.messages ?? [], resp.page.start);
+			if (resp.page.reset || resp.page.snapshotVersion !== snapshotVersion) {
+				const snapshot = resp.snapshot;
+				title = snapshot.title;
+				agentId = snapshot.agentId;
+				sharedAt = snapshot.sharedAt;
+				messages = olderMessages;
+				totalMessages = resp.page.totalMessages;
+				nextBefore = resp.page.nextBefore;
+				snapshotVersion = resp.page.snapshotVersion;
+				await tick();
+				window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });
+				return;
+			}
+			// Capture the live viewport immediately before prepending. The reader may
+			// scroll while the request is in flight.
+			const previousHeight = document.documentElement.scrollHeight;
+			const previousScrollY = window.scrollY;
+			messages = [...olderMessages, ...messages];
+			nextBefore = resp.page.nextBefore;
+			totalMessages = resp.page.totalMessages;
+			snapshotVersion = resp.page.snapshotVersion;
+			await tick();
+			const addedHeight = document.documentElement.scrollHeight - previousHeight;
+			window.scrollTo({ top: previousScrollY + addedHeight, behavior: 'instant' });
+		} catch {
+			olderPageError = true;
+		} finally {
+			isLoadingEarlier = false;
+		}
+	}
 
 	function formattedSharedDate(): string {
 		if (!sharedAt) return '';
@@ -91,8 +147,8 @@
 		});
 	}
 
-	function toggleThinking(idx: number) {
-		thinkingStates[idx] = !thinkingStates[idx];
+	function toggleThinking(messageIndex: number) {
+		thinkingStates[messageIndex] = !thinkingStates[messageIndex];
 	}
 
 	function isGroupedWith(prev: ChatMessage | null, current: ChatMessage): boolean {
@@ -166,8 +222,30 @@
 			</div>
 		{:else}
 			<div class="space-y-1">
-				{#each messages as message, idx}
-					{@const prevMessage = idx > 0 ? messages[idx - 1] : null}
+				{#if nextBefore !== null || olderPageError}
+					<div class="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+						<div class="h-px flex-1 bg-border/70"></div>
+						<button
+							type="button"
+							class="h-8 rounded-md px-3 hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+							disabled={isLoadingEarlier}
+							aria-busy={isLoadingEarlier}
+							onclick={loadEarlier}
+						>
+							{#if isLoadingEarlier}
+								{m.chat_transcript_loading_earlier()}
+							{:else if olderPageError}
+								{m.chat_transcript_retry_earlier()}
+							{:else}
+								{m.chat_transcript_load_earlier()}
+							{/if}
+						</button>
+						<div class="h-px flex-1 bg-border/70"></div>
+					</div>
+				{/if}
+				{#each messages as entry, idx (entry.index)}
+					{@const message = entry.message}
+					{@const prevMessage = idx > 0 ? messages[idx - 1].message : null}
 					{@const isGrouped = isGroupedWith(prevMessage, message)}
 					<svelte:boundary>
 						{#snippet failed(error)}
@@ -209,19 +287,20 @@
 										<button
 											type="button"
 											class="flex w-full items-center gap-2 text-left cursor-pointer"
-											onclick={() => toggleThinking(idx)}
-											aria-expanded={thinkingStates[idx] ?? true}
+											onclick={() => toggleThinking(entry.index)}
+											aria-expanded={thinkingStates[entry.index] ?? true}
 										>
 											<span class="text-xs font-medium text-muted-foreground"
 												>{m.chat_message_thinking()}</span
 											>
 											<ChevronRight
-												class="ml-auto w-3 h-3 transition-transform {(thinkingStates[idx] ?? true)
+												class="ml-auto w-3 h-3 transition-transform {(thinkingStates[entry.index] ??
+												true)
 													? 'rotate-90'
 													: ''}"
 											/>
 										</button>
-										{#if thinkingStates[idx] ?? true}
+										{#if thinkingStates[entry.index] ?? true}
 											<div class="mt-0.5 text-sm text-foreground/90">
 												<Markdown source={message.content} variant="thinking" />
 											</div>
@@ -249,7 +328,7 @@
 			class="max-w-4xl mx-auto px-4 sm:px-6 flex items-center justify-between text-xs text-muted-foreground"
 		>
 			<span>{m.shared_view_via_app()}</span>
-			<span>{messages.length} messages</span>
+			<span>{messages.length} of {totalMessages} messages</span>
 		</div>
 	</footer>
 </div>

--- a/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
+++ b/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
@@ -1,0 +1,144 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SharedChatPageTestHost from './SharedChatPageTestHost.svelte';
+import * as sharesApi from '$lib/api/shares';
+import type { GetSharedChatResponse } from '$shared/share-types';
+
+vi.mock('$lib/api/shares', () => ({
+	getSharedChat: vi.fn(),
+}));
+
+function response(
+	contents: string[],
+	start: number,
+	totalMessages = 250,
+	pageOverrides: Partial<GetSharedChatResponse['page']> = {},
+): GetSharedChatResponse {
+	return {
+		snapshot: {
+			shareToken: 'share-token',
+			chatId: 'chat-1',
+			title: 'Large shared chat',
+			agentId: 'codex',
+			model: 'gpt-5',
+			projectPath: '/workspace/garcon',
+			sharedAt: pageOverrides.snapshotVersion ?? '2025-01-02T03:04:05.000Z',
+			messages: contents.map((content, index) => ({
+				type: 'assistant-message',
+				timestamp: `2025-01-02T03:05:${String(index).padStart(2, '0')}.000Z`,
+				content,
+			})),
+		},
+		page: {
+			snapshotVersion: '2025-01-02T03:04:05.000Z',
+			totalMessages,
+			start,
+			end: start + contents.length,
+			nextBefore: start > 0 ? start : null,
+			...pageOverrides,
+		},
+	};
+}
+
+describe('SharedChatPage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubGlobal('scrollTo', vi.fn());
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn(() => ({
+				matches: false,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+			})),
+		);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('renders a bounded newest page and prepends older messages on demand', async () => {
+		vi.mocked(sharesApi.getSharedChat)
+			.mockResolvedValueOnce(response(['newest-1', 'newest-2'], 50))
+			.mockResolvedValueOnce(response(['oldest-1', 'oldest-2'], 0));
+
+		render(SharedChatPageTestHost);
+
+		await screen.findByText('newest-1');
+		const newestMessage = screen.getByText('newest-1').closest('.chat-message');
+		expect(screen.getByText('2 of 250 messages')).toBeTruthy();
+		expect(sharesApi.getSharedChat).toHaveBeenNthCalledWith(1, 'share-token');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Load earlier messages' }));
+
+		await screen.findByText('oldest-1');
+		await waitFor(() => {
+			expect(sharesApi.getSharedChat).toHaveBeenNthCalledWith(
+				2,
+				'share-token',
+				50,
+				'2025-01-02T03:04:05.000Z',
+			);
+		});
+		expect(screen.getByText('4 of 250 messages')).toBeTruthy();
+		expect(screen.getByText('newest-1').closest('.chat-message')).toBe(newestMessage);
+		expect(screen.queryByRole('button', { name: 'Load earlier messages' })).toBeNull();
+	});
+
+	it('anchors from the viewport position when an older-page request completes', async () => {
+		let resolveOlder!: (value: GetSharedChatResponse) => void;
+		vi.mocked(sharesApi.getSharedChat)
+			.mockResolvedValueOnce(response(['newest'], 50))
+			.mockImplementationOnce(
+				() => new Promise<GetSharedChatResponse>((resolve) => (resolveOlder = resolve)),
+			);
+		const scrollTo = vi.mocked(window.scrollTo);
+		let scrollY = 40;
+		vi.spyOn(window, 'scrollY', 'get').mockImplementation(() => scrollY);
+		vi.spyOn(document.documentElement, 'scrollHeight', 'get')
+			.mockReturnValueOnce(1_000)
+			.mockReturnValueOnce(1_250);
+
+		render(SharedChatPageTestHost);
+		await screen.findByText('newest');
+		await fireEvent.click(screen.getByRole('button', { name: 'Load earlier messages' }));
+		await waitFor(() => expect(sharesApi.getSharedChat).toHaveBeenCalledTimes(2));
+
+		scrollY = 275;
+		resolveOlder(response(['older'], 0));
+		await screen.findByText('older');
+		await waitFor(() =>
+			expect(scrollTo).toHaveBeenLastCalledWith({ top: 525, behavior: 'instant' }),
+		);
+	});
+
+	it('restarts from the newest page when a share updates between page requests', async () => {
+		vi.mocked(sharesApi.getSharedChat)
+			.mockResolvedValueOnce(response(['old-newest'], 50))
+			.mockResolvedValueOnce(
+				response(['updated-newest'], 70, 270, {
+					snapshotVersion: '2025-01-02T04:04:05.000Z',
+					reset: true,
+				}),
+			);
+
+		render(SharedChatPageTestHost);
+		await screen.findByText('old-newest');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Load earlier messages' }));
+
+		await screen.findByText('updated-newest');
+		expect(screen.queryByText('old-newest')).toBeNull();
+		expect(screen.getByText('1 of 270 messages')).toBeTruthy();
+		await waitFor(() => {
+			expect(sharesApi.getSharedChat).toHaveBeenNthCalledWith(
+				2,
+				'share-token',
+				50,
+				'2025-01-02T03:04:05.000Z',
+			);
+		});
+	});
+});

--- a/web/src/lib/components/chat/__tests__/SharedChatPageTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/SharedChatPageTestHost.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import SharedChatPage from '../SharedChatPage.svelte';
+	import { setAppTitle } from '$lib/context';
+	import { createAppTitleStore } from '$lib/stores/app-title.svelte';
+
+	let { token = 'share-token' }: { token?: string } = $props();
+	setAppTitle(createAppTitleStore());
+</script>
+
+<SharedChatPage {token} />


### PR DESCRIPTION
## What was broken

Large shared-chat pages embedded the full plain-text transcript directly in the HTML fallback, then the SPA fetched the full snapshot again. The reported share has **4,084 messages** and an **~8MB snapshot**, so mobile browsers parsed a huge raw `<pre>` before hydration. That matched the screenshot: raw transcript visible, slow load, broken scroll.

## Fix

- Keep canonical shared HTML bounded: metadata + small no-JS fallback linking to the transcript instead of embedding it.
- Preserve agent access through explicit machine-readable routes and content negotiation:
  - `Link: </shared/llm/:token>; rel="alternate"; type="text/plain"`
  - `<link rel="alternate" type="text/plain" ...>` in HTML
  - `/shared/:token` returns text for generic/no `Accept`, HTML for browser navigation, and honors weighted/rejected media ranges.
  - `Vary: Accept` prevents the service worker from reusing cached HTML for text requests.
- Add paginated shared snapshot reads: `/api/v1/shared?token=...&limit=200&before=...&version=...`, with explicit no-store caching.
- Load newest messages first in the shared UI and add `Load earlier messages`.
- Key rendered messages by their absolute snapshot index so prepends preserve component/disclosure state.
- Preserve scroll position from the live viewport when an older-page request completes, rather than from the click-time position.
- Keep old unpaginated API behavior when `limit` is omitted.
- Tie older-page cursors to `snapshotVersion` (`sharedAt`) so same-token share updates reset to the newest page instead of mixing generations and losing appended messages.

## Evidence

Original production snapshot copied into local repro:

- Messages: **4,084**
- Snapshot bytes: **8,255,592**

Fixed local repro:

- `/shared/:token` HTML: **8,657 bytes**
- `/api/v1/shared?...&limit=200`: **431,490 bytes**, **200 of 4,084 messages**, `nextBefore=3884`
- `/shared/:token` with `Accept: text/plain`: **7,935,565 bytes** transcript for agents
- Browser DOM after load: **89** rendered message articles, **scrollable=true**, footer `200 of 4084 messages`
- After `Load earlier messages`: **180** rendered articles, footer `400 of 4084 messages`, scroll anchor preserved

## Tests

Passed:

- `bun run lint`
- `bun run check`
- `bun test server/routes/__tests__/shares.test.js` — **14 tests passed**
- `bun run --cwd web test --run src/lib/components/chat/__tests__/SharedChatPage.test.ts` — **3 tests passed**
- `bun run test:cli` — **258 tests passed**
- `bun run --cwd web test --run --shard={1,2,3}/3` — **377 files / 3,741 tests passed**
- GitHub `server-tests` on final commit `5ae6a15a`