### PR TITLE
Fix responsive desktop composer resizing

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -72,6 +72,7 @@
 	"chat_composer_reply_placeholder": "Reply...",
 	"chat_composer_remove_image": "Remove attachment {name}",
 	"chat_composer_queue_message": "Queue message",
+	"chat_composer_resize": "Resize message composer",
 	"chat_composer_send_message": "Send message",
 	"chat_composer_thinking_effort": "Thinking effort",
 	"chat_composer_agent_setting_thinking": "Thinking",

--- a/web/src/lib/components/chat/ComposerResizeHandle.svelte
+++ b/web/src/lib/components/chat/ComposerResizeHandle.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+
+	interface Props {
+		value: number;
+		minimum: number;
+		maximum: number;
+		label: string;
+		onPreview: (value: number) => void;
+		onCommit: (value: number) => void;
+		onCancel: () => void;
+		onReset: () => void;
+	}
+
+	let { value, minimum, maximum, label, onPreview, onCommit, onCancel, onReset }: Props = $props();
+
+	let pointerId = $state<number | null>(null);
+	let startY = 0;
+	let startHeight = 0;
+	let previewValue = $state<number | null>(null);
+	let previousCursor = '';
+	let previousUserSelect = '';
+
+	function clamp(next: number): number {
+		return Math.min(maximum, Math.max(minimum, Math.round(next)));
+	}
+
+	function startResize(event: PointerEvent): void {
+		if (!(event.currentTarget instanceof HTMLElement)) return;
+		if (event.isPrimary === false || event.button !== 0) return;
+
+		event.preventDefault();
+		pointerId = event.pointerId;
+		startY = event.clientY;
+		startHeight = value;
+		previousCursor = document.body.style.cursor;
+		previousUserSelect = document.body.style.userSelect;
+		document.body.style.cursor = 'row-resize';
+		document.body.style.userSelect = 'none';
+		event.currentTarget.setPointerCapture(event.pointerId);
+	}
+
+	function previewResize(event: PointerEvent): void {
+		if (pointerId !== event.pointerId) return;
+		event.preventDefault();
+		previewValue = clamp(startHeight + startY - event.clientY);
+		onPreview(previewValue);
+	}
+
+	function stopResize(event: PointerEvent, commit: boolean): void {
+		if (pointerId !== event.pointerId) return;
+		const target = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+		finishResize(commit);
+		if (target?.hasPointerCapture(event.pointerId)) {
+			target.releasePointerCapture(event.pointerId);
+		}
+	}
+
+	function finishResize(commit: boolean): void {
+		if (pointerId === null) return;
+		const next = previewValue;
+		pointerId = null;
+		previewValue = null;
+		document.body.style.cursor = previousCursor;
+		document.body.style.userSelect = previousUserSelect;
+		if (commit && next !== null) onCommit(next);
+		else onCancel();
+	}
+
+	function handleKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Home') {
+			event.preventDefault();
+			onCommit(clamp(minimum));
+			return;
+		}
+		if (event.key === 'End') {
+			event.preventDefault();
+			onCommit(clamp(maximum));
+			return;
+		}
+		const increases = event.key === 'ArrowUp' || event.key === 'ArrowRight';
+		const decreases = event.key === 'ArrowDown' || event.key === 'ArrowLeft';
+		if (!increases && !decreases) return;
+		event.preventDefault();
+		const step = event.shiftKey ? 40 : 10;
+		onCommit(clamp(value + (increases ? step : -step)));
+	}
+
+	onDestroy(() => finishResize(false));
+</script>
+
+<div
+	data-composer-resize-handle
+	class="pointer-events-none absolute -top-1 left-0 right-0 z-40 h-3"
+>
+	<input
+		type="range"
+		min={minimum}
+		max={maximum}
+		step="1"
+		value={Math.round(previewValue ?? value)}
+		class="peer pointer-events-auto absolute inset-0 m-0 h-full w-full cursor-row-resize touch-none appearance-none opacity-0"
+		aria-label={label}
+		aria-orientation="vertical"
+		title={label}
+		onpointerdown={startResize}
+		onpointermove={previewResize}
+		onpointerup={(event) => stopResize(event, true)}
+		onpointercancel={(event) => stopResize(event, false)}
+		onlostpointercapture={() => finishResize(false)}
+		ondblclick={onReset}
+		onkeydown={handleKeydown}
+	/>
+	<span
+		class={`pointer-events-none absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-transparent transition-colors peer-hover:bg-primary/20 peer-focus-visible:bg-ring ${pointerId !== null ? 'bg-primary/30' : ''}`}
+	></span>
+</div>

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -3,6 +3,7 @@
 	import FileMentionMenu from './FileMentionMenu.svelte';
 	import SlashCommandMenu from './SlashCommandMenu.svelte';
 	import ComposerBottomBar from './ComposerBottomBar.svelte';
