### PR TITLE
Fix stale file listings after workspace remounts

### DIFF
--- a/integration-tests/tests/e2e/file-tree-parent-navigation.test.ts
+++ b/integration-tests/tests/e2e/file-tree-parent-navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Page } from "puppeteer-core";
 import { withE2eFixture } from "../../support/e2e-fixture.js";
@@ -59,7 +59,197 @@ describe("Lightpanda file tree parent navigation", () => {
       fixture.assertNoBrowserErrors();
     });
   });
+
+  test("keeps breadcrumb and expanded listings synchronized across presentation changes", async () => {
+    await withE2eFixture("file-tree-responsive-listing", async (fixture) => {
+      const rootPath = fixture.integration.dirs.project;
+      const firstLevelPath = join(rootPath, "level-one");
+      const secondLevelPath = join(firstLevelPath, "level-two");
+      const firstSiblingPath = join(rootPath, "sibling-a");
+      const secondSiblingPath = join(rootPath, "sibling-b");
+      await Promise.all([
+        mkdir(secondLevelPath, { recursive: true }),
+        mkdir(firstSiblingPath, { recursive: true }),
+        mkdir(secondSiblingPath, { recursive: true }),
+      ]);
+      await Promise.all([
+        writeFile(join(rootPath, "root-only.txt"), "root\n", "utf8"),
+        writeFile(join(firstLevelPath, "first-only.txt"), "first\n", "utf8"),
+        writeFile(join(secondLevelPath, "second-only.txt"), "second\n", "utf8"),
+        writeFile(join(firstSiblingPath, "a-only.txt"), "a\n", "utf8"),
+        writeFile(join(firstSiblingPath, "shared.txt"), "a shared\n", "utf8"),
+        writeFile(join(secondSiblingPath, "b-only.txt"), "b\n", "utf8"),
+        writeFile(join(secondSiblingPath, "shared.txt"), "b shared\n", "utf8"),
+      ]);
+
+      const rootEntries = [
+        firstLevelPath,
+        firstSiblingPath,
+        secondSiblingPath,
+        join(rootPath, "root-only.txt"),
+      ];
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.setViewport(1_440, 900);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat("file-tree-responsive-listing-seed", {
+        projectPath: rootPath,
+      });
+      if (await app.hasButton("Open sidebar"))
+        await app.clickButton("Open sidebar");
+      await app.selectSidebarWorkspaceSurface("Files");
+      await expectFileListing(fixture.page, rootPath, rootEntries);
+
+      await enterDirectory(fixture.page, firstLevelPath);
+      await expectFileListing(fixture.page, firstLevelPath, [
+        secondLevelPath,
+        join(firstLevelPath, "first-only.txt"),
+      ]);
+      await enterDirectory(fixture.page, secondLevelPath);
+      await expectFileListing(fixture.page, secondLevelPath, [
+        join(secondLevelPath, "second-only.txt"),
+      ]);
+
+      await fixture.page.evaluate(() => {
+        document.documentElement.dataset.fileTreeHostMoveRealm = "retained";
+      });
+      await app.openWorkspaceActions("sidebar");
+      await app.waitForMenuItemEnabled("Move to main view");
+      await app.clickMenuItem("Move to main view");
+      await expectFileListing(fixture.page, secondLevelPath, [
+        join(secondLevelPath, "second-only.txt"),
+      ]);
+      expect(
+        await fixture.page.evaluate(
+          () => document.documentElement.dataset.fileTreeHostMoveRealm,
+        ),
+      ).toBe("retained");
+      await navigateToBreadcrumb(fixture.page, rootPath);
+      await expectFileListing(fixture.page, rootPath, rootEntries);
+
+      await app.setViewport(390, 844);
+      await app.clickButton("Files");
+      await expectFileListing(fixture.page, rootPath, rootEntries);
+      await enterDirectory(fixture.page, firstLevelPath);
+      await expectFileListing(fixture.page, firstLevelPath, [
+        secondLevelPath,
+        join(firstLevelPath, "first-only.txt"),
+      ]);
+      await enterDirectory(fixture.page, secondLevelPath);
+      await expectFileListing(fixture.page, secondLevelPath, [
+        join(secondLevelPath, "second-only.txt"),
+      ]);
+      await navigateToBreadcrumb(fixture.page, rootPath);
+      await expectFileListing(fixture.page, rootPath, rootEntries);
+
+      await expandDirectory(fixture.page, firstSiblingPath);
+      await expectFileListing(fixture.page, rootPath, [
+        ...rootEntries,
+        join(firstSiblingPath, "a-only.txt"),
+        join(firstSiblingPath, "shared.txt"),
+      ]);
+      await expandDirectory(fixture.page, secondSiblingPath);
+      const expandedEntries = [
+        ...rootEntries,
+        join(firstSiblingPath, "a-only.txt"),
+        join(firstSiblingPath, "shared.txt"),
+        join(secondSiblingPath, "b-only.txt"),
+        join(secondSiblingPath, "shared.txt"),
+      ];
+      await expectFileListing(fixture.page, rootPath, expandedEntries);
+
+      await app.setViewport(1_440, 900);
+      if (await app.hasButton("Open sidebar"))
+        await app.clickButton("Open sidebar");
+      await app.selectSidebarWorkspaceSurface("Files");
+      await expectFileListing(fixture.page, rootPath, rootEntries);
+      fixture.assertNoBrowserErrors();
+    });
+  });
 });
