### PR TITLE
Restore chat half-page shortcuts

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1304,6 +1304,8 @@
 	"settings_shortcut_navigate_chat_below": "Go to chat below",
 	"settings_shortcut_toggle_main_sidebar_focus": "Toggle focus between main view and workspace sidebar",
 	"settings_shortcut_open_settings": "Open settings",
+	"settings_shortcut_scroll_half_page_up": "Scroll up half a page",
+	"settings_shortcut_scroll_half_page_down": "Scroll down half a page",
 	"settings_shortcut_send_message": "Send message",
 	"settings_shortcut_system_default": "System default",
 	"settings_shortcut_custom": "Custom",

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -1267,17 +1267,82 @@ describe('ConversationScrollController', () => {
 		expect(fixture.state.invalidatePendingWindowNavigation).toHaveBeenCalledTimes(2);
 	});
 
-	it('keeps Ctrl-U half-page scrolling on the viewport port', () => {
+	it('scrolls the feed half a viewport in either direction', () => {
 		const scroller = document.createElement('div');
 		Object.defineProperty(scroller, 'clientHeight', { value: 600 });
 		document.body.append(scroller);
 		scroller.tabIndex = -1;
 		scroller.focus();
 		const { controller, viewport } = controllerFixture({ scroller });
-		const event = new KeyboardEvent('keydown', { key: 'u', ctrlKey: true, cancelable: true });
-		controller.handleHalfPageScroll(event);
-		expect(event.defaultPrevented).toBe(true);
+
+		const up = new KeyboardEvent('keydown', { key: 'u', ctrlKey: true, cancelable: true });
+		controller.scrollFeedHalfPage(up, 'earlier');
+		expect(up.defaultPrevented).toBe(true);
 		expect(viewport.scrollBy).toHaveBeenCalledWith(-300);
+
+		const down = new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, cancelable: true });
+		controller.scrollFeedHalfPage(down, 'later');
+		expect(down.defaultPrevented).toBe(true);
+		expect(viewport.scrollBy).toHaveBeenLastCalledWith(300);
+
 		scroller.remove();
+	});
+
+	it('reconciles pinned state after a viewport-owned half-page scroll', () => {
+		const scroller = document.createElement('div');
+		Object.defineProperty(scroller, 'clientHeight', { value: 600 });
+		document.body.append(scroller);
+		scroller.tabIndex = -1;
+		scroller.focus();
+		let atEnd = false;
+		const viewport = fakeViewport({
+			isAtEnd: vi.fn(() => atEnd),
+			ownsScrollPosition: vi.fn(() => true),
+		});
+		const { controller, state } = controllerFixture({ scroller, viewport });
+
+		controller.scrollFeedHalfPage(
+			new KeyboardEvent('keydown', { key: 'u', ctrlKey: true, cancelable: true }),
+			'earlier',
+		);
+		expect(controller.isPinnedToBottom).toBe(false);
+		expect(state.isUserScrolledUp).toBe(true);
+
+		atEnd = true;
+		controller.scrollFeedHalfPage(
+			new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, cancelable: true }),
+			'later',
+		);
+		expect(controller.isPinnedToBottom).toBe(true);
+		expect(state.isUserScrolledUp).toBe(false);
+		expect(viewport.scrollToEnd).toHaveBeenCalledOnce();
+
+		scroller.remove();
+	});
+
+	it('consumes half-page shortcuts but only scrolls from feed or composer focus', () => {
+		const scroller = document.createElement('div');
+		Object.defineProperty(scroller, 'clientHeight', { value: 600 });
+		document.body.append(scroller);
+		const outside = document.createElement('button');
+		const textarea = document.createElement('textarea');
+		document.body.append(outside, textarea);
+		const { controller, viewport } = controllerFixture({ scroller });
+
+		outside.focus();
+		const ignored = new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, cancelable: true });
+		controller.scrollFeedHalfPage(ignored, 'later');
+		expect(ignored.defaultPrevented).toBe(true);
+		expect(viewport.scrollBy).not.toHaveBeenCalled();
+
+		textarea.focus();
+		const handled = new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, cancelable: true });
+		controller.scrollFeedHalfPage(handled, 'later');
+		expect(handled.defaultPrevented).toBe(true);
+		expect(viewport.scrollBy).toHaveBeenCalledWith(300);
+
+		scroller.remove();
+		outside.remove();
+		textarea.remove();
 	});
 });

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -234,6 +234,10 @@ export class ConversationScrollController {
 			return;
 		}
 		if (this.deps.getViewport()?.ownsScrollPosition()) return;
