### PR TITLE
Remove redundant Compare header title

### DIFF
--- a/web/src/lib/components/git/GitComparisonHeader.svelte
+++ b/web/src/lib/components/git/GitComparisonHeader.svelte
@@ -49,8 +49,7 @@
 			</button>
 		{/if}
 		<div class="min-w-0 flex-1">
-			<h3 class="text-sm font-semibold text-foreground">{m.git_compare_title()}</h3>
-			<div class="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+			<div class="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
 				<span class="truncate" title={snapshot.from.label}>{snapshot.from.label}</span>
 				<span class="shrink-0 font-mono text-[10px]">{snapshot.from.shortHash}</span>
 				<ArrowRight class="h-3.5 w-3.5" aria-hidden="true" />

--- a/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
+++ b/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
@@ -58,6 +58,17 @@ describe('GitComparisonScreen', () => {
 		expect(screen.queryByText('Loading comparison')).toBeNull();
 	});
 
+	it('shows the compared revisions without a redundant screen title', () => {
+		const comparison = new GitComparisonController();
+		comparison.snapshot = readySnapshot();
+
+		renderScreen(comparison, false);
+
+		expect(screen.getByText('HEAD~1')).toBeTruthy();
+		expect(screen.getByText('Working Tree')).toBeTruthy();
+		expect(screen.queryByText('Compare revisions')).toBeNull();
+	});
+
 	it('offers local back navigation without exposing the standalone Edit action', async () => {
 		const comparison = new GitComparisonController();
 		comparison.error = 'Revision older was not found.';

--- a/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
+++ b/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
@@ -883,7 +883,8 @@ describe('GitHistoryView', () => {
 		await fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
 
 		expect(onOpenSelectedComparison).toHaveBeenCalledOnce();
-		expect(await screen.findByText('Compare revisions')).toBeTruthy();
+		expect(await screen.findByText('newer')).toBeTruthy();
+		expect(screen.queryByText('Compare revisions')).toBeNull();
 		expect(getGitComparisonSnapshot).toHaveBeenCalledWith(
 			'/project',
 			{ kind: 'revision', revision: 'older' },


### PR DESCRIPTION
The Compare view is already identified by its tab and toolbar, so repeating 'Compare revisions' consumes vertical space without adding context. This removes that title from loaded comparison summaries while preserving the selected revision range, statistics, navigation controls, and comparison dialog heading.