### PR TITLE
Stop chat transcript paging stalls

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -1484,10 +1484,6 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
     await withDiagnosticTimeout('the first held earlier-page request', firstPageRequest);
     expect(loadAheadDistance).toBeGreaterThan(0);
     expect(await transcriptBoundaryIntersectsViewport(fixture.page, 'earlier')).toBe(false);
-    const earlierLoadingIndicator = fixture.page.locator(
-      '[data-chat-earlier-loading-indicator]',
-    );
-    await earlierLoadingIndicator.waitFor({ state: 'visible' });
 
     expect(
       await fixture.page.locator('[data-transcript-page-boundary="earlier"]').count(),
@@ -1580,7 +1576,6 @@ async function verifyEarlierPrefetchDuringProcessing(fixture: ChromiumFixture): 
       fixture.page,
       modelCountBeforePrefetch + 50,
     );
-    await earlierLoadingIndicator.waitFor({ state: 'detached' });
     const prependFrames = await finishReadingAnchorFrameSampler(fixture.page);
     expect(
       Math.max(

--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -165,6 +165,12 @@ async function waitForStableModelCount(page: Page, minimum: number): Promise<num
   }, minimum);
 }
 
+async function transcriptEntryCount(page: Page): Promise<number> {
+  return page
+    .locator(SIZER_SELECTOR)
+    .evaluate((sizer) => Number((sizer as HTMLElement).dataset.chatTranscriptEntryCount ?? 0));
+}
+
 async function virtualDataRevision(page: Page): Promise<number> {
   return page
     .locator(SIZER_SELECTOR)
@@ -1804,28 +1810,7 @@ async function verifyLaterPageReadingPosition(
   await waitForTranscriptReady(fixture.page);
 
   await signalScrollIntent(fixture.page, 'earlier');
-  const prefetchPosition = await fixture.page
-    .locator(FEED_SELECTOR)
-    .evaluate(async (feedElement) => {
-      const feed = feedElement as HTMLElement;
-      const settle = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-      const targetDistance = Math.max(51, feed.clientHeight * 0.75);
-      let stableFrames = 0;
-      for (let attempt = 0; attempt < 30; attempt += 1) {
-        const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
-        if (maximum > targetDistance) {
-          feed.scrollTop = maximum - targetDistance;
-          feed.dispatchEvent(new Event('scroll', { bubbles: true }));
-        }
-        await settle();
-        const distanceFromEnd = feed.scrollHeight - feed.clientHeight - feed.scrollTop;
-        stableFrames = Math.abs(distanceFromEnd - targetDistance) <= 1 ? stableFrames + 1 : 0;
-        if (stableFrames >= 4) {
-          return { distanceFromEnd, viewportHeight: feed.clientHeight };
-        }
-      }
-      throw new Error('The later-page prefetch position did not settle.');
-    });
+  const prefetchPosition = await positionNearLaterPageBoundary(fixture.page);
   expect(prefetchPosition.distanceFromEnd).toBeGreaterThan(50);
   expect(prefetchPosition.distanceFromEnd).toBeLessThanOrEqual(prefetchPosition.viewportHeight);
   const anchor = await readingAnchor(fixture.page);
@@ -1856,6 +1841,31 @@ async function verifyLaterPageReadingPosition(
     .waitFor();
   await waitForStablePinnedTranscriptLayout(fixture.page, 'live-append-after-return');
   fixture.assertNoBrowserErrors();
+}
+
+async function positionNearLaterPageBoundary(
+  page: Page,
+): Promise<{ distanceFromEnd: number; viewportHeight: number }> {
+  return page.locator(FEED_SELECTOR).evaluate(async (feedElement) => {
+    const feed = feedElement as HTMLElement;
+    const settle = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const targetDistance = Math.max(51, feed.clientHeight * 0.75);
+    let stableFrames = 0;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const maximum = Math.max(0, feed.scrollHeight - feed.clientHeight);
+      if (maximum > targetDistance) {
+        feed.scrollTop = maximum - targetDistance;
+        feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+      }
+      await settle();
+      const distanceFromEnd = feed.scrollHeight - feed.clientHeight - feed.scrollTop;
+      stableFrames = Math.abs(distanceFromEnd - targetDistance) <= 1 ? stableFrames + 1 : 0;
+      if (stableFrames >= 4) {
+        return { distanceFromEnd, viewportHeight: feed.clientHeight };
+      }
+    }
+    throw new Error('The later-page prefetch position did not settle.');
+  });
 }
 
 async function verifyConcurrentAppendNavigation(
@@ -2466,46 +2476,43 @@ async function verifyTextScaleTransitions(fixture: ChromiumFixture, chatId: stri
   fixture.assertNoBrowserErrors();
 }
 
-async function verifyCountShrinkMeasurements(fixture: ChromiumFixture): Promise<void> {
-  const chatId = await seedTranscript(fixture.integration, 110, 'chromium-count-shrink');
-  const { initialModelCount } = await prepareTranscript(fixture, chatId);
-  let expandedModelCount = initialModelCount;
-  for (let pageIndex = 0; pageIndex < 4 && expandedModelCount <= 200; pageIndex += 1) {
-    await revealEarlierTranscript(fixture.page, expandedModelCount);
-    expandedModelCount = await waitForStableModelCount(fixture.page, expandedModelCount + 1);
+async function verifyBoundedWindowLaterPage(fixture: ChromiumFixture): Promise<void> {
+  const chatId = await seedTranscript(fixture.integration, 110, 'chromium-bounded-window');
+  await prepareTranscript(fixture, chatId);
+  let entryCount = await transcriptEntryCount(fixture.page);
+  for (let pageIndex = 0; pageIndex < 4 && entryCount < 200; pageIndex += 1) {
+    const previousRevision = await virtualDataRevision(fixture.page);
+    await scrollToPosition(fixture.page, 'start');
+    await waitForVirtualDataRevisionAfter(fixture.page, previousRevision);
+    entryCount = await transcriptEntryCount(fixture.page);
+    expect(entryCount).toBeLessThanOrEqual(200);
   }
-  expect(expandedModelCount).toBeGreaterThan(200);
+  expect(entryCount).toBe(200);
 
-  await scrollToPosition(fixture.page, 'end', false);
-  expect((await viewportPolicy(fixture.page)).pinned).toBe(false);
+  const earlierRevision = await virtualDataRevision(fixture.page);
+  await scrollToPosition(fixture.page, 'start');
+  await waitForVirtualDataRevisionAfter(fixture.page, earlierRevision);
+  expect(await transcriptEntryCount(fixture.page)).toBe(200);
+
+  const prefetchPosition = await positionNearLaterPageBoundary(fixture.page);
+  expect(prefetchPosition.distanceFromEnd).toBeGreaterThan(50);
+  expect(prefetchPosition.distanceFromEnd).toBeLessThanOrEqual(prefetchPosition.viewportHeight);
+  const anchor = await readingAnchor(fixture.page);
+  const laterRevision = await virtualDataRevision(fixture.page);
   await signalScrollIntent(fixture.page, 'later');
   await fixture.page.locator(FEED_SELECTOR).dispatchEvent('scroll');
-  await fixture.page.waitForFunction(
-    ({ selector, previousCount }) => {
-      const sizer = document.querySelector<HTMLElement>(selector);
-      const current = Number(sizer?.dataset.chatVirtualModelCount ?? 0);
-      return current > 0 && current < previousCount;
-    },
-    { selector: SIZER_SELECTOR, previousCount: expandedModelCount },
-    { timeout: 20_000 },
-  );
-  await waitForStablePinnedTranscriptLayout(fixture.page, 'post-compaction');
+  await waitForVirtualDataRevisionAfter(fixture.page, laterRevision);
+  expect(await transcriptEntryCount(fixture.page)).toBe(200);
+  const restored = await anchorByKey(fixture.page, anchor.key);
+  expect(
+    Math.abs(restored.offset - anchor.offset),
+    JSON.stringify({ anchor, restored }),
+  ).toBeLessThanOrEqual(1);
 
-  const compactedGeometry = await transcriptGeometry(fixture.page);
-  expect(compactedGeometry.modelCount).toBeLessThan(expandedModelCount);
-  expect(compactedGeometry.itemCount).toBeGreaterThan(2);
-  expect(compactedGeometry.transcriptItemCount).toBeGreaterThan(1);
-  expect(compactedGeometry.overlaps).toEqual([]);
-  expect(await mountedConversationDiscontinuities(fixture.page)).toEqual([]);
-
-  await appendTurn(fixture.integration, chatId, 'chromium-post-shrink-append');
-  await fixture.page
-    .locator(FEED_SELECTOR)
-    .getByText('echo:chromium-post-shrink-append', { exact: true })
-    .waitFor();
-  await waitForStablePinnedTranscriptLayout(fixture.page, 'post-shrink-publication');
-  const postPublicationGeometry = await transcriptGeometry(fixture.page);
-  expect(postPublicationGeometry.overlaps).toEqual([]);
+  const boundedGeometry = await transcriptGeometry(fixture.page);
+  expect(boundedGeometry.itemCount).toBeGreaterThan(2);
+  expect(boundedGeometry.transcriptItemCount).toBeGreaterThan(1);
+  expect(boundedGeometry.overlaps).toEqual([]);
   expect(await mountedConversationDiscontinuities(fixture.page)).toEqual([]);
   fixture.assertNoBrowserErrors();
 }
@@ -2734,13 +2741,13 @@ describe('Chromium transcript virtualization', () => {
     );
   }, 120_000);
 
-  test('preserves survivor geometry after live-edge compaction and a later publication', async () => {
+  test('bounds the retained transcript while preserving later-page geometry', async () => {
     if (!environment) throw new Error('Scripted Claude environment was not initialized.');
     await withChromiumFixture(
-      'transcript-count-shrink-measurements',
+      'transcript-bounded-window-later-page',
       async (fixture, markPhase) => {
-        markPhase('expanding and compacting the transcript window');
-        await verifyCountShrinkMeasurements(fixture);
+        markPhase('paging across the bounded transcript window');
+        await verifyBoundedWindowLaterPage(fixture);
       },
       diagnostics,
       { serverEnvironment: environment.serverEnvironment },

--- a/integration-tests/tests/e2e/transcript-scrolling.test.ts
+++ b/integration-tests/tests/e2e/transcript-scrolling.test.ts
@@ -234,7 +234,7 @@ describe("Lightpanda transcript scrolling", () => {
         { selector: FEED_SELECTOR },
       );
       expect((await virtualTranscriptSnapshot(fixture.page)).busy).toBe(true);
-      await fixture.page.waitForSelector('[data-chat-earlier-loading-indicator]');
+      await app.waitForText("Loading earlier messages...");
       expect(await app.hasButton("Load earlier messages")).toBe(false);
       await releasePageRequest(fixture.page);
       await waitForModelCount(fixture.page, initial.modelCount + 50);

--- a/integration-tests/tests/e2e/transcript-scrolling.test.ts
+++ b/integration-tests/tests/e2e/transcript-scrolling.test.ts
@@ -234,7 +234,6 @@ describe("Lightpanda transcript scrolling", () => {
         { selector: FEED_SELECTOR },
       );
       expect((await virtualTranscriptSnapshot(fixture.page)).busy).toBe(true);
-      await app.waitForText("Loading earlier messages...");
       expect(await app.hasButton("Load earlier messages")).toBe(false);
       await releasePageRequest(fixture.page);
       await waitForModelCount(fixture.page, initial.modelCount + 50);

--- a/server-agents/claude/src/agents/claude/__tests__/history-loader.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/history-loader.test.js
@@ -496,7 +496,7 @@ describe('loadClaudeChatMessagePage', () => {
     ]);
   });
 
-  it('matches full-loader ordering for out-of-order timestamps at arbitrary offsets', async () => {
+  it('keeps canonical whole-transcript revisions across windows and off-window changes', async () => {
     const timestamps = [5, 0, 1, 2, 3, 4];
     const lines = timestamps.map((second, index) => JSON.stringify({
       sessionId: 'session-1',
@@ -510,12 +510,25 @@ describe('loadClaudeChatMessagePage', () => {
 
     await withTempJsonl(lines, async (filePath) => {
       const full = await loadClaudeChatMessages(filePath);
+      const latestPage = await loadClaudeChatMessagePage(filePath, 2, 0);
       for (const offset of [0, 2]) {
         const page = await loadClaudeChatMessagePage(filePath, 2, offset);
         const end = full.length - offset;
         expect(page.messages).toEqual(full.slice(end - 2, end));
         expect(page.revision).toBe(transcriptRevision(full));
       }
+
+      const changedLines = [...lines];
+      const changedEntry = JSON.parse(changedLines[1]);
+      changedEntry.message.content = [{ type: 'text', text: 'changed outside the latest page' }];
+      changedLines[1] = JSON.stringify(changedEntry);
+      await fs.writeFile(filePath, `${changedLines.join('\n')}\n`, 'utf8');
+
+      const changedFull = await loadClaudeChatMessages(filePath);
+      const changedPage = await loadClaudeChatMessagePage(filePath, 2, 0);
+      expect(changedPage.messages).toEqual(latestPage.messages);
+      expect(changedPage.revision).not.toBe(latestPage.revision);
+      expect(changedPage.revision).toBe(transcriptRevision(changedFull));
     });
   });
 

--- a/server-agents/claude/src/agents/claude/history-loader.ts
+++ b/server-agents/claude/src/agents/claude/history-loader.ts
@@ -22,7 +22,11 @@ import { extractCompactionSummary, parseCompactMetadata } from './compaction.js'
 import { stripResolvedFileMentionContext } from '@garcon/server-agent-common/shared/file-mention-context';
 import { attachNativeMessageSource, getNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { parseFirstJsonlValue } from '@garcon/server-agent-common/lib/jsonl';
-import type { AgentLogger, AgentTranscriptPage } from '@garcon/server-agent-interface';
+import type {
+  AgentLogger,
+  AgentTranscriptPage,
+  AgentTranscriptRevision,
+} from '@garcon/server-agent-interface';
 import {
   TranscriptRevisionAccumulator,
   attachCompactionRevisionSource,
@@ -453,7 +457,7 @@ async function scanClaudeMessagePage(
 ): Promise<{
   total: number;
   messages: ChatMessage[];
-  revision: string;
+  revision: AgentTranscriptRevision;
   requiresFullLoad: boolean;
 }> {
   let total = 0;

--- a/server-agents/codex/src/agents/codex/__tests__/history-loader.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/history-loader.test.js
@@ -709,7 +709,7 @@ describe('loadCodexChatMessages', () => {
     ]);
   });
 
-  it('matches full-loader ordering for out-of-order timestamps at arbitrary offsets', async () => {
+  it('keeps canonical whole-transcript revisions across windows and off-window changes', async () => {
     const timestamps = [5, 0, 1, 2, 3, 4];
     const lines = timestamps.map((second, index) => JSON.stringify({
       type: 'response_item',
@@ -723,12 +723,25 @@ describe('loadCodexChatMessages', () => {
 
     await withTempJsonl(lines, async (filePath) => {
       const full = await loadCodexChatMessages(filePath);
+      const latestPage = await loadCodexChatMessagePage(filePath, 2, 0);
       for (const offset of [0, 2]) {
         const page = await loadCodexChatMessagePage(filePath, 2, offset);
         const end = full.length - offset;
         expect(page.messages).toEqual(full.slice(end - 2, end));
         expect(page.revision).toBe(transcriptRevision(full));
       }
+
+      const changedLines = [...lines];
+      const changedEntry = JSON.parse(changedLines[1]);
+      changedEntry.payload.content = [{ type: 'output_text', text: 'changed outside the latest page' }];
+      changedLines[1] = JSON.stringify(changedEntry);
+      await fs.writeFile(filePath, `${changedLines.join('\n')}\n`, 'utf8');
+
+      const changedFull = await loadCodexChatMessages(filePath);
+      const changedPage = await loadCodexChatMessagePage(filePath, 2, 0);
+      expect(changedPage.messages).toEqual(latestPage.messages);
+      expect(changedPage.revision).not.toBe(latestPage.revision);
+      expect(changedPage.revision).toBe(transcriptRevision(changedFull));
     });
   });
 

--- a/server-agents/codex/src/agents/codex/history-loader.ts
+++ b/server-agents/codex/src/agents/codex/history-loader.ts
@@ -9,7 +9,11 @@ import {
 } from './history-normalizer.js';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import type { ChatMessage } from '@garcon/common/chat-types';
-import type { AgentLogger, AgentTranscriptPage } from '@garcon/server-agent-interface';
+import type {
+  AgentLogger,
+  AgentTranscriptPage,
+  AgentTranscriptRevision,
+} from '@garcon/server-agent-interface';
 import { parseFirstJsonlValue } from '@garcon/server-agent-common/lib/jsonl';
 import {
   TranscriptRevisionAccumulator,
@@ -191,7 +195,7 @@ async function scanCodexMessagePage(
 ): Promise<{
   summary: CodexMessageSummary;
   messages: ChatMessage[];
-  revision: string;
+  revision: AgentTranscriptRevision;
   requiresFullLoad: boolean;
 }> {
   const summary: CodexMessageSummary = {

--- a/server-agents/interface/src/contracts/transcript.ts
+++ b/server-agents/interface/src/contracts/transcript.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from '@garcon/common/chat-types';
 import type { JsonObject } from '@garcon/common/json';
 import type { NativeSeedReceipt } from '@garcon/common/transcript-seed';
 import type { AgentTranscriptIndexSourceRef } from './transcript-index.js';
+import type { AgentTranscriptRevision } from '../transcript-revision.js';
 
 export interface AgentTranscript {
   /**
@@ -15,7 +16,7 @@ export interface AgentTranscript {
     request: AgentTranscriptRequest & { readonly page: { readonly limit: number; readonly offset: number } },
   ): Promise<AgentTranscriptPage | null>;
   preview(request: AgentTranscriptRequest): Promise<AgentTranscriptPreview | null>;
-  revision(request: AgentTranscriptRequest): Promise<string>;
+  revision(request: AgentTranscriptRequest): Promise<AgentTranscriptRevision>;
   resolveIndexSource(
     request: AgentTranscriptRequest,
   ): Promise<AgentTranscriptIndexSourceRef | null>;
@@ -39,7 +40,7 @@ export type AgentTranscriptSourceLocation =
 
 export interface AgentTranscriptSnapshot {
   readonly messages: readonly ChatMessage[];
-  readonly revision: string;
+  readonly revision: AgentTranscriptRevision;
 }
 
 export interface AgentTranscriptRequest {
@@ -60,7 +61,8 @@ export interface AgentTranscriptPage {
   readonly hasMore: boolean;
   readonly offset: number;
   readonly limit: number;
-  readonly revision: string;
+  /** Canonically identifies the complete rendered transcript, independent of the requested window. */
+  readonly revision: AgentTranscriptRevision;
 }
 
 export interface AgentTranscriptReleaseRequest extends AgentTranscriptRequest {

--- a/server-agents/interface/src/testing/__tests__/conformance.test.ts
+++ b/server-agents/interface/src/testing/__tests__/conformance.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import type { AgentIntegration } from '../../index.js';
+import { computeAgentTranscriptRevision } from '../../transcript-revision.js';
 import { validateAgentIntegration } from '../conformance.js';
 
 const settings = { ownerId: 'other', schemaVersion: 1, values: {} } as const;
+const emptyRevision = computeAgentTranscriptRevision([]);
 
 const integration = {
   descriptor: {
@@ -27,9 +29,9 @@ const integration = {
   },
   transcript: {
     resolveNativeSession: async () => null,
-    load: async () => ({ messages: [], revision: 'empty' }),
+    load: async () => ({ messages: [], revision: emptyRevision }),
     preview: async () => null,
-    revision: async () => 'empty',
+    revision: async () => emptyRevision,
     resolveIndexSource: async () => null,
     refreshIndexSource: async () => null,
     describeSource: async () => null,

--- a/server-agents/interface/src/transcript-revision.ts
+++ b/server-agents/interface/src/transcript-revision.ts
@@ -6,6 +6,12 @@ import {
 
 const COMPACTION_REVISION_SOURCE = Symbol.for('garcon.compactionRevisionSource');
 
+declare const agentTranscriptRevisionBrand: unique symbol;
+
+export type AgentTranscriptRevision = string & {
+  readonly [agentTranscriptRevisionBrand]: true;
+};
+
 type CompactionRevisionSource = NativeMessageSource & {
   readonly pairingTimestamp?: number;
 };
@@ -54,10 +60,10 @@ export class TranscriptRevisionAccumulator {
     this.#fragmentCount += other.#fragmentCount;
   }
 
-  finish(): string {
+  finish(): AgentTranscriptRevision {
     const digest = this.#sumA.toString(16).padStart(8, '0')
       + this.#sumB.toString(16).padStart(8, '0');
-    return `v3:${this.#messageCount}:${this.#fragmentCount}:${digest}`;
+    return `v3:${this.#messageCount}:${this.#fragmentCount}:${digest}` as AgentTranscriptRevision;
   }
 
   #addValue(kind: string, value: unknown, source?: unknown): void {
@@ -107,7 +113,9 @@ export function attachCompactionRevisionSource<T extends object>(
   return target;
 }
 
-export function computeAgentTranscriptRevision(messages: readonly ChatMessage[]): string {
+export function computeAgentTranscriptRevision(
+  messages: readonly ChatMessage[],
+): AgentTranscriptRevision {
   return computeAgentTranscriptRevisions(messages).full;
 }
 
@@ -116,7 +124,7 @@ export const transcriptRevision = computeAgentTranscriptRevision;
 export function computeAgentTranscriptRevisions(
   messages: readonly ChatMessage[],
   prefixLength = messages.length,
-): { readonly prefix: string; readonly full: string } {
+): { readonly prefix: AgentTranscriptRevision; readonly full: AgentTranscriptRevision } {
   const accumulator = new TranscriptRevisionAccumulator();
   let prefix = prefixLength === 0 ? accumulator.finish() : undefined;
   for (let index = 0; index < messages.length; index += 1) {

--- a/server/chats/__tests__/chat-transcript-test-helpers.js
+++ b/server/chats/__tests__/chat-transcript-test-helpers.js
@@ -63,6 +63,7 @@ export function historyPage(messages, limit, offset, options = {}) {
     carryOverRevision: snapshot.carryOverRevision,
     agentOwnershipEpoch: snapshot.agentOwnershipEpoch,
     archivedLogicalCount: snapshot.archivedLogicalCount,
+    nativePrefixDigest: options.nativePrefixDigest ?? null,
   };
 }
 

--- a/server/chats/__tests__/chat-view-store.test.js
+++ b/server/chats/__tests__/chat-view-store.test.js
@@ -774,7 +774,7 @@ describe('ChatViewStore', () => {
 
       await store.getOrCreateMessages('chat-1', snapshotLoader(async () => initialHistory));
       const fullGeneration = store.getCursor('chat-1').generationId;
-      expect(fullGeneration).not.toBe(initial.generationId);
+      expect(fullGeneration).toBe(initial.generationId);
       await store.reconcileNativeSnapshot('chat-1', nativeReconciliation(initialHistory));
       const preserved = store.getCursor('chat-1').generationId;
       await store.reconcileNativeSnapshot('chat-1', nativeReconciliation([
@@ -1055,8 +1055,44 @@ describe('ChatViewStore', () => {
 
     const loaded = await store.getOrCreateMessages('chat-1', snapshotLoader(loadAll));
     expect(loaded.map((message) => message.content)).toEqual(['one', 'two', 'three']);
+    expect(store.getCursor('chat-1')?.generationId).toBe(page.generationId);
     expect(store.getLoadedMessages('chat-1')).toHaveLength(3);
     expect(loadAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('rotates a page generation when the full snapshot revision changed', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = [user('one'), assistant('two'), assistant('three')];
+    const page = await store.getOrCreatePage('chat-1', {
+      loadAll: snapshotLoader(async () => history),
+      loadPage: async (limit, offset) => historyPage(history, limit, offset),
+    }, 1);
+
+    await store.getOrCreateMessages(
+      'chat-1',
+      snapshotLoader(async () => history, { nativeRevision: 'changed-native-revision' }),
+    );
+
+    expect(store.getCursor('chat-1')?.generationId).not.toBe(page.generationId);
+  });
+
+  it('rotates a page generation when retained native content changed under the same revision', async () => {
+    const store = new ChatViewStore(() => false);
+    const history = [user('one'), assistant('two'), assistant('three')];
+    const pageSnapshot = transcriptSnapshot(history);
+    const page = await store.getOrCreatePage('chat-1', {
+      loadAll: snapshotLoader(async () => history),
+      loadPage: async (limit, offset) => historyPage(history, limit, offset, {
+        compositeRevision: pageSnapshot.compositeRevision,
+      }),
+    }, 1);
+
+    await store.getOrCreateMessages('chat-1', snapshotLoader(
+      async () => [user('one'), assistant('two'), assistant('changed-three')],
+      { compositeRevision: pageSnapshot.compositeRevision },
+    ));
+
+    expect(store.getCursor('chat-1')?.generationId).not.toBe(page.generationId);
   });
 
   it('requires a snapshot when a replay cursor predates the retained tail', async () => {

--- a/server/chats/__tests__/ordered-chat-transcript-reader.test.js
+++ b/server/chats/__tests__/ordered-chat-transcript-reader.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { UserMessage } from '../../../common/chat-types.js';
 import { createNativeSeedReceipt } from '../../../common/transcript-seed.js';
+import { transcriptRevision } from '../../lib/transcript-revision.js';
 import { OrderedChatTranscriptReader } from '../ordered-chat-transcript-reader.js';
 
 const timestamp = '2026-08-07T00:00:00.000Z';
@@ -92,6 +93,7 @@ describe('OrderedChatTranscriptReader', () => {
     const latest = await reader.loadPage('chat-1', 3, 0);
     expect(latest.messages.map((message) => message.content)).toEqual(['n2', 'n3', 'n4']);
     expect(latest.total).toBe(7);
+    expect(latest.nativePrefixDigest).toBeNull();
     expect(loadArchivedPage).not.toHaveBeenCalled();
 
     const spanning = await reader.loadPage('chat-1', 4, 2);
@@ -139,6 +141,7 @@ describe('OrderedChatTranscriptReader', () => {
       offsetFromNewest: 0,
     });
     expect(page.messages.map((message) => message.content)).toEqual(['n2', 'n3']);
+    expect(page.nativePrefixDigest).toBe(transcriptRevision(native));
     expect(loadNativeSnapshot).toHaveBeenCalledTimes(2);
   });
 

--- a/server/chats/chat-view-contracts.ts
+++ b/server/chats/chat-view-contracts.ts
@@ -11,6 +11,7 @@ export interface ChatHistoryPage {
   carryOverRevision: string;
   agentOwnershipEpoch: string;
   archivedLogicalCount: number;
+  nativePrefixDigest: string | null;
 }
 
 export interface ChatTranscriptSnapshot {
@@ -34,4 +35,3 @@ export interface AppendedChatViewMessages {
   lastSeq: number;
   skipped?: boolean;
 }
-

--- a/server/chats/chat-view-native-reconciliation.ts
+++ b/server/chats/chat-view-native-reconciliation.ts
@@ -100,17 +100,9 @@ export function reconcileNativeSnapshotView(
   const retainedLiveEntries = previous?.messages.filter(
     (entry) => entry.seq > previous.historyLastSeq,
   ) ?? [];
-  const previousNativeCount = previous
-    ? Math.max(0, previous.historyLastSeq - snapshot.archivedLogicalCount)
-    : 0;
-  const priorNativePrefixMatches = Boolean(
-    previous
-    && persistenceMatches(previous, snapshot)
-    && previous.nativePrefixDigest !== null
-    && nativeMessages.length >= previousNativeCount
-    && transcriptRevision(nativeMessages.slice(0, previousNativeCount))
-      === previous.nativePrefixDigest,
-  );
+  const priorNativePrefixMatches = previous
+    ? nativePrefixMatchesView(previous, snapshot, nativeMessages)
+    : false;
   const retainedLiveStartSeq = previous
     ? Math.max(previous.historyLastSeq + 1, previous.retainedStartSeq)
     : snapshot.archivedLogicalCount + 1;
@@ -193,6 +185,36 @@ export function persistenceMatches(
   return view.carryOverRevision === input.carryOverRevision
     && view.agentOwnershipEpoch === input.agentOwnershipEpoch
     && view.archivedLogicalCount === input.archivedLogicalCount;
+}
+
+export function nativePrefixMatchesView(
+  view: MutableChatView,
+  snapshot: NativeSnapshotReconciliation,
+  nativeMessages: readonly ChatMessage[],
+): boolean {
+  if (!persistenceMatches(view, snapshot)) return false;
+  const previousNativeCount = Math.max(
+    0,
+    view.historyLastSeq - snapshot.archivedLogicalCount,
+  );
+  if (nativeMessages.length < previousNativeCount) return false;
+  const retainedNativeOverlapMatches = view.messages
+    .filter((entry) => (
+      entry.seq > snapshot.archivedLogicalCount
+      && entry.seq <= view.historyLastSeq
+    ))
+    .every((entry) => retainedMessageMatchesNative(
+      entry.message,
+      nativeMessages[entry.seq - snapshot.archivedLogicalCount - 1],
+    ));
+  if (!retainedNativeOverlapMatches) return false;
+  if (view.nativePrefixDigest !== null) {
+    return transcriptRevision(nativeMessages.slice(0, previousNativeCount))
+      === view.nativePrefixDigest;
+  }
+  // Canonical page and snapshot revisions identify the same complete transcript,
+  // which bootstraps page-backed views without treating native growth as safe.
+  return view.compositeRevision === snapshot.compositeRevision;
 }
 
 function createNativeOnlyGeneration(input: ReconcileNativeViewInput & {

--- a/server/chats/chat-view-store.ts
+++ b/server/chats/chat-view-store.ts
@@ -6,7 +6,6 @@ import { createLogger } from '../lib/log.js';
 import {
   OrderedTranscriptDigest,
   orderedTranscriptDigest,
-  transcriptRevision,
 } from '../lib/transcript-revision.js';
 import {
   exactMessageIdentityKeys,
@@ -18,7 +17,7 @@ import {
   type ChatViewGenerationTransition as GenerationTransition,
   type MutableChatView as ChatView,
   type NativeSnapshotReconciliation,
-  persistenceMatches,
+  nativePrefixMatchesView,
   reconcileNativeSnapshotView,
 } from './chat-view-native-reconciliation.js';
 import { ChatViewOperationalNotices } from './chat-view-operational-notices.js';
@@ -561,17 +560,9 @@ export class ChatViewStore {
     const retainedLiveEntries = previous?.messages.filter(
       (entry) => entry.seq > previous.historyLastSeq,
     ) ?? [];
-    const previousNativeCount = previous
-      ? Math.max(0, previous.historyLastSeq - snapshot.archivedLogicalCount)
-      : 0;
-    const priorNativePrefixMatches = Boolean(
-      previous
-      && persistenceMatches(previous, snapshot)
-      && previous.nativePrefixDigest !== null
-      && snapshot.nativeMessages.length >= previousNativeCount
-      && transcriptRevision(snapshot.nativeMessages.slice(0, previousNativeCount))
-        === previous.nativePrefixDigest,
-    );
+    const priorNativePrefixMatches = previous
+      ? nativePrefixMatchesView(previous, snapshot, reconciledNativeMessages)
+      : false;
     const retainedLiveStartSeq = previous
       ? Math.max(previous.historyLastSeq + 1, previous.retainedStartSeq)
       : 1;
@@ -720,7 +711,7 @@ export class ChatViewStore {
       carryOverRevision: page.carryOverRevision,
       agentOwnershipEpoch: page.agentOwnershipEpoch,
       archivedLogicalCount: page.archivedLogicalCount,
-      nativePrefixDigest: null,
+      nativePrefixDigest: page.nativePrefixDigest,
       evictedLiveDigest: new OrderedTranscriptDigest(),
       streamFence: this.captureFence(chatId),
       lastAccessAt: now,

--- a/server/chats/ordered-chat-transcript-reader.ts
+++ b/server/chats/ordered-chat-transcript-reader.ts
@@ -214,6 +214,9 @@ export class OrderedChatTranscriptReader {
     const nativeMessages = native.kind === 'snapshot'
       ? sliceFromNewest(native.messages, boundedLimit, boundedOffset)
       : native.messages;
+    const nativePrefixDigest = native.kind === 'snapshot'
+      ? transcriptRevision(native.messages)
+      : null;
     const messages: ChatMessage[] = [];
     const archivedEnd = Math.min(end, archivedCount);
     if (start < archivedEnd) {
@@ -244,6 +247,7 @@ export class OrderedChatTranscriptReader {
       carryOverRevision,
       agentOwnershipEpoch: entry.agentOwnershipEpoch,
       archivedLogicalCount: archivedCount,
+      nativePrefixDigest,
     };
   }
 

--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-	ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
 	ActiveTranscriptState,
 	INITIAL_VISIBLE_MESSAGES,
 } from '../active-transcript-state.svelte.js';
+import { ACTIVE_TRANSCRIPT_RETENTION_LIMIT } from '../transcript-page-progress.js';
 import { ChatTranscriptCache } from '../chat-transcript-cache.svelte';
 import {
 	AssistantMessage,

--- a/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts
@@ -210,7 +210,49 @@ describe('ActiveTranscriptState', () => {
 		expect(chat.visibleRows).toHaveLength(INITIAL_VISIBLE_MESSAGES);
 	});
 
-	it('preserves expanded history until it is explicitly compacted at the live edge', () => {
+	it('bounds oversized generation replacements to the recent message window', () => {
+		const chat = new ActiveTranscriptState();
+		const messageCount = ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 25;
+		const messages = Array.from({ length: messageCount }, (_, index) =>
+			entry(index + 1, assistant(`message-${index + 1}`)),
+		);
+
+		chat.replaceGeneration('chat-1', 'generation-1', messages, {
+			lastSeq: messageCount,
+			pageOldestSeq: 1,
+			hasMore: false,
+		});
+
+		expect(chat.entries).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		expect(chat.entries[0]?.seq).toBe(26);
+		expect(chat.entries.at(-1)?.seq).toBe(messageCount);
+		expect(chat.oldestSeq).toBe(26);
+		expect(chat.hasEarlierMessages).toBe(true);
+	});
+
+	it('bounds oversized snapshot pages to the recent message window', () => {
+		const chat = new ActiveTranscriptState();
+		const messageCount = ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 25;
+		const messages = Array.from({ length: messageCount }, (_, index) =>
+			entry(index + 1, assistant(`message-${index + 1}`)),
+		);
+		const epoch = chat.beginSnapshotLoad();
+
+		expect(
+			chat.setFromPage(
+				'chat-1',
+				page({ messages, lastSeq: messageCount, pageOldestSeq: 1 }),
+				epoch,
+			),
+		).toBe('applied');
+		expect(chat.entries).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		expect(chat.entries[0]?.seq).toBe(26);
+		expect(chat.entries.at(-1)?.seq).toBe(messageCount);
+		expect(chat.oldestSeq).toBe(26);
+		expect(chat.hasEarlierMessages).toBe(true);
+	});
+
+	it('bounds expanded history while retaining the live edge', () => {
 		const chat = new ActiveTranscriptState();
 		const initial = Array.from({ length: ACTIVE_TRANSCRIPT_RETENTION_LIMIT }, (_, index) =>
 			entry(index + 1, assistant(`message-${index + 1}`)),
@@ -234,14 +276,43 @@ describe('ActiveTranscriptState', () => {
 			),
 		);
 
-		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 50);
-		expect(chat.visibleMessageCount).toBe(INITIAL_VISIBLE_MESSAGES + 50);
-		expect(chat.compactToRecentMessages()).toBe(true);
 		expect(chat.chatMessages).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
 		expect(contentOf(chat.chatMessages[0])).toBe('message-51');
+		expect(chat.visibleMessageCount).toBe(INITIAL_VISIBLE_MESSAGES + 50);
 		expect(chat.oldestSeq).toBe(51);
 		expect(chat.hasEarlierMessages).toBe(true);
-		expect(chat.visibleMessageCount).toBe(INITIAL_VISIBLE_MESSAGES);
+		expect(chat.compactToRecentMessages()).toBe(false);
+	});
+
+	it('detaches a scrolled-up window when live growth reaches the retention limit', () => {
+		const chat = new ActiveTranscriptState();
+		const initial = Array.from({ length: ACTIVE_TRANSCRIPT_RETENTION_LIMIT }, (_, index) =>
+			entry(index + 1, assistant(`message-${index + 1}`)),
+		);
+		chat.replaceGeneration('chat-1', 'generation-1', initial, {
+			lastSeq: ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+			pageOldestSeq: 1,
+			hasMore: false,
+		});
+		chat.isUserScrolledUp = true;
+
+		chat.applyMessages(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(
+					ACTIVE_TRANSCRIPT_RETENTION_LIMIT + index + 1,
+					assistant(`message-${ACTIVE_TRANSCRIPT_RETENTION_LIMIT + index + 1}`),
+				),
+			),
+		);
+
+		expect(chat.entries.map((message) => message.seq)).toEqual(
+			Array.from({ length: ACTIVE_TRANSCRIPT_RETENTION_LIMIT }, (_, index) => index + 1),
+		);
+		expect(chat.lastSeq).toBe(ACTIVE_TRANSCRIPT_RETENTION_LIMIT + 50);
+		expect(chat.hasEarlierMessages).toBe(false);
+		expect(chat.hasLaterMessages).toBe(true);
 	});
 
 	it('deduplicates overlapping earlier pages before extending the loaded window', async () => {
@@ -274,6 +345,56 @@ describe('ActiveTranscriptState', () => {
 			Array.from({ length: 51 }, (_, index) => index + 50),
 		);
 		expect(chat.visibleMessageCount).toBe(INITIAL_VISIBLE_MESSAGES + 1);
+	});
+
+	it('keeps repeated bidirectional paging within the retained entry window', async () => {
+		const chat = new ActiveTranscriptState();
+		const total = 400;
+		chat.replaceGeneration(
+			'chat-1',
+			'generation-1',
+			Array.from({ length: 50 }, (_, index) =>
+				entry(index + 351, assistant(`message-${index + 351}`)),
+			),
+			{ lastSeq: total, pageOldestSeq: 351, hasMore: true },
+		);
+		vi.mocked(getChatMessages).mockImplementation(async (request) => {
+			const limit = request.limit ?? 50;
+			const end = Math.min(total, (request.beforeSeq ?? total + 1) - 1);
+			const start = Math.max(1, end - limit + 1);
+			const messages = Array.from({ length: end - start + 1 }, (_, index) =>
+				entry(start + index, assistant(`message-${start + index}`)),
+			);
+			return {
+				chatId: 'chat-1',
+				limit,
+				...page({
+					messages,
+					lastSeq: total,
+					pageOldestSeq: start,
+					hasMore: start > 1,
+				}),
+			};
+		});
+
+		for (let pageIndex = 0; pageIndex < 7; pageIndex += 1) {
+			await expect(chat.loadEarlierPage('chat-1')).resolves.toBe('loaded');
+			expect(chat.entries.length).toBeLessThanOrEqual(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		}
+		expect(chat.entries[0]?.seq).toBe(1);
+		expect(chat.entries.at(-1)?.seq).toBe(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		expect(chat.hasEarlierMessages).toBe(false);
+		expect(chat.hasLaterMessages).toBe(true);
+
+		for (let pageIndex = 0; pageIndex < 4; pageIndex += 1) {
+			await expect(chat.loadLaterPage('chat-1')).resolves.toBe('loaded');
+			expect(chat.entries.length).toBeLessThanOrEqual(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+		}
+		expect(chat.entries[0]?.seq).toBe(201);
+		expect(chat.entries.at(-1)?.seq).toBe(total);
+		expect(chat.hasEarlierMessages).toBe(true);
+		expect(chat.hasLaterMessages).toBe(false);
+		expect(chat.visibleMessageCount).toBe(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
 	});
 
 	it('fails an earlier page that claims more history without advancing', async () => {

--- a/web/src/lib/chat/transcript/__tests__/chat-transcript-cache.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/chat-transcript-cache.test.ts
@@ -121,6 +121,55 @@ describe('ChatTranscriptCache', () => {
 		]);
 	});
 
+	it('cancels a pending cache write when a persisted transcript becomes stale', () => {
+		const storage = new LocalChatTranscriptStorage();
+		storage.persist('chat-1', [entry(1, 'persisted')], {
+			generationId: 'generation-1',
+			lastSeq: 1,
+		});
+		const cache = new ChatTranscriptCache({ limit: 100, storage });
+		cache.replaceFromPage(
+			'chat-1',
+			page('generation-1', [entry(1, 'persisted'), entry(2, 'pending')]),
+		);
+
+		cache.markStale('chat-1');
+		cache.flush();
+
+		expect(storage.restore('chat-1')).toMatchObject({
+			entries: [entry(1, 'persisted')],
+			stale: true,
+		});
+		expect(cache.listCursors()).toEqual([]);
+	});
+
+	it('does not persist the first cache draft after its transcript becomes stale', () => {
+		const storage = new LocalChatTranscriptStorage();
+		const cache = new ChatTranscriptCache({ limit: 100, storage });
+		cache.replaceFromPage('chat-1', page('generation-1', [entry(1, 'pending')]));
+
+		cache.markStale('chat-1');
+		cache.flush();
+
+		expect(storage.restore('chat-1')).toBeNull();
+		expect(cache.listCursors()).toEqual([]);
+	});
+
+	it('does not fall through stale memory to a contradictory persisted cursor', () => {
+		const storage = new LocalChatTranscriptStorage();
+		storage.persist('chat-1', [entry(1, 'persisted')], {
+			generationId: 'generation-1',
+			lastSeq: 1,
+		});
+		const cache = new ChatTranscriptCache({ limit: 100, storage });
+		cache.get('chat-1');
+		cache.markStale('chat-1');
+		storage.markValidated('chat-1');
+
+		expect(storage.listCursors()).toHaveLength(1);
+		expect(cache.listCursors()).toEqual([]);
+	});
+
 	it('prunes memory entries after maxEntries is exceeded', () => {
 		const cache = new ChatTranscriptCache({ limit: 100, maxEntries: 2 });
 

--- a/web/src/lib/chat/transcript/__tests__/chat-transcript-storage.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/chat-transcript-storage.test.ts
@@ -175,6 +175,22 @@ describe('LocalChatTranscriptStorage', () => {
 		]);
 	});
 
+	it('excludes stale transcripts from reconnect cursors', () => {
+		storage.persist('chat-1', [entry(1, 'a')], {
+			generationId: 'generation-1',
+			lastSeq: 1,
+		});
+		storage.persist('chat-2', [entry(1, 'b')], {
+			generationId: 'generation-2',
+			lastSeq: 1,
+		});
+		storage.markStale('chat-2');
+
+		expect(storage.listCursors()).toEqual([
+			{ chatId: 'chat-1', generationId: 'generation-1', lastSeq: 1 },
+		]);
+	});
+
 	it('remove and clearAll delete snapshots and index state', () => {
 		persist(storage, 'chat-1', [entry(1, 'a')]);
 		persist(storage, 'chat-2', [entry(1, 'b')]);

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -512,7 +512,7 @@ describe('ConversationScrollController', () => {
 		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));
 	});
 
-	it('fills the earlier load-ahead zone after a slow page advances its cursor', async () => {
+	it('does not chain an earlier page after its initiating intent expires', async () => {
 		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
 		let resolveFirstPage!: (result: 'loaded') => void;
 		const firstPage = new Promise<'loaded'>((resolve) => (resolveFirstPage = resolve));
@@ -533,7 +533,8 @@ describe('ConversationScrollController', () => {
 		fixture.state.feedMutationClock = mutationClock(1, 1);
 		resolveFirstPage('loaded');
 
-		await vi.waitFor(() => expect(loadEarlierPage).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(fixture.viewport.waitForLayout).toHaveBeenCalledOnce());
+		expect(loadEarlierPage).toHaveBeenCalledOnce();
 		now.mockRestore();
 	});
 

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -70,6 +70,16 @@ function idlePageState(): TranscriptPageState {
 	return { status: 'idle', error: null };
 }
 
+function retainTranscriptEntries(
+	entries: ChatViewMessage[],
+	edge: TranscriptPageDirection,
+): ChatViewMessage[] {
+	if (entries.length <= ACTIVE_TRANSCRIPT_RETENTION_LIMIT) return entries;
+	return edge === 'earlier'
+		? entries.slice(0, ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
+		: entries.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+}
+
 export type ChatDisplayRow = ChatTranscriptRow | LocalNoticeRow;
 function pendingInputsFromPage(page: Pick<ChatPage, 'pendingUserInputs'>): PendingUserInput[] {
 	return sortPendingInputs(
@@ -323,30 +333,32 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		const applied = applyChatViewMessages(this.entries, messages, this.lastSeq);
 		let entriesChanged = applied.status === 'applied' && applied.changed;
 		if (applied.status === 'applied') {
-			const shouldCompact =
-				!this.isUserScrolledUp && this.visibleMessageCount <= INITIAL_VISIBLE_MESSAGES;
-			const nextEntries =
-				shouldCompact && applied.messages.length > ACTIVE_TRANSCRIPT_RETENTION_LIMIT
-					? applied.messages.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
-					: applied.messages;
+			const exceedsRetentionLimit = applied.messages.length > ACTIVE_TRANSCRIPT_RETENTION_LIMIT;
+			const nextEntries = exceedsRetentionLimit
+				? this.isUserScrolledUp
+					? applied.messages.slice(0, ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
+					: applied.messages.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
+				: applied.messages;
 			this.generationId = generationId;
 			if (nextEntries !== this.entries) this.entries = nextEntries;
 			this.lastSeq = applied.lastSeq;
 			this.oldestSeq = this.entries[0]?.seq ?? 0;
-			if (nextEntries.length < applied.messages.length) {
+			if (exceedsRetentionLimit && !this.isUserScrolledUp) {
 				this.hasEarlierMessages = true;
-				this.visibleMessageCount = Math.min(this.visibleMessageCount, INITIAL_VISIBLE_MESSAGES);
-				this.#preserveExpandedVisibleWindow = false;
 			}
+			this.visibleMessageCount = Math.min(
+				this.visibleMessageCount,
+				ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+			);
 		} else {
 			const restored = this.transcriptCache.get(chatId);
 			if (!restored || restored.generationId !== generationId) return 'gap-detected';
 			this.#invalidatePageLoad();
 			entriesChanged = true;
 			this.generationId = restored.generationId;
-			this.entries = restored.messages;
+			this.entries = retainTranscriptEntries(restored.messages, 'later');
 			this.lastSeq = restored.lastSeq;
-			this.oldestSeq = restored.oldestSeq;
+			this.oldestSeq = this.entries[0]?.seq ?? 0;
 		}
 		if (entriesChanged) {
 			this.clearLocalNotices(noticeRevision);
@@ -403,6 +415,7 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 			pendingUserInputs?: PendingUserInput[];
 		},
 	): void {
+		const retainedMessages = retainTranscriptEntries(messages, 'later');
 		this.#invalidatePageLoad();
 		this.#preserveExpandedVisibleWindow = false;
 		this.historyState = { kind: 'complete' };
@@ -418,11 +431,11 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		});
 		this.windowRevision += 1;
 		this.generationId = generationId;
-		this.entries = messages;
+		this.entries = retainedMessages;
 		this.lastSeq = options.lastSeq;
-		this.oldestSeq = options.pageOldestSeq;
-		this.hasEarlierMessages = options.hasMore;
-		this.totalMessages = messages.length;
+		this.oldestSeq = retainedMessages[0]?.seq ?? 0;
+		this.hasEarlierMessages = options.hasMore || retainedMessages.length < messages.length;
+		this.totalMessages = retainedMessages.length;
 		this.#replacePendingUserInputs(options.pendingUserInputs ?? []);
 		this.visibleMessageCount = INITIAL_VISIBLE_MESSAGES;
 		this.localNotices = [];
@@ -465,12 +478,13 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 			this.#preserveExpandedVisibleWindow = false;
 			this.visibleMessageCount = Math.min(this.visibleMessageCount, INITIAL_VISIBLE_MESSAGES);
 		}
+		const retainedMessages = retainTranscriptEntries(page.messages, 'later');
 		this.generationId = page.generationId;
-		this.entries = page.messages;
+		this.entries = retainedMessages;
 		this.lastSeq = page.lastSeq;
-		this.oldestSeq = page.pageOldestSeq;
-		this.hasEarlierMessages = page.hasMore;
-		this.totalMessages = page.messages.length;
+		this.oldestSeq = retainedMessages[0]?.seq ?? 0;
+		this.hasEarlierMessages = page.hasMore || retainedMessages.length < page.messages.length;
+		this.totalMessages = retainedMessages.length;
 		if (this.#pendingUserInputsRevision === this.#pendingUserInputsRevisionAtLoadStart) {
 			this.#replacePendingUserInputs(pendingInputsFromPage(page));
 		}
@@ -638,12 +652,16 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 			this.hasEarlierMessages = false;
 			return 'exhausted';
 		}
-		this.entries = [...addedMessages, ...this.entries];
+		const mergedEntries = [...addedMessages, ...this.entries];
+		this.entries = retainTranscriptEntries(mergedEntries, 'earlier');
 		this.oldestSeq = addedMessages[0].seq;
 		this.lastSeq = Math.max(this.lastSeq, page.lastSeq);
 		this.hasEarlierMessages = page.hasMore;
 		this.totalMessages = this.entries.length;
-		this.visibleMessageCount += addedMessages.length;
+		this.visibleMessageCount = Math.min(
+			this.visibleMessageCount + addedMessages.length,
+			ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+		);
 		this.#rememberExpandedVisibleWindow();
 		this.#recordFeedMutation('history-earlier');
 		return 'loaded';
@@ -656,10 +674,17 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 			throw new Error('Later transcript page did not advance the loaded window');
 		}
 
-		this.entries = applied.messages;
+		const addedMessageCount = applied.messages.length - previousEntryCount;
+		const trimmedEarlier = applied.messages.length > ACTIVE_TRANSCRIPT_RETENTION_LIMIT;
+		this.entries = retainTranscriptEntries(applied.messages, 'later');
 		this.lastSeq = Math.max(this.lastSeq, page.lastSeq);
+		this.oldestSeq = this.entries[0]?.seq ?? 0;
+		if (trimmedEarlier) this.hasEarlierMessages = true;
 		this.totalMessages = this.entries.length;
-		this.visibleMessageCount += this.entries.length - previousEntryCount;
+		this.visibleMessageCount = Math.min(
+			this.visibleMessageCount + addedMessageCount,
+			ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+		);
 		this.#rememberExpandedVisibleWindow();
 		this.#recordFeedMutation('history-later');
 		return 'loaded';
@@ -878,11 +903,12 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 
 			this.#preserveExpandedVisibleWindow = false;
 			this.windowRevision += 1;
-			this.entries = page.messages;
-			this.oldestSeq = page.pageOldestSeq;
+			const retainedMessages = retainTranscriptEntries(page.messages, 'earlier');
+			this.entries = retainedMessages;
+			this.oldestSeq = retainedMessages[0]?.seq ?? 0;
 			this.hasEarlierMessages = false;
-			this.totalMessages = page.messages.length;
-			this.visibleMessageCount = page.messages.length;
+			this.totalMessages = retainedMessages.length;
+			this.visibleMessageCount = retainedMessages.length;
 			if (this.hasLaterMessages) {
 				this.isUserScrolledUp = true;
 			}
@@ -950,15 +976,17 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		// Publishes the bounded cache window atomically; the virtual feed limits mounted row work.
 		const restored = this.transcriptCache.get(chatId);
 		if (!restored) return null;
-		this.entries = restored.messages;
+		const retainedMessages = retainTranscriptEntries(restored.messages, 'later');
+		this.entries = retainedMessages;
 		this.generationId = restored.generationId;
 		this.lastSeq = restored.lastSeq;
-		this.oldestSeq = restored.oldestSeq;
-		this.totalMessages = restored.messages.length;
+		this.oldestSeq = retainedMessages[0]?.seq ?? 0;
+		this.totalMessages = retainedMessages.length;
 		// Preserves the earlier boundary across cache restore so validation cannot insert it after paint.
-		this.hasEarlierMessages = restored.oldestSeq > 1;
-		this.loadStatus = restored.messages.length === 0 ? 'empty' : 'loaded';
-		return { count: restored.messages.length, stale: restored.stale };
+		this.hasEarlierMessages =
+			restored.oldestSeq > 1 || retainedMessages.length < restored.messages.length;
+		this.loadStatus = retainedMessages.length === 0 ? 'empty' : 'loaded';
+		return { count: retainedMessages.length, stale: restored.stale };
 	}
 
 	removeCachedMessages(chatId: string): void {

--- a/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
+++ b/web/src/lib/chat/transcript/active-transcript-state.svelte.ts
@@ -5,34 +5,33 @@ import {
 	type ChatViewMessage,
 	type ChatViewPage,
 } from '$shared/chat-view';
-import {
-	AssistantMessage,
-	ErrorMessage,
-	PermissionRequestMessage,
-	ThinkingMessage,
-	UserMessage,
-	isToolUseMessage,
-	type ChatMessage,
-	type UserMessageDeliveryStatus,
-} from '$shared/chat-types';
-import { normalizePendingUserInput, type PendingUserInput } from '$shared/pending-user-input';
+import { UserMessage, type ChatMessage, type UserMessageDeliveryStatus } from '$shared/chat-types';
+import type { PendingUserInput } from '$shared/pending-user-input';
 import { ChatTranscriptCache } from './chat-transcript-cache.svelte';
 import { getChatMessages } from '$lib/api/chats.js';
 import type { LocalNoticeRow, LocalNoticeType } from '$lib/chat/transcript/local-notice.js';
 import { createRandomId } from '$lib/utils/random-id';
 import { ConversationFeedMutationState } from './ConversationFeedMutationState.svelte.js';
-import type { ConversationFeedMutationKind } from './conversation-feed-mutations.js';
+import {
+	responseMessageType,
+	type ConversationFeedMutationKind,
+} from './conversation-feed-mutations.js';
 import type {
 	ActiveTranscriptPort,
 	ChatCursor,
 	ChatLoadMessagesOptions,
 	ChatRestoreResult,
 } from './active-transcript-port.js';
-import { collectEarlierTranscriptMessages } from './transcript-page-progress.js';
+import {
+	ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+	collectEarlierTranscriptMessages,
+	retainTranscriptEntries,
+} from './transcript-page-progress.js';
 import { displayLocalNotices } from './degraded-history-notice.js';
 import {
 	applyPendingDeliveryStatuses,
 	mergeRowsWithPendingInputs,
+	normalizePendingInputs,
 	sortPendingInputs,
 	uniqueEntriesByClientRequestId,
 	type ChatTranscriptRow,
@@ -47,7 +46,6 @@ export type { ChatTranscriptRow } from './transcript-row-projection.js';
 
 const MESSAGES_PER_PAGE = 50;
 export const INITIAL_VISIBLE_MESSAGES = 100;
-export const ACTIVE_TRANSCRIPT_RETENTION_LIMIT = 200;
 type ChatHistoryPage = Awaited<ReturnType<typeof getChatMessages>>;
 type ChatPage = Extract<ChatHistoryPage, { historyState: { kind: 'complete' } }>;
 type SnapshotBatch = { generationId: string; messages: ChatViewMessage[]; noticeRevision: number };
@@ -66,28 +64,9 @@ export interface TranscriptPageState {
 	error: string | null;
 }
 
-function idlePageState(): TranscriptPageState {
-	return { status: 'idle', error: null };
-}
-
-function retainTranscriptEntries(
-	entries: ChatViewMessage[],
-	edge: TranscriptPageDirection,
-): ChatViewMessage[] {
-	if (entries.length <= ACTIVE_TRANSCRIPT_RETENTION_LIMIT) return entries;
-	return edge === 'earlier'
-		? entries.slice(0, ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
-		: entries.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
-}
+const idlePageState = (): TranscriptPageState => ({ status: 'idle', error: null });
 
 export type ChatDisplayRow = ChatTranscriptRow | LocalNoticeRow;
-function pendingInputsFromPage(page: Pick<ChatPage, 'pendingUserInputs'>): PendingUserInput[] {
-	return sortPendingInputs(
-		page.pendingUserInputs
-			.map(normalizePendingUserInput)
-			.filter((input): input is PendingUserInput => Boolean(input)),
-	);
-}
 
 export class ActiveTranscriptState implements ActiveTranscriptPort {
 	readonly transcriptCache: ChatTranscriptCache;
@@ -486,7 +465,7 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		this.hasEarlierMessages = page.hasMore || retainedMessages.length < page.messages.length;
 		this.totalMessages = retainedMessages.length;
 		if (this.#pendingUserInputsRevision === this.#pendingUserInputsRevisionAtLoadStart) {
-			this.#replacePendingUserInputs(pendingInputsFromPage(page));
+			this.#replacePendingUserInputs(normalizePendingInputs(page.pendingUserInputs));
 		}
 		this.clearLocalNotices(this.#localNoticeRevisionAtLoadStart);
 		this.loadStatus = page.messages.length === 0 ? 'empty' : 'loaded';
@@ -1014,14 +993,4 @@ export class ActiveTranscriptState implements ActiveTranscriptPort {
 		if (!this.#preserveExpandedVisibleWindow) return;
 		this.visibleMessageCount = Math.max(this.visibleMessageCount, this.displayMessageCount);
 	}
-}
-
-function responseMessageType(message: ChatMessage): string | null {
-	return message instanceof AssistantMessage ||
-		message instanceof ThinkingMessage ||
-		message instanceof ErrorMessage ||
-		message instanceof PermissionRequestMessage ||
-		isToolUseMessage(message)
-		? message.type
-		: null;
 }

--- a/web/src/lib/chat/transcript/chat-transcript-cache.svelte.ts
+++ b/web/src/lib/chat/transcript/chat-transcript-cache.svelte.ts
@@ -259,6 +259,7 @@ export class ChatTranscriptCache {
 
 	markStale(chatId: string): void {
 		if (!chatId) return;
+		this.#persistence.remove(chatId);
 		const current = this.#entries.get(chatId);
 		if (current) this.#entries.set(chatId, { ...current, stale: true });
 		this.#storage.markStale(chatId);
@@ -288,7 +289,7 @@ export class ChatTranscriptCache {
 			);
 		if (memory.length >= boundedLimit) return memory.slice(0, boundedLimit);
 
-		const seen = new Set(memory.map((cursor) => cursor.chatId));
+		const seen = new Set(this.#entries.keys());
 		const persisted = this.#storage
 			.listCursors(boundedLimit)
 			.filter((cursor: CachedChatCursor) => !seen.has(cursor.chatId));

--- a/web/src/lib/chat/transcript/chat-transcript-storage.ts
+++ b/web/src/lib/chat/transcript/chat-transcript-storage.ts
@@ -267,9 +267,11 @@ export class LocalChatTranscriptStorage {
 		const boundedLimit = Math.max(0, Math.floor(limit));
 		if (boundedLimit === 0) return [];
 		try {
-			const sorted = [...readIndex().entries].sort(
-				(a, b) => new Date(b.lastAccessedAt).getTime() - new Date(a.lastAccessedAt).getTime(),
-			);
+			const sorted = readIndex()
+				.entries.filter((entry) => !entry.stale)
+				.sort(
+					(a, b) => new Date(b.lastAccessedAt).getTime() - new Date(a.lastAccessedAt).getTime(),
+				);
 			const cursors: CachedChatCursor[] = [];
 			for (const entry of sorted) {
 				if (cursors.length >= boundedLimit) break;

--- a/web/src/lib/chat/transcript/conversation-feed-mutations.ts
+++ b/web/src/lib/chat/transcript/conversation-feed-mutations.ts
@@ -1,3 +1,12 @@
+import {
+	AssistantMessage,
+	ErrorMessage,
+	PermissionRequestMessage,
+	ThinkingMessage,
+	isToolUseMessage,
+	type ChatMessage,
+} from '$shared/chat-types';
+
 export type ConversationFeedMutationKind =
 	| 'initial'
 	| 'live-append'
@@ -46,4 +55,14 @@ export function conversationFeedEndBehavior(
 		return 'restore-if-pinned';
 	}
 	return 'preserve-reading-position';
+}
+
+export function responseMessageType(message: ChatMessage): string | null {
+	return message instanceof AssistantMessage ||
+		message instanceof ThinkingMessage ||
+		message instanceof ErrorMessage ||
+		message instanceof PermissionRequestMessage ||
+		isToolUseMessage(message)
+		? message.type
+		: null;
 }

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -331,19 +331,7 @@ export class ConversationScrollController {
 		}
 		this.#syncBoundaryLatch(direction);
 		if (reason === 'button') this.#preserveHistoryBrowsing();
-		const earlierBoundaryAdvanced =
-			direction === 'earlier' &&
-			requestBoundarySignature !== null &&
-			this.#earlierBoundarySignature() !== requestBoundarySignature;
-		const shouldContinueEarlierPrefetch =
-			direction === 'earlier' &&
-			earlierBoundaryAdvanced &&
-			this.#userScrollIntent.direction === 'earlier';
-		if (
-			(continuedPageIntent || shouldContinueEarlierPrefetch) &&
-			this.#isNearPageBoundary(direction) &&
-			(result === 'loaded' || earlierBoundaryAdvanced)
-		) {
+		if (continuedPageIntent && this.#isNearPageBoundary(direction) && result === 'loaded') {
 			if (direction === 'later') this.#laterBoundaryArmed = true;
 			this.#handleBoundaryProximity(direction, true);
 		}
@@ -630,19 +618,11 @@ export class ConversationScrollController {
 		} else if (!this.#laterBoundaryArmed) {
 			return;
 		}
-		// Earlier browsing remains armed across a slow drag or momentum scroll and
-		// advances only with the cursor. Later paging still requires fresh input.
 		const intent = this.#userScrollIntent;
 		const hasEligibleIntent =
-			direction === 'earlier'
-				? intent.direction === 'earlier' &&
-					((intent.epoch > this.#consumedIntentEpoch.earlier &&
-						this.#hasRecentUserScrollIntent()) ||
-						(this.#earlierBoundaryRequestSignature !== null &&
-							this.#earlierBoundaryRequestSignature !== this.#earlierBoundarySignature()))
-				: intent.epoch > this.#consumedIntentEpoch.later &&
-					intent.direction === 'later' &&
-					this.#hasRecentUserScrollIntent();
+			intent.epoch > this.#consumedIntentEpoch[direction] &&
+			intent.direction === direction &&
+			this.#hasRecentUserScrollIntent();
 		if (!hasEligibleIntent) {
 			return;
 		}

--- a/web/src/lib/chat/transcript/transcript-page-progress.ts
+++ b/web/src/lib/chat/transcript/transcript-page-progress.ts
@@ -1,5 +1,17 @@
 import type { ChatViewMessage } from '$shared/chat-view';
 
+export const ACTIVE_TRANSCRIPT_RETENTION_LIMIT = 200;
+
+export function retainTranscriptEntries(
+	entries: ChatViewMessage[],
+	edge: 'earlier' | 'later',
+): ChatViewMessage[] {
+	if (entries.length <= ACTIVE_TRANSCRIPT_RETENTION_LIMIT) return entries;
+	return edge === 'earlier'
+		? entries.slice(0, ACTIVE_TRANSCRIPT_RETENTION_LIMIT)
+		: entries.slice(-ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
+}
+
 export function collectEarlierTranscriptMessages(
 	currentOldestSeq: number,
 	pageMessages: readonly ChatViewMessage[],

--- a/web/src/lib/chat/transcript/transcript-row-projection.ts
+++ b/web/src/lib/chat/transcript/transcript-row-projection.ts
@@ -1,6 +1,6 @@
 import { UserMessage, type ChatMessage } from '$shared/chat-types';
 import type { ChatViewMessage } from '$shared/chat-view';
-import type { PendingUserInput } from '$shared/pending-user-input';
+import { normalizePendingUserInput, type PendingUserInput } from '$shared/pending-user-input';
 
 export interface ChatTranscriptRow {
 	kind: 'message';
@@ -11,6 +11,14 @@ export interface ChatTranscriptRow {
 
 export function sortPendingInputs(inputs: PendingUserInput[]): PendingUserInput[] {
 	return inputs.slice().sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+}
+
+export function normalizePendingInputs(inputs: readonly unknown[]): PendingUserInput[] {
+	return sortPendingInputs(
+		inputs
+			.map(normalizePendingUserInput)
+			.filter((input): input is PendingUserInput => Boolean(input)),
+	);
 }
 
 export function uniqueEntriesByClientRequestId(entries: ChatViewMessage[]): ChatViewMessage[] {

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -421,17 +421,15 @@
 		<!-- Keeps automatic loading outside TanStack geometry so prepends cannot move the reading anchor. -->
 		<div
 			class={cn(
-				'pointer-events-none absolute left-1/2 z-10 flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-none',
-				reserveTopFloatingToolbar
-					? 'top-[calc(var(--workspace-floating-taskbar-inset)+0.5rem)]'
-					: 'top-2',
+				'pointer-events-none absolute inset-x-0 z-10 flex h-8 items-center justify-center gap-1.5 border-b border-border bg-background text-xs text-muted-foreground',
+				reserveTopFloatingToolbar ? 'top-[var(--workspace-floating-taskbar-inset)]' : 'top-0',
 			)}
 			role="status"
 			aria-live="polite"
 			data-chat-earlier-loading-indicator
 		>
 			<Loader2 class="size-3.5 animate-spin" aria-hidden="true" />
-			<span class="sr-only">{m.chat_transcript_loading_earlier()}</span>
+			<span>{m.chat_transcript_loading_earlier()}</span>
 		</div>
 	{/if}
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex -- scroll container needs programmatic focus for Ctrl+U/D; follow-up: CLEANUP_ROUND_TWO.md#a11y-suppression-register -->

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -174,12 +174,6 @@
 			isPreparingInitialScroll && 'invisible',
 		),
 	);
-	const showEarlierLoadingStatus = $derived(
-		!isPreparingInitialScroll &&
-			chatState.displayMessageCount > 0 &&
-			chatState.pageStates.earlier.status === 'loading' &&
-			chatState.pageStates.earlier.error === null,
-	);
 	const activePendingPermissionRequests = $derived.by(() =>
 		pendingPermissionRequests.filter(
 			(request) => !request.chatId || request.chatId === chatState.activeChatId,
@@ -416,20 +410,6 @@
 				<Loader2 class="h-4 w-4 animate-spin" />
 				<span>{m.chat_chat_loading_chat_messages()}</span>
 			</div>
-		</div>
-	{:else if showEarlierLoadingStatus}
-		<!-- Keeps automatic loading outside TanStack geometry so prepends cannot move the reading anchor. -->
-		<div
-			class={cn(
-				'pointer-events-none absolute inset-x-0 z-10 flex h-8 items-center justify-center gap-1.5 border-b border-border bg-background text-xs text-muted-foreground',
-				reserveTopFloatingToolbar ? 'top-[var(--workspace-floating-taskbar-inset)]' : 'top-0',
-			)}
-			role="status"
-			aria-live="polite"
-			data-chat-earlier-loading-indicator
-		>
-			<Loader2 class="size-3.5 animate-spin" aria-hidden="true" />
-			<span>{m.chat_transcript_loading_earlier()}</span>
 		</div>
 	{/if}
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex -- scroll container needs programmatic focus for Ctrl+U/D; follow-up: CLEANUP_ROUND_TWO.md#a11y-suppression-register -->

--- a/web/src/lib/components/chat/ConversationFeed.svelte
+++ b/web/src/lib/components/chat/ConversationFeed.svelte
@@ -366,6 +366,7 @@
 			data-chat-virtual-count={virtualItems.length}
 			data-chat-virtual-model-count={projection.model.items.length}
 			data-chat-virtual-data-revision={projection.projectedDataRevision}
+			data-chat-transcript-entry-count={chatState.entries.length}
 			data-chat-transcript-scale={String(textScale)}
 		>
 			{#each virtualItems as virtualItem (virtualItem.key)}

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -189,13 +189,7 @@
 		loadVisibleChatSnapshot: (chatId) => loadVisiblePreviewSnapshot?.(chatId),
 		onVisibleChatMessages: (chatId, generationId, messages, lastSeq) =>
 			applyVisiblePreviewMessages?.(chatId, generationId, messages, lastSeq),
-		loadBackgroundSnapshot: async (chatId) => {
-			if (sessions.selectedChatId === chatId) {
-				await chatState.loadMessages(chatId);
-				return;
-			}
-			backgroundTranscriptLoader.queueLoad(chatId);
-		},
+		markBackgroundStale: (chatId) => transcriptCache.markStale(chatId),
 		onBackgroundMessages: (chatId, generationId, messages, lastSeq) => {
 			const applied = transcriptCache.applyMessages(chatId, generationId, messages, lastSeq);
 			if (applied.status !== 'applied') return false;

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -345,14 +345,15 @@ describe('ConversationFeed', () => {
 		expect(container.querySelector('[data-chat-virtual-sizer]')).toBeTruthy();
 	});
 
-	it('keeps a varied twenty-thousand-item transcript below the mounted DOM budget', async () => {
+	it('bounds a twenty-thousand-entry payload before virtual projection', async () => {
 		const { container } = render(ConversationFeedTestHost, {
 			transcriptScenario: 'twenty-thousand',
 		});
 		await waitFor(
 			() => {
 				const sizer = container.querySelector('[data-chat-virtual-sizer]');
-				expect(sizer?.getAttribute('data-chat-virtual-model-count')).toBe('20002');
+				expect(sizer?.getAttribute('data-chat-transcript-entry-count')).toBe('200');
+				expect(sizer?.getAttribute('data-chat-virtual-model-count')).toBe('202');
 				const mountedItems = container.querySelectorAll('[data-chat-virtual-item]').length;
 				const mountedTranscriptRows = container.querySelectorAll('[data-chat-row-id]').length;
 				expect(mountedItems).toBeGreaterThan(0);

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -255,25 +255,6 @@ describe('ConversationFeed', () => {
 		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBeNull();
 	});
 
-	it('shows automatic earlier loading outside virtual geometry', () => {
-		const { container } = render(ConversationFeedTestHost, {
-			reserveTopFloatingToolbar: true,
-			transcriptScenario: 'loading-earlier',
-		});
-		const viewport = screen.getByRole('region', { name: 'Chat messages' });
-		const indicator = container.querySelector<HTMLElement>('[data-chat-earlier-loading-indicator]');
-
-		expect(indicator?.textContent).toContain('Loading earlier messages...');
-		expect(indicator?.classList.contains('top-[var(--workspace-floating-taskbar-inset)]')).toBe(
-			true,
-		);
-		expect(indicator?.closest('[data-chat-virtual-sizer]')).toBeNull();
-		expect(viewport.contains(indicator)).toBe(false);
-		expect(viewport.getAttribute('aria-busy')).toBe('true');
-		expect(screen.queryByRole('button', { name: 'Load earlier messages' })).toBeNull();
-		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBeNull();
-	});
-
 	it('renders later loading below the transcript without a native bottom anchor', async () => {
 		const { container } = render(ConversationFeedTestHost, {
 			transcriptScenario: 'loading-later',
@@ -306,7 +287,6 @@ describe('ConversationFeed', () => {
 		const loading = await screen.findByRole('button', { name: 'Loading earlier messages...' });
 		expect(loading.getAttribute('aria-busy')).toBe('true');
 		expect(container.querySelector('[data-transcript-page-boundary="earlier"]')).toBe(boundary);
-		expect(container.querySelector('[data-chat-earlier-loading-indicator]')).toBeNull();
 	});
 
 	it('passes durable and pending row identities to mounted virtual rows', async () => {

--- a/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeed.test.ts
@@ -264,18 +264,7 @@ describe('ConversationFeed', () => {
 		const indicator = container.querySelector<HTMLElement>('[data-chat-earlier-loading-indicator]');
 
 		expect(indicator?.textContent).toContain('Loading earlier messages...');
-		expect(
-			indicator?.classList.contains('top-[calc(var(--workspace-floating-taskbar-inset)+0.5rem)]'),
-		).toBe(true);
-		expect(indicator?.classList.contains('left-1/2')).toBe(true);
-		expect(indicator?.classList.contains('-translate-x-1/2')).toBe(true);
-		expect(indicator?.classList.contains('size-8')).toBe(true);
-		expect(indicator?.classList.contains('rounded-full')).toBe(true);
-		expect(indicator?.classList.contains('border')).toBe(true);
-		expect(indicator?.classList.contains('bg-background')).toBe(true);
-		expect(indicator?.classList.contains('shadow-none')).toBe(true);
-		expect(indicator?.classList.contains('inset-x-0')).toBe(false);
-		expect(screen.getByText('Loading earlier messages...').classList.contains('sr-only')).toBe(
+		expect(indicator?.classList.contains('top-[var(--workspace-floating-taskbar-inset)]')).toBe(
 			true,
 		);
 		expect(indicator?.closest('[data-chat-virtual-sizer]')).toBeNull();

--- a/web/src/lib/components/chat/__tests__/ConversationFeedProjectionState.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedProjectionState.test.ts
@@ -5,6 +5,7 @@ import {
 	type ChatDisplayRow,
 } from '$lib/chat/transcript/active-transcript-state.svelte.js';
 import type { ConversationFeedMutationClock } from '$lib/chat/transcript/conversation-feed-mutations.js';
+import { ACTIVE_TRANSCRIPT_RETENTION_LIMIT } from '$lib/chat/transcript/transcript-page-progress.js';
 import { ConversationFeedProjectionState } from '../ConversationFeedProjectionState.svelte.js';
 import { estimateConversationFeedItemSize } from '../conversation-feed-virtual-items.js';
 
@@ -86,10 +87,11 @@ describe('ConversationFeedProjectionState', () => {
 		expect(streamed.renderModel).not.toBe(first.renderModel);
 	});
 
-	it('extends a fully revealed deep transcript incrementally for assistant appends', () => {
+	it('extends a retained transcript incrementally below the retention limit', () => {
 		const transcript = new ActiveTranscriptState();
 		const projections = new ConversationFeedProjectionState();
-		const deepEntries = Array.from({ length: 20_000 }, (_, index) => ({
+		const initialCount = ACTIVE_TRANSCRIPT_RETENTION_LIMIT - 1;
+		const deepEntries = Array.from({ length: initialCount }, (_, index) => ({
 			seq: index + 1,
 			message:
 				index % 2 === 0
@@ -97,7 +99,7 @@ describe('ConversationFeedProjectionState', () => {
 					: new AssistantMessage(TS, `response ${index + 1}`),
 		}));
 		transcript.replaceGeneration('chat-1', 'generation-1', deepEntries, {
-			lastSeq: 20_000,
+			lastSeq: initialCount,
 			pageOldestSeq: 1,
 			hasMore: false,
 		});
@@ -109,7 +111,10 @@ describe('ConversationFeedProjectionState', () => {
 		const oldEndKey = first.model.items.at(-1)?.key;
 
 		transcript.applyMessages('chat-1', 'generation-1', [
-			{ seq: 20_001, message: new AssistantMessage(TS, 'new response') },
+			{
+				seq: ACTIVE_TRANSCRIPT_RETENTION_LIMIT,
+				message: new AssistantMessage(TS, 'new response'),
+			},
 		]);
 		const appendedRows = transcript.visibleRows;
 		const appendedTail = appendedRows.at(-1);
@@ -119,18 +124,19 @@ describe('ConversationFeedProjectionState', () => {
 			input({ rows: appendedRows, mutationClock: transcript.feedMutationClock }),
 		);
 
-		expect(appendedRows).toHaveLength(20_001);
+		const appendedRowId = `generation-1:${ACTIVE_TRANSCRIPT_RETENTION_LIMIT}`;
+		expect(appendedRows).toHaveLength(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
 		expect(appendedRows[0]?.id).toBe(initialRows[0]?.id);
-		expect(appended.renderModel.items[10_000]).toBe(first.renderModel.items[10_000]);
-		expect(appended.model.items[10_001]).toBe(first.model.items[10_001]);
+		expect(appended.renderModel.items[100]).toBe(first.renderModel.items[100]);
+		expect(appended.model.items[101]).toBe(first.model.items[101]);
 		expect(appended.model.indexByKey).not.toBe(first.model.indexByKey);
 		expect(appended.model.indexByRowId).not.toBe(first.model.indexByRowId);
 		expect(appended.model.targetByDomAnchorId).not.toBe(first.model.targetByDomAnchorId);
-		expect(first.model.indexByRowId.has('generation-1:20001')).toBe(false);
-		expect(first.model.targetByDomAnchorId.has('generation-1:20001')).toBe(false);
+		expect(first.model.indexByRowId.has(appendedRowId)).toBe(false);
+		expect(first.model.targetByDomAnchorId.has(appendedRowId)).toBe(false);
 		expect(oldEndKey).toBeDefined();
 		expect(first.model.indexByKey.get(oldEndKey!)).toBe(first.model.items.length - 1);
-		expect(appended.model.indexByRowId.get('generation-1:20001')).toBe(20_001);
+		expect(appended.model.indexByRowId.get(appendedRowId)).toBe(ACTIVE_TRANSCRIPT_RETENTION_LIMIT);
 		expect(appended.model.items.at(-2)).toMatchObject({
 			kind: 'transcript',
 			item: { message: appendedTail.message },

--- a/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedTestHost.svelte
@@ -27,7 +27,6 @@
 		transcriptScenario?:
 			| 'empty'
 			| 'local-truncation'
-			| 'loading-earlier'
 			| 'loading-later'
 			| 'error-earlier'
 			| 'row-ids'
@@ -88,9 +87,6 @@
 		});
 		if (initialTranscriptScenario === 'loading-later') {
 			chatState.pageStates.later = { status: 'loading', error: null };
-		}
-		if (initialTranscriptScenario === 'loading-earlier') {
-			chatState.pageStates.earlier = { status: 'loading', error: null };
 		}
 		if (initialTranscriptScenario === 'error-earlier') {
 			chatState.pageStates.earlier = { status: 'error', error: 'Network unavailable' };

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -201,7 +201,7 @@ function createReconnectDeps(
 		getVisibleChatCursor: vi.fn((chatId: string) => options.visibleCursors?.[chatId] ?? null),
 		loadVisibleChatSnapshot: vi.fn(async () => undefined),
 		onVisibleChatMessages: vi.fn(),
-		loadBackgroundSnapshot: vi.fn(async () => undefined),
+		markBackgroundStale: vi.fn(),
 		onBackgroundMessages: vi.fn(),
 	} satisfies ChatReconnectCoordinatorOptions;
 }
@@ -226,7 +226,7 @@ function clearConnectionCalls(deps: ReturnType<typeof createReconnectDeps>): voi
 		deps.getVisibleChatCursor,
 		deps.loadVisibleChatSnapshot,
 		deps.onVisibleChatMessages,
-		deps.loadBackgroundSnapshot,
+		deps.markBackgroundStale,
 		deps.onBackgroundMessages,
 	]) {
 		fn.mockClear();
@@ -1012,7 +1012,7 @@ describe('ChatReconnectCoordinator', () => {
 		expect(deps.loadVisibleChatSnapshot).toHaveBeenCalledWith('chat-2');
 	});
 
-	it('loads background snapshots for non-resumable cached cursors', async () => {
+	it('defers background snapshots for non-resumable cached cursors', async () => {
 		const deps = createReconnectDeps({
 			selectedChatId: 'chat-1',
 			backgroundCursors: [{ chatId: 'chat-2', generationId: 'generation-2', lastSeq: 1 }],
@@ -1024,10 +1024,11 @@ describe('ChatReconnectCoordinator', () => {
 
 		await reconnectAfterFirstConnection(deps);
 
-		expect(deps.loadBackgroundSnapshot).toHaveBeenCalledWith('chat-2');
+		expect(deps.markBackgroundStale).toHaveBeenCalledWith('chat-2');
+		expect(deps.chatState.loadMessages).not.toHaveBeenCalled();
 	});
 
-	it('loads background snapshots when background delta apply reports a gap', async () => {
+	it('defers background snapshots when background delta apply reports a gap', async () => {
 		const deps = createReconnectDeps({
 			selectedChatId: 'chat-1',
 			backgroundCursors: [{ chatId: 'chat-2', generationId: 'generation-2', lastSeq: 1 }],
@@ -1040,7 +1041,38 @@ describe('ChatReconnectCoordinator', () => {
 
 		await reconnectAfterFirstConnection(deps);
 
-		expect(deps.loadBackgroundSnapshot).toHaveBeenCalledWith('chat-2');
+		expect(deps.markBackgroundStale).toHaveBeenCalledWith('chat-2');
+		expect(deps.chatState.loadMessages).not.toHaveBeenCalled();
+	});
+
+	it('marks twenty non-resumable background cursors stale without loading snapshots', async () => {
+		const backgroundCursors = Array.from({ length: 20 }, (_, index) => ({
+			chatId: `chat-${index + 2}`,
+			generationId: `generation-${index + 2}`,
+			lastSeq: 1,
+		}));
+		const subscribeResponses = Object.fromEntries(
+			backgroundCursors.map((cursor) => [
+				cursor.chatId,
+				snapshotRequiredResponse(cursor.chatId, `next-${cursor.generationId}`),
+			]),
+		);
+		const deps = createReconnectDeps({
+			selectedChatId: 'chat-1',
+			backgroundCursors,
+			subscribeResponses: {
+				'chat-1': deltaResponse('chat-1', 'generation-selected'),
+				...subscribeResponses,
+			},
+		});
+
+		await reconnectAfterFirstConnection(deps);
+
+		expect(deps.markBackgroundStale).toHaveBeenCalledTimes(20);
+		expect(deps.markBackgroundStale.mock.calls.map(([chatId]) => chatId)).toEqual(
+			backgroundCursors.map((cursor) => cursor.chatId),
+		);
+		expect(deps.chatState.loadMessages).not.toHaveBeenCalled();
 	});
 
 	it('discards stale reconnect responses when a newer reconnect begins', async () => {

--- a/web/src/lib/ws/reconnect-coordinator.svelte.ts
+++ b/web/src/lib/ws/reconnect-coordinator.svelte.ts
@@ -62,7 +62,7 @@ export interface ChatReconnectCoordinatorOptions {
 		messages: ChatViewMessage[],
 		lastSeq: number,
 	) => Promise<boolean | void> | boolean | void;
-	loadBackgroundSnapshot: (chatId: string) => Promise<void> | void;
+	markBackgroundStale: (chatId: string) => void;
 	onBackgroundMessages?: (
 		chatId: string,
 		generationId: string,
@@ -343,12 +343,12 @@ export class ChatReconnectCoordinator {
 				const message = await this.#subscribe(cursor.chatId, cursor.generationId, cursor.lastSeq);
 				if (epoch !== this.#reconnectEpoch) return;
 				if (message.mode === 'snapshot-required') {
-					await this.options.loadBackgroundSnapshot(cursor.chatId);
+					this.options.markBackgroundStale(cursor.chatId);
 					shouldRefresh = true;
 					continue;
 				}
 				if (message.messages.length === 0 && message.lastSeq > cursor.lastSeq) {
-					await this.options.loadBackgroundSnapshot(cursor.chatId);
+					this.options.markBackgroundStale(cursor.chatId);
 					shouldRefresh = true;
 					continue;
 				}
@@ -360,7 +360,7 @@ export class ChatReconnectCoordinator {
 						message.lastSeq,
 					);
 					if (applied === false) {
-						await this.options.loadBackgroundSnapshot(cursor.chatId);
+						this.options.markBackgroundStale(cursor.chatId);
 					}
 					shouldRefresh = true;
 				}


### PR DESCRIPTION
Large carried-over transcripts could trigger unbounded retained windows, stale scroll-intent paging chains, repeated page-backed generation rotations, and eager background snapshot loads. This change caps active transcript windows at 200 entries with bidirectional cursors and anchor preservation, requires fresh input for automatic paging, preserves unchanged page-backed generations using canonical transcript revisions, and defers invisible reconnect recovery until selection.