+		this.#reconcileUserScroll(inferredDirection);
+	}
+
+	#reconcileUserScroll(inferredDirection: TranscriptPageDirection | null): void {
 		this.#applyInferredIntentDirection(inferredDirection);
 		const nearBottom = this.isNearBottom();
 		const hasRecentUserScrollIntent = this.#hasRecentUserScrollIntent();
@@ -543,16 +547,21 @@ export class ConversationScrollController {
 		void this.#restoreVisibleViewport();
 	}
 
-	handleHalfPageScroll(event: KeyboardEvent): void {
+	// Scrolls the feed half a viewport in the given direction when focus is inside
+	// the composer or the scroll container; binding matching belongs to the caller.
+	scrollFeedHalfPage(event: KeyboardEvent, direction: TranscriptPageDirection): void {
 		const scrollContainer = this.deps.getScrollContainer();
-		if (!scrollContainer || !event.ctrlKey || event.key !== 'u') return;
+		if (!scrollContainer) return;
+		event.preventDefault();
 		const active = document.activeElement;
 		const inTextarea = active?.tagName === 'TEXTAREA';
 		const inContainer = scrollContainer.contains(active) || active === scrollContainer;
 		if (!inTextarea && !inContainer) return;
-		event.preventDefault();
-		this.noteUserScrollIntent('earlier');
-		this.deps.getViewport()?.scrollBy(-scrollContainer.clientHeight / 2);
+		this.noteUserScrollIntent(direction);
+		const half = scrollContainer.clientHeight / 2;
+		const viewport = this.deps.getViewport();
+		viewport?.scrollBy(direction === 'later' ? half : -half);
+		if (viewport) this.#reconcileUserScroll(direction);
 	}
 
 	async #mutatePage(

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -53,6 +53,10 @@
 	import { isChatProcessing } from '$lib/chat/sessions/chat-processing.js';
 	import { CHAT_SURFACE_ID } from '$lib/workspace/surface-types.js';
 	import {
+		getEffectiveGlobalShortcut,
+		globalShortcutMatchesEvent,
+	} from '$lib/workspace/global-shortcuts.js';
+	import {
 		composerCapReservation,
 		shouldReserveComposerCapSlot,
 	} from '$lib/chat/composer/composer-cap-layout.js';
@@ -492,7 +496,16 @@
 			controller.handleAbort();
 			return true;
 		}
-		scroll.handleHalfPageScroll(event);
+		const overrides = localSettings.globalShortcuts;
+		const up = getEffectiveGlobalShortcut('scroll-half-page-up', overrides);
+		if (up && globalShortcutMatchesEvent(up, event)) {
+			scroll.scrollFeedHalfPage(event, 'earlier');
+		} else {
+			const down = getEffectiveGlobalShortcut('scroll-half-page-down', overrides);
+			if (down && globalShortcutMatchesEvent(down, event)) {
+				scroll.scrollFeedHalfPage(event, 'later');
+			}
+		}
 		return event.defaultPrevented;
 	}
 

--- a/web/src/lib/components/settings/__tests__/KeyboardShortcutsSection.test.ts
+++ b/web/src/lib/components/settings/__tests__/KeyboardShortcutsSection.test.ts
@@ -22,16 +22,18 @@ describe('KeyboardShortcutsSection', () => {
 		await fireEvent.keyDown(changeNewChat, { key: 'd', ctrlKey: true });
 
 		expect(screen.getByRole('status').textContent).toContain(
-			'Ctrl+D was removed from Delete selected chat',
+			'Ctrl+D was removed from Scroll down half a page',
 		);
 		expect(
-			within(screen.getByRole('group', { name: 'Delete selected chat' })).getByText('Unassigned'),
+			within(screen.getByRole('group', { name: 'Scroll down half a page' })).getByText(
+				'Unassigned',
+			),
 		).toBeTruthy();
 		expect(
 			JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.localSettings) ?? '{}').globalShortcuts,
 		).toMatchObject({
 			'new-chat': { key: 'd', ctrl: true },
-			'delete-chat': null,
+			'scroll-half-page-down': null,
 		});
 	});
 