+
+async function expectFileListing(
+  page: Page,
+  directoryPath: string,
+  expectedEntryPaths: string[],
+): Promise<void> {
+  const expectedPaths = [...expectedEntryPaths].sort();
+  await page.waitForFunction(
+    ({ expectedDirectoryPath, expectedPaths }) => {
+      const currentPath = document
+        .querySelector('[data-file-tree-breadcrumbs] [aria-current="location"]')
+        ?.getAttribute("title");
+      const rows = [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-file-tree-row-key]:not([data-file-tree-row-key="file-tree-parent-row"])',
+        ),
+      ];
+      const paths = rows
+        .map((row) =>
+          row.querySelector('[role="rowheader"]')?.getAttribute("title"),
+        )
+        .filter((path): path is string => typeof path === "string")
+        .sort();
+      const keys = rows.map((row) => row.dataset.fileTreeRowKey);
+      return (
+        currentPath === expectedDirectoryPath &&
+        document.querySelector("[data-file-tree-loading]") === null &&
+        paths.length === expectedPaths.length &&
+        paths.every((path, index) => path === expectedPaths[index]) &&
+        keys.every((key) => typeof key === "string") &&
+        new Set(keys).size === keys.length
+      );
+    },
+    { timeout: 20_000 },
+    { expectedDirectoryPath: directoryPath, expectedPaths },
+  );
+
+  const listing = await page.evaluate(() => {
+    const rows = [
+      ...document.querySelectorAll<HTMLElement>(
+        '[data-file-tree-row-key]:not([data-file-tree-row-key="file-tree-parent-row"])',
+      ),
+    ];
+    return {
+      paths: rows
+        .map((row) =>
+          row.querySelector('[role="rowheader"]')?.getAttribute("title"),
+        )
+        .filter((path): path is string => typeof path === "string")
+        .sort(),
+      keys: rows.map((row) => row.dataset.fileTreeRowKey),
+    };
+  });
+  expect(listing.paths).toEqual(expectedPaths);
+  expect(new Set(listing.keys).size).toBe(listing.keys.length);
+}
+
+async function navigateToBreadcrumb(page: Page, path: string): Promise<void> {
+  await page.evaluate((targetPath) => {
+    const breadcrumb = [
+      ...document.querySelectorAll<HTMLButtonElement>(
+        "[data-file-tree-breadcrumbs] button",
+      ),
+    ].find((button) => button.getAttribute("aria-label") === targetPath);
+    if (!breadcrumb) throw new Error(`Missing breadcrumb: ${targetPath}`);
+    breadcrumb.click();
+  }, path);
+}
+
+async function expandDirectory(page: Page, path: string): Promise<void> {
+  await page.evaluate((directoryPath) => {
+    const header = [
+      ...document.querySelectorAll<HTMLElement>(
+        '[data-file-tree-row] [role="rowheader"]',
+      ),
+    ].find((element) => element.getAttribute("title") === directoryPath);
+    const row = header?.closest<HTMLElement>("[data-file-tree-row]");
+    const disclosure = row?.querySelector<HTMLButtonElement>("button");
+    if (!row || !disclosure)
+      throw new Error(`Missing directory disclosure: ${directoryPath}`);
+    if (row.getAttribute("aria-expanded") !== "true") disclosure.click();
+  }, path);
+}
 
 async function waitForDirectory(page: Page, path: string): Promise<void> {
   await page.waitForFunction(

--- a/web/src/lib/components/files/__tests__/FileTree.test.ts
+++ b/web/src/lib/components/files/__tests__/FileTree.test.ts
@@ -56,6 +56,30 @@ function response(
 	};
 }
 
+function responseAt(directoryPath: string, entries: FileTreeEntry[]): FileTreeResponse {
+	const segments = directoryPath.slice('/workspace'.length).split('/').filter(Boolean);
+	let breadcrumbPath = '/workspace';
+	return {
+		fileRootPath: '/workspace',
+		directory: {
+			path: directoryPath,
+			relativePath: segments.join('/'),
+			parentPath:
+				directoryPath === '/workspace'
+					? null
+					: directoryPath.slice(0, directoryPath.lastIndexOf('/')) || '/',
+			breadcrumbs: [
+				{ name: 'workspace', path: '/workspace' },
+				...segments.map((segment) => {
+					breadcrumbPath = `${breadcrumbPath}/${segment}`;
+					return { name: segment, path: breadcrumbPath };
+				}),
+			],
+		},
+		entries,
+	};
+}
+
 function renderReady(entries: FileTreeEntry[]) {
 	const store = new FileTreeStore();
 	store.navigation = { kind: 'ready', response: response(entries) };
@@ -125,6 +149,65 @@ describe('FileTree', () => {
 			kind: 'loading',
 			target: { path: src.path, reason: 'directory-row' },
 		});
+	});
+
+	it('replaces directory rows across consecutive entries and breadcrumb navigation', async () => {
+		const firstPath = '/workspace/project/first';
+		const secondPath = `${firstPath}/second`;
+		const first = entry('first', 'directory');
+		const second = entry('second', 'directory', firstPath);
+		const firstOnly = entry('first-only.txt', 'file', firstPath);
+		const secondOnly = entry('second-only.txt', 'file', secondPath);
+		const projectOnly = entry('project-only.txt', 'file');
+		vi.mocked(filesApi.getTree)
+			.mockResolvedValueOnce(responseAt(firstPath, [second, firstOnly]))
+			.mockResolvedValueOnce(responseAt(secondPath, [secondOnly]))
+			.mockResolvedValueOnce(responseAt('/workspace/project', [first, projectOnly]));
+		const { container, store } = renderReady([first]);
+		store.activate();
+
+		await fireEvent.click(
+			container.querySelector<HTMLElement>(`[data-file-tree-row-key="${first.path}"]`)!,
+		);
+		await screen.findByRole('rowheader', { name: /^first-only\.txt/ });
+		await fireEvent.click(
+			container.querySelector<HTMLElement>(`[data-file-tree-row-key="${second.path}"]`)!,
+		);
+		await screen.findByRole('rowheader', { name: /^second-only\.txt/ });
+
+		expect(screen.queryByRole('rowheader', { name: /^first-only\.txt/ })).toBeNull();
+		await fireEvent.click(screen.getByRole('button', { name: '/workspace/project' }));
+		await screen.findByRole('rowheader', { name: /^project-only\.txt/ });
+
+		expect(store.currentDirectoryPath).toBe('/workspace/project');
+		expect(screen.queryByRole('rowheader', { name: /^second-only\.txt/ })).toBeNull();
+		const keys = [...container.querySelectorAll<HTMLElement>('[data-file-tree-row-key]')].map(
+			(row) => row.dataset.fileTreeRowKey,
+		);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it('keeps overlapping child names owned by their expanded sibling directories', async () => {
+		const first = entry('first', 'directory');
+		const second = entry('second', 'directory');
+		const firstChild = entry('shared.txt', 'file', first.path);
+		const secondChild = entry('shared.txt', 'file', second.path);
+		vi.mocked(filesApi.getTree)
+			.mockResolvedValueOnce(responseAt(first.path, [firstChild]))
+			.mockResolvedValueOnce(responseAt(second.path, [secondChild]));
+		const { container, store } = renderReady([first, second]);
+		store.activate();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Expand first' }));
+		await waitFor(() => expect(store.childrenCache.get(first.path)).toEqual([firstChild]));
+		await fireEvent.click(screen.getByRole('button', { name: 'Expand second' }));
+		await waitFor(() => expect(store.childrenCache.get(second.path)).toEqual([secondChild]));
+
+		expect(screen.getAllByRole('rowheader', { name: /^shared\.txt/ })).toHaveLength(2);
+		const keys = [...container.querySelectorAll<HTMLElement>('[data-file-tree-row-key]')].map(
+			(row) => row.dataset.fileTreeRowKey,
+		);
+		expect(new Set(keys).size).toBe(keys.length);
 	});
 
 	it('opens a file from anywhere on its row', async () => {

--- a/web/src/lib/workspace/__tests__/SingletonSurfaceRegistryTemplateHost.svelte
+++ b/web/src/lib/workspace/__tests__/SingletonSurfaceRegistryTemplateHost.svelte
@@ -7,4 +7,7 @@
 {#if registry}
 	{@const controller = registry.files()}
 	<span>{controller.presentationVisible ? 'visible' : 'hidden'}</span>
+	{#each controller.tree.filteredRows as row (row.key)}
+		<span data-singleton-file-row={row.entry.path}>{row.entry.name}</span>
+	{/each}
 {/if}

--- a/web/src/lib/workspace/__tests__/singleton-surfaces.test.ts
+++ b/web/src/lib/workspace/__tests__/singleton-surfaces.test.ts
@@ -1,12 +1,44 @@
 import { cleanup, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { FileTreeResponse } from '$shared/file-contracts';
 import { CommitController } from '$lib/git/commit/commit-controller.svelte.js';
 import { createGitSurfaceTestDeps } from '$lib/git/__tests__/git-surface-test-deps.js';
 import { PullRequestsStore } from '$lib/git/pull-requests/pull-requests-store.svelte.js';
 import { SingletonSurfaceRegistry } from '$lib/workspace/singleton-surfaces.svelte.js';
 import SingletonSurfaceRegistryTemplateHost from './SingletonSurfaceRegistryTemplateHost.svelte';
 
-afterEach(cleanup);
+const registries: SingletonSurfaceRegistry[] = [];
+
+afterEach(() => {
+	cleanup();
+	for (const registry of registries.splice(0)) registry.destroy();
+});
+
+function fileTreeResponse(directoryPath: string, fileName: string): FileTreeResponse {
+	return {
+		fileRootPath: '/workspace',
+		directory: {
+			path: directoryPath,
+			relativePath: directoryPath.slice('/workspace/'.length),
+			parentPath: '/workspace',
+			breadcrumbs: [
+				{ name: 'workspace', path: '/workspace' },
+				{ name: directoryPath.split('/').at(-1) ?? directoryPath, path: directoryPath },
+			],
+		},
+		entries: [
+			{
+				name: fileName,
+				path: `${directoryPath}/${fileName}`,
+				relativePath: `${directoryPath.slice('/workspace/'.length)}/${fileName}`,
+				type: 'file',
+				size: 1,
+				modified: null,
+				permissionsRwx: 'rw-r--r--',
+			},
+		],
+	};
+}
 
 function createRegistry() {
 	const commits: Array<{
@@ -45,6 +77,7 @@ function createRegistry() {
 			return controller;
 		},
 	});
+	registries.push(registry);
 	return {
 		registry,
 		commits,
@@ -105,15 +138,27 @@ describe('SingletonSurfaceRegistry', () => {
 		expect(files.presentationVisible).toBe(false);
 	});
 
-	it('keeps template access pure when Files remounts with a retained controller', () => {
+	it('keeps lazy Files derivations live when their presentation owner is destroyed', async () => {
 		const { registry } = createRegistry();
 		registry.setPresentationVisible('files', true);
 		const first = render(SingletonSurfaceRegistryTemplateHost, { registry });
+		const files = registry.files();
+		files.tree.navigation = {
+			kind: 'ready',
+			response: fileTreeResponse('/workspace/first', 'first-only.txt'),
+		};
 		expect(screen.getByText('visible')).toBeTruthy();
+		expect(await screen.findByText('first-only.txt')).toBeTruthy();
 		first.unmount();
 
+		files.tree.navigation = {
+			kind: 'ready',
+			response: fileTreeResponse('/workspace/second', 'second-only.txt'),
+		};
 		expect(() => render(SingletonSurfaceRegistryTemplateHost, { registry })).not.toThrow();
 		expect(screen.getByText('visible')).toBeTruthy();
+		expect(await screen.findByText('second-only.txt')).toBeTruthy();
+		expect(screen.queryByText('first-only.txt')).toBeNull();
 	});
 
 	it('retains each controller across Git placement remounts', () => {

--- a/web/src/lib/workspace/singleton-surfaces.svelte.ts
+++ b/web/src/lib/workspace/singleton-surfaces.svelte.ts
@@ -1,4 +1,3 @@
-import { untrack } from 'svelte';
 import type { PortableSingletonKind } from '$lib/workspace/surface-types.js';
 import type { PortableSingletonController } from '$lib/workspace/portable-singleton-controller.js';
 import { FileTreeStore } from '$lib/files/tree/file-tree.svelte.js';
@@ -51,8 +50,13 @@ type SingletonControllerFactories = {
 	[K in PortableSingletonKind]: () => SingletonControllerByKind[K];
 };
 
+interface OwnedSingletonController {
+	controller: PortableSingletonController;
+	destroyRoot: () => void;
+}
+
 export class SingletonSurfaceRegistry {
-	#controllers = new Map<PortableSingletonKind, PortableSingletonController>();
+	#controllers = new Map<PortableSingletonKind, OwnedSingletonController>();
 	readonly #factories: SingletonControllerFactories;
 	#projectState: WorkspaceProjectState = { kind: 'absent' };
 	#pullRequestsCapability: {
@@ -107,7 +111,7 @@ export class SingletonSurfaceRegistry {
 	}
 
 	commitIfPresent(): CommitController | null {
-		return (this.#controllers.get('commit') as CommitController | undefined) ?? null;
+		return (this.#controllers.get('commit')?.controller as CommitController | undefined) ?? null;
 	}
 
 	pullRequests(): PullRequestsStore {
@@ -116,50 +120,52 @@ export class SingletonSurfaceRegistry {
 
 	setProjectState(projectState: WorkspaceProjectState): void {
 		this.#projectState = projectState;
-		for (const controller of this.#controllers.values()) {
-			controller.setProjectState(projectState);
+		for (const owned of this.#controllers.values()) {
+			owned.controller.setProjectState(projectState);
 		}
 	}
 
 	setPullRequestsCapability(hasChecked: boolean, available: boolean): void {
 		this.#pullRequestsCapability = { hasChecked, available };
-		const controller = this.#controllers.get('pull-requests') as PullRequestsStore | undefined;
+		const controller = this.#controllers.get('pull-requests')?.controller as
+			PullRequestsStore | undefined;
 		controller?.setCapability(hasChecked, available);
 	}
 
 	setPresentationVisible(kind: PortableSingletonKind, visible: boolean): void {
 		if (this.#visible[kind] === visible) return;
 		this.#visible[kind] = visible;
-		this.#controllers.get(kind)?.setPresentationVisible(visible);
+		this.#controllers.get(kind)?.controller.setPresentationVisible(visible);
 	}
 
 	disposeSurface(kind: PortableSingletonKind): void {
 		this.#visible[kind] = false;
-		const controller = this.#controllers.get(kind);
-		if (!controller) return;
-		controller.setPresentationVisible(false);
-		controller.dispose();
+		const owned = this.#controllers.get(kind);
+		if (!owned) return;
 		this.#controllers.delete(kind);
+		try {
+			owned.controller.setPresentationVisible(false);
+			owned.controller.dispose();
+		} finally {
+			owned.destroyRoot();
+		}
 	}
 
 	destroy(): void {
-		for (const [kind, controller] of this.#controllers) {
-			this.#visible[kind] = false;
-			controller.setPresentationVisible(false);
-			controller.dispose();
-		}
-		this.#controllers.clear();
+		for (const kind of [...this.#controllers.keys()]) this.disposeSurface(kind);
 	}
 
 	#controller<K extends PortableSingletonKind>(kind: K): SingletonControllerByKind[K] {
 		const existing = this.#controllers.get(kind);
-		if (existing) return existing as SingletonControllerByKind[K];
-		return untrack(() => {
-			const controller = this.#factories[kind]();
+		if (existing) return existing.controller as SingletonControllerByKind[K];
+		let controller!: SingletonControllerByKind[K];
+		// A registry-owned root keeps lazy rune state alive across presentation remounts.
+		const destroyRoot = $effect.root(() => {
+			controller = this.#factories[kind]();
 			controller.setProjectState(this.#projectState);
 			controller.setPresentationVisible(this.#visible[kind]);
-			this.#controllers.set(kind, controller);
-			return controller;
 		});
+		this.#controllers.set(kind, { controller, destroyRoot });
+		return controller;
 	}
 }


### PR DESCRIPTION
Lazy singleton controllers inherited a transient Svelte presentation owner, so remounting Files could freeze derived rows while navigation advanced, producing stale directory listings and duplicate keys. This gives each lazy controller a registry-owned effect root with explicit teardown and adds regression coverage for nested navigation, breadcrumbs, sibling expansion, and in-page presentation remounts.