+	import ComposerResizeHandle from './ComposerResizeHandle.svelte';
 	import ComposerSnippetPalette from './ComposerSnippetPalette.svelte';
 	import AgentSettingsControls from './AgentSettingsControls.svelte';
 	import LoadingStatus from './LoadingStatus.svelte';
@@ -678,13 +679,11 @@
 	const imageListClass = $derived(cn('p-2 bg-muted/40 rounded-lg mx-2 mt-2'));
 	const textareaClass = $derived(
 		cn(
-			'block w-full bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-ring text-foreground placeholder:text-muted-foreground disabled:opacity-50 resize-none max-h-[40vh] sm:max-h-[500px] overflow-y-auto text-base leading-6 transition-all duration-200',
+			'block w-full bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-ring text-foreground placeholder:text-muted-foreground disabled:opacity-50 resize-none max-h-[40vh] sm:max-h-[500px] overflow-y-auto text-base leading-6 transition-colors duration-200',
 			'px-4 py-2.5 sm:px-5 sm:py-4 min-h-[48px]',
 		),
 	);
 
-	// Composer resize via drag handle. Persists height to browser storage and
-	// mutates the DOM directly during drag to avoid render latency.
 	const COMPOSER_DEFAULT_HEIGHT = 140;
 	const COMPOSER_MIN_HEIGHT = 52;
 	const COMPOSER_MAX_HEIGHT = 500;
@@ -694,58 +693,25 @@
 	}
 
 	let composerHeight = $state(COMPOSER_DEFAULT_HEIGHT);
-	let dragCleanup: (() => void) | null = null;
+	let composerHeightPreview = $state<number | null>(null);
+	const renderedComposerHeight = $derived(composerHeightPreview ?? composerHeight);
 
-	// Initialise from persisted browser storage on mount.
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const stored = Number(getLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight));
-		if (Number.isFinite(stored)) composerHeight = clampHeight(stored);
+	onMount(() => {
+		const stored = getLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight);
+		if (stored === null || stored.trim() === '') return;
+		const parsed = Number(stored);
+		if (Number.isFinite(parsed)) composerHeight = clampHeight(parsed);
 	});
 
