### PR TITLE
Keep composer resize feedback live

### DIFF
--- a/integration-tests/tests/chromium/composer-resize.test.ts
+++ b/integration-tests/tests/chromium/composer-resize.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { Locator, Page } from "playwright";
+import {
+  withChromiumFixture,
+  type ChromiumFixture,
+} from "../../support/chromium-fixture.js";
+
+const COMPOSER_TEXTAREA = "[data-composer] textarea";
+
+async function openChat(fixture: ChromiumFixture): Promise<void> {
+  const chatId = fixture.integration.newChatId();
+  const started = await fixture.integration.client.startDirectChat({
+    chatId,
+    content: "composer-resize-chromium",
+    projectPath: fixture.integration.dirs.project,
+    agent: fixture.integration.directAgents.openAi,
+  });
+  await fixture.integration.client.waitForTurnTerminal(chatId, started.turnId);
+  const response = await fixture.page.goto(
+    `${fixture.integration.garcon.baseUrl}/chat/${encodeURIComponent(chatId)}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  if (!response?.ok())
+    throw new Error(`SPA navigation failed with ${response?.status()}.`);
+  await fixture.page.locator(COMPOSER_TEXTAREA).waitFor({ state: "visible" });
+}
+
+async function waitForInlineHeight(page: Page, height: number): Promise<void> {
+  await page.waitForFunction(
+    ({ selector, expectedHeight }) =>
+      document.querySelector<HTMLTextAreaElement>(selector)?.style.height ===
+      `${expectedHeight}px`,
+    { selector: COMPOSER_TEXTAREA, expectedHeight: height },
+  );
+}
+
+async function renderedHeight(textarea: Locator): Promise<number> {
+  const bounds = await textarea.boundingBox();
+  if (!bounds) throw new Error("Missing composer textarea geometry.");
+  return bounds.height;
+}
+
+describe("Chromium composer resizing", () => {
+  test("renders every drag frame after content auto-growth and preserves the committed height", async () => {
+    await withChromiumFixture(
+      "composer-live-resize",
+      async (fixture, markPhase) => {
+        markPhase("opening a settled chat");
+        await openChat(fixture);
+        const textarea = fixture.page.locator(COMPOSER_TEXTAREA);
+        const handle = fixture.page.getByRole("slider", {
+          name: "Resize message composer",
+        });
+
+        markPhase("auto-growing the composer with a long draft");
+        const longDraft = Array.from(
+          { length: 24 },
+          (_, index) => `Draft line ${index + 1}`,
+        ).join("\n");
+        await textarea.fill(longDraft);
+        await waitForInlineHeight(fixture.page, 300);
+        expect(await renderedHeight(textarea)).toBeCloseTo(300, 0);
+
+        markPhase("shrinking the auto-grown composer with pointer capture");
+        const handleBounds = await handle.boundingBox();
+        if (!handleBounds)
+          throw new Error("Missing composer resize handle geometry.");
+        const pointerX = handleBounds.x + handleBounds.width / 2;
+        const pointerY = handleBounds.y + handleBounds.height / 2;
+        await fixture.page.mouse.move(pointerX, pointerY);
+        await fixture.page.mouse.down();
+        await fixture.page.mouse.move(pointerX, pointerY + 100, { steps: 8 });
+        await waitForInlineHeight(fixture.page, 200);
+        expect(await renderedHeight(textarea)).toBeCloseTo(200, 0);
+        expect(
+          await fixture.page.evaluate(() =>
+            localStorage.getItem("composerHeight"),
+          ),
+        ).toBeNull();
+        await fixture.page.mouse.up();
+
+        await fixture.page.waitForFunction(
+          () => localStorage.getItem("composerHeight") === "200",
+        );
+        expect(await renderedHeight(textarea)).toBeCloseTo(200, 0);
+
+        markPhase("reloading the committed empty composer");
+        await textarea.fill("");
+        await waitForInlineHeight(fixture.page, 200);
+        await fixture.page.reload({ waitUntil: "domcontentloaded" });
+        await fixture.page
+          .locator(COMPOSER_TEXTAREA)
+          .waitFor({ state: "visible" });
+        await waitForInlineHeight(fixture.page, 200);
+        expect(
+          await renderedHeight(fixture.page.locator(COMPOSER_TEXTAREA)),
+        ).toBeCloseTo(200, 0);
+        fixture.assertNoBrowserErrors();
+      },
+    );
+  });
+});

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -39,6 +39,12 @@
 	import { isChatProcessing } from '$lib/chat/sessions/chat-processing.js';
 	import { PromptComposerUiState } from './prompt-composer-state.svelte';
 	import {
+		COMPOSER_DEFAULT_HEIGHT,
+		COMPOSER_MAX_HEIGHT,
+		COMPOSER_MIN_HEIGHT,
+		PromptComposerHeightState,
+	} from './prompt-composer-height-state.svelte.js';
+	import {
 		buildPermissionOptions,
 		buildThinkingOptions,
 	} from '$lib/chat/composer/composer-controls.js';
@@ -273,16 +279,36 @@
 		imageAttachments.revokeAll();
 	});
 
-	// Auto-resize textarea to content height. On mobile, caps lower to
-	// preserve message feed visibility; on desktop uses the stored height.
-	const MOBILE_AUTO_MAX = 150;
-	const DESKTOP_AUTO_MAX = 300;
+	const composerHeight = new PromptComposerHeightState();
 
-	function autoResize() {
-		if (!textarea) return;
-		const cap = appShell.isMobile ? MOBILE_AUTO_MAX : DESKTOP_AUTO_MAX;
-		textarea.style.height = 'auto';
-		textarea.style.height = `${Math.min(textarea.scrollHeight, cap)}px`;
+	function autoResize(): void {
+		if (!textarea || !isVisible) return;
+		composerHeight.fitToContent(textarea, appShell.isMobile);
+	}
+
+	// Programmatic draft changes do not emit input events. The effect measures
+	// the updated DOM value while Svelte remains the sole owner of its height.
+	$effect(() => {
+		const target = textarea;
+		const inputText = composerState.inputText;
+		const mobile = appShell.isMobile;
+		const visible = isVisible;
+		if (!target || !visible || target.value !== inputText) return;
+		untrack(() => composerHeight.fitToContent(target, mobile));
+	});
+
+	onMount(() => {
+		const stored = getLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight);
+		if (stored === null || stored.trim() === '') return;
+		const parsed = Number(stored);
+		if (!Number.isFinite(parsed)) return;
+		composerHeight.restorePreferredHeight(parsed);
+		if (appShell.isMobile) autoResize();
+	});
+
+	function commitComposerHeight(height: number): void {
+		const committedHeight = composerHeight.commit(height);
+		setLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight, String(Math.round(committedHeight)));
 	}
 
 	// Reveals blocks appended from another surface without moving focus away from that surface.
@@ -691,35 +717,6 @@
 			'px-4 py-2.5 sm:px-5 sm:py-4 min-h-[48px]',
 		),
 	);
-
-	const COMPOSER_DEFAULT_HEIGHT = 140;
-	const COMPOSER_MIN_HEIGHT = 52;
-	const COMPOSER_MAX_HEIGHT = 500;
-
-	function clampHeight(h: number): number {
-		return Math.max(COMPOSER_MIN_HEIGHT, Math.min(COMPOSER_MAX_HEIGHT, h));
-	}
-
-	let composerHeight = $state(COMPOSER_DEFAULT_HEIGHT);
-	let composerHeightPreview = $state<number | null>(null);
-	const renderedComposerHeight = $derived(composerHeightPreview ?? composerHeight);
-
-	onMount(() => {
-		const stored = getLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight);
-		if (stored === null || stored.trim() === '') return;
-		const parsed = Number(stored);
-		if (Number.isFinite(parsed)) composerHeight = clampHeight(parsed);
-	});
-
-	function previewComposerHeight(height: number): void {
-		composerHeightPreview = clampHeight(height);
-	}
-
-	function commitComposerHeight(height: number): void {
-		composerHeight = clampHeight(height);
-		composerHeightPreview = null;
-		setLocalStorageItem(LOCAL_STORAGE_KEYS.composerHeight, String(Math.round(composerHeight)));
-	}
 </script>
 
 {#snippet composerSurface()}
@@ -854,8 +851,7 @@
 						readonly={snippetExpansion.pending}
 						aria-busy={snippetExpansion.pending}
 						class={textareaClass}
-						style:min-height={appShell.isMobile ? undefined : `${renderedComposerHeight}px`}
-					></textarea>
+						style:height={`${composerHeight.renderedHeight}px`}></textarea>
 				</div>
 			</div>
 
@@ -954,13 +950,13 @@
 		/>
 		{#if !appShell.isMobile}
 			<ComposerResizeHandle
-				value={renderedComposerHeight}
+				value={composerHeight.renderedHeight}
 				minimum={COMPOSER_MIN_HEIGHT}
 				maximum={COMPOSER_MAX_HEIGHT}
 				label={m.chat_composer_resize()}
-				onPreview={previewComposerHeight}
+				onPreview={(height) => composerHeight.preview(height)}
 				onCommit={commitComposerHeight}
-				onCancel={() => (composerHeightPreview = null)}
+				onCancel={() => composerHeight.cancelPreview()}
 				onReset={() => commitComposerHeight(COMPOSER_DEFAULT_HEIGHT)}
 			/>
 		{/if}

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -86,7 +86,7 @@ describe('PromptComposer focus', () => {
 		expect(composer?.className).not.toContain('shadow-sm');
 	});
 
-	it('previews and persists composer resizing while the selected chat is processing', async () => {
+	it('keeps manual resizing live after content auto-expands while the selected chat is processing', async () => {
 		const { rerender } = render(PromptComposerTestHost, {
 			selectedChatId: 'chat-1',
 			selectedStatus: 'running',
@@ -98,17 +98,19 @@ describe('PromptComposer focus', () => {
 		slider.setPointerCapture = vi.fn();
 		slider.hasPointerCapture = vi.fn(() => true);
 		slider.releasePointerCapture = vi.fn();
+		Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 420 });
 
-		expect(textarea.style.minHeight).toBe('140px');
+		await fireEvent.input(textarea, { target: { value: 'A long prompt' } });
+		expect(textarea.style.height).toBe('300px');
 		await fireEvent.pointerDown(slider, {
 			pointerId: 11,
 			clientY: 400,
 			button: 0,
 			isPrimary: true,
 		});
-		await fireEvent.pointerMove(slider, { pointerId: 11, clientY: 300 });
+		await fireEvent.pointerMove(slider, { pointerId: 11, clientY: 540 });
 
-		expect(textarea.style.minHeight).toBe('240px');
+		expect(textarea.style.height).toBe('160px');
 		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.composerHeight)).toBeNull();
 
 		await rerender({
@@ -118,12 +120,32 @@ describe('PromptComposer focus', () => {
 			isSubmitting: false,
 			quickCommitRefreshing: true,
 		});
-		expect(textarea.style.minHeight).toBe('240px');
+		expect(textarea.style.height).toBe('160px');
 
-		await fireEvent.pointerUp(slider, { pointerId: 11, clientY: 300 });
+		await fireEvent.pointerUp(slider, { pointerId: 11, clientY: 540 });
 
-		expect(textarea.style.minHeight).toBe('240px');
-		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.composerHeight)).toBe('240');
+		expect(textarea.style.height).toBe('160px');
+		expect(localStorage.getItem(LOCAL_STORAGE_KEYS.composerHeight)).toBe('160');
+	});
+
+	it('removes stale content height when the draft is cleared programmatically', async () => {
+		render(PromptComposerTestHost, {
+			selectedChatId: 'chat-programmatic-clear',
+			selectedStatus: 'running',
+		});
+		const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+		Object.defineProperty(textarea, 'scrollHeight', {
+			configurable: true,
+			get: () => (textarea.value ? 420 : 48),
+		});
+
+		await fireEvent.input(textarea, { target: { value: 'A long prompt' } });
+		expect(textarea.style.height).toBe('300px');
+
+		await fireEvent.click(screen.getByTestId('clear-draft'));
+
+		expect(textarea.value).toBe('');
+		expect(textarea.style.height).toBe('140px');
 	});
 
 	it('opens a live expanded editor and restores directional selection on Escape', async () => {

--- a/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
@@ -381,6 +381,11 @@
 	onclick={() => composer.appendDraftBlock(selectedChatId, 'Appended review block')}
 	>Append draft</button
 >
+<button
+	type="button"
+	data-testid="clear-draft"
+	onclick={() => composer.clearAfterSubmit(selectedChatId)}>Clear draft</button
+>
 
 <div data-testid="snippet-load-count">{snippetLoadCount}</div>
 {#each notifications.items as notification (notification.id)}

--- a/web/src/lib/components/chat/prompt-composer-height-state.svelte.ts
+++ b/web/src/lib/components/chat/prompt-composer-height-state.svelte.ts
@@ -1,0 +1,56 @@
+export const COMPOSER_DEFAULT_HEIGHT = 140;
+export const COMPOSER_MIN_HEIGHT = 52;
+export const COMPOSER_MAX_HEIGHT = 500;
+
+const COMPOSER_CONTENT_MIN_HEIGHT = 48;
+const MOBILE_CONTENT_MAX_HEIGHT = 150;
+const DESKTOP_CONTENT_MAX_HEIGHT = 300;
+
+function clampHeight(height: number): number {
+	return Math.max(COMPOSER_MIN_HEIGHT, Math.min(COMPOSER_MAX_HEIGHT, height));
+}
+
+export class PromptComposerHeightState {
+	#preferredHeight = $state(COMPOSER_DEFAULT_HEIGHT);
+	#contentHeight = $state(COMPOSER_DEFAULT_HEIGHT);
+	#previewHeight = $state<number | null>(null);
+
+	get renderedHeight(): number {
+		return this.#previewHeight ?? this.#contentHeight;
+	}
+
+	restorePreferredHeight(height: number): void {
+		this.#preferredHeight = clampHeight(height);
+		this.#contentHeight = this.#preferredHeight;
+	}
+
+	fitToContent(target: HTMLTextAreaElement, isMobile: boolean): void {
+		const renderedHeight = target.style.height;
+		// Releases the constraint only for measurement; rendered height remains state-owned.
+		target.style.height = 'auto';
+		const maximum = isMobile ? MOBILE_CONTENT_MAX_HEIGHT : DESKTOP_CONTENT_MAX_HEIGHT;
+		const measuredHeight = Math.max(
+			COMPOSER_CONTENT_MIN_HEIGHT,
+			Math.min(target.scrollHeight, maximum),
+		);
+		target.style.height = renderedHeight;
+		this.#contentHeight = isMobile
+			? measuredHeight
+			: Math.max(this.#preferredHeight, measuredHeight);
+	}
+
+	preview(height: number): void {
+		this.#previewHeight = clampHeight(height);
+	}
+
+	cancelPreview(): void {
+		this.#previewHeight = null;
+	}
+
+	commit(height: number): number {
+		this.#preferredHeight = clampHeight(height);
+		this.#contentHeight = this.#preferredHeight;
+		this.#previewHeight = null;
+		return this.#preferredHeight;
+	}
+}


### PR DESCRIPTION
Composer autosizing could leave an explicit textarea height that masked drag previews, causing resize changes to appear only after reload. This gives a rune-backed composer height state sole ownership of the rendered height across content growth, pointer previews, committed preferences, and programmatic draft changes so resizing stays immediate even while an agent is processing.