--- a/web/src/lib/components/settings/__tests__/Settings.test.ts
+++ b/web/src/lib/components/settings/__tests__/Settings.test.ts
@@ -258,6 +258,8 @@ describe('Settings', () => {
 			).toBeTruthy();
 			expect(screen.getByText('New chat')).toBeTruthy();
 			expect(screen.getByText('Delete selected chat')).toBeTruthy();
+			expect(screen.getByText('Scroll up half a page')).toBeTruthy();
+			expect(screen.getByText('Scroll down half a page')).toBeTruthy();
 			expect(screen.getByText('Send message')).toBeTruthy();
 			expect(screen.getByText('/compact')).toBeTruthy();
 			expect(screen.getByText('/fork [<prompt>]')).toBeTruthy();

--- a/web/src/lib/components/settings/__tests__/keyboard-shortcut-entries.logic.test.ts
+++ b/web/src/lib/components/settings/__tests__/keyboard-shortcut-entries.logic.test.ts
@@ -21,6 +21,9 @@ describe('keyboard shortcut entries', () => {
 			'O',
 		]);
 		expect(shortcutKeys.get('New chat')).toEqual(['Ctrl', 'N']);
+		expect(shortcutKeys.get('Delete selected chat')).toEqual(['Ctrl', 'Shift', 'D']);
+		expect(shortcutKeys.get('Scroll up half a page')).toEqual(['Ctrl', 'U']);
+		expect(shortcutKeys.get('Scroll down half a page')).toEqual(['Ctrl', 'D']);
 	});
 
 	it('documents the schedule-in command syntax', () => {

--- a/web/src/lib/components/settings/keyboard-shortcut-entries.ts
+++ b/web/src/lib/components/settings/keyboard-shortcut-entries.ts
@@ -30,6 +30,8 @@ export const GLOBAL_SHORTCUTS: readonly ShortcutEntry[] = [
 		label: m.settings_shortcut_toggle_main_sidebar_focus,
 	},
 	{ id: 'open-settings', label: m.settings_shortcut_open_settings },
+	{ id: 'scroll-half-page-up', label: m.settings_shortcut_scroll_half_page_up },
+	{ id: 'scroll-half-page-down', label: m.settings_shortcut_scroll_half_page_down },
 ];
 
 export const SLASH_COMMANDS: readonly SlashCommandEntry[] = [

--- a/web/src/lib/components/shared/__tests__/keyboard-shortcuts.test.ts
+++ b/web/src/lib/components/shared/__tests__/keyboard-shortcuts.test.ts
@@ -59,7 +59,7 @@ describe('KeyboardShortcuts', () => {
 		}
 	});
 
-	it('requests delete on Ctrl-D', async () => {
+	it('requests delete on Ctrl-Shift-D', async () => {
 		const appShell = createMockAppShell();
 		const navigation = createMockNavigation();
 
@@ -69,9 +69,29 @@ describe('KeyboardShortcuts', () => {
 			onToggleCommandMenu: vi.fn(),
 		});
 
-		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', ctrlKey: true }));
+		window.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'D', ctrlKey: true, shiftKey: true }),
+		);
 
 		expect(appShell.requestDeleteSelectedChat).toHaveBeenCalledTimes(1);
+	});
+
+	it('consumes Ctrl-D without deleting while the chat list owns focus', () => {
+		const appShell = createMockAppShell();
+		const event = new KeyboardEvent('keydown', {
+			key: 'd',
+			ctrlKey: true,
+			cancelable: true,
+		});
+
+		render(KeyboardShortcutsHost, {
+			appShell,
+			navigation: createMockNavigation(),
+		});
+		window.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(appShell.requestDeleteSelectedChat).not.toHaveBeenCalled();
 	});
 
 	it('uses a customized delete shortcut immediately', () => {
@@ -98,12 +118,14 @@ describe('KeyboardShortcuts', () => {
 			globalShortcuts: { 'delete-chat': null },
 		});
 
-		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', ctrlKey: true }));
+		window.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'D', ctrlKey: true, shiftKey: true }),
+		);
 
 		expect(appShell.requestDeleteSelectedChat).not.toHaveBeenCalled();
 	});
 
-	it('requests delete instead of scrolling while Chat owns focus', async () => {
+	it('leaves Ctrl-D to feed scrolling while Chat owns focus', async () => {
 		const appShell = createMockAppShell();
 		const navigation = createMockNavigation();
 
@@ -119,7 +141,39 @@ describe('KeyboardShortcuts', () => {
 		input.focus();
 
 		try {
-			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, bubbles: true }));
+			input.dispatchEvent(
+				new KeyboardEvent('keydown', { key: 'd', ctrlKey: true, bubbles: true }),
+			);
+			expect(appShell.requestDeleteSelectedChat).not.toHaveBeenCalled();
+		} finally {
+			input.remove();
+		}
+	});
+
+	it('requests delete on Ctrl-Shift-D while Chat owns focus', async () => {
+		const appShell = createMockAppShell();
+		const navigation = createMockNavigation();
+
+		render(KeyboardShortcutsHost, {
+			appShell,
+			navigation,
+			onToggleCommandMenu: vi.fn(),
+			focusOwner: 'chat',
+		});
+
+		const input = document.createElement('input');
+		document.body.appendChild(input);
+		input.focus();
+
+		try {
+			input.dispatchEvent(
+				new KeyboardEvent('keydown', {
+					key: 'D',
+					ctrlKey: true,
+					shiftKey: true,
+					bubbles: true,
+				}),
+			);
 			expect(appShell.requestDeleteSelectedChat).toHaveBeenCalledOnce();
 		} finally {
 			input.remove();

--- a/web/src/lib/workspace/__tests__/global-shortcuts.test.ts
+++ b/web/src/lib/workspace/__tests__/global-shortcuts.test.ts
@@ -11,7 +11,19 @@ import {
 
 describe('global shortcuts', () => {
 	it('uses defaults until a command is customized or disabled', () => {
-		expect(getEffectiveGlobalShortcut('delete-chat', {})).toEqual({ key: 'd', ctrl: true });
+		expect(getEffectiveGlobalShortcut('delete-chat', {})).toEqual({
+			key: 'd',
+			ctrl: true,
+			shift: true,
+		});
+		expect(getEffectiveGlobalShortcut('scroll-half-page-up', {})).toEqual({
+			key: 'u',
+			ctrl: true,
+		});
+		expect(getEffectiveGlobalShortcut('scroll-half-page-down', {})).toEqual({
+			key: 'd',
+			ctrl: true,
+		});
 		expect(
 			getEffectiveGlobalShortcut('delete-chat', {
 				'delete-chat': { key: 'x', ctrl: true },
@@ -54,15 +66,15 @@ describe('global shortcuts', () => {
 	it('auto-unassigns the previous command when assigning a duplicate', () => {
 		const result = assignGlobalShortcut({}, 'new-chat', { key: 'd', ctrl: true });
 
-		expect(result.unassignedId).toBe('delete-chat');
-		expect(result.overrides['delete-chat']).toBeNull();
+		expect(result.unassignedId).toBe('scroll-half-page-down');
+		expect(result.overrides['scroll-half-page-down']).toBeNull();
 		expect(result.overrides['new-chat']).toEqual({ key: 'd', ctrl: true });
 	});
 
 	it('auto-unassigns a custom conflict when restoring a system default', () => {
 		const result = resetGlobalShortcut(
 			{
-				'new-chat': { key: 'd', ctrl: true },
+				'new-chat': { key: 'd', ctrl: true, shift: true },
 				'delete-chat': null,
 			},
 			'delete-chat',
@@ -83,6 +95,20 @@ describe('global shortcuts', () => {
 			}),
 		).toEqual({
 			'delete-chat': { key: 'x', ctrl: true },
+		});
+	});
+
+	it('disables defaults that conflict with persisted custom bindings', () => {
+		expect(
+			sanitizeGlobalShortcutOverrides({
+				'navigate-tab-left': { key: 'D', ctrl: true, shift: true },
+				'rename-chat': { key: 'D', ctrl: true },
+			}),
+		).toEqual({
+			'navigate-tab-left': { key: 'd', ctrl: true, shift: true },
+			'rename-chat': { key: 'd', ctrl: true },
+			'delete-chat': null,
+			'scroll-half-page-down': null,
 		});
 	});
 

--- a/web/src/lib/workspace/global-shortcuts.ts
+++ b/web/src/lib/workspace/global-shortcuts.ts
@@ -10,6 +10,8 @@ export const GLOBAL_SHORTCUT_IDS = [
 	'navigate-chat-below',
 	'toggle-main-sidebar-focus',
 	'open-settings',
+	'scroll-half-page-up',
+	'scroll-half-page-down',
 ] as const;
 
 export type GlobalShortcutId = (typeof GLOBAL_SHORTCUT_IDS)[number];
@@ -37,7 +39,7 @@ export const GLOBAL_SHORTCUT_DEFINITIONS: readonly GlobalShortcutDefinition[] = 
 	{ id: 'open-sidebar-search', defaultBinding: { key: 's', primary: true } },
 	{ id: 'new-chat', defaultBinding: { key: 'n', ctrl: true } },
 	{ id: 'rename-chat', defaultBinding: { key: 'r', ctrl: true } },
-	{ id: 'delete-chat', defaultBinding: { key: 'd', ctrl: true } },
+	{ id: 'delete-chat', defaultBinding: { key: 'd', ctrl: true, shift: true } },
 	{ id: 'navigate-tab-left', defaultBinding: { key: 'j', ctrl: true, shift: true } },
 	{ id: 'navigate-tab-right', defaultBinding: { key: 'l', ctrl: true, shift: true } },
 	{ id: 'navigate-chat-above', defaultBinding: { key: 'p', ctrl: true, shift: true } },
@@ -47,6 +49,8 @@ export const GLOBAL_SHORTCUT_DEFINITIONS: readonly GlobalShortcutDefinition[] = 
 		defaultBinding: { key: 'o', ctrl: true, shift: true },
 	},
 	{ id: 'open-settings', defaultBinding: { key: ',', ctrl: true } },
+	{ id: 'scroll-half-page-up', defaultBinding: { key: 'u', ctrl: true } },
+	{ id: 'scroll-half-page-down', defaultBinding: { key: 'd', ctrl: true } },
 ];
 
 const definitionById = new Map(
@@ -85,6 +89,18 @@ export function sanitizeGlobalShortcutOverrides(value: unknown): GlobalShortcutO
 		}
 		const binding = normalizeBinding(candidate[id]);
 		if (binding && isSafeGlobalShortcutBinding(binding)) overrides[id] = binding;
+	}
+
+	// Preserves persisted custom bindings when a later release adds or moves a default.
+	for (const definition of GLOBAL_SHORTCUT_DEFINITIONS) {
+		if (Object.hasOwn(overrides, definition.id)) continue;
+		const conflictsWithOverride = GLOBAL_SHORTCUT_IDS.some((id) => {
+			const binding = overrides[id];
+			return binding
+				? globalShortcutBindingsConflict(definition.defaultBinding, binding)
+				: false;
+		});
+		if (conflictsWithOverride) overrides[definition.id] = null;
 	}
 	return overrides;
 }

--- a/web/src/lib/workspace/workspace-shortcuts.ts
+++ b/web/src/lib/workspace/workspace-shortcuts.ts
@@ -142,6 +142,8 @@ export class WorkspaceShortcutDispatcher {
 		} else if (matches('delete-chat')) {
 			event.preventDefault();
 			this.deps.appShell.requestDeleteSelectedChat();
+		} else if (matches('scroll-half-page-up') || matches('scroll-half-page-down')) {
+			event.preventDefault();
 		}
 	}
 


### PR DESCRIPTION
Restores conventional half-page transcript navigation by assigning customizable Ctrl+U and Ctrl+D shortcuts to scroll up and down, while moving chat deletion to Ctrl+Shift+D to remove the conflict. Keyboard scrolling now follows the transcript controller's pinning behavior, shortcut dispatch suppresses browser defaults consistently, and persisted custom bindings continue to take precedence as the defaults change.