-	function handleResizeStart(event: PointerEvent) {
-		event.preventDefault();
-		const startY = event.clientY;
-		const startHeight = composerHeight;
-		const ta = textarea;
-		if (!ta) return;
-
-		document.body.style.cursor = 'row-resize';
-		document.body.style.userSelect = 'none';
-		document.body.style.touchAction = 'none';
-
-		function onPointerMove(e: PointerEvent) {
-			if (ta) ta.style.minHeight = `${clampHeight(startHeight + startY - e.clientY)}px`;
-		}
-
-		function onPointerUp(e: PointerEvent) {
-			document.removeEventListener('pointermove', onPointerMove);
-			document.removeEventListener('pointerup', onPointerUp);
-			document.body.style.cursor = '';
-			document.body.style.userSelect = '';
-			document.body.style.touchAction = '';
-			dragCleanup = null;
-			const finalHeight = clampHeight(startHeight + startY - e.clientY);
-			composerHeight = finalHeight;
-			setLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight, String(Math.round(finalHeight)));
-		}
-
-		document.addEventListener('pointermove', onPointerMove);
-		document.addEventListener('pointerup', onPointerUp);
-
-		dragCleanup = () => {
-			document.removeEventListener('pointermove', onPointerMove);
-			document.removeEventListener('pointerup', onPointerUp);
-			document.body.style.cursor = '';
-			document.body.style.userSelect = '';
-			document.body.style.touchAction = '';
-		};
+	function previewComposerHeight(height: number): void {
+		composerHeightPreview = clampHeight(height);
 	}
 
-	onDestroy(() => {
-		dragCleanup?.();
-		dragCleanup = null;
-	});
+	function commitComposerHeight(height: number): void {
+		composerHeight = clampHeight(height);
+		composerHeightPreview = null;
+		setLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight, String(Math.round(composerHeight)));
+	}
 </script>
 
 {#snippet composerSurface()}
@@ -880,7 +846,8 @@
 						readonly={snippetExpansion.pending}
 						aria-busy={snippetExpansion.pending}
 						class={textareaClass}
-						style:min-height={appShell.isMobile ? undefined : `${composerHeight}px`}></textarea>
+						style:min-height={appShell.isMobile ? undefined : `${renderedComposerHeight}px`}
+					></textarea>
 				</div>
 			</div>
 
@@ -977,12 +944,16 @@
 			onCommit={() => onQuickCommit?.()}
 		/>
 		{#if !appShell.isMobile}
-			<!-- Keeps the grab zone outside the clipped rounded surface. -->
-			<!-- svelte-ignore a11y_no_static_element_interactions -- pointer-only resize handle supplements composer sizing controls; follow-up: CLEANUP_ROUND_TWO.md#a11y-suppression-register -->
-			<div
-				onpointerdown={handleResizeStart}
-				class="absolute left-0 right-0 -top-1 z-40 h-3 cursor-row-resize touch-none"
-			></div>
+			<ComposerResizeHandle
+				value={renderedComposerHeight}
+				minimum={COMPOSER_MIN_HEIGHT}
+				maximum={COMPOSER_MAX_HEIGHT}
+				label={m.chat_composer_resize()}
+				onPreview={previewComposerHeight}
+				onCommit={commitComposerHeight}
+				onCancel={() => (composerHeightPreview = null)}
+				onReset={() => commitComposerHeight(COMPOSER_DEFAULT_HEIGHT)}
+			/>
 		{/if}
 		{@render composerSurface()}
 	</div>

--- a/web/src/lib/components/chat/__tests__/ComposerResizeHandle.test.ts
+++ b/web/src/lib/components/chat/__tests__/ComposerResizeHandle.test.ts
@@ -1,0 +1,126 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ComposerResizeHandle from '../ComposerResizeHandle.svelte';
+
+function renderHandle() {
+	const onPreview = vi.fn();
+	const onCommit = vi.fn();
+	const onCancel = vi.fn();
+	const onReset = vi.fn();
+	const result = render(ComposerResizeHandle, {
+		value: 140,
+		minimum: 52,
+		maximum: 500,
+		label: 'Resize message composer',
+		onPreview,
+		onCommit,
+		onCancel,
+		onReset,
+	});
+	return { ...result, onPreview, onCommit, onCancel, onReset };
+}
+
+describe('ComposerResizeHandle', () => {
+	afterEach(() => {
+		cleanup();
+		document.body.style.cursor = '';
+		document.body.style.userSelect = '';
+	});
+
+	it('previews captured pointer movement and commits once on release', async () => {
+		const { onPreview, onCommit, onCancel } = renderHandle();
+		const slider = screen.getByRole('slider', { name: 'Resize message composer' });
+		slider.setPointerCapture = vi.fn();
+		slider.hasPointerCapture = vi.fn(() => true);
+		slider.releasePointerCapture = vi.fn();
+		document.body.style.cursor = 'crosshair';
+		document.body.style.userSelect = 'text';
+
+		await fireEvent.pointerDown(slider, {
+			pointerId: 7,
+			clientY: 500,
+			button: 0,
+			isPrimary: true,
+		});
+		await fireEvent.pointerMove(slider, { pointerId: 7, clientY: 450 });
+		await fireEvent.pointerMove(slider, { pointerId: 7, clientY: 420 });
+
+		expect(onPreview.mock.calls).toEqual([[190], [220]]);
+		expect(onCommit).not.toHaveBeenCalled();
+		expect(document.body.style.cursor).toBe('row-resize');
+		expect(document.body.style.userSelect).toBe('none');
+
+		await fireEvent.pointerUp(slider, { pointerId: 7, clientY: 420 });
+
+		expect(onCommit).toHaveBeenCalledOnce();
+		expect(onCommit).toHaveBeenCalledWith(220);
+		expect(onCancel).not.toHaveBeenCalled();
+		expect(slider.releasePointerCapture).toHaveBeenCalledWith(7);
+		expect(document.body.style.cursor).toBe('crosshair');
+		expect(document.body.style.userSelect).toBe('text');
+	});
+
+	it('cancels its reactive preview when pointer capture is interrupted', async () => {
+		const { onPreview, onCommit, onCancel } = renderHandle();
+		const slider = screen.getByRole('slider', { name: 'Resize message composer' });
+		slider.setPointerCapture = vi.fn();
+		slider.hasPointerCapture = vi.fn(() => false);
+
+		await fireEvent.pointerDown(slider, {
+			pointerId: 8,
+			clientY: 300,
+			button: 0,
+			isPrimary: true,
+		});
+		await fireEvent.pointerMove(slider, { pointerId: 8, clientY: 350 });
+		await fireEvent.pointerCancel(slider, { pointerId: 8 });
+
+		expect(onPreview).toHaveBeenCalledWith(90);
+		expect(onCancel).toHaveBeenCalledOnce();
+		expect(onCommit).not.toHaveBeenCalled();
+	});
+
+	it('supports standard slider keys and double-click reset', async () => {
+		const { onCommit, onReset } = renderHandle();
+		const slider = screen.getByRole('slider', { name: 'Resize message composer' });
+
+		expect(slider.getAttribute('min')).toBe('52');
+		expect(slider.getAttribute('max')).toBe('500');
+		expect(slider.getAttribute('step')).toBe('1');
+		expect(slider.getAttribute('aria-orientation')).toBe('vertical');
+		expect((slider as HTMLInputElement).value).toBe('140');
+
+		await fireEvent.keyDown(slider, { key: 'ArrowUp' });
+		await fireEvent.keyDown(slider, { key: 'ArrowDown', shiftKey: true });
+		await fireEvent.keyDown(slider, { key: 'Home' });
+		await fireEvent.keyDown(slider, { key: 'End' });
+		await fireEvent.doubleClick(slider);
+
+		expect(onCommit.mock.calls).toEqual([[150], [100], [52], [500]]);
+		expect(onReset).toHaveBeenCalledOnce();
+	});
+
+	it('ignores non-primary and secondary pointers', async () => {
+		const { onPreview, onCommit } = renderHandle();
+		const slider = screen.getByRole('slider', { name: 'Resize message composer' });
+		slider.setPointerCapture = vi.fn();
+
+		await fireEvent.pointerDown(slider, {
+			pointerId: 9,
+			clientY: 300,
+			button: 2,
+			isPrimary: true,
+		});
+		await fireEvent.pointerDown(slider, {
+			pointerId: 10,
+			clientY: 300,
+			button: 0,
+			isPrimary: false,
+		});
+		await fireEvent.pointerMove(slider, { pointerId: 10, clientY: 200 });
+
+		expect(slider.setPointerCapture).not.toHaveBeenCalled();
+		expect(onPreview).not.toHaveBeenCalled();
+		expect(onCommit).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import PromptComposerTestHost from './PromptComposerTestHost.svelte';
 import type { GitQuickSummaryReady } from '$lib/api/git.js';
-import { chatDraftStorageKey } from '$lib/utils/local-persistence.js';
+import { chatDraftStorageKey, LOCAL_STORAGE_KEYS } from '$lib/utils/local-persistence.js';
 import * as snippetsApi from '$lib/api/snippets';
 
 const appCss = readFileSync('src/app.css', 'utf8');
@@ -62,6 +62,7 @@ describe('PromptComposer focus', () => {
 		cleanup();
 		vi.mocked(snippetsApi.expandSnippet).mockReset();
 		document.querySelector('[data-testid="outside-focus"]')?.remove();
+		localStorage.removeItem(LOCAL_STORAGE_KEYS.composerHeight);
 	});
 
 	it('renders without a surface shadow', () => {
@@ -74,6 +75,46 @@ describe('PromptComposer focus', () => {
 
 		expect(composer?.className).toContain('shadow-none');
 		expect(composer?.className).not.toContain('shadow-sm');
+	});
+
+	it('previews and persists composer resizing while the selected chat is processing', async () => {
+		const { rerender } = render(PromptComposerTestHost, {
+			selectedChatId: 'chat-1',
+			selectedStatus: 'running',
+			selectedIsProcessing: true,
+			isSubmitting: false,
+		});
+		const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+		const slider = screen.getByRole('slider', { name: 'Resize message composer' });
+		slider.setPointerCapture = vi.fn();
+		slider.hasPointerCapture = vi.fn(() => true);
+		slider.releasePointerCapture = vi.fn();
+
+		expect(textarea.style.minHeight).toBe('140px');
+		await fireEvent.pointerDown(slider, {
+			pointerId: 11,
+			clientY: 400,
+			button: 0,
+			isPrimary: true,
+		});
+		await fireEvent.pointerMove(slider, { pointerId: 11, clientY: 300 });
+
+		expect(textarea.style.minHeight).toBe('240px');
+		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.composerHeight)).toBeNull();
+
+		await rerender({
+			selectedChatId: 'chat-1',
+			selectedStatus: 'running',
+			selectedIsProcessing: true,
+			isSubmitting: false,
+			quickCommitRefreshing: true,
+		});
+		expect(textarea.style.minHeight).toBe('240px');
+
+		await fireEvent.pointerUp(slider, { pointerId: 11, clientY: 300 });
+
+		expect(textarea.style.minHeight).toBe('240px');
+		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.composerHeight)).toBe('240');
 	});
 
 	it('routes exact enabled Ctrl+Enter through steer-preferred submission', async () => {


### PR DESCRIPTION
## Summary
- Replace document-level drag listeners and direct textarea style mutation with a focused Svelte resize handle that uses pointer capture and reactive preview state.
- Remove height transitions from the textarea, persist only committed heights, restore cancelled previews, and preserve the 140px default when storage is empty.
- Add keyboard-accessible resizing and focused coverage for pointer lifecycle, processing-state updates, persistence, and cancellation.

## Validation
- bun run check
- bun run test
- bun run start with a random port and isolated workspace
- Chromium at 1440x1000: drag samples tracked 140 -> 180 -> 220 -> 260px exactly; release persisted 260px and reload restored it
- Processing-state component test keeps the live preview stable across reactive updates

## Manual verification note
The composer remains mounted and unkeyed across chat changes; the resize path does not alter chat identity, focus, or scroll ownership. Desktop pointer verification showed no focus or scroll jump while resizing.