### PR TITLE
Highlight syntax in Git diff views

### DIFF
--- a/integration-tests/tests/chromium/git-pinned-file-header.test.ts
+++ b/integration-tests/tests/chromium/git-pinned-file-header.test.ts
@@ -26,10 +26,12 @@ async function runGit(projectPath: string, args: string[]): Promise<void> {
 }
 
 function largeFileContents(file: string, revision: string): string {
+  const stem = file.replace(/\W/g, '_');
   return (
     Array.from(
       { length: 180 },
-      (_, index) => `${file} ${revision} line ${String(index + 1).padStart(3, '0')}`,
+      (_, index) =>
+        `export const ${stem}_${revision}_${String(index + 1).padStart(3, '0')} = ${index + 1};`,
     ).join('\n') + '\n'
   );
 }
@@ -38,16 +40,16 @@ async function createGitFixture(projectPath: string): Promise<void> {
   await runGit(projectPath, ['init', '-b', 'main']);
   await runGit(projectPath, ['config', 'user.email', 'test@example.com']);
   await runGit(projectPath, ['config', 'user.name', 'Chromium Test']);
-  for (const file of ['alpha.txt', 'beta.txt']) {
+  for (const file of ['alpha.ts', 'beta.ts']) {
     await writeFile(join(projectPath, file), largeFileContents(file, 'baseline'), 'utf8');
   }
-  await runGit(projectPath, ['add', 'alpha.txt', 'beta.txt']);
+  await runGit(projectPath, ['add', 'alpha.ts', 'beta.ts']);
   await runGit(projectPath, ['commit', '-m', 'baseline revision']);
-  for (const file of ['alpha.txt', 'beta.txt']) {
+  for (const file of ['alpha.ts', 'beta.ts']) {
     await writeFile(join(projectPath, file), largeFileContents(file, 'committed'), 'utf8');
   }
   await runGit(projectPath, ['commit', '-am', 'large revision']);
-  for (const file of ['alpha.txt', 'beta.txt']) {
+  for (const file of ['alpha.ts', 'beta.ts']) {
     await writeFile(join(projectPath, file), largeFileContents(file, 'working'), 'utf8');
   }
 }
@@ -97,6 +99,7 @@ async function openWorkspaceSurface(page: Page, label: string): Promise<void> {
 async function waitForDiff(page: Page, panelSelector: string): Promise<void> {
   await page.locator(`${panelSelector} [data-git-file-header]`).first().waitFor();
   await page.locator(`${panelSelector} [data-git-diff-content-row]`).first().waitFor();
+  await page.locator(`${panelSelector} .cm-code-keyword`).first().waitFor();
   await page.evaluate(
     () =>
       new Promise<void>((resolve) =>
@@ -262,13 +265,13 @@ describe('Chromium pinned Git file headers', () => {
       });
       const originalStage = fixture.page.locator(
         `${WORKBENCH_PANEL} [data-git-virtual-row]` +
-          ' [data-git-file-header][data-file-path="alpha.txt"]' +
+          ' [data-git-file-header][data-file-path="alpha.ts"]' +
           ' button[title="Stage file"]',
       );
       await originalStage.focus();
       markPhase('pinning the unified Workbench header');
       await scrollDiffTo(fixture.page, WORKBENCH_PANEL, 60);
-      await waitForPinnedPath(fixture.page, WORKBENCH_PANEL, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, WORKBENCH_PANEL, 'alpha.ts');
       expect(await originalStage.evaluate((element) => document.activeElement === element)).toBe(
         true,
       );
@@ -287,7 +290,7 @@ describe('Chromium pinned Git file headers', () => {
           document
             .querySelector(
               `${selector} [data-git-virtual-row]:has(` +
-                '[data-git-file-header][data-file-path="alpha.txt"])',
+                '[data-git-file-header][data-file-path="alpha.ts"])',
             )
             ?.hasAttribute('inert') === true,
         WORKBENCH_PANEL,
@@ -303,7 +306,7 @@ describe('Chromium pinned Git file headers', () => {
       await setSplitMode(fixture.page);
       await waitForDiff(fixture.page, WORKBENCH_PANEL);
       await scrollDiffTo(fixture.page, WORKBENCH_PANEL, 60);
-      await waitForPinnedPath(fixture.page, WORKBENCH_PANEL, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, WORKBENCH_PANEL, 'alpha.ts');
       expectPinnedGeometry(await diffGeometry(fixture.page, WORKBENCH_PANEL), 60);
 
       markPhase('checking mobile containment');
@@ -314,7 +317,7 @@ describe('Chromium pinned Git file headers', () => {
       });
       if (await diffTab.count()) await diffTab.first().click();
       await scrollDiffTo(fixture.page, WORKBENCH_PANEL, 60);
-      await waitForPinnedPath(fixture.page, WORKBENCH_PANEL, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, WORKBENCH_PANEL, 'alpha.ts');
       const mobileGeometry = await diffGeometry(fixture.page, WORKBENCH_PANEL);
       expectPinnedGeometry(mobileGeometry, 60);
       expect(mobileGeometry.intersectsClose).toBe(false);
@@ -326,14 +329,14 @@ describe('Chromium pinned Git file headers', () => {
       await fixture.page.locator(COMPARE_PANEL).waitFor();
       await waitForDiff(fixture.page, COMPARE_PANEL);
       await scrollDiffTo(fixture.page, COMPARE_PANEL, 60);
-      await waitForPinnedPath(fixture.page, COMPARE_PANEL, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, COMPARE_PANEL, 'alpha.ts');
       const compareGeometry = await diffGeometry(fixture.page, COMPARE_PANEL);
       expect(Math.abs(compareGeometry.topDelta)).toBeLessThanOrEqual(1);
       expect(compareGeometry.rightOverflow).toBeLessThanOrEqual(1);
       expect(
         await fixture.page
           .locator(`${COMPARE_PANEL} [data-git-pinned-file-header]`)
-          .getByText('alpha.txt', { exact: true })
+          .getByText('alpha.ts', { exact: true })
           .count(),
       ).toBe(1);
 
@@ -347,7 +350,7 @@ describe('Chromium pinned Git file headers', () => {
         .click();
       await waitForDiff(fixture.page, HISTORY_PANEL);
       await scrollDiffTo(fixture.page, HISTORY_PANEL, 60);
-      await waitForPinnedPath(fixture.page, HISTORY_PANEL, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, HISTORY_PANEL, 'alpha.ts');
       const historyGeometry = await diffGeometry(fixture.page, HISTORY_PANEL);
       expect(Math.abs(historyGeometry.topDelta)).toBeLessThanOrEqual(1);
       expect(historyGeometry.rightOverflow).toBeLessThanOrEqual(1);

--- a/integration-tests/tests/e2e/git-view-surfaces.test.ts
+++ b/integration-tests/tests/e2e/git-view-surfaces.test.ts
@@ -34,9 +34,11 @@ async function createHistoryFixture(projectPath: string): Promise<void> {
 }
 
 function largeFileContents(file: string, revision: string): string {
+  const stem = file.replace(/\W/g, '_');
   return Array.from(
     { length: 180 },
-    (_, index) => `${file} ${revision} line ${String(index + 1).padStart(3, '0')}`,
+    (_, index) =>
+      `export const ${stem}_${revision}_${String(index + 1).padStart(3, '0')} = ${index + 1};`,
   ).join('\n') + '\n';
 }
 
@@ -44,16 +46,16 @@ async function createPinnedHeaderFixture(projectPath: string): Promise<void> {
   await runGit(projectPath, ['init', '-b', 'main']);
   await runGit(projectPath, ['config', 'user.email', 'test@example.com']);
   await runGit(projectPath, ['config', 'user.name', 'E2E Test']);
-  for (const file of ['alpha.txt', 'beta.txt']) {
+  for (const file of ['alpha.ts', 'beta.ts']) {
     await writeFile(join(projectPath, file), largeFileContents(file, 'baseline'), 'utf8');
   }
-  await runGit(projectPath, ['add', 'alpha.txt', 'beta.txt']);
+  await runGit(projectPath, ['add', 'alpha.ts', 'beta.ts']);
   await runGit(projectPath, ['commit', '-m', 'baseline revision']);
-  for (const file of ['alpha.txt', 'beta.txt']) {
+  for (const file of ['alpha.ts', 'beta.ts']) {
     await writeFile(join(projectPath, file), largeFileContents(file, 'committed'), 'utf8');
   }
   await runGit(projectPath, ['commit', '-am', 'large revision']);
-  for (const file of ['alpha.txt', 'beta.txt']) {
+  for (const file of ['alpha.ts', 'beta.ts']) {
     await writeFile(join(projectPath, file), largeFileContents(file, 'working'), 'utf8');
   }
 }
@@ -232,7 +234,8 @@ describe('Lightpanda standalone Git views', () => {
       const initialWorkbench = await pinnedHeaderSnapshot(fixture.page, workbenchPanel);
       expect(initialWorkbench.path).toBeNull();
       await scrollDiffTo(fixture.page, workbenchPanel, 60);
-      await waitForPinnedPath(fixture.page, workbenchPanel, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, workbenchPanel, 'alpha.ts');
+      await fixture.page.waitForSelector(`${workbenchPanel} .cm-code-keyword`);
       const pinnedWorkbench = await pinnedHeaderSnapshot(fixture.page, workbenchPanel);
       expect(pinnedWorkbench.scrollTop).toBe(60);
       expect(pinnedWorkbench.scrollHeight).toBe(initialWorkbench.scrollHeight);
@@ -266,17 +269,18 @@ describe('Lightpanda standalone Git views', () => {
         button.click();
       });
       await fixture.page.waitForSelector(
-        `${workbenchPanel} [data-git-file-header][data-file-path="alpha.txt"]`,
+        `${workbenchPanel} [data-git-file-header][data-file-path="alpha.ts"]`,
       );
       await fixture.page.waitForSelector(`${workbenchPanel} [data-git-diff-content-row]`);
       await scrollDiffTo(fixture.page, workbenchPanel, 60);
-      await waitForPinnedPath(fixture.page, workbenchPanel, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, workbenchPanel, 'alpha.ts');
       const retainedWorkbench = await pinnedHeaderSnapshot(fixture.page, workbenchPanel);
 
       await app.selectMainWorkspaceSurface('Open Git Compare');
       await fixture.page.waitForSelector(`${comparePanel} [data-git-file-header]`);
       await scrollDiffTo(fixture.page, comparePanel, 60);
-      await waitForPinnedPath(fixture.page, comparePanel, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, comparePanel, 'alpha.ts');
+      await fixture.page.waitForSelector(`${comparePanel} .cm-code-keyword`);
       const compareSnapshot = await pinnedHeaderSnapshot(fixture.page, comparePanel);
       expect(compareSnapshot.scrollTop).toBe(60);
 
@@ -299,7 +303,8 @@ describe('Lightpanda standalone Git views', () => {
       );
       await fixture.page.waitForSelector(`${historyPanel} [data-git-file-header]`);
       await scrollDiffTo(fixture.page, historyPanel, 60);
-      await waitForPinnedPath(fixture.page, historyPanel, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, historyPanel, 'alpha.ts');
+      await fixture.page.waitForSelector(`${historyPanel} .cm-code-keyword`);
 
       await app.setViewport(390, 844);
       await app.clickButton('Chat');
@@ -328,7 +333,7 @@ describe('Lightpanda standalone Git views', () => {
         button?.click();
       });
       await scrollDiffTo(fixture.page, historyPanel, 60);
-      await waitForPinnedPath(fixture.page, historyPanel, 'alpha.txt');
+      await waitForPinnedPath(fixture.page, historyPanel, 'alpha.ts');
       expect(await fixture.page.$eval(
         `${historyPanel} [data-git-pinned-file-header]`,
         (header) =>

--- a/integration-tests/tests/e2e/git-view-surfaces.test.ts
+++ b/integration-tests/tests/e2e/git-view-surfaces.test.ts
@@ -307,7 +307,8 @@ describe('Lightpanda standalone Git views', () => {
       await fixture.page.waitForSelector(`${historyPanel} .cm-code-keyword`);
 
       await app.setViewport(390, 844);
-      await app.clickButton('Chat');
+      await app.waitForButton('Close view');
+      await app.clickButton('Close view');
       await fixture.page.waitForSelector(
         '[role="tabpanel"][data-workspace-surface-id="singleton:chat"][aria-hidden="false"]',
       );

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -377,12 +377,12 @@
 	--git-untracked: 214 82% 45%;
 	--git-renamed: 271 76% 53%;
 
-	--diff-add-bg: 138 76% 95%;
-	--diff-add-fg: 134 60% 28%;
-	--diff-add-line-num: 134 40% 50%;
-	--diff-del-bg: 353 100% 96%;
-	--diff-del-fg: 355 72% 36%;
-	--diff-del-line-num: 355 40% 50%;
+	--diff-add-bg: 133 80% 92%;
+	--diff-add-fg: 213 13% 14%;
+	--diff-add-line-num: 213 13% 14%;
+	--diff-del-bg: 5.5 100% 95.7%;
+	--diff-del-fg: 213 13% 14%;
+	--diff-del-line-num: 213 13% 14%;
 	--diff-hunk-header-bg: 214 60% 95%;
 
 	--safe-area-inset-top: env(safe-area-inset-top);
@@ -577,12 +577,12 @@
 	--git-untracked: 214 92% 68%;
 	--git-renamed: 271 81% 72%;
 
-	--diff-add-bg: 145 90% 12%;
-	--diff-add-fg: 132 68% 83%;
-	--diff-add-line-num: 132 40% 55%;
-	--diff-del-bg: 356 89% 14%;
-	--diff-del-fg: 9 100% 88%;
-	--diff-del-line-num: 9 50% 55%;
+	--diff-add-bg: 156 36% 11%;
+	--diff-add-fg: 210 66.7% 96.5%;
+	--diff-add-line-num: 210 66.7% 96.5%;
+	--diff-del-bg: 338.6 23.3% 11.8%;
+	--diff-del-fg: 210 66.7% 96.5%;
+	--diff-del-line-num: 210 66.7% 96.5%;
 	--diff-hunk-header-bg: 214 40% 18%;
 
 	--markdown-code-background: 0 0% 11%;

--- a/web/src/lib/components/git/GitDiffSyntaxText.svelte
+++ b/web/src/lib/components/git/GitDiffSyntaxText.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { CodeHighlightSegment } from '$lib/highlighting/code-highlight-types.js';
+
+	interface Props {
+		className: string;
+		prefix: string;
+		text: string;
+		segments?: readonly CodeHighlightSegment[];
+	}
+
+	let { className, prefix, text, segments }: Props = $props();
+</script>
+
+<span class="code-highlight {className}"
+	>{prefix}{#if segments}{#each segments as segment}{#if segment.className}<span
+					class={segment.className}>{segment.text}</span
+				>{:else}{segment.text}{/if}{/each}{:else}{text}{/if}</span
+>

--- a/web/src/lib/components/git/GitVirtualDiffRow.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffRow.svelte
@@ -11,6 +11,7 @@
 	} from '$lib/git/review/git-diff-rows.js';
 	import GitVirtualCommentComposer from './GitVirtualCommentComposer.svelte';
 	import GitCommentAppendError from './GitCommentAppendError.svelte';
+	import GitDiffSyntaxText from './GitDiffSyntaxText.svelte';
 	import type {
 		GitDiffCommentInteraction,
 		GitDiffRowInteraction,
@@ -286,15 +287,21 @@
 								row.selectableLineKeys(),
 							)}
 					>
-						<span class="{row.view.textClass} select-text"
-							>{row.view.textPrefix}{row.view.text}</span
-						>
+						<GitDiffSyntaxText
+							className="{row.view.textClass} select-text"
+							prefix={row.view.textPrefix}
+							text={row.view.text}
+							segments={row.view.segments}
+						/>
 					</button>
 				{:else}
 					<div class="whitespace-pre-wrap break-all pl-2 pr-8 text-left">
-						<span class="{row.view.textClass} select-text"
-							>{row.view.textPrefix}{row.view.text}</span
-						>
+						<GitDiffSyntaxText
+							className="{row.view.textClass} select-text"
+							prefix={row.view.textPrefix}
+							text={row.view.text}
+							segments={row.view.segments}
+						/>
 					</div>
 				{/if}
 				{@render reviewAffordance(row.file.path, defaultTarget)}
@@ -413,9 +420,12 @@
 												row.selectableLineKeys(),
 											)}
 									>
-										<span class="{cellView.textClass} select-text"
-											>{cellView.textPrefix}{cellView.cell.text}</span
-										>
+										<GitDiffSyntaxText
+											className="{cellView.textClass} select-text"
+											prefix={cellView.textPrefix}
+											text={cellView.cell.text}
+											segments={cellView.segments}
+										/>
 									</button>
 								{:else}
 									<div
@@ -424,9 +434,12 @@
 											? 'pl-7'
 											: 'pl-2'}"
 									>
-										<span class="{cellView.textClass} select-text"
-											>{cellView.textPrefix}{cellView.cell.text}</span
-										>
+										<GitDiffSyntaxText
+											className="{cellView.textClass} select-text"
+											prefix={cellView.textPrefix}
+											text={cellView.cell.text}
+											segments={cellView.segments}
+										/>
 									</div>
 								{/if}
 								{#if workbenchControls && row.actionTarget && (cellView.cell.kind === 'add' || cellView.cell.kind === 'del')}

--- a/web/src/lib/components/git/GitVirtualDiffViewport.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffViewport.svelte
@@ -63,6 +63,7 @@
 	let configuredScrollElement: HTMLDivElement | null = null;
 	let presentedSource: GitVirtualReviewRowSource | null = null;
 	let presentedMeasurementRevision = '';
+	let scrollIntentRevision = 0;
 	let demandEffectRuns = 0;
 	let demandPublications = 0;
 	let rowLineHeight = $derived(Math.max(18, Math.round(fontSize * 1.5)));
@@ -117,6 +118,7 @@
 	});
 
 	function completeScrollRequest(): void {
+		scrollIntentRevision += 1;
 		if (servicedScrollRequestId) completedScrollRequestId = servicedScrollRequestId;
 	}
 
@@ -144,6 +146,9 @@
 		const scrollElement = viewportRef;
 		if (!scrollElement || nextLayoutIdentity === measuredLayoutIdentity) return;
 		measuredLayoutIdentity = nextLayoutIdentity;
+		scrollIntentRevision += 1;
+		presentedSource = null;
+		presentedMeasurementRevision = '';
 		lastScrollRequestKey = '';
 		pendingScrollRequestKey = '';
 		scrollRequestSequence += 1;
@@ -169,11 +174,13 @@
 		if (!preserveScroll || !scrollElement) return;
 
 		const scrollTop = scrollElement.scrollTop;
+		const intentRevision = scrollIntentRevision;
 		void tick().then(() => {
 			if (
 				source === nextSource &&
 				viewportRef === scrollElement &&
-				nextSource.measurementRevision === nextMeasurementRevision
+				nextSource.measurementRevision === nextMeasurementRevision &&
+				scrollIntentRevision === intentRevision
 			) {
 				if (scrollElement.scrollTop !== scrollTop) scrollElement.scrollTop = scrollTop;
 			}
@@ -305,6 +312,7 @@
 		}
 		const requestKey = `${requestId}\0${targetIndex}\0${targetState}`;
 		if (requestKey === lastScrollRequestKey || requestKey === pendingScrollRequestKey) return;
+		scrollIntentRevision += 1;
 		pendingScrollRequestKey = requestKey;
 		const requestSequence = ++scrollRequestSequence;
 		const start = Math.max(0, targetIndex - 6);
@@ -349,6 +357,7 @@
 				}
 				pendingScrollRequestKey = '';
 				lastScrollRequestKey = requestKey;
+				scrollIntentRevision += 1;
 				$virtualizer.scrollToIndex(targetIndex, { align: 'start' });
 				servicedScrollRequestId = requestId;
 				servicedScrollRequestState = targetState;

--- a/web/src/lib/components/git/GitVirtualDiffViewport.svelte
+++ b/web/src/lib/components/git/GitVirtualDiffViewport.svelte
@@ -60,6 +60,9 @@
 	let measuredLayoutIdentity: string | null = null;
 	let performanceFrame: number | null = null;
 	let configuredMeasurementKey = '';
+	let configuredScrollElement: HTMLDivElement | null = null;
+	let presentedSource: GitVirtualReviewRowSource | null = null;
+	let presentedMeasurementRevision = '';
 	let demandEffectRuns = 0;
 	let demandPublications = 0;
 	let rowLineHeight = $derived(Math.max(18, Math.round(fontSize * 1.5)));
@@ -153,6 +156,30 @@
 		});
 	});
 
+	$effect.pre(() => {
+		const nextSource = source;
+		const nextMeasurementRevision = nextSource.measurementRevision;
+		const scrollElement = viewportRef;
+		const preserveScroll =
+			presentedSource !== null &&
+			presentedSource !== nextSource &&
+			presentedMeasurementRevision === nextMeasurementRevision;
+		presentedSource = nextSource;
+		presentedMeasurementRevision = nextMeasurementRevision;
+		if (!preserveScroll || !scrollElement) return;
+
+		const scrollTop = scrollElement.scrollTop;
+		void tick().then(() => {
+			if (
+				source === nextSource &&
+				viewportRef === scrollElement &&
+				nextSource.measurementRevision === nextMeasurementRevision
+			) {
+				if (scrollElement.scrollTop !== scrollTop) scrollElement.scrollTop = scrollTop;
+			}
+		});
+	});
+
 	$effect(() => {
 		const measurementRevision = source.measurementRevision;
 		const count = source.rowCount;
@@ -160,13 +187,18 @@
 		const rowOverscan = overscan;
 		const lineHeight = rowLineHeight;
 		untrack(() => {
-			const measurementKey = `${measurementRevision}\0${lineHeight}`;
-			if (measurementKey !== configuredMeasurementKey) {
-				configuredMeasurementKey = measurementKey;
-				const measurementSource = source;
-				estimateSizeForOptions = (index) => measurementSource.estimateRowHeight(index, lineHeight);
-				itemKeyForOptions = (index) => measurementSource.rowKey(index);
+			const measurementKey = `${measurementRevision}\0${count}\0${rowOverscan}\0${lineHeight}`;
+			if (
+				measurementKey === configuredMeasurementKey &&
+				scrollElement === configuredScrollElement
+			) {
+				return;
 			}
+			configuredMeasurementKey = measurementKey;
+			configuredScrollElement = scrollElement;
+			const measurementSource = source;
+			estimateSizeForOptions = (index) => measurementSource.estimateRowHeight(index, lineHeight);
+			itemKeyForOptions = (index) => measurementSource.rowKey(index);
 			$virtualizer.setOptions({
 				count,
 				getScrollElement: () => scrollElement,

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
@@ -622,6 +622,62 @@ describe('Git virtual diff refresh', () => {
 		observer.disconnect();
 	});
 
+	it('does not restore presentation scroll over a newer user scroll', async () => {
+		const rows = [makeHeaderRow(0), makeUnifiedRow(0), makeHeaderRow(1)];
+		const props = makeSurfaceProps(rows);
+		const { container, rerender } = render(GitVirtualDiffSurface, { props });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+		viewport.scrollTop = 60;
+		let userScrolled = false;
+		const observer = new MutationObserver(() => {
+			if (userScrolled || !container.querySelector('.cm-code-keyword')) return;
+			userScrolled = true;
+			viewport.dispatchEvent(new WheelEvent('wheel'));
+			viewport.scrollTop = 90;
+		});
+		observer.observe(viewport, { childList: true, subtree: true });
+
+		const highlightedRows = rows.map((row) =>
+			row.kind === 'unified-row'
+				? {
+						...row,
+						view: {
+							...row.view,
+							segments: [{ text: 'added line', className: 'cm-code-keyword' }],
+						},
+					}
+				: row,
+		);
+
+		await rerender({
+			...props,
+			source: arrayGitVirtualReviewRowSource(highlightedRows, fileIndexes(highlightedRows)),
+		});
+
+		await waitFor(() => expect(userScrolled).toBe(true));
+		await waitFor(() => expect(viewport.scrollTop).toBe(90));
+		observer.disconnect();
+	});
+
+	it('lets a layout reset win over presentation scroll restoration', async () => {
+		const rows = [makeHeaderRow(0), makeUnifiedRow(0), makeHeaderRow(1)];
+		const props = makeSurfaceProps(rows);
+		const { container, rerender } = render(GitVirtualDiffSurface, { props });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+		viewport.scrollTop = 300;
+		const replacementRows = rows.map((row) =>
+			row.kind === 'file-header' ? { ...row, isFocused: true } : row,
+		);
+
+		await rerender({
+			...props,
+			layoutIdentity: 'layout-b',
+			source: arrayGitVirtualReviewRowSource(replacementRows, fileIndexes(replacementRows)),
+		});
+
+		await waitFor(() => expect(viewport.scrollTop).toBe(0));
+	});
+
 	it('republishes a new review document without resetting the layout scroll', async () => {
 		const rows = [makeHeaderRow(0), makeHeaderRow(1), makeHeaderRow(2)];
 		const onBodyDemand = vi.fn();

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRefresh.test.ts
@@ -22,6 +22,7 @@ type TestRefreshedVirtualizerOptions = Partial<VirtualizerOptions<HTMLElement, H
 let initialVirtualizerOptions: TestInitialVirtualizerOptions | null;
 let refreshedVirtualizerOptions: TestRefreshedVirtualizerOptions | null;
 let measureCalls: number;
+let setOptionsCalls: number;
 let scrollToIndexCalls: number[];
 let publishVisibleRange: (startIndex: number, endIndex?: number) => void;
 
@@ -42,6 +43,7 @@ vi.mock('@tanstack/svelte-virtual', async () => {
 				getVirtualItems: () => virtualItems,
 				getTotalSize: () => 126,
 				setOptions: (next: TestRefreshedVirtualizerOptions) => {
+					setOptionsCalls += 1;
 					refreshedVirtualizerOptions = next;
 				},
 				measureElement: () => undefined,
@@ -221,6 +223,7 @@ describe('Git virtual diff refresh', () => {
 		initialVirtualizerOptions = null;
 		refreshedVirtualizerOptions = null;
 		measureCalls = 0;
+		setOptionsCalls = 0;
 		scrollToIndexCalls = [];
 	});
 
@@ -565,6 +568,7 @@ describe('Git virtual diff refresh', () => {
 		await waitFor(() => expect(refreshedVirtualizerOptions?.estimateSize).toBeTruthy());
 		const estimateSize = refreshedVirtualizerOptions?.estimateSize;
 		const getItemKey = refreshedVirtualizerOptions?.getItemKey;
+		const initialSetOptionsCalls = setOptionsCalls;
 
 		await rerender({
 			...props,
@@ -575,7 +579,47 @@ describe('Git virtual diff refresh', () => {
 
 		expect(refreshedVirtualizerOptions?.estimateSize).toBe(estimateSize);
 		expect(refreshedVirtualizerOptions?.getItemKey).toBe(getItemKey);
+		expect(setOptionsCalls).toBe(initialSetOptionsCalls);
 		expect(measureCalls).toBe(1);
+	});
+
+	it('restores scroll after presentation-only rows update the rendered DOM', async () => {
+		const rows = [makeHeaderRow(0), makeUnifiedRow(0), makeHeaderRow(1)];
+		const props = makeSurfaceProps(rows);
+		const { container, rerender } = render(GitVirtualDiffSurface, { props });
+		const viewport = container.querySelector<HTMLElement>('[data-git-virtual-diff-root]')!;
+		viewport.scrollTop = 60;
+		let shifted = false;
+		const observer = new MutationObserver(() => {
+			if (shifted || !container.querySelector('.cm-code-keyword')) return;
+			shifted = true;
+			viewport.scrollTop = 34;
+		});
+		observer.observe(viewport, { childList: true, subtree: true });
+
+		const highlightedRows = rows.map((row) =>
+			row.kind === 'unified-row'
+				? {
+						...row,
+						view: {
+							...row.view,
+							segments: [
+								{ text: 'added ', className: null },
+								{ text: 'line', className: 'cm-code-keyword' },
+							],
+						},
+					}
+				: row,
+		);
+
+		await rerender({
+			...props,
+			source: arrayGitVirtualReviewRowSource(highlightedRows, fileIndexes(highlightedRows)),
+		});
+
+		await waitFor(() => expect(shifted).toBe(true));
+		await waitFor(() => expect(viewport.scrollTop).toBe(60));
+		observer.disconnect();
 	});
 
 	it('republishes a new review document without resetting the layout scroll', async () => {

--- a/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
+++ b/web/src/lib/components/git/__tests__/GitVirtualDiffRow.test.ts
@@ -5,6 +5,7 @@ import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git';
 import type { GitVirtualReviewRow } from '$lib/git/review/git-virtual-review-document.svelte.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
 import { buildGitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+import type { GitDiffSyntaxResults } from '$lib/git/review/git-diff-syntax.js';
 import GitVirtualDiffRow from '../GitVirtualDiffRow.svelte';
 
 function buildVirtualRows(options: Parameters<typeof buildGitVirtualReviewRowSource>[0]) {
@@ -32,7 +33,39 @@ const file: GitReviewFileSummary = {
 	isTooLarge: false,
 };
 
-function buildRows(diffMode: 'unified' | 'split'): DiffContentRow[] {
+function syntaxResults(): GitDiffSyntaxResults {
+	return {
+		[file.path]: {
+			cacheKey: 'syntax',
+			filePath: file.path,
+			bodyFingerprint: file.bodyFingerprint,
+			before: {
+				path: file.path,
+				languageKey: 'typescript',
+				lines: new Map([
+					[0, [{ text: 'old line', className: 'cm-code-string' }]],
+					[2, [{ text: 'shared line', className: 'cm-code-name' }]],
+				]),
+				characterCount: 19,
+				segmentCount: 2,
+			},
+			after: {
+				path: file.path,
+				languageKey: 'typescript',
+				lines: new Map([
+					[1, [{ text: 'new line', className: 'cm-code-keyword' }]],
+					[2, [{ text: 'shared line', className: 'cm-code-comment' }]],
+				]),
+				characterCount: 19,
+				segmentCount: 2,
+			},
+			characterCount: 38,
+			segmentCount: 4,
+		},
+	};
+}
+
+function buildRows(diffMode: 'unified' | 'split', highlighted = false): DiffContentRow[] {
 	const patch =
 		'diff --git a/src/example.ts b/src/example.ts\n@@ -1,2 +1,2 @@\n-old line\n+new line\n shared line\n';
 	const body: GitReviewFileBody = {
@@ -85,6 +118,7 @@ function buildRows(diffMode: 'unified' | 'split'): DiffContentRow[] {
 			},
 			selectedLineKeys: new Set(),
 		},
+		...(highlighted ? { syntaxResults: syntaxResults() } : {}),
 	}).filter((row): row is DiffContentRow => row.kind === 'unified-row' || row.kind === 'split-row');
 }
 
@@ -131,14 +165,14 @@ function renderRow(row: DiffContentRow, overrides: Partial<GitVirtualDiffRowProp
 	return { ...render(GitVirtualDiffRow, { props }), props };
 }
 
-function findUnifiedRow(kind: 'add' | 'context'): UnifiedContentRow {
-	return buildRows('unified').find(
+function findUnifiedRow(kind: 'add' | 'context', highlighted = false): UnifiedContentRow {
+	return buildRows('unified', highlighted).find(
 		(row): row is UnifiedContentRow => row.kind === 'unified-row' && row.view.row.kind === kind,
 	)!;
 }
 
-function findSplitChangeRow(): SplitContentRow {
-	return buildRows('split').find(
+function findSplitChangeRow(highlighted = false): SplitContentRow {
+	return buildRows('split', highlighted).find(
 		(row): row is SplitContentRow => row.kind === 'split-row' && row.view.left?.cell.kind === 'del',
 	)!;
 }
@@ -290,5 +324,44 @@ describe('GitVirtualDiffRow', () => {
 		for (const button of container.querySelectorAll('button')) {
 			expect(button.textContent?.trim() || button.getAttribute('aria-label')).toBeTruthy();
 		}
+	});
+
+	it('renders unified syntax spans without absorbing the diff prefix', async () => {
+		const row = findUnifiedRow('add', true);
+		const onAddComment = vi.fn();
+		const { container } = renderRow(row, {
+			interaction: { ...renderRowInteraction(), onAddComment },
+		});
+		const token = container.querySelector<HTMLElement>('.cm-code-keyword');
+		const text = token?.closest<HTMLElement>('.code-highlight');
+
+		expect(token?.textContent).toBe('new line');
+		expect(text?.textContent).toBe('+new line');
+		expect(text?.childNodes[0]?.textContent).toBe('+');
+		await fireEvent.click(token!);
+		expect(onAddComment).toHaveBeenCalledWith(file.path, 'after', 1);
+	});
+
+	it('renders independent before and after syntax in split mode', () => {
+		const { container } = renderRow(findSplitChangeRow(true));
+		const before = container.querySelector<HTMLElement>('.cm-code-string');
+		const after = container.querySelector<HTMLElement>('.cm-code-keyword');
+
+		expect(before?.closest('.code-highlight')?.textContent).toBe('-old line');
+		expect(after?.closest('.code-highlight')?.textContent).toBe('+new line');
+	});
+
+	it('renders malicious-looking highlighted source as text', () => {
+		const unsafeText = '<img src=x onerror=alert(1)>';
+		const row = findUnifiedRow('add');
+		row.view = {
+			...row.view,
+			text: unsafeText,
+			segments: [{ text: unsafeText, className: 'cm-code-string' }],
+		};
+		const { container } = renderRow(row);
+
+		expect(container.querySelector('img')).toBeNull();
+		expect(container.querySelector('.code-highlight')?.textContent).toBe(`+${unsafeText}`);
 	});
 });

--- a/web/src/lib/git/review/__tests__/git-diff-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-document.test.ts
@@ -153,6 +153,54 @@ describe('GitDiffDocumentController', () => {
 		await vi.waitFor(() => expect(addedSyntaxSegments(controller)).toBeDefined());
 	});
 
+	it('does not retain viewport paths as navigation syntax demand', async () => {
+		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
+		const syntax = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter: async () => ({ highlightGitDiffFile: highlighter }),
+		});
+		const controller = new GitDiffDocumentController(syntax);
+		const loadBodies = vi.fn(async (_snapshot: unknown, requested: Array<{ path: string }>) =>
+			bodyResponse(
+				'doc',
+				requested.map(({ path }) => path),
+			),
+		);
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('a.ts'), file('b.ts')],
+				limits: { ...limits, maxLoadedRows: 20 },
+				firstBodyCandidates: [],
+			},
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
+		);
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['a.ts'],
+		});
+		await vi.waitFor(() => expect(syntax.results['a.ts']).toBeDefined());
+
+		syntax.replaceBodies({});
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: 'doc',
+			filePaths: ['b.ts'],
+		});
+		await vi.waitFor(() => expect(syntax.results['b.ts']).toBeDefined());
+
+		expect(syntax.results['a.ts']).toBeUndefined();
+	});
+
 	it('replays early demand into syntax and honors document cache clearing', async () => {
 		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
 		const syntax = new GitDiffSyntaxController({

--- a/web/src/lib/git/review/__tests__/git-diff-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-document.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import type { GitReviewFileBody } from '$lib/api/git.js';
 import { createGitPatchIndex } from '../git-patch-index.js';
 import { commitFileToReviewFile, GitDiffDocumentController } from '../git-diff-document.svelte.js';
+import { GitDiffSyntaxController } from '../git-diff-syntax-controller.svelte.js';
+import {
+	gitDiffSyntaxCacheKey,
+	type GitDiffSyntaxAttempt,
+	type GitDiffSyntaxFileInput,
+} from '../git-diff-syntax.js';
 
 const limits = {
 	maxSummaryFiles: 100,
@@ -82,7 +88,99 @@ function testCommentSource() {
 	};
 }
 
+function highlightedAttempt(input: GitDiffSyntaxFileInput): GitDiffSyntaxAttempt {
+	return {
+		status: 'highlighted',
+		result: {
+			cacheKey: gitDiffSyntaxCacheKey(input.documentId, input.file, input.body),
+			filePath: input.file.path,
+			bodyFingerprint: input.body.bodyFingerprint,
+			before: null,
+			after: {
+				path: input.file.path,
+				languageKey: 'typescript',
+				lines: new Map([[0, [{ text: 'one', className: 'cm-code-keyword' }]]]),
+				characterCount: 3,
+				segmentCount: 1,
+			},
+			characterCount: 3,
+			segmentCount: 1,
+		},
+	};
+}
+
+function addedSyntaxSegments(controller: GitDiffDocumentController) {
+	return controller.rowSource
+		.rowsInRange(0, controller.rowSource.rowCount)
+		.flatMap((row) =>
+			row.kind === 'unified-row' && row.view.row.kind === 'add' ? [row.view.segments] : [],
+		)[0];
+}
+
 describe('GitDiffDocumentController', () => {
+	it('replays early demand into syntax and honors document cache clearing', async () => {
+		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
+		const syntax = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter: async () => ({ highlightGitDiffFile: highlighter }),
+		});
+		const controller = new GitDiffDocumentController(syntax);
+		const loadBodies = vi.fn(async (_snapshot: unknown, requested: Array<{ path: string }>) =>
+			bodyResponse(
+				'doc',
+				requested.map(({ path }) => path),
+			),
+		);
+		const snapshot = {
+			project: '/project',
+			documentId: 'doc',
+			files: [file('a.ts')],
+			limits,
+			firstBodyCandidates: [],
+		};
+		const options = {
+			contextLines: 5,
+			diffMode: 'unified' as const,
+			loadBodies,
+			onError: vi.fn(),
+			commentSource: testCommentSource(),
+		};
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: snapshot.documentId,
+			filePaths: ['a.ts'],
+		});
+
+		controller.open(snapshot, options);
+
+		await vi.waitFor(() => expect(highlighter).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(addedSyntaxSegments(controller)).toEqual([
+				{ text: 'one', className: 'cm-code-keyword' },
+			]),
+		);
+
+		controller.clear({ preserveCache: true });
+		expect(controller.rowSource.rowCount).toBe(0);
+		controller.open(snapshot, options);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: snapshot.documentId,
+			filePaths: ['a.ts'],
+		});
+		await vi.waitFor(() => expect(addedSyntaxSegments(controller)).toBeDefined());
+		expect(highlighter).toHaveBeenCalledOnce();
+
+		controller.clear();
+		controller.open(snapshot, options);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: snapshot.documentId,
+			filePaths: ['a.ts'],
+		});
+		await vi.waitFor(() => expect(highlighter).toHaveBeenCalledTimes(2));
+	});
+
 	it('reconciles retained viewport demand when the matching document becomes ready', async () => {
 		const controller = new GitDiffDocumentController();
 		const loadBodies = vi.fn(async (_snapshot: unknown, requested: Array<{ path: string }>) =>

--- a/web/src/lib/git/review/__tests__/git-diff-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-document.test.ts
@@ -118,6 +118,41 @@ function addedSyntaxSegments(controller: GitDiffDocumentController) {
 }
 
 describe('GitDiffDocumentController', () => {
+	it('highlights the initial visible body without waiting for viewport demand', async () => {
+		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
+		const syntax = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter: async () => ({ highlightGitDiffFile: highlighter }),
+		});
+		const controller = new GitDiffDocumentController(syntax);
+		const loadBodies = vi.fn(async (_snapshot: unknown, requested: Array<{ path: string }>) =>
+			bodyResponse(
+				'doc',
+				requested.map(({ path }) => path),
+			),
+		);
+
+		controller.open(
+			{
+				project: '/project',
+				documentId: 'doc',
+				files: [file('a.ts')],
+				limits,
+				firstBodyCandidates: ['a.ts'],
+			},
+			{
+				contextLines: 5,
+				diffMode: 'unified',
+				loadBodies,
+				onError: vi.fn(),
+				commentSource: testCommentSource(),
+			},
+		);
+
+		await vi.waitFor(() => expect(highlighter).toHaveBeenCalledOnce());
+		await vi.waitFor(() => expect(addedSyntaxSegments(controller)).toBeDefined());
+	});
+
 	it('replays early demand into syntax and honors document cache clearing', async () => {
 		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
 		const syntax = new GitDiffSyntaxController({

--- a/web/src/lib/git/review/__tests__/git-diff-rows.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-rows.test.ts
@@ -9,74 +9,108 @@ import {
 	renderUnifiedDiffRow,
 	type GitDiffComposerDraft,
 } from '$lib/git/review/git-diff-rows.js';
+import type { GitDiffFileSyntaxResult } from '$lib/git/review/git-diff-syntax.js';
 
 function makeReviewData(): GitRenderedDiffRow[] {
 	return [
-			{
-				key: 'hunk:0:hunk-0',
-				kind: 'hunk',
-				hunkIndex: 0,
-				hunkId: 'hunk-0',
-				beforeLine: null,
-				afterLine: null,
-				text: '@@ -1,3 +1,4 @@',
-				diffLineIndex: -1,
-			},
-			{
-				key: 'line:0:context:1:1',
-				kind: 'context',
-				hunkIndex: 0,
-				hunkId: 'hunk-0',
-				beforeLine: 1,
-				afterLine: 1,
-				text: 'const a = 1;',
-				diffLineIndex: 0,
-			},
-			{
-				key: 'line:1:del:2',
-				kind: 'del',
-				hunkIndex: 0,
-				hunkId: 'hunk-0',
-				beforeLine: 2,
-				afterLine: null,
-				text: 'const b = 2;',
-				diffLineIndex: 1,
-			},
-			{
-				key: 'line:2:add:2',
-				kind: 'add',
-				hunkIndex: 0,
-				hunkId: 'hunk-0',
-				beforeLine: null,
-				afterLine: 2,
-				text: 'const b = 3;',
-				diffLineIndex: 2,
-			},
-			{
-				key: 'line:3:add:3',
-				kind: 'add',
-				hunkIndex: 0,
-				hunkId: 'hunk-0',
-				beforeLine: null,
-				afterLine: 3,
-				text: 'const c = 4;',
-				diffLineIndex: 3,
-			},
-			{
-				key: 'line:4:context:3:4',
-				kind: 'context',
-				hunkIndex: 0,
-				hunkId: 'hunk-0',
-				beforeLine: 3,
-				afterLine: 4,
-				text: 'console.log(a);',
-				diffLineIndex: 4,
-			},
+		{
+			key: 'hunk:0:hunk-0',
+			kind: 'hunk',
+			hunkIndex: 0,
+			hunkId: 'hunk-0',
+			beforeLine: null,
+			afterLine: null,
+			text: '@@ -1,3 +1,4 @@',
+			diffLineIndex: -1,
+		},
+		{
+			key: 'line:0:context:1:1',
+			kind: 'context',
+			hunkIndex: 0,
+			hunkId: 'hunk-0',
+			beforeLine: 1,
+			afterLine: 1,
+			text: 'const a = 1;',
+			diffLineIndex: 0,
+		},
+		{
+			key: 'line:1:del:2',
+			kind: 'del',
+			hunkIndex: 0,
+			hunkId: 'hunk-0',
+			beforeLine: 2,
+			afterLine: null,
+			text: 'const b = 2;',
+			diffLineIndex: 1,
+		},
+		{
+			key: 'line:2:add:2',
+			kind: 'add',
+			hunkIndex: 0,
+			hunkId: 'hunk-0',
+			beforeLine: null,
+			afterLine: 2,
+			text: 'const b = 3;',
+			diffLineIndex: 2,
+		},
+		{
+			key: 'line:3:add:3',
+			kind: 'add',
+			hunkIndex: 0,
+			hunkId: 'hunk-0',
+			beforeLine: null,
+			afterLine: 3,
+			text: 'const c = 4;',
+			diffLineIndex: 3,
+		},
+		{
+			key: 'line:4:context:3:4',
+			kind: 'context',
+			hunkIndex: 0,
+			hunkId: 'hunk-0',
+			beforeLine: 3,
+			afterLine: 4,
+			text: 'console.log(a);',
+			diffLineIndex: 4,
+		},
 	];
 }
 
 function buildUnifiedDiffRows(rows: GitRenderedDiffRow[]) {
 	return rows.map(renderUnifiedDiffRow);
+}
+
+function syntaxResult(): GitDiffFileSyntaxResult {
+	return {
+		cacheKey: 'syntax',
+		filePath: 'src/app.ts',
+		bodyFingerprint: 'fingerprint',
+		before: {
+			path: 'src/app.ts',
+			languageKey: 'typescript',
+			lines: new Map([
+				[0, [{ text: 'const a = 1;', className: 'cm-code-name' }]],
+				[1, [{ text: 'const b = 2;', className: 'cm-code-deletion' }]],
+				[4, [{ text: 'console.log(a);', className: 'cm-code-name' }]],
+			]),
+			characterCount: 42,
+			segmentCount: 3,
+		},
+		after: {
+			path: 'src/app.ts',
+			languageKey: 'typescript',
+			lines: new Map([
+				[0, [{ text: 'const a = 1;', className: 'cm-code-keyword' }]],
+				[2, [{ text: 'const b = 3;', className: 'cm-code-addition' }]],
+				[3, [{ text: 'const c = 4;', className: 'cm-code-addition' }]],
+				[4, [{ text: 'console.log(a);', className: 'cm-code-title' }]],
+			]),
+			characterCount: 55,
+			segmentCount: 4,
+		},
+		characterCount: 97,
+		segmentCount: 7,
+	};
 }
 
 describe('git diff rows', () => {
@@ -173,5 +207,43 @@ describe('git diff rows', () => {
 		expect(views[2].right?.selectionKey).toBe(
 			makeLineSelectionKey('src/app.ts', 'unstaged', 'after', 2),
 		);
+	});
+
+	it('projects before and after syntax segments onto unified rows', () => {
+		const views = buildUnifiedDiffRowViews({
+			rows: buildUnifiedDiffRows(makeReviewData()),
+			filePath: 'src/app.ts',
+			activeTab: 'unstaged',
+			readOnly: false,
+			selectedLineKeys: new Set(),
+			composerTarget: null,
+			syntaxResult: syntaxResult(),
+		});
+
+		expect(views[0].segments).toBeUndefined();
+		expect(views[1].segments?.[0].className).toBe('cm-code-keyword');
+		expect(views[2].segments?.[0].className).toBe('cm-code-deletion');
+		expect(views[3].segments?.[0].className).toBe('cm-code-addition');
+		expect(views[5].segments?.[0].className).toBe('cm-code-title');
+		expect(views[2].text).toBe('const b = 2;');
+	});
+
+	it('projects each split cell from its own syntax side', () => {
+		const views = buildSplitDiffRowViews({
+			rows: buildSplitDiffRows(buildUnifiedDiffRows(makeReviewData())),
+			filePath: 'src/app.ts',
+			activeTab: 'unstaged',
+			readOnly: false,
+			selectedLineKeys: new Set(),
+			composerTarget: null,
+			syntaxResult: syntaxResult(),
+		});
+
+		expect(views[0].left).toBeNull();
+		expect(views[1].left?.segments?.[0].className).toBe('cm-code-name');
+		expect(views[1].right?.segments?.[0].className).toBe('cm-code-keyword');
+		expect(views[2].left?.segments?.[0].className).toBe('cm-code-deletion');
+		expect(views[2].right?.segments?.[0].className).toBe('cm-code-addition');
+		expect(views[3].left?.segments).toBeUndefined();
 	});
 });

--- a/web/src/lib/git/review/__tests__/git-diff-syntax-controller.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-syntax-controller.test.ts
@@ -397,6 +397,22 @@ describe('GitDiffSyntaxController cache lifecycle', () => {
 		expect(controller.results['b.ts']).toBeDefined();
 	});
 
+	it('does not republish an active cached result for repeated demand', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value));
+		const fileValue = file('a.ts');
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		const publishedResults = controller.results;
+
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+
+		expect(controller.results).toBe(publishedResults);
+		expect(highlighter).toHaveBeenCalledOnce();
+	});
+
 	it('contains a thrown highlighter and continues the queue', async () => {
 		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => {
 			if (value.file.path === 'a.ts') throw new Error('parser failed');

--- a/web/src/lib/git/review/__tests__/git-diff-syntax-controller.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-syntax-controller.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git.js';
+import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
+import {
+	GitDiffSyntaxController,
+	type GitDiffSyntaxControllerDependencies,
+	type GitDiffSyntaxHighlighterPort,
+} from '$lib/git/review/git-diff-syntax-controller.svelte.js';
+import {
+	gitDiffSyntaxCacheKey,
+	type GitDiffFileSyntaxResult,
+	type GitDiffSyntaxAttempt,
+	type GitDiffSyntaxFileInput,
+} from '$lib/git/review/git-diff-syntax.js';
+
+const PATCH = '@@ -1 +1 @@\n-const oldValue = 1;\n+const newValue = 2;\n';
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+	reject(reason: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
+}
+
+function file(path: string, fingerprint = `fingerprint:${path}`): GitReviewFileSummary {
+	return {
+		path,
+		indexStatus: 'M',
+		workTreeStatus: ' ',
+		category: 'normal',
+		additions: 1,
+		deletions: 1,
+		estimatedRows: 3,
+		bodyState: 'unloaded',
+		bodyFingerprint: fingerprint,
+		isGenerated: false,
+		isBinary: false,
+		isTooLarge: false,
+	};
+}
+
+function body(path: string, fingerprint = `fingerprint:${path}`): GitReviewFileBody {
+	const patchIndex = createGitPatchIndex(PATCH);
+	return {
+		path,
+		bodyFingerprint: fingerprint,
+		bodyState: 'loaded',
+		category: 'normal',
+		isBinary: false,
+		isTooLarge: false,
+		renderedRowCount: patchIndex.rowCount,
+		patchBytes: PATCH.length,
+		patch: PATCH,
+		patchIndex,
+	};
+}
+
+function highlighted(input: GitDiffSyntaxFileInput, weight = 1): GitDiffSyntaxAttempt {
+	const result: GitDiffFileSyntaxResult = {
+		cacheKey: gitDiffSyntaxCacheKey(input.documentId, input.file, input.body),
+		filePath: input.file.path,
+		bodyFingerprint: input.body.bodyFingerprint,
+		before: {
+			path: input.file.originalPath ?? input.file.path,
+			languageKey: 'typescript',
+			lines: new Map([[0, [{ text: 'const oldValue = 1;', className: 'cm-code-keyword' }]]]),
+			characterCount: weight,
+			segmentCount: weight,
+		},
+		after: null,
+		characterCount: weight,
+		segmentCount: weight,
+	};
+	return { status: 'highlighted', result };
+}
+
+function dependencies(
+	highlightGitDiffFile: GitDiffSyntaxHighlighterPort['highlightGitDiffFile'],
+	overrides: Partial<GitDiffSyntaxControllerDependencies> = {},
+): GitDiffSyntaxControllerDependencies {
+	return {
+		waitForWorkSlot: async () => {},
+		loadHighlighter: async () => ({ highlightGitDiffFile }),
+		...overrides,
+	};
+}
+
+function demand(documentId: string, paths: string[], kind: 'viewport' | 'navigation' = 'viewport') {
+	return { kind, documentId, filePaths: paths } as const;
+}
+
+async function flushPromises(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('GitDiffSyntaxController demand', () => {
+	it('waits for both eligible demand and a matching loaded body', async () => {
+		const loadHighlighter = vi.fn(async () => ({ highlightGitDiffFile: vi.fn() }));
+		const controller = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter,
+		});
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, {});
+
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		expect(loadHighlighter).not.toHaveBeenCalled();
+
+		controller.replaceBodies({ 'a.ts': body('a.ts') });
+		await flushPromises();
+		expect(loadHighlighter).toHaveBeenCalledOnce();
+	});
+
+	it('does not highlight a prefetched body without viewport or navigation demand', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value));
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileValue = file('a.ts');
+
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+		await flushPromises();
+
+		expect(highlighter).not.toHaveBeenCalled();
+	});
+
+	it('waits for the scheduled work slot before importing the highlighter', async () => {
+		const workSlot = deferred<void>();
+		const loadHighlighter = vi.fn(async () => ({
+			highlightGitDiffFile: vi.fn(
+				async () =>
+					({
+						status: 'plain',
+						reason: 'unsupported-language',
+					}) as const,
+			),
+		}));
+		const controller = new GitDiffSyntaxController({
+			waitForWorkSlot: () => workSlot.promise,
+			loadHighlighter,
+		});
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		expect(loadHighlighter).not.toHaveBeenCalled();
+
+		workSlot.resolve();
+		await flushPromises();
+		expect(loadHighlighter).toHaveBeenCalledOnce();
+	});
+
+	it('caches an ineligible demand without importing the highlighter', async () => {
+		const loadHighlighter = vi.fn(async () => ({ highlightGitDiffFile: vi.fn() }));
+		const generated = {
+			...file('generated.ts'),
+			category: 'generated' as const,
+			isGenerated: true,
+		};
+		const controller = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter,
+		});
+		controller.open(
+			{ documentId: 'doc', files: [generated] },
+			{ 'generated.ts': body('generated.ts') },
+		);
+
+		controller.handleDemand(demand('doc', ['generated.ts']));
+		await flushPromises();
+
+		expect(loadHighlighter).not.toHaveBeenCalled();
+	});
+
+	it('deduplicates duplicate viewport and navigation demand', async () => {
+		const pending = deferred<GitDiffSyntaxAttempt>();
+		const highlighter = vi.fn(() => pending.promise);
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+
+		controller.handleDemand(demand('doc', ['a.ts']));
+		controller.handleDemand(demand('doc', ['a.ts'], 'navigation'));
+		await flushPromises();
+
+		expect(highlighter).toHaveBeenCalledOnce();
+		pending.resolve(highlighted(highlighter.mock.calls[0][0]));
+		await flushPromises();
+	});
+
+	it('runs files sequentially and prioritizes navigation over queued viewport work', async () => {
+		const attempts = new Map<string, Deferred<GitDiffSyntaxAttempt>>();
+		const order: string[] = [];
+		const highlighter = vi.fn((value: GitDiffSyntaxFileInput) => {
+			order.push(value.file.path);
+			const pending = deferred<GitDiffSyntaxAttempt>();
+			attempts.set(value.file.path, pending);
+			return pending.promise;
+		});
+		const files = [file('a.ts'), file('b.ts'), file('c.ts')];
+		const bodies = Object.fromEntries(files.map((value) => [value.path, body(value.path)]));
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		controller.open({ documentId: 'doc', files }, bodies);
+
+		controller.handleDemand(demand('doc', ['a.ts', 'b.ts']));
+		await flushPromises();
+		controller.handleDemand(demand('doc', ['c.ts'], 'navigation'));
+		attempts.get('a.ts')?.resolve(highlighted(highlighter.mock.calls[0][0]));
+		await flushPromises();
+
+		expect(order).toEqual(['a.ts', 'c.ts']);
+		attempts.get('c.ts')?.resolve(highlighted(highlighter.mock.calls[1][0]));
+		await flushPromises();
+		expect(order).toEqual(['a.ts', 'c.ts', 'b.ts']);
+		attempts.get('b.ts')?.resolve(highlighted(highlighter.mock.calls[2][0]));
+		await flushPromises();
+	});
+});
+
+describe('GitDiffSyntaxController stale work', () => {
+	it('discards a result after document replacement', async () => {
+		const pending = deferred<GitDiffSyntaxAttempt>();
+		const highlighter = vi.fn(() => pending.promise);
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileA = file('a.ts');
+		controller.open({ documentId: 'doc-a', files: [fileA] }, { 'a.ts': body('a.ts') });
+		controller.handleDemand(demand('doc-a', ['a.ts']));
+		await flushPromises();
+		const oldInput = highlighter.mock.calls[0][0];
+
+		controller.open({ documentId: 'doc-b', files: [file('b.ts')] }, { 'b.ts': body('b.ts') });
+		pending.resolve(highlighted(oldInput));
+		await flushPromises();
+
+		expect(controller.results).toEqual({});
+	});
+
+	it('discards a result after body fingerprint replacement and accepts the new key', async () => {
+		const attempts: Deferred<GitDiffSyntaxAttempt>[] = [];
+		const highlighter = vi.fn(() => {
+			const pending = deferred<GitDiffSyntaxAttempt>();
+			attempts.push(pending);
+			return pending.promise;
+		});
+		const oldFile = file('a.ts', 'old');
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		controller.open({ documentId: 'doc', files: [oldFile] }, { 'a.ts': body('a.ts', 'old') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		const oldInput = highlighter.mock.calls[0][0];
+
+		const newFile = file('a.ts', 'new');
+		controller.open({ documentId: 'doc', files: [newFile] }, { 'a.ts': body('a.ts', 'new') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		attempts[0].resolve(highlighted(oldInput));
+		await flushPromises();
+		const newInput = highlighter.mock.calls[1][0];
+		attempts[1].resolve(highlighted(newInput));
+		await flushPromises();
+
+		expect(controller.results['a.ts']?.bodyFingerprint).toBe('new');
+	});
+
+	it('rejects a highlighted result with mismatched identity fields', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => {
+			const attempt = highlighted(value);
+			if (attempt.status !== 'highlighted') return attempt;
+			return { ...attempt, result: { ...attempt.result, cacheKey: 'wrong' } };
+		});
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+
+		expect(controller.results).toEqual({});
+	});
+});
+
+describe('GitDiffSyntaxController cache lifecycle', () => {
+	it('reactivates a cached result after body eviction and reload', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value));
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		expect(controller.results['a.ts']).toBeDefined();
+
+		controller.replaceBodies({});
+		expect(controller.results['a.ts']).toBeUndefined();
+		controller.replaceBodies({ 'a.ts': body('a.ts') });
+		await flushPromises();
+
+		expect(controller.results['a.ts']).toBeDefined();
+		expect(highlighter).toHaveBeenCalledOnce();
+	});
+
+	it('caches terminal plain attempts without retrying on later demand', async () => {
+		const highlighter = vi.fn(async () => ({ status: 'plain', reason: 'parse-timeout' }) as const);
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		controller.handleDemand(demand('doc', []));
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+
+		expect(highlighter).toHaveBeenCalledOnce();
+	});
+
+	it('preserves cache on close but clears it on reset', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value));
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		const fileValue = file('a.ts');
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+
+		controller.close({ preserveCache: true });
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		expect(highlighter).toHaveBeenCalledOnce();
+
+		controller.reset();
+		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		expect(highlighter).toHaveBeenCalledTimes(2);
+	});
+
+	it('removes active and cached data on explicit invalidation and path pruning', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value));
+		const files = [file('a.ts'), file('b.ts')];
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		controller.open({ documentId: 'doc', files }, { 'a.ts': body('a.ts'), 'b.ts': body('b.ts') });
+		controller.handleDemand(demand('doc', ['a.ts', 'b.ts']));
+		await flushPromises();
+
+		controller.replaceBodies({ 'b.ts': body('b.ts') });
+		controller.invalidateFile('a.ts');
+		controller.pruneToFilePaths(new Set(['b.ts']));
+
+		expect(controller.results['a.ts']).toBeUndefined();
+		expect(controller.results['b.ts']).toBeDefined();
+	});
+
+	it.each([
+		{ files: 1, characters: 100, segments: 100 },
+		{ files: 10, characters: 3, segments: 100 },
+		{ files: 10, characters: 100, segments: 3 },
+	])('enforces the cache limits %j', async (limits) => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value, 2));
+		const files = [file('a.ts'), file('b.ts')];
+		const controller = new GitDiffSyntaxController(dependencies(highlighter), limits);
+		controller.open({ documentId: 'doc', files }, { 'a.ts': body('a.ts'), 'b.ts': body('b.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		controller.handleDemand(demand('doc', ['b.ts']));
+		await flushPromises();
+
+		expect(controller.results['a.ts']).toBeUndefined();
+		expect(controller.results['b.ts']).toBeDefined();
+	});
+
+	it('publishes immutable result records', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => highlighted(value));
+		const files = [file('a.ts'), file('b.ts')];
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		controller.open({ documentId: 'doc', files }, { 'a.ts': body('a.ts'), 'b.ts': body('b.ts') });
+		controller.handleDemand(demand('doc', ['a.ts']));
+		await flushPromises();
+		const firstResults = controller.results;
+
+		controller.handleDemand(demand('doc', ['a.ts', 'b.ts']));
+		await flushPromises();
+
+		expect(controller.results).not.toBe(firstResults);
+		expect(firstResults['b.ts']).toBeUndefined();
+		expect(controller.results['b.ts']).toBeDefined();
+	});
+
+	it('contains a thrown highlighter and continues the queue', async () => {
+		const highlighter = vi.fn(async (value: GitDiffSyntaxFileInput) => {
+			if (value.file.path === 'a.ts') throw new Error('parser failed');
+			return highlighted(value);
+		});
+		const files = [file('a.ts'), file('b.ts')];
+		const controller = new GitDiffSyntaxController(dependencies(highlighter));
+		controller.open({ documentId: 'doc', files }, { 'a.ts': body('a.ts'), 'b.ts': body('b.ts') });
+
+		controller.handleDemand(demand('doc', ['a.ts', 'b.ts']));
+		await flushPromises();
+
+		expect(controller.results['a.ts']).toBeUndefined();
+		expect(controller.results['b.ts']).toBeDefined();
+		expect(highlighter).toHaveBeenCalledTimes(2);
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-diff-syntax-controller.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-syntax-controller.test.ts
@@ -104,7 +104,11 @@ async function flushPromises(): Promise<void> {
 
 describe('GitDiffSyntaxController demand', () => {
 	it('waits for both eligible demand and a matching loaded body', async () => {
-		const loadHighlighter = vi.fn(async () => ({ highlightGitDiffFile: vi.fn() }));
+		const loadHighlighter = vi.fn(async () => ({
+			highlightGitDiffFile: vi.fn(
+				async () => ({ status: 'plain', reason: 'unsupported-language' }) as const,
+			),
+		}));
 		const controller = new GitDiffSyntaxController({
 			waitForWorkSlot: async () => {},
 			loadHighlighter,
@@ -183,7 +187,7 @@ describe('GitDiffSyntaxController demand', () => {
 
 	it('deduplicates duplicate viewport and navigation demand', async () => {
 		const pending = deferred<GitDiffSyntaxAttempt>();
-		const highlighter = vi.fn(() => pending.promise);
+		const highlighter = vi.fn((_value: GitDiffSyntaxFileInput) => pending.promise);
 		const controller = new GitDiffSyntaxController(dependencies(highlighter));
 		const fileValue = file('a.ts');
 		controller.open({ documentId: 'doc', files: [fileValue] }, { 'a.ts': body('a.ts') });
@@ -229,7 +233,7 @@ describe('GitDiffSyntaxController demand', () => {
 describe('GitDiffSyntaxController stale work', () => {
 	it('discards a result after document replacement', async () => {
 		const pending = deferred<GitDiffSyntaxAttempt>();
-		const highlighter = vi.fn(() => pending.promise);
+		const highlighter = vi.fn((_value: GitDiffSyntaxFileInput) => pending.promise);
 		const controller = new GitDiffSyntaxController(dependencies(highlighter));
 		const fileA = file('a.ts');
 		controller.open({ documentId: 'doc-a', files: [fileA] }, { 'a.ts': body('a.ts') });
@@ -246,7 +250,7 @@ describe('GitDiffSyntaxController stale work', () => {
 
 	it('discards a result after body fingerprint replacement and accepts the new key', async () => {
 		const attempts: Deferred<GitDiffSyntaxAttempt>[] = [];
-		const highlighter = vi.fn(() => {
+		const highlighter = vi.fn((_value: GitDiffSyntaxFileInput) => {
 			const pending = deferred<GitDiffSyntaxAttempt>();
 			attempts.push(pending);
 			return pending.promise;

--- a/web/src/lib/git/review/__tests__/git-diff-syntax.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-syntax.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git.js';
+import type { LoadedCodeMirrorLanguage } from '$lib/highlighting/codemirror-language-registry.js';
+import { loadCodeMirrorLanguageForFile } from '$lib/highlighting/codemirror-language-registry.js';
+import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
+import {
+	GIT_DIFF_SYNTAX_LIMITS,
+	buildGitDiffSyntheticSides,
+	gitDiffSyntaxCacheKey,
+	gitDiffSyntaxSkipReason,
+	waitForGitDiffSyntaxWorkSlot,
+	type GitDiffSyntheticSide,
+	type GitDiffSyntaxFileInput,
+	type GitDiffSyntaxSideAttempt,
+} from '$lib/git/review/git-diff-syntax.js';
+import {
+	highlightGitDiffFile,
+	highlightGitDiffSyntheticSide,
+	type GitDiffSyntaxHighlightDependencies,
+} from '$lib/git/review/git-diff-syntax-highlighter.js';
+
+const PATCH = `diff --git a/src/example.ts b/src/example.ts
+--- a/src/example.ts
++++ b/src/example.ts
+@@ -1,3 +1,3 @@
+ function example() {
+-\tconst oldValue = "old";
++\tconst newValue = "new";
+ }
+@@ -10 +10 @@
+-const tail = false;
++const tail = true;
+`;
+
+function file(
+	path = 'src/example.ts',
+	overrides: Partial<GitReviewFileSummary> = {},
+): GitReviewFileSummary {
+	return {
+		path,
+		indexStatus: 'M',
+		workTreeStatus: ' ',
+		category: 'normal',
+		additions: 2,
+		deletions: 2,
+		estimatedRows: 9,
+		bodyState: 'unloaded',
+		bodyFingerprint: `fingerprint:${path}`,
+		isGenerated: false,
+		isBinary: false,
+		isTooLarge: false,
+		...overrides,
+	};
+}
+
+function body(
+	path = 'src/example.ts',
+	patch = PATCH,
+	overrides: Partial<GitReviewFileBody> = {},
+): GitReviewFileBody {
+	const patchIndex = createGitPatchIndex(patch);
+	return {
+		path,
+		bodyFingerprint: `fingerprint:${path}`,
+		bodyState: 'loaded',
+		category: 'normal',
+		isBinary: false,
+		isTooLarge: false,
+		renderedRowCount: patchIndex.rowCount,
+		patchBytes: new TextEncoder().encode(patch).byteLength,
+		patch,
+		patchIndex,
+		...overrides,
+	};
+}
+
+function input(
+	fileValue = file(),
+	bodyValue = body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint }),
+): GitDiffSyntaxFileInput {
+	return { documentId: 'document:syntax', file: fileValue, body: bodyValue };
+}
+
+function projectSide(
+	side: GitDiffSyntheticSide,
+	path: string,
+	loaded: LoadedCodeMirrorLanguage,
+): GitDiffSyntaxSideAttempt {
+	return {
+		status: 'highlighted',
+		result: {
+			path,
+			languageKey: loaded.key,
+			lines: new Map(
+				side.lines.flatMap((line) =>
+					line.diffLineIndex === null
+						? []
+						: [[line.diffLineIndex, [{ text: line.text, className: null }]] as const],
+				),
+			),
+			characterCount: side.characterCount,
+			segmentCount: side.lines.filter((line) => line.diffLineIndex !== null).length,
+		},
+	};
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe('Git diff syntax reconstruction', () => {
+	it('builds independent before and after snippets with unmapped hunk separators', () => {
+		const reconstructed = buildGitDiffSyntheticSides(body());
+
+		expect(reconstructed.sides.before?.text).toBe(
+			'function example() {\n\tconst oldValue = "old";\n}\n\nconst tail = false;',
+		);
+		expect(reconstructed.sides.after?.text).toBe(
+			'function example() {\n\tconst newValue = "new";\n}\n\nconst tail = true;',
+		);
+		expect(reconstructed.sides.before?.lines.map((line) => line.diffLineIndex)).toEqual([
+			0,
+			1,
+			3,
+			null,
+			4,
+		]);
+		expect(reconstructed.sides.after?.lines.map((line) => line.diffLineIndex)).toEqual([
+			0,
+			2,
+			3,
+			null,
+			5,
+		]);
+	});
+
+	it('preserves mapped empty rows separately from hunk separators', () => {
+		const patch = `@@ -1,2 +1,2 @@\n context\n-\n+replacement\n`;
+		const reconstructed = buildGitDiffSyntheticSides(body('empty.ts', patch));
+
+		expect(reconstructed.sides.before?.lines).toEqual([
+			{ text: 'context', diffLineIndex: 0 },
+			{ text: '', diffLineIndex: 1 },
+		]);
+	});
+
+	it('discards only the synthetic side that exceeds its character budget', () => {
+		const longDeletion = 'x'.repeat(GIT_DIFF_SYNTAX_LIMITS.maxSyntheticCharactersPerSide + 1);
+		const patch = `@@ -1 +1 @@\n-${longDeletion}\n+const next = true;\n`;
+		const reconstructed = buildGitDiffSyntheticSides(body('large.ts', patch));
+
+		expect(reconstructed.beforeExceeded).toBe(true);
+		expect(reconstructed.sides.before).toBeNull();
+		expect(reconstructed.sides.after?.text).toBe('const next = true;');
+	});
+});
+
+describe('Git diff syntax eligibility', () => {
+	it.each([
+		[{ category: 'generated', isGenerated: true }, 'excluded'],
+		[{ category: 'lockfile' }, 'excluded'],
+		[{ category: 'binary', isBinary: true }, 'excluded'],
+		[{ category: 'large', isTooLarge: true }, 'excluded'],
+	])('skips excluded file metadata %j', (overrides, reason) => {
+		const fileValue = file('asset.ts', overrides);
+
+		expect(
+			gitDiffSyntaxSkipReason(
+				input(
+					fileValue,
+					body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint }),
+				),
+			),
+		).toBe(reason);
+	});
+
+	it('skips row-heavy bodies before loading a language', () => {
+		const bodyValue = body('large.ts', PATCH, {
+			renderedRowCount: GIT_DIFF_SYNTAX_LIMITS.maxRenderedRows + 1,
+		});
+
+		expect(gitDiffSyntaxSkipReason(input(file('large.ts'), bodyValue))).toBe('row-limit');
+	});
+
+	it('keys results by version, document, fingerprint, and both rename paths', () => {
+		const fileValue = file('src/after.py', { originalPath: 'src/before.js' });
+		const bodyValue = body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint });
+
+		expect(JSON.parse(gitDiffSyntaxCacheKey('doc', fileValue, bodyValue))).toEqual([
+			1,
+			'doc',
+			fileValue.bodyFingerprint,
+			'src/before.js',
+			'src/after.py',
+		]);
+	});
+});
+
+describe('Git diff syntax highlighting', () => {
+	it('highlights a multiline side and preserves every source character', async () => {
+		const loaded = await loadCodeMirrorLanguageForFile('src/example.ts');
+		const side = buildGitDiffSyntheticSides(body()).sides.after;
+		expect(loaded).not.toBeNull();
+		expect(side).not.toBeNull();
+		if (!loaded || !side) return;
+		loaded.language.parser.parse(side.text);
+
+		const result = highlightGitDiffSyntheticSide(side, 'src/example.ts', loaded);
+
+		expect(result.status).toBe('highlighted');
+		if (result.status !== 'highlighted') return;
+		for (const line of side.lines) {
+			if (line.diffLineIndex === null) continue;
+			expect(
+				result.result.lines
+					.get(line.diffLineIndex)
+					?.map((segment) => segment.text)
+					.join(''),
+			).toBe(line.text);
+		}
+		expect(
+			Array.from(result.result.lines.values()).some((segments) =>
+				segments.some((segment) => segment.className === 'cm-code-keyword'),
+			),
+		).toBe(true);
+	});
+
+	it('retains multiline parser state when the opener is present in hunk context', async () => {
+		const patch = '@@ -1,3 +1,3 @@\n value = """\n-old\n+new\n """\n';
+		const side = buildGitDiffSyntheticSides(body('example.py', patch)).sides.after;
+		const loaded = await loadCodeMirrorLanguageForFile('example.py');
+		expect(side).not.toBeNull();
+		expect(loaded).not.toBeNull();
+		if (!side || !loaded) return;
+		loaded.language.parser.parse(side.text);
+
+		const result = highlightGitDiffSyntheticSide(side, 'example.py', loaded);
+
+		expect(result.status).toBe('highlighted');
+		if (result.status !== 'highlighted') return;
+		expect(
+			result.result.lines
+				.get(2)
+				?.map((segment) => segment.text)
+				.join(''),
+		).toBe('new');
+		expect(
+			result.result.lines
+				.get(2)
+				?.some((segment) => segment.className?.split(/\s+/).includes('cm-code-string')),
+		).toBe(true);
+	});
+
+	it('loads distinct before and after languages for a rename', async () => {
+		const fileValue = file('src/after.py', { originalPath: 'src/before.js' });
+		const bodyValue = body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint });
+		const loadedPaths: string[] = [];
+		const deps: GitDiffSyntaxHighlightDependencies = {
+			loadLanguage: async (path) => {
+				loadedPaths.push(path);
+				return loadCodeMirrorLanguageForFile(path);
+			},
+			waitForWorkSlot: async () => {},
+			highlightSide: projectSide,
+		};
+
+		const result = await highlightGitDiffFile(
+			input(fileValue, bodyValue),
+			new AbortController().signal,
+			deps,
+		);
+
+		expect(result.status).toBe('highlighted');
+		expect(loadedPaths).toEqual(['src/after.py', 'src/before.js']);
+		if (result.status !== 'highlighted') return;
+		expect(result.result.before?.languageKey).toBe('javascript');
+		expect(result.result.after?.languageKey).toBe('python');
+	});
+
+	it('returns a partial result when one side is unsupported', async () => {
+		const fileValue = file('src/after.ts', { originalPath: 'src/before.unknown' });
+		const bodyValue = body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint });
+		const deps: GitDiffSyntaxHighlightDependencies = {
+			loadLanguage: loadCodeMirrorLanguageForFile,
+			waitForWorkSlot: async () => {},
+			highlightSide: projectSide,
+		};
+
+		const result = await highlightGitDiffFile(
+			input(fileValue, bodyValue),
+			new AbortController().signal,
+			deps,
+		);
+
+		expect(result.status).toBe('highlighted');
+		if (result.status !== 'highlighted') return;
+		expect(result.result.before).toBeNull();
+		expect(result.result.after?.lines.size).toBeGreaterThan(0);
+	});
+
+	it.each([
+		['@@ -0,0 +1 @@\n+const added = true;\n', 'after'],
+		['@@ -1 +0,0 @@\n-const deleted = true;\n', 'before'],
+	] as const)('loads only the existing side for %s', async (patch, expectedSide) => {
+		const loadLanguage = vi.fn(loadCodeMirrorLanguageForFile);
+		const fileValue = file('single.ts');
+		const bodyValue = body(fileValue.path, patch, { bodyFingerprint: fileValue.bodyFingerprint });
+
+		const result = await highlightGitDiffFile(
+			input(fileValue, bodyValue),
+			new AbortController().signal,
+			{
+				loadLanguage,
+				waitForWorkSlot: async () => {},
+				highlightSide: projectSide,
+			},
+		);
+
+		expect(result.status).toBe('highlighted');
+		expect(loadLanguage).toHaveBeenCalledOnce();
+		if (result.status !== 'highlighted') return;
+		expect(result.result[expectedSide]).not.toBeNull();
+		expect(result.result[expectedSide === 'after' ? 'before' : 'after']).toBeNull();
+	});
+
+	it('keeps the other side when one synthetic side exceeds the character limit', async () => {
+		const deletion = 'x'.repeat(GIT_DIFF_SYNTAX_LIMITS.maxSyntheticCharactersPerSide + 1);
+		const patch = `@@ -1 +1 @@\n-${deletion}\n+const next = true;\n`;
+		const fileValue = file('large.ts');
+		const bodyValue = body(fileValue.path, patch, { bodyFingerprint: fileValue.bodyFingerprint });
+
+		const result = await highlightGitDiffFile(
+			input(fileValue, bodyValue),
+			new AbortController().signal,
+			{
+				loadLanguage: loadCodeMirrorLanguageForFile,
+				waitForWorkSlot: async () => {},
+				highlightSide: projectSide,
+			},
+		);
+
+		expect(result.status).toBe('highlighted');
+		if (result.status !== 'highlighted') return;
+		expect(result.result.before).toBeNull();
+		expect(result.result.after).not.toBeNull();
+	});
+
+	it.each(['parse-timeout', 'segment-limit', 'invalid-segment-text', 'error'] as const)(
+		'falls back to plain text for a %s side outcome',
+		async (reason) => {
+			const loaded = await loadCodeMirrorLanguageForFile('src/example.ts');
+			const deps: GitDiffSyntaxHighlightDependencies = {
+				loadLanguage: async () => loaded,
+				waitForWorkSlot: async () => {},
+				highlightSide: () => ({ status: 'plain', reason }),
+			};
+
+			await expect(
+				highlightGitDiffFile(input(), new AbortController().signal, deps),
+			).resolves.toEqual({ status: 'plain', reason });
+		},
+	);
+
+	it('does not load a language for an ineligible file', async () => {
+		const loadLanguage = vi.fn(loadCodeMirrorLanguageForFile);
+		const fileValue = file('generated.ts', { category: 'generated', isGenerated: true });
+		const bodyValue = body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint });
+
+		await expect(
+			highlightGitDiffFile(input(fileValue, bodyValue), new AbortController().signal, {
+				loadLanguage,
+				waitForWorkSlot: async () => {},
+				highlightSide: projectSide,
+			}),
+		).resolves.toEqual({ status: 'plain', reason: 'excluded' });
+		expect(loadLanguage).not.toHaveBeenCalled();
+	});
+
+	it('cancels after a deferred language load without parsing', async () => {
+		let resolveLanguage!: (value: LoadedCodeMirrorLanguage | null) => void;
+		const pendingLanguage = new Promise<LoadedCodeMirrorLanguage | null>((resolve) => {
+			resolveLanguage = resolve;
+		});
+		const abort = new AbortController();
+		const highlightSide = vi.fn(projectSide);
+		const attempt = highlightGitDiffFile(input(), abort.signal, {
+			loadLanguage: () => pendingLanguage,
+			waitForWorkSlot: async () => {},
+			highlightSide,
+		});
+
+		abort.abort();
+		resolveLanguage(await loadCodeMirrorLanguageForFile('src/example.ts'));
+
+		await expect(attempt).resolves.toEqual({ status: 'cancelled' });
+		expect(highlightSide).not.toHaveBeenCalled();
+	});
+
+	it('contains patch-index and parser exceptions as plain text outcomes', async () => {
+		const bodyValue = body();
+		const malformedBody: GitReviewFileBody = {
+			...bodyValue,
+			get patchIndex() {
+				throw new Error('malformed patch');
+			},
+		};
+
+		await expect(
+			highlightGitDiffFile(input(file(), malformedBody), new AbortController().signal, {
+				loadLanguage: loadCodeMirrorLanguageForFile,
+				waitForWorkSlot: async () => {},
+				highlightSide: projectSide,
+			}),
+		).resolves.toEqual({ status: 'plain', reason: 'error' });
+
+		await expect(
+			highlightGitDiffFile(input(), new AbortController().signal, {
+				loadLanguage: loadCodeMirrorLanguageForFile,
+				waitForWorkSlot: async () => {},
+				highlightSide: () => {
+					throw new Error('parser failed');
+				},
+			}),
+		).resolves.toEqual({ status: 'plain', reason: 'error' });
+	});
+});
+
+describe('Git diff syntax work slots', () => {
+	it('uses the timer fallback when requestIdleCallback is unavailable', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal('requestIdleCallback', undefined);
+		const pending = waitForGitDiffSyntaxWorkSlot(new AbortController().signal);
+		let finished = false;
+		void pending.then(() => {
+			finished = true;
+		});
+
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(finished).toBe(true);
+	});
+
+	it('resolves promptly when a pending work slot is aborted', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal('requestIdleCallback', undefined);
+		const abort = new AbortController();
+		const pending = waitForGitDiffSyntaxWorkSlot(abort.signal);
+
+		abort.abort();
+
+		await expect(pending).resolves.toBeUndefined();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});

--- a/web/src/lib/git/review/__tests__/git-diff-syntax.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-syntax.test.ts
@@ -157,7 +157,7 @@ describe('Git diff syntax reconstruction', () => {
 });
 
 describe('Git diff syntax eligibility', () => {
-	it.each([
+	it.each<[Partial<GitReviewFileSummary>, 'excluded']>([
 		[{ category: 'generated', isGenerated: true }, 'excluded'],
 		[{ category: 'lockfile' }, 'excluded'],
 		[{ category: 'binary', isBinary: true }, 'excluded'],
@@ -401,7 +401,7 @@ describe('Git diff syntax highlighting', () => {
 		const bodyValue = body();
 		const malformedBody: GitReviewFileBody = {
 			...bodyValue,
-			get patchIndex() {
+			get patchIndex(): never {
 				throw new Error('malformed patch');
 			},
 		};

--- a/web/src/lib/git/review/__tests__/git-diff-syntax.test.ts
+++ b/web/src/lib/git/review/__tests__/git-diff-syntax.test.ts
@@ -252,6 +252,31 @@ describe('Git diff syntax highlighting', () => {
 		).toBe(true);
 	});
 
+	it('keeps syntax offsets aligned with CRLF source lines', async () => {
+		const patch =
+			'@@ -1,3 +1,3 @@\n function example() {\r\n-\tconst oldValue = 1;\r\n+\tconst newValue = 2;\r\n }\r\n';
+		const side = buildGitDiffSyntheticSides(body('example.ts', patch)).sides.after;
+		const loaded = await loadCodeMirrorLanguageForFile('example.ts');
+		expect(side).not.toBeNull();
+		expect(loaded).not.toBeNull();
+		if (!side || !loaded) return;
+		loaded.language.parser.parse(side.text);
+
+		const result = highlightGitDiffSyntheticSide(side, 'example.ts', loaded);
+
+		expect(result.status).toBe('highlighted');
+		if (result.status !== 'highlighted') return;
+		expect(
+			result.result.lines.get(2)?.find((segment) => segment.className === 'cm-code-keyword')?.text,
+		).toBe('const');
+		expect(
+			result.result.lines
+				.get(2)
+				?.map((segment) => segment.text)
+				.join(''),
+		).toBe('\tconst newValue = 2;\r');
+	});
+
 	it('loads distinct before and after languages for a rename', async () => {
 		const fileValue = file('src/after.py', { originalPath: 'src/before.js' });
 		const bodyValue = body(fileValue.path, PATCH, { bodyFingerprint: fileValue.bodyFingerprint });
@@ -451,5 +476,19 @@ describe('Git diff syntax work slots', () => {
 
 		await expect(pending).resolves.toBeUndefined();
 		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('does not require cancelIdleCallback when idle scheduling is available', async () => {
+		let idleCallback!: IdleRequestCallback;
+		vi.stubGlobal('requestIdleCallback', (callback: IdleRequestCallback) => {
+			idleCallback = callback;
+			return 1;
+		});
+		vi.stubGlobal('cancelIdleCallback', undefined);
+		const pending = waitForGitDiffSyntaxWorkSlot(new AbortController().signal);
+
+		expect(() => idleCallback({ didTimeout: false, timeRemaining: () => 50 })).not.toThrow();
+
+		await expect(pending).resolves.toBeUndefined();
 	});
 });

--- a/web/src/lib/git/review/__tests__/git-review-performance.test.ts
+++ b/web/src/lib/git/review/__tests__/git-review-performance.test.ts
@@ -56,4 +56,18 @@ describe('Git review performance marks', () => {
 			performance.getEntriesByName('garcon.git-review.visible-body-ready', 'measure'),
 		).toHaveLength(1);
 	});
+
+	it.each([
+		'syntax-reconstruct',
+		'syntax-language-load',
+		'syntax-parse',
+		'syntax-project',
+	] as const)('records the %s phase without source metadata', (phase) => {
+		const span = startGitReviewPerformanceSpan(phase);
+
+		finishGitReviewPerformanceSpan(span);
+
+		expect(performance.getEntriesByName(`garcon.git-review.${phase}`, 'measure')).toHaveLength(1);
+		expect(performance.getEntriesByType('mark')).toHaveLength(0);
+	});
 });

--- a/web/src/lib/git/review/__tests__/git-virtual-review-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-virtual-review-document.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
 	GitReviewDocumentSummary,
 	GitReviewFileBody,
@@ -6,10 +6,18 @@ import type {
 } from '$lib/api/git.js';
 import { createGitPatchIndex } from '$lib/git/review/git-patch-index.js';
 import { buildGitVirtualReviewRowSource } from '$lib/git/review/git-virtual-review-row-source.js';
+import {
+	GitVirtualReviewDocumentController,
+	type GitVirtualReviewDocumentDeps,
+} from '$lib/git/review/git-virtual-review-document.svelte.js';
+import { GitDiffSyntaxController } from '$lib/git/review/git-diff-syntax-controller.svelte.js';
+import {
+	gitDiffSyntaxCacheKey,
+	type GitDiffSyntaxAttempt,
+	type GitDiffSyntaxFileInput,
+} from '$lib/git/review/git-diff-syntax.js';
 
-function buildVirtualRows(
-	options: Parameters<typeof buildGitVirtualReviewRowSource>[0],
-) {
+function buildVirtualRows(options: Parameters<typeof buildGitVirtualReviewRowSource>[0]) {
 	const source = buildGitVirtualReviewRowSource(options);
 	return source.rowsInRange(0, source.rowCount);
 }
@@ -93,6 +101,57 @@ function baseOptions(summary: GitReviewDocumentSummary) {
 			selectedLineKeys: new Set<string>(),
 		},
 	};
+}
+
+function highlightedAttempt(input: GitDiffSyntaxFileInput): GitDiffSyntaxAttempt {
+	return {
+		status: 'highlighted',
+		result: {
+			cacheKey: gitDiffSyntaxCacheKey(input.documentId, input.file, input.body),
+			filePath: input.file.path,
+			bodyFingerprint: input.body.bodyFingerprint,
+			before: null,
+			after: {
+				path: input.file.path,
+				languageKey: 'typescript',
+				lines: new Map([[0, [{ text: 'new line', className: 'cm-code-keyword' }]]]),
+				characterCount: 8,
+				segmentCount: 1,
+			},
+			characterCount: 8,
+			segmentCount: 1,
+		},
+	};
+}
+
+function documentDeps(visibleFilePaths: () => string[]): GitVirtualReviewDocumentDeps {
+	return {
+		targetKey: () => 'target',
+		targetProjectPath: () => null,
+		activeTab: () => 'unstaged',
+		visibleFilePaths,
+		selectedFile: () => null,
+		selectedLineKeys: () => new Set(),
+		composerState: () => ({
+			open: false,
+			focusPending: false,
+			filePath: '',
+			side: 'after',
+			line: 0,
+			body: '',
+			severity: 'note',
+		}),
+		surfaceError: vi.fn(),
+		markExternallyStale: vi.fn(),
+	};
+}
+
+function addedSyntaxSegments(controller: GitVirtualReviewDocumentController) {
+	return controller.rowSource
+		.rowsInRange(0, controller.rowSource.rowCount)
+		.flatMap((row) =>
+			row.kind === 'unified-row' && row.view.row.kind === 'add' ? [row.view.segments] : [],
+		)[0];
 }
 
 describe('buildVirtualRows', () => {
@@ -218,5 +277,62 @@ describe('buildVirtualRows', () => {
 			title: 'Diff limit reached',
 			message: 'Showing 1 of 2 changed files.',
 		});
+	});
+});
+
+describe('GitVirtualReviewDocumentController syntax', () => {
+	it('activates demanded retained bodies and follows workbench cache policy', async () => {
+		let visiblePaths = ['a.ts'];
+		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
+		const syntax = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter: async () => ({ highlightGitDiffFile: highlighter }),
+		});
+		const controller = new GitVirtualReviewDocumentController(
+			documentDeps(() => visiblePaths),
+			syntax,
+		);
+		const summary = makeSummary([makeFile('a.ts')]);
+		controller.fileBodies = { 'a.ts': makeBody('a.ts') };
+		controller.applySummary(summary);
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: summary.documentId,
+			filePaths: ['a.ts'],
+		});
+
+		await vi.waitFor(() => expect(highlighter).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(addedSyntaxSegments(controller)).toEqual([
+				{ text: 'new line', className: 'cm-code-keyword' },
+			]),
+		);
+
+		controller.clearForDisplayChange();
+		expect(controller.rowSource.rowCount).toBe(0);
+		controller.fileBodies = { 'a.ts': makeBody('a.ts') };
+		controller.applySummary(summary);
+		await vi.waitFor(() => expect(addedSyntaxSegments(controller)).toBeDefined());
+		expect(highlighter).toHaveBeenCalledOnce();
+
+		controller.refreshAllData();
+		controller.fileBodies = { 'a.ts': makeBody('a.ts') };
+		controller.applySummary(summary);
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: summary.documentId,
+			filePaths: ['a.ts'],
+		});
+		await vi.waitFor(() => expect(highlighter).toHaveBeenCalledTimes(2));
+
+		visiblePaths = [];
+		controller.pruneToFilePaths(new Set());
+		expect(controller.fileBodies).toEqual({});
+		expect(
+			controller.rowSource
+				.rowsInRange(0, controller.rowSource.rowCount)
+				.some((row) => row.kind === 'unified-row' || row.kind === 'split-row'),
+		).toBe(false);
 	});
 });

--- a/web/src/lib/git/review/__tests__/git-virtual-review-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-virtual-review-document.test.ts
@@ -303,6 +303,40 @@ describe('GitVirtualReviewDocumentController syntax', () => {
 		expect(syntax.results['b.ts']).toBeUndefined();
 	});
 
+	it('does not retain viewport paths as navigation syntax demand', async () => {
+		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
+		const syntax = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter: async () => ({ highlightGitDiffFile: highlighter }),
+		});
+		const deps = documentDeps(() => ['a.ts', 'b.ts']);
+		deps.targetProjectPath = () => '/project';
+		const controller = new GitVirtualReviewDocumentController(deps, syntax);
+		const summary = makeSummary([makeFile('a.ts'), makeFile('b.ts')]);
+		const bodies = { 'a.ts': makeBody('a.ts'), 'b.ts': makeBody('b.ts') };
+		controller.fileBodies = bodies;
+		controller.applySummary(summary);
+
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: summary.documentId,
+			filePaths: ['a.ts'],
+		});
+		await vi.waitFor(() => expect(syntax.results['a.ts']).toBeDefined());
+
+		syntax.replaceBodies({ 'b.ts': bodies['b.ts'] });
+		controller.handleBodyDemand({
+			kind: 'viewport',
+			documentId: summary.documentId,
+			filePaths: ['b.ts'],
+		});
+		await vi.waitFor(() => expect(syntax.results['b.ts']).toBeDefined());
+
+		syntax.replaceBodies(bodies);
+
+		expect(syntax.results['a.ts']).toBeUndefined();
+	});
+
 	it('activates demanded retained bodies and follows workbench cache policy', async () => {
 		let visiblePaths = ['a.ts'];
 		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));

--- a/web/src/lib/git/review/__tests__/git-virtual-review-document.test.ts
+++ b/web/src/lib/git/review/__tests__/git-virtual-review-document.test.ts
@@ -281,6 +281,28 @@ describe('buildVirtualRows', () => {
 });
 
 describe('GitVirtualReviewDocumentController syntax', () => {
+	it('highlights the initial visible body without highlighting prefetched bodies', async () => {
+		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));
+		const syntax = new GitDiffSyntaxController({
+			waitForWorkSlot: async () => {},
+			loadHighlighter: async () => ({ highlightGitDiffFile: highlighter }),
+		});
+		const controller = new GitVirtualReviewDocumentController(
+			documentDeps(() => ['a.ts', 'b.ts']),
+			syntax,
+		);
+		const summary = makeSummary([makeFile('a.ts'), makeFile('b.ts')]);
+		controller.fileBodies = { 'a.ts': makeBody('a.ts'), 'b.ts': makeBody('b.ts') };
+		controller.applySummary(summary);
+
+		controller.requestInitialBodies('/project', ['a.ts', 'b.ts']);
+
+		await vi.waitFor(() => expect(highlighter).toHaveBeenCalledOnce());
+		expect(highlighter.mock.calls[0]?.[0].file.path).toBe('a.ts');
+		expect(syntax.results['a.ts']).toBeDefined();
+		expect(syntax.results['b.ts']).toBeUndefined();
+	});
+
 	it('activates demanded retained bodies and follows workbench cache policy', async () => {
 		let visiblePaths = ['a.ts'];
 		const highlighter = vi.fn(async (input: GitDiffSyntaxFileInput) => highlightedAttempt(input));

--- a/web/src/lib/git/review/__tests__/git-virtual-review-row-source.test.ts
+++ b/web/src/lib/git/review/__tests__/git-virtual-review-row-source.test.ts
@@ -6,6 +6,7 @@ import {
 	buildGitVirtualReviewRowSource,
 	type GitVirtualReviewRowSource,
 } from '$lib/git/review/git-virtual-review-row-source.js';
+import type { GitDiffFileSyntaxResult } from '$lib/git/review/git-diff-syntax.js';
 
 function summary(path: string, renderedRows: number): GitReviewFileSummary {
 	return {
@@ -282,5 +283,97 @@ describe('Git virtual review row source', () => {
 		expect(buildGitVirtualReviewRowSource(composerOpen).measurementRevision).not.toBe(
 			buildGitVirtualReviewRowSource(composerClosed).measurementRevision,
 		);
+	});
+
+	it('joins syntax by file and diff line without changing virtualization identity', () => {
+		const file = {
+			...summary('src/new.py', 4),
+			originalPath: 'src/old.ts',
+		};
+		const patch = `diff --git a/src/old.ts b/src/new.py
+@@ -1,2 +1,2 @@
+-const oldValue = 1;
++new_value = 2
+ shared
+`;
+		const patchIndex = createGitPatchIndex(patch);
+		const body: GitReviewFileBody = {
+			path: file.path,
+			bodyFingerprint: file.bodyFingerprint,
+			bodyState: 'loaded',
+			category: 'normal',
+			isBinary: false,
+			isTooLarge: false,
+			renderedRowCount: patchIndex.rowCount,
+			patchBytes: patch.length,
+			patch,
+			patchIndex,
+		};
+		const syntax: GitDiffFileSyntaxResult = {
+			cacheKey: 'syntax',
+			filePath: file.path,
+			bodyFingerprint: body.bodyFingerprint,
+			before: {
+				path: 'src/old.ts',
+				languageKey: 'typescript',
+				lines: new Map([
+					[0, [{ text: 'const oldValue = 1;', className: 'cm-code-keyword' }]],
+					[2, [{ text: 'shared', className: 'cm-code-name' }]],
+				]),
+				characterCount: 25,
+				segmentCount: 2,
+			},
+			after: {
+				path: 'src/new.py',
+				languageKey: 'python',
+				lines: new Map([
+					[1, [{ text: 'new_value = 2', className: 'cm-code-name' }]],
+					[2, [{ text: 'shared', className: 'cm-code-title' }]],
+				]),
+				characterCount: 20,
+				segmentCount: 2,
+			},
+			characterCount: 45,
+			segmentCount: 4,
+		};
+		const baseOptions = options([file], { [file.path]: body });
+		const plain = buildGitVirtualReviewRowSource(baseOptions);
+		const highlighted = buildGitVirtualReviewRowSource({
+			...baseOptions,
+			syntaxResults: { [file.path]: syntax },
+		});
+
+		expect(highlighted.rowCount).toBe(plain.rowCount);
+		expect(highlighted.measurementRevision).toBe(plain.measurementRevision);
+		for (let index = 0; index < plain.rowCount; index += 1) {
+			expect(highlighted.rowKey(index)).toBe(plain.rowKey(index));
+			expect(highlighted.estimateRowHeight(index, 20)).toBe(plain.estimateRowHeight(index, 20));
+			expect(highlighted.rowAt(index)?.id).toBe(plain.rowAt(index)?.id);
+		}
+		expect(highlighted.rowAt(2)).toMatchObject({
+			kind: 'unified-row',
+			view: { segments: [{ text: 'const oldValue = 1;', className: 'cm-code-keyword' }] },
+		});
+		expect(highlighted.rowAt(3)).toMatchObject({
+			kind: 'unified-row',
+			view: { segments: [{ text: 'new_value = 2', className: 'cm-code-name' }] },
+		});
+		expect(highlighted.rowAt(4)).toMatchObject({
+			kind: 'unified-row',
+			view: { segments: [{ text: 'shared', className: 'cm-code-title' }] },
+		});
+
+		const split = buildGitVirtualReviewRowSource({
+			...baseOptions,
+			diffMode: 'split',
+			syntaxResults: { [file.path]: syntax },
+		});
+		expect(split.rowAt(2)).toMatchObject({
+			kind: 'split-row',
+			view: {
+				left: { segments: [{ className: 'cm-code-keyword' }] },
+				right: { segments: [{ className: 'cm-code-name' }] },
+			},
+		});
 	});
 });

--- a/web/src/lib/git/review/git-diff-document.svelte.ts
+++ b/web/src/lib/git/review/git-diff-document.svelte.ts
@@ -401,6 +401,13 @@ export class GitDiffDocumentController {
 		if (this.aggregateLimit) return 'limited';
 		if (purpose === 'prefetch' && this.prefetchStopped) return 'already-satisfied';
 		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
+		if (purpose === 'visible' && uniquePaths.length > 0) {
+			this.syntax.handleDemand({
+				kind: 'navigation',
+				documentId: snapshot.documentId,
+				filePaths: uniquePaths,
+			});
+		}
 		this.seedCachedBodies(uniquePaths, purpose);
 		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath));

--- a/web/src/lib/git/review/git-diff-document.svelte.ts
+++ b/web/src/lib/git/review/git-diff-document.svelte.ts
@@ -251,7 +251,7 @@ export class GitDiffDocumentController {
 		});
 		this.demandReconciler.markReadinessChanged();
 		const [priority, ...prefetch] = snapshot.firstBodyCandidates;
-		if (priority) this.requestBodies([priority], 'visible');
+		if (priority) this.requestNavigationBodies([priority]);
 		this.requestBodies(prefetch, 'prefetch');
 	}
 
@@ -263,7 +263,7 @@ export class GitDiffDocumentController {
 	focusFile(filePath: string): void {
 		this.focusedFilePath = filePath;
 		this.discardErrorBody(filePath);
-		this.requestBodies([filePath], 'visible');
+		this.requestNavigationBodies([filePath]);
 		this.scrollToken += 1;
 		this.scrollRequest = { filePath, token: this.scrollToken };
 	}
@@ -392,6 +392,18 @@ export class GitDiffDocumentController {
 		});
 	}
 
+	private requestNavigationBodies(filePaths: readonly string[]): GitReviewDemandOutcome {
+		const snapshot = this.snapshot;
+		if (snapshot) {
+			this.syntax.handleDemand({
+				kind: 'navigation',
+				documentId: snapshot.documentId,
+				filePaths,
+			});
+		}
+		return this.requestBodies(filePaths, 'visible');
+	}
+
 	private requestBodies(
 		filePaths: readonly string[],
 		purpose: GitReviewBodyPurpose,
@@ -401,13 +413,6 @@ export class GitDiffDocumentController {
 		if (this.aggregateLimit) return 'limited';
 		if (purpose === 'prefetch' && this.prefetchStopped) return 'already-satisfied';
 		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
-		if (purpose === 'visible' && uniquePaths.length > 0) {
-			this.syntax.handleDemand({
-				kind: 'navigation',
-				documentId: snapshot.documentId,
-				filePaths: uniquePaths,
-			});
-		}
 		this.seedCachedBodies(uniquePaths, purpose);
 		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath));

--- a/web/src/lib/git/review/git-diff-document.svelte.ts
+++ b/web/src/lib/git/review/git-diff-document.svelte.ts
@@ -41,6 +41,7 @@ import {
 	type GitReviewDemandOutcome,
 } from './git-review-body-demand.js';
 import { GitReviewDemandReconciler } from './git-review-demand-reconciler.js';
+import { GitDiffSyntaxController } from './git-diff-syntax-controller.svelte.js';
 import {
 	assertGitReviewLoadingOwnership,
 	traceGitReviewDemand,
@@ -110,7 +111,7 @@ export class GitDiffDocumentController {
 	private onExpired: ((message: string) => void) | null = null;
 	private commentSource: GitReviewCommentSource | null = null;
 
-	constructor() {
+	constructor(private readonly syntax = new GitDiffSyntaxController()) {
 		this.demandReconciler = new GitReviewDemandReconciler({
 			currentDocumentId: () => this.snapshot?.documentId ?? null,
 			requestViewportPaths: (filePaths) => this.requestBodies(filePaths, 'visible'),
@@ -189,6 +190,7 @@ export class GitDiffDocumentController {
 			summary,
 			visibleFilePaths: summary.files.map((file) => file.path),
 			fileBodies: this.fileBodies,
+			syntaxResults: this.syntax.results,
 			loadingBodies: this.loadingBodies,
 			focusedFilePath: this.focusedFilePath,
 			diffMode: this.diffMode,
@@ -211,6 +213,8 @@ export class GitDiffDocumentController {
 		this.diffMode = options.diffMode;
 		this.contextLines = options.contextLines;
 		this.fileBodies = {};
+		this.syntax.open({ documentId: snapshot.documentId, files: snapshot.files }, {});
+		this.replayViewportSyntaxDemand(snapshot.documentId);
 		this.prefetchStopped = false;
 		this.loadingBodies = new Set();
 		this.scrollRequest = null;
@@ -265,6 +269,7 @@ export class GitDiffDocumentController {
 	}
 
 	handleBodyDemand(demand: GitReviewBodyDemand): void {
+		this.syntax.handleDemand(demand);
 		this.demandReconciler.handle(demand);
 	}
 
@@ -352,6 +357,7 @@ export class GitDiffDocumentController {
 		this.snapshot = null;
 		this.summariesByPath.clear();
 		this.fileBodies = {};
+		this.syntax.close(options);
 		this.prefetchStopped = false;
 		this.loadingBodies = new Set();
 		this.scrollRequest = null;
@@ -369,6 +375,21 @@ export class GitDiffDocumentController {
 		this.commentSource = null;
 		if (!options.preserveCache) this.clearBodyCache();
 		this.demandReconciler.clear();
+	}
+
+	private replaceFileBodies(next: Record<string, GitReviewFileBody>): void {
+		this.fileBodies = next;
+		this.syntax.replaceBodies(next);
+	}
+
+	private replayViewportSyntaxDemand(documentId: string): void {
+		const demand = this.demandReconciler.snapshot();
+		if (demand.documentId !== documentId) return;
+		this.syntax.handleDemand({
+			kind: 'viewport',
+			documentId,
+			filePaths: demand.filePaths,
+		});
 	}
 
 	private requestBodies(
@@ -468,7 +489,7 @@ export class GitDiffDocumentController {
 				this.cacheBody(file, body, snapshot.limits.maxLoadedPatchBytes);
 			}
 		}
-		this.fileBodies = next;
+		this.replaceFileBodies(next);
 	}
 
 	private collectionLimitBody(
@@ -538,8 +559,10 @@ export class GitDiffDocumentController {
 
 	private discardErrorBody(filePath: string): void {
 		if (this.fileBodies[filePath]?.bodyState !== 'error') return;
-		this.fileBodies = Object.fromEntries(
-			Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
+		this.replaceFileBodies(
+			Object.fromEntries(
+				Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
+			),
 		);
 	}
 
@@ -586,7 +609,7 @@ export class GitDiffDocumentController {
 				changed = true;
 			}
 		}
-		if (changed) this.fileBodies = next;
+		if (changed) this.replaceFileBodies(next);
 	}
 
 	private pinnedBodyPaths(documentId: string | null): Set<string> {

--- a/web/src/lib/git/review/git-diff-rows.ts
+++ b/web/src/lib/git/review/git-diff-rows.ts
@@ -1,5 +1,7 @@
 import type { GitDiffTab } from '$lib/api/git.js';
+import type { CodeHighlightSegment } from '$lib/highlighting/code-highlight-types.js';
 import type { GitRenderedDiffRow } from './git-rendered-diff-types.js';
+import type { GitDiffFileSyntaxResult } from './git-diff-syntax.js';
 import type { GitDiffSeverity, GitDiffSide } from '$lib/git/review/git-inline-comment.svelte.js';
 import { makeLineSelectionKey } from '$lib/git/review/git-line-selection.svelte.js';
 
@@ -68,6 +70,7 @@ export interface UnifiedDiffRowView {
 	textClass: string;
 	textPrefix: string;
 	text: string;
+	segments?: readonly CodeHighlightSegment[];
 	showComposer: boolean;
 	beforeContextTarget: GitDiffLineContextTarget | null;
 	afterContextTarget: GitDiffLineContextTarget | null;
@@ -83,6 +86,7 @@ export interface SplitDiffCellView {
 	lineNumClass: string;
 	textClass: string;
 	textPrefix: string;
+	segments?: readonly CodeHighlightSegment[];
 	contextTarget: GitDiffLineContextTarget | null;
 }
 
@@ -102,6 +106,7 @@ interface BuildUnifiedRowViewsOptions {
 	readOnly: boolean;
 	selectedLineKeys: Set<string>;
 	composerTarget: GitDiffComposerTarget | null;
+	syntaxResult?: GitDiffFileSyntaxResult;
 }
 
 interface BuildSplitRowViewsOptions {
@@ -111,6 +116,7 @@ interface BuildSplitRowViewsOptions {
 	readOnly: boolean;
 	selectedLineKeys: Set<string>;
 	composerTarget: GitDiffComposerTarget | null;
+	syntaxResult?: GitDiffFileSyntaxResult;
 }
 
 export function renderUnifiedDiffRow(row: GitRenderedDiffRow): RenderedDiffRow {
@@ -248,27 +254,29 @@ export function buildUnifiedDiffRowView(
 	options: Omit<BuildUnifiedRowViewsOptions, 'rows'>,
 	row: RenderedDiffRow,
 ): UnifiedDiffRowView {
-		const selectionKey = getUnifiedSelectionKey(row, options.filePath, options.activeTab);
-		const isSelectable = !options.readOnly && selectionKey !== null;
-		const isSelected = isSelectable && options.selectedLineKeys.has(selectionKey);
-		const showComposer = isComposerForUnifiedRow(row, options.composerTarget);
+	const selectionKey = getUnifiedSelectionKey(row, options.filePath, options.activeTab);
+	const isSelectable = !options.readOnly && selectionKey !== null;
+	const isSelected = isSelectable && options.selectedLineKeys.has(selectionKey);
+	const showComposer = isComposerForUnifiedRow(row, options.composerTarget);
+	const segments = unifiedSyntaxSegments(row, options.syntaxResult);
 
-		return {
-			key: row.key,
-			row,
-			isHunkHeader: row.kind === 'hunk-header',
-			isSelectable,
-			selectionKey,
-			bgClass: rowBgClass(row.kind, isSelected, showComposer),
-			lineNumClass: lineNumClass(row.kind),
-			textClass: unifiedTextClass(row.kind),
-			textPrefix: unifiedTextPrefix(row.kind),
-			text: unifiedText(row),
-			showComposer,
-			beforeContextTarget: getUnifiedContextTarget(row, 'before'),
-			afterContextTarget: getUnifiedContextTarget(row, 'after'),
-			rowContextTarget: getUnifiedContextTarget(row, row.kind === 'del' ? 'before' : 'after'),
-		};
+	return {
+		key: row.key,
+		row,
+		isHunkHeader: row.kind === 'hunk-header',
+		isSelectable,
+		selectionKey,
+		bgClass: rowBgClass(row.kind, isSelected, showComposer),
+		lineNumClass: lineNumClass(row.kind),
+		textClass: unifiedTextClass(row.kind),
+		textPrefix: unifiedTextPrefix(row.kind),
+		text: unifiedText(row),
+		...(segments ? { segments } : {}),
+		showComposer,
+		beforeContextTarget: getUnifiedContextTarget(row, 'before'),
+		afterContextTarget: getUnifiedContextTarget(row, 'after'),
+		rowContextTarget: getUnifiedContextTarget(row, row.kind === 'del' ? 'before' : 'after'),
+	};
 }
 
 export function buildSplitDiffRowViews(options: BuildSplitRowViewsOptions): SplitDiffRowView[] {
@@ -300,6 +308,7 @@ function buildSplitCellView(
 	const isSelected = isSelectable && options.selectedLineKeys.has(selectionKey);
 	const isComposerTarget =
 		cell.line !== null && isComposerForCell(side, cell.line, options.composerTarget);
+	const segments = splitSyntaxSegments(cell, side, options.syntaxResult);
 
 	return {
 		side,
@@ -310,8 +319,27 @@ function buildSplitCellView(
 		lineNumClass: splitLineNumClass(cell.kind),
 		textClass: splitTextClass(cell.kind),
 		textPrefix: splitTextPrefix(cell.kind),
+		...(segments ? { segments } : {}),
 		contextTarget: getSplitContextTarget(cell, side, hunkIndex),
 	};
+}
+
+function unifiedSyntaxSegments(
+	row: RenderedDiffRow,
+	result: GitDiffFileSyntaxResult | undefined,
+): readonly CodeHighlightSegment[] | undefined {
+	if (row.kind === 'hunk-header') return undefined;
+	const side = row.kind === 'del' ? result?.before : result?.after;
+	return side?.lines.get(row.diffLineIndex);
+}
+
+function splitSyntaxSegments(
+	cell: SplitDiffCell,
+	side: GitDiffSide,
+	result: GitDiffFileSyntaxResult | undefined,
+): readonly CodeHighlightSegment[] | undefined {
+	if (cell.kind === 'empty') return undefined;
+	return (side === 'before' ? result?.before : result?.after)?.lines.get(cell.diffLineIndex);
 }
 
 function getUnifiedSelectionKey(

--- a/web/src/lib/git/review/git-diff-syntax-controller.svelte.ts
+++ b/web/src/lib/git/review/git-diff-syntax-controller.svelte.ts
@@ -349,6 +349,7 @@ export class GitDiffSyntaxController {
 
 	private publish(filePath: string, result: GitDiffFileSyntaxResult): void {
 		if (!this.cache.has(result.cacheKey)) return;
+		if (this.results[filePath]?.cacheKey === result.cacheKey) return;
 		this.results = { ...this.results, [filePath]: result };
 	}
 

--- a/web/src/lib/git/review/git-diff-syntax-controller.svelte.ts
+++ b/web/src/lib/git/review/git-diff-syntax-controller.svelte.ts
@@ -1,0 +1,409 @@
+import type { GitReviewFileBody } from '$lib/api/git.js';
+import {
+	normalizeGitReviewDemandFilePaths,
+	type GitReviewBodyDemand,
+} from './git-review-body-demand.js';
+import {
+	gitDiffSyntaxCacheKey,
+	gitDiffSyntaxSkipReason,
+	waitForGitDiffSyntaxWorkSlot,
+	type GitDiffFileSyntaxResult,
+	type GitDiffSyntaxAttempt,
+	type GitDiffSyntaxDocument,
+	type GitDiffSyntaxFile,
+	type GitDiffSyntaxFileInput,
+	type GitDiffSyntaxResults,
+} from './git-diff-syntax.js';
+
+interface SyntaxJob {
+	generation: number;
+	filePath: string;
+	cacheKey: string;
+}
+
+interface SyntaxCandidate {
+	input: GitDiffSyntaxFileInput;
+	cacheKey: string;
+}
+
+interface SyntaxCacheEntry {
+	filePath: string;
+	cacheKey: string;
+	attempt: Exclude<GitDiffSyntaxAttempt, { status: 'cancelled' }>;
+	characterCount: number;
+	segmentCount: number;
+}
+
+export interface GitDiffSyntaxHighlighterPort {
+	highlightGitDiffFile: (
+		input: GitDiffSyntaxFileInput,
+		signal: AbortSignal,
+	) => Promise<GitDiffSyntaxAttempt>;
+}
+
+export interface GitDiffSyntaxControllerDependencies {
+	waitForWorkSlot: (signal: AbortSignal) => Promise<void>;
+	loadHighlighter: () => Promise<GitDiffSyntaxHighlighterPort>;
+}
+
+export interface GitDiffSyntaxCacheLimits {
+	files: number;
+	characters: number;
+	segments: number;
+}
+
+const DEFAULT_CACHE_LIMITS: GitDiffSyntaxCacheLimits = Object.freeze({
+	files: 64,
+	characters: 2_000_000,
+	segments: 100_000,
+});
+
+type GitDiffSyntaxHighlighterModule = typeof import('./git-diff-syntax-highlighter.js');
+
+let highlighterModulePromise: Promise<GitDiffSyntaxHighlighterModule> | null = null;
+
+function loadGitDiffSyntaxHighlighter(): Promise<GitDiffSyntaxHighlighterModule> {
+	highlighterModulePromise ??= import('./git-diff-syntax-highlighter.js').catch((error) => {
+		highlighterModulePromise = null;
+		throw error;
+	});
+	return highlighterModulePromise;
+}
+
+const DEFAULT_DEPENDENCIES = {
+	waitForWorkSlot: waitForGitDiffSyntaxWorkSlot,
+	loadHighlighter: loadGitDiffSyntaxHighlighter,
+} satisfies GitDiffSyntaxControllerDependencies;
+
+export class GitDiffSyntaxController {
+	results = $state.raw<GitDiffSyntaxResults>({});
+
+	private currentDocument: GitDiffSyntaxDocument | null = null;
+	private filesByPath = new Map<string, GitDiffSyntaxFile>();
+	private bodies: Record<string, GitReviewFileBody> = {};
+	private viewportPaths = new Set<string>();
+	private navigationPaths = new Set<string>();
+	private queue: SyntaxJob[] = [];
+	private queuedKeys = new Set<string>();
+	private activeJob: SyntaxJob | null = null;
+	private activeAbort: AbortController | null = null;
+	private generation = 0;
+	private draining = false;
+	private cache = new Map<string, SyntaxCacheEntry>();
+	private cachedCharacters = 0;
+	private cachedSegments = 0;
+
+	constructor(
+		private readonly deps: GitDiffSyntaxControllerDependencies = DEFAULT_DEPENDENCIES,
+		private readonly cacheLimits: GitDiffSyntaxCacheLimits = DEFAULT_CACHE_LIMITS,
+	) {}
+
+	open(currentDocument: GitDiffSyntaxDocument, bodies: Record<string, GitReviewFileBody>): void {
+		this.cancelQueuedWork();
+		this.generation += 1;
+		this.currentDocument = currentDocument;
+		this.filesByPath = new Map(currentDocument.files.map((file) => [file.path, file]));
+		this.viewportPaths = new Set();
+		this.navigationPaths = new Set();
+		this.results = {};
+		this.replaceBodies(bodies);
+	}
+
+	handleDemand(demand: GitReviewBodyDemand): void {
+		if (demand.documentId !== this.currentDocument?.documentId) return;
+		const paths = normalizeGitReviewDemandFilePaths(demand.filePaths);
+		if (demand.kind === 'viewport') {
+			this.viewportPaths = new Set(paths);
+		} else {
+			for (const path of paths) this.navigationPaths.add(path);
+		}
+		this.reconcileDemand();
+	}
+
+	replaceBodies(bodies: Record<string, GitReviewFileBody>): void {
+		this.bodies = bodies;
+		if (this.activeJob && !this.isCurrent(this.activeJob)) this.activeAbort?.abort();
+		this.pruneActiveResultsToBodies();
+		this.reconcileDemand();
+	}
+
+	invalidateFile(filePath: string): void {
+		if (this.activeJob?.filePath === filePath) this.activeAbort?.abort();
+		this.removeActiveResult(filePath);
+		this.removeCachedPath(filePath);
+		this.reconcileDemand();
+	}
+
+	pruneToFilePaths(filePaths: ReadonlySet<string>): void {
+		this.viewportPaths = intersect(this.viewportPaths, filePaths);
+		this.navigationPaths = intersect(this.navigationPaths, filePaths);
+		this.filesByPath = new Map(
+			Array.from(this.filesByPath).filter(([filePath]) => filePaths.has(filePath)),
+		);
+		if (this.currentDocument) {
+			this.currentDocument = {
+				...this.currentDocument,
+				files: this.currentDocument.files.filter((file) => filePaths.has(file.path)),
+			};
+		}
+		this.pruneActiveResultsToPaths(filePaths);
+		this.pruneCacheToPaths(filePaths);
+		this.reconcileDemand();
+	}
+
+	close(options: { preserveCache?: boolean } = {}): void {
+		this.cancelQueuedWork();
+		this.generation += 1;
+		this.currentDocument = null;
+		this.filesByPath.clear();
+		this.bodies = {};
+		this.viewportPaths.clear();
+		this.navigationPaths.clear();
+		this.results = {};
+		if (!options.preserveCache) this.clearCache();
+	}
+
+	reset(): void {
+		this.close({ preserveCache: false });
+	}
+
+	private reconcileDemand(): void {
+		this.queue = [];
+		this.queuedKeys.clear();
+		for (const filePath of this.navigationPaths) this.enqueue(filePath);
+		for (const filePath of this.viewportPaths) this.enqueue(filePath);
+		if (this.queue.length > 0) void this.drainQueue();
+	}
+
+	private enqueue(filePath: string): void {
+		const candidate = this.currentCandidate(filePath);
+		if (!candidate) return;
+		if (this.activeJob?.cacheKey === candidate.cacheKey) return;
+		if (this.queuedKeys.has(candidate.cacheKey)) return;
+
+		const cached = this.cacheGet(candidate.cacheKey);
+		if (cached) {
+			if (cached.attempt.status === 'highlighted') {
+				this.publish(filePath, cached.attempt.result);
+			}
+			this.navigationPaths.delete(filePath);
+			return;
+		}
+
+		this.queue.push({
+			generation: this.generation,
+			filePath,
+			cacheKey: candidate.cacheKey,
+		});
+		this.queuedKeys.add(candidate.cacheKey);
+	}
+
+	private isCurrent(job: SyntaxJob): boolean {
+		if (job.generation !== this.generation) return false;
+		return this.currentCandidate(job.filePath)?.cacheKey === job.cacheKey;
+	}
+
+	private currentCandidate(filePath: string): SyntaxCandidate | null {
+		const currentDocument = this.currentDocument;
+		const file = this.filesByPath.get(filePath);
+		const body = this.bodies[filePath];
+		if (
+			!currentDocument ||
+			!file ||
+			!body ||
+			body.bodyState !== 'loaded' ||
+			body.patch === null ||
+			body.bodyFingerprint !== file.bodyFingerprint
+		) {
+			return null;
+		}
+		return {
+			input: { documentId: currentDocument.documentId, file, body },
+			cacheKey: gitDiffSyntaxCacheKey(currentDocument.documentId, file, body),
+		};
+	}
+
+	private async drainQueue(): Promise<void> {
+		if (this.draining) return;
+		this.draining = true;
+		try {
+			while (this.queue.length > 0) {
+				const job = this.queue.shift()!;
+				this.queuedKeys.delete(job.cacheKey);
+				if (!this.isCurrent(job) || !this.isDemanded(job.filePath)) continue;
+
+				const abort = new AbortController();
+				this.activeJob = job;
+				this.activeAbort = abort;
+				let attempt: GitDiffSyntaxAttempt;
+				try {
+					attempt = await this.highlightJob(job, abort.signal);
+				} catch {
+					attempt = { status: 'plain', reason: 'error' };
+				} finally {
+					this.activeJob = null;
+					this.activeAbort = null;
+				}
+				if (attempt.status === 'cancelled' || !this.isCurrent(job)) continue;
+
+				const retained = this.cacheAttempt(job, attempt);
+				if (retained?.attempt.status === 'highlighted') {
+					this.publish(job.filePath, retained.attempt.result);
+				}
+				this.navigationPaths.delete(job.filePath);
+			}
+		} finally {
+			this.draining = false;
+			if (this.queue.length > 0) void this.drainQueue();
+		}
+	}
+
+	private async highlightJob(job: SyntaxJob, signal: AbortSignal): Promise<GitDiffSyntaxAttempt> {
+		const candidate = this.currentCandidate(job.filePath);
+		if (!candidate || candidate.cacheKey !== job.cacheKey) return { status: 'cancelled' };
+		const skipReason = gitDiffSyntaxSkipReason(candidate.input);
+		if (skipReason) return { status: 'plain', reason: skipReason };
+		await this.deps.waitForWorkSlot(signal);
+		if (signal.aborted || !this.isCurrent(job)) return { status: 'cancelled' };
+		const highlighter = await this.deps.loadHighlighter();
+		if (signal.aborted || !this.isCurrent(job)) return { status: 'cancelled' };
+		return highlighter.highlightGitDiffFile(candidate.input, signal);
+	}
+
+	private cacheAttempt(
+		job: SyntaxJob,
+		attempt: Exclude<GitDiffSyntaxAttempt, { status: 'cancelled' }>,
+	): SyntaxCacheEntry | null {
+		let normalizedAttempt = attempt;
+		if (attempt.status === 'highlighted') {
+			const current = this.currentCandidate(job.filePath);
+			if (
+				attempt.result.cacheKey !== job.cacheKey ||
+				attempt.result.filePath !== job.filePath ||
+				attempt.result.bodyFingerprint !== current?.input.body.bodyFingerprint
+			) {
+				normalizedAttempt = { status: 'plain', reason: 'error' };
+			}
+		}
+
+		this.removeCacheKey(job.cacheKey);
+		const entry: SyntaxCacheEntry = {
+			filePath: job.filePath,
+			cacheKey: job.cacheKey,
+			attempt: normalizedAttempt,
+			characterCount:
+				normalizedAttempt.status === 'highlighted' ? normalizedAttempt.result.characterCount : 0,
+			segmentCount:
+				normalizedAttempt.status === 'highlighted' ? normalizedAttempt.result.segmentCount : 0,
+		};
+		this.cache.set(job.cacheKey, entry);
+		this.cachedCharacters += entry.characterCount;
+		this.cachedSegments += entry.segmentCount;
+		this.trimCache();
+		return this.cache.get(job.cacheKey) ?? null;
+	}
+
+	private cacheGet(cacheKey: string): SyntaxCacheEntry | null {
+		const entry = this.cache.get(cacheKey);
+		if (!entry) return null;
+		this.cache.delete(cacheKey);
+		this.cache.set(cacheKey, entry);
+		return entry;
+	}
+
+	private trimCache(): void {
+		while (
+			this.cache.size > this.cacheLimits.files ||
+			this.cachedCharacters > this.cacheLimits.characters ||
+			this.cachedSegments > this.cacheLimits.segments
+		) {
+			let evictionKey: string | undefined;
+			for (const [cacheKey, entry] of this.cache) {
+				if (!this.isDemanded(entry.filePath)) {
+					evictionKey = cacheKey;
+					break;
+				}
+			}
+			evictionKey ??= this.cache.keys().next().value;
+			if (evictionKey === undefined) break;
+			this.removeCacheKey(evictionKey);
+		}
+	}
+
+	private removeCacheKey(cacheKey: string): void {
+		const entry = this.cache.get(cacheKey);
+		if (!entry) return;
+		this.cache.delete(cacheKey);
+		this.cachedCharacters -= entry.characterCount;
+		this.cachedSegments -= entry.segmentCount;
+		if (this.results[entry.filePath]?.cacheKey === cacheKey) {
+			this.removeActiveResult(entry.filePath);
+		}
+	}
+
+	private removeCachedPath(filePath: string): void {
+		for (const [cacheKey, entry] of Array.from(this.cache)) {
+			if (entry.filePath === filePath) this.removeCacheKey(cacheKey);
+		}
+	}
+
+	private publish(filePath: string, result: GitDiffFileSyntaxResult): void {
+		if (!this.cache.has(result.cacheKey)) return;
+		this.results = { ...this.results, [filePath]: result };
+	}
+
+	private removeActiveResult(filePath: string): void {
+		if (!this.results[filePath]) return;
+		const next = { ...this.results };
+		delete next[filePath];
+		this.results = next;
+	}
+
+	private pruneActiveResultsToBodies(): void {
+		const next = { ...this.results };
+		let changed = false;
+		for (const [filePath, result] of Object.entries(next)) {
+			if (this.currentCandidate(filePath)?.cacheKey === result.cacheKey) continue;
+			delete next[filePath];
+			changed = true;
+		}
+		if (changed) this.results = next;
+	}
+
+	private pruneActiveResultsToPaths(filePaths: ReadonlySet<string>): void {
+		const next = { ...this.results };
+		let changed = false;
+		for (const filePath of Object.keys(next)) {
+			if (filePaths.has(filePath)) continue;
+			delete next[filePath];
+			changed = true;
+		}
+		if (changed) this.results = next;
+	}
+
+	private pruneCacheToPaths(filePaths: ReadonlySet<string>): void {
+		for (const [cacheKey, entry] of Array.from(this.cache)) {
+			if (!filePaths.has(entry.filePath)) this.removeCacheKey(cacheKey);
+		}
+	}
+
+	private clearCache(): void {
+		this.cache.clear();
+		this.cachedCharacters = 0;
+		this.cachedSegments = 0;
+	}
+
+	private cancelQueuedWork(): void {
+		this.activeAbort?.abort();
+		this.queue = [];
+		this.queuedKeys.clear();
+	}
+
+	private isDemanded(filePath: string): boolean {
+		return this.navigationPaths.has(filePath) || this.viewportPaths.has(filePath);
+	}
+}
+
+function intersect(values: ReadonlySet<string>, allowed: ReadonlySet<string>): Set<string> {
+	return new Set(Array.from(values).filter((value) => allowed.has(value)));
+}

--- a/web/src/lib/git/review/git-diff-syntax-highlighter.ts
+++ b/web/src/lib/git/review/git-diff-syntax-highlighter.ts
@@ -1,5 +1,5 @@
 import { ensureSyntaxTree } from '@codemirror/language';
-import { EditorState } from '@codemirror/state';
+import { EditorState, Text } from '@codemirror/state';
 import { highlightCode } from '@lezer/highlight';
 
 import { codeTagHighlighter } from '$lib/highlighting/codemirror-code-highlighter.js';
@@ -51,9 +51,12 @@ export function highlightGitDiffSyntheticSide(
 	loaded: LoadedCodeMirrorLanguage,
 ): GitDiffSyntaxSideAttempt {
 	const editorState = EditorState.create({
-		doc: side.text,
+		doc: Text.of(side.lines.map((line) => line.text)),
 		extensions: loaded.language.extension,
 	});
+	if (editorState.doc.length !== side.text.length) {
+		return { status: 'plain', reason: 'invalid-segment-text' };
+	}
 	const parseSpan = startGitReviewPerformanceSpan('syntax-parse');
 	let tree;
 	try {

--- a/web/src/lib/git/review/git-diff-syntax-highlighter.ts
+++ b/web/src/lib/git/review/git-diff-syntax-highlighter.ts
@@ -1,0 +1,228 @@
+import { ensureSyntaxTree } from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+import { highlightCode } from '@lezer/highlight';
+
+import { codeTagHighlighter } from '$lib/highlighting/codemirror-code-highlighter.js';
+import {
+	appendCodeHighlightSegment,
+	type CodeHighlightSegment,
+} from '$lib/highlighting/code-highlight-types.js';
+import {
+	loadCodeMirrorLanguageForFile,
+	type LoadedCodeMirrorLanguage,
+} from '$lib/highlighting/codemirror-language-registry.js';
+import {
+	finishGitReviewPerformanceSpan,
+	startGitReviewPerformanceSpan,
+} from './git-review-performance.js';
+import {
+	GIT_DIFF_SYNTAX_LIMITS,
+	buildGitDiffSyntheticSides,
+	gitDiffSyntaxCacheKey,
+	gitDiffSyntaxSkipReason,
+	waitForGitDiffSyntaxWorkSlot,
+	type GitDiffSyntheticSide,
+	type GitDiffSyntaxAttempt,
+	type GitDiffSyntaxFileInput,
+	type GitDiffSyntaxPlainReason,
+	type GitDiffSyntaxSideAttempt,
+	type GitDiffSyntaxSideResult,
+} from './git-diff-syntax.js';
+
+export interface GitDiffSyntaxHighlightDependencies {
+	loadLanguage: (filePath: string) => Promise<LoadedCodeMirrorLanguage | null>;
+	waitForWorkSlot: (signal: AbortSignal) => Promise<void>;
+	highlightSide: (
+		side: GitDiffSyntheticSide,
+		path: string,
+		loaded: LoadedCodeMirrorLanguage,
+	) => GitDiffSyntaxSideAttempt;
+}
+
+const DEFAULT_GIT_DIFF_SYNTAX_HIGHLIGHT_DEPENDENCIES = {
+	loadLanguage: loadCodeMirrorLanguageForFile,
+	waitForWorkSlot: waitForGitDiffSyntaxWorkSlot,
+	highlightSide: highlightGitDiffSyntheticSide,
+} satisfies GitDiffSyntaxHighlightDependencies;
+
+export function highlightGitDiffSyntheticSide(
+	side: GitDiffSyntheticSide,
+	path: string,
+	loaded: LoadedCodeMirrorLanguage,
+): GitDiffSyntaxSideAttempt {
+	const editorState = EditorState.create({
+		doc: side.text,
+		extensions: loaded.language.extension,
+	});
+	const parseSpan = startGitReviewPerformanceSpan('syntax-parse');
+	let tree;
+	try {
+		tree = ensureSyntaxTree(
+			editorState,
+			editorState.doc.length,
+			GIT_DIFF_SYNTAX_LIMITS.parseTimeoutMs,
+		);
+	} finally {
+		finishGitReviewPerformanceSpan(parseSpan);
+	}
+	if (!tree) return { status: 'plain', reason: 'parse-timeout' };
+
+	const projectSpan = startGitReviewPerformanceSpan('syntax-project');
+	try {
+		const highlightedLines = new Map<number, readonly CodeHighlightSegment[]>();
+		let currentSegments: CodeHighlightSegment[] = [];
+		let syntheticLineIndex = 0;
+		let segmentCount = 0;
+		let invalidText = false;
+		let segmentLimitExceeded = false;
+
+		const finishLine = (): void => {
+			const sourceLine = side.lines[syntheticLineIndex];
+			if (!sourceLine) {
+				invalidText = true;
+				return;
+			}
+			const highlightedText = currentSegments.map((segment) => segment.text).join('');
+			if (highlightedText !== sourceLine.text) invalidText = true;
+			if (sourceLine.diffLineIndex !== null) {
+				highlightedLines.set(sourceLine.diffLineIndex, currentSegments);
+			}
+			segmentCount += currentSegments.length;
+			if (segmentCount > GIT_DIFF_SYNTAX_LIMITS.maxSegmentsPerSide) {
+				segmentLimitExceeded = true;
+			}
+			currentSegments = [];
+			syntheticLineIndex += 1;
+		};
+
+		highlightCode(
+			side.text,
+			tree,
+			codeTagHighlighter,
+			(text, classes) => appendCodeHighlightSegment(currentSegments, text, classes || null),
+			finishLine,
+		);
+		finishLine();
+
+		if (segmentLimitExceeded) return { status: 'plain', reason: 'segment-limit' };
+		if (invalidText || syntheticLineIndex !== side.lines.length) {
+			return { status: 'plain', reason: 'invalid-segment-text' };
+		}
+		return {
+			status: 'highlighted',
+			result: {
+				path,
+				languageKey: loaded.key,
+				lines: highlightedLines,
+				characterCount: side.characterCount,
+				segmentCount,
+			},
+		};
+	} finally {
+		finishGitReviewPerformanceSpan(projectSpan);
+	}
+}
+
+export async function highlightGitDiffFile(
+	input: GitDiffSyntaxFileInput,
+	signal: AbortSignal,
+	deps: GitDiffSyntaxHighlightDependencies = DEFAULT_GIT_DIFF_SYNTAX_HIGHLIGHT_DEPENDENCIES,
+): Promise<GitDiffSyntaxAttempt> {
+	const { documentId, file, body } = input;
+	if (signal.aborted) return { status: 'cancelled' };
+	const skipReason = gitDiffSyntaxSkipReason(input);
+	if (skipReason) return { status: 'plain', reason: skipReason };
+
+	try {
+		await deps.waitForWorkSlot(signal);
+		if (signal.aborted) return { status: 'cancelled' };
+
+		const reconstructSpan = startGitReviewPerformanceSpan('syntax-reconstruct');
+		let reconstructed;
+		try {
+			reconstructed = buildGitDiffSyntheticSides(body);
+		} finally {
+			finishGitReviewPerformanceSpan(reconstructSpan);
+		}
+
+		const beforePath = file.originalPath ?? file.path;
+		const afterPath = file.path;
+		const languageLoads = new Map<string, Promise<LoadedCodeMirrorLanguage | null>>();
+		const load = (path: string): Promise<LoadedCodeMirrorLanguage | null> => {
+			const existing = languageLoads.get(path);
+			if (existing) return existing;
+			const pending = deps.loadLanguage(path);
+			languageLoads.set(path, pending);
+			return pending;
+		};
+
+		const languageSpan = startGitReviewPerformanceSpan('syntax-language-load');
+		let loadedAfter: LoadedCodeMirrorLanguage | null;
+		let loadedBefore: LoadedCodeMirrorLanguage | null;
+		try {
+			[loadedAfter, loadedBefore] = await Promise.all([
+				reconstructed.sides.after ? load(afterPath) : Promise.resolve(null),
+				reconstructed.sides.before ? load(beforePath) : Promise.resolve(null),
+			]);
+		} finally {
+			finishGitReviewPerformanceSpan(languageSpan);
+		}
+		if (signal.aborted) return { status: 'cancelled' };
+
+		const plainReasons: GitDiffSyntaxPlainReason[] = [];
+		const runSide = async (
+			side: GitDiffSyntheticSide | null,
+			path: string,
+			loaded: LoadedCodeMirrorLanguage | null,
+		): Promise<GitDiffSyntaxSideResult | null> => {
+			if (!side) return null;
+			if (!loaded) {
+				plainReasons.push('unsupported-language');
+				return null;
+			}
+			await deps.waitForWorkSlot(signal);
+			if (signal.aborted) return null;
+			try {
+				const attempt = deps.highlightSide(side, path, loaded);
+				if (attempt.status === 'plain') {
+					plainReasons.push(attempt.reason);
+					return null;
+				}
+				return attempt.result;
+			} catch {
+				plainReasons.push('error');
+				return null;
+			}
+		};
+
+		const after = await runSide(reconstructed.sides.after, afterPath, loadedAfter);
+		if (signal.aborted) return { status: 'cancelled' };
+		const before = await runSide(reconstructed.sides.before, beforePath, loadedBefore);
+		if (signal.aborted) return { status: 'cancelled' };
+
+		if (!before && !after) {
+			return {
+				status: 'plain',
+				reason:
+					reconstructed.beforeExceeded || reconstructed.afterExceeded
+						? 'character-limit'
+						: (plainReasons[0] ?? 'excluded'),
+			};
+		}
+
+		return {
+			status: 'highlighted',
+			result: {
+				cacheKey: gitDiffSyntaxCacheKey(documentId, file, body),
+				filePath: file.path,
+				bodyFingerprint: body.bodyFingerprint,
+				before,
+				after,
+				characterCount: (before?.characterCount ?? 0) + (after?.characterCount ?? 0),
+				segmentCount: (before?.segmentCount ?? 0) + (after?.segmentCount ?? 0),
+			},
+		};
+	} catch {
+		return signal.aborted ? { status: 'cancelled' } : { status: 'plain', reason: 'error' };
+	}
+}

--- a/web/src/lib/git/review/git-diff-syntax.ts
+++ b/web/src/lib/git/review/git-diff-syntax.ts
@@ -227,7 +227,9 @@ export function waitForGitDiffSyntaxWorkSlot(signal: AbortSignal): Promise<void>
 		const finish = (): void => {
 			if (settled) return;
 			settled = true;
-			if (idleId !== null) cancelIdleCallback(idleId);
+			if (idleId !== null && typeof cancelIdleCallback === 'function') {
+				cancelIdleCallback(idleId);
+			}
 			if (timerId !== null) clearTimeout(timerId);
 			signal.removeEventListener('abort', finish);
 			resolve();

--- a/web/src/lib/git/review/git-diff-syntax.ts
+++ b/web/src/lib/git/review/git-diff-syntax.ts
@@ -1,0 +1,245 @@
+import type { GitReviewFileBody, GitReviewFileSummary } from '$lib/api/git.js';
+import type { CodeHighlightSegment } from '$lib/highlighting/code-highlight-types.js';
+
+export const GIT_DIFF_SYNTAX_VERSION = 1;
+
+export const GIT_DIFF_SYNTAX_LIMITS = Object.freeze({
+	maxRenderedRows: 2_000,
+	maxSyntheticCharactersPerSide: 200_000,
+	maxSegmentsPerSide: 50_000,
+	parseTimeoutMs: 12,
+	workSlotTimeoutMs: 100,
+});
+
+export type GitDiffSyntaxFile = Pick<
+	GitReviewFileSummary,
+	| 'path'
+	| 'originalPath'
+	| 'bodyFingerprint'
+	| 'category'
+	| 'isGenerated'
+	| 'isBinary'
+	| 'isTooLarge'
+>;
+
+export interface GitDiffSyntaxDocument {
+	documentId: string;
+	files: readonly GitDiffSyntaxFile[];
+}
+
+export interface GitDiffSyntaxFileInput {
+	documentId: string;
+	file: GitDiffSyntaxFile;
+	body: GitReviewFileBody;
+}
+
+export interface GitDiffSyntheticLine {
+	text: string;
+	diffLineIndex: number | null;
+}
+
+export interface GitDiffSyntheticSide {
+	text: string;
+	lines: readonly GitDiffSyntheticLine[];
+	characterCount: number;
+}
+
+export interface GitDiffSyntheticSides {
+	before: GitDiffSyntheticSide | null;
+	after: GitDiffSyntheticSide | null;
+}
+
+export interface GitDiffSyntheticSidesResult {
+	sides: GitDiffSyntheticSides;
+	beforeExceeded: boolean;
+	afterExceeded: boolean;
+}
+
+export interface GitDiffSyntaxSideResult {
+	path: string;
+	languageKey: string;
+	lines: ReadonlyMap<number, readonly CodeHighlightSegment[]>;
+	characterCount: number;
+	segmentCount: number;
+}
+
+export interface GitDiffFileSyntaxResult {
+	cacheKey: string;
+	filePath: string;
+	bodyFingerprint: string;
+	before: GitDiffSyntaxSideResult | null;
+	after: GitDiffSyntaxSideResult | null;
+	characterCount: number;
+	segmentCount: number;
+}
+
+export type GitDiffSyntaxResults = Readonly<Record<string, GitDiffFileSyntaxResult>>;
+
+export type GitDiffSyntaxPlainReason =
+	| 'excluded'
+	| 'row-limit'
+	| 'character-limit'
+	| 'unsupported-language'
+	| 'parse-timeout'
+	| 'segment-limit'
+	| 'invalid-segment-text'
+	| 'error';
+
+export type GitDiffSyntaxSideAttempt =
+	| { status: 'highlighted'; result: GitDiffSyntaxSideResult }
+	| {
+			status: 'plain';
+			reason: 'parse-timeout' | 'segment-limit' | 'invalid-segment-text' | 'error';
+	  };
+
+export type GitDiffSyntaxAttempt =
+	| { status: 'highlighted'; result: GitDiffFileSyntaxResult }
+	| { status: 'plain'; reason: GitDiffSyntaxPlainReason }
+	| { status: 'cancelled' };
+
+export function gitDiffSyntaxSkipReason(
+	input: GitDiffSyntaxFileInput,
+): GitDiffSyntaxPlainReason | null {
+	const { file, body } = input;
+	if (
+		body.bodyState !== 'loaded' ||
+		body.patch === null ||
+		body.bodyFingerprint !== file.bodyFingerprint ||
+		body.isBinary ||
+		body.isTooLarge ||
+		file.isGenerated ||
+		file.isBinary ||
+		file.isTooLarge ||
+		file.category === 'generated' ||
+		file.category === 'lockfile' ||
+		file.category === 'binary' ||
+		file.category === 'large' ||
+		body.category === 'generated' ||
+		body.category === 'lockfile' ||
+		body.category === 'binary' ||
+		body.category === 'large'
+	) {
+		return 'excluded';
+	}
+	return body.renderedRowCount > GIT_DIFF_SYNTAX_LIMITS.maxRenderedRows ? 'row-limit' : null;
+}
+
+export function gitDiffSyntaxCacheKey(
+	documentId: string,
+	file: GitDiffSyntaxFile,
+	body: GitReviewFileBody,
+): string {
+	return JSON.stringify([
+		GIT_DIFF_SYNTAX_VERSION,
+		documentId,
+		body.bodyFingerprint,
+		file.originalPath ?? file.path,
+		file.path,
+	]);
+}
+
+class SyntheticSideBuilder {
+	private readonly lines: GitDiffSyntheticLine[] = [];
+	private lastHunkIndex: number | null = null;
+	private characterCount = 0;
+	private exceeded = false;
+
+	append(text: string, diffLineIndex: number, hunkIndex: number): void {
+		if (this.exceeded) return;
+		if (this.lastHunkIndex !== null && this.lastHunkIndex !== hunkIndex) {
+			this.push({ text: '', diffLineIndex: null });
+		}
+		this.push({ text, diffLineIndex });
+		this.lastHunkIndex = hunkIndex;
+	}
+
+	finish(): GitDiffSyntheticSide | null {
+		if (this.exceeded || this.lines.length === 0) return null;
+		return {
+			lines: this.lines,
+			text: this.lines.map((line) => line.text).join('\n'),
+			characterCount: this.characterCount,
+		};
+	}
+
+	get didExceedLimit(): boolean {
+		return this.exceeded;
+	}
+
+	private push(line: GitDiffSyntheticLine): void {
+		if (this.exceeded) return;
+		const separatorCharacters = this.lines.length === 0 ? 0 : 1;
+		this.characterCount += separatorCharacters + line.text.length;
+		if (this.characterCount > GIT_DIFF_SYNTAX_LIMITS.maxSyntheticCharactersPerSide) {
+			this.exceeded = true;
+			this.lines.length = 0;
+			return;
+		}
+		this.lines.push(line);
+	}
+}
+
+export function buildGitDiffSyntheticSides(body: GitReviewFileBody): GitDiffSyntheticSidesResult {
+	if (body.bodyState !== 'loaded' || body.patch === null) {
+		return {
+			sides: { before: null, after: null },
+			beforeExceeded: false,
+			afterExceeded: false,
+		};
+	}
+
+	const patchIndex = body.patchIndex;
+	if (!patchIndex) {
+		return {
+			sides: { before: null, after: null },
+			beforeExceeded: false,
+			afterExceeded: false,
+		};
+	}
+
+	const before = new SyntheticSideBuilder();
+	const after = new SyntheticSideBuilder();
+	for (let index = 0; index < patchIndex.rowCount; index += 1) {
+		const row = patchIndex.rowAt(index);
+		if (row.kind === 'hunk') continue;
+		if (row.kind === 'context' || row.kind === 'del') {
+			before.append(row.text, row.diffLineIndex, row.hunkIndex);
+		}
+		if (row.kind === 'context' || row.kind === 'add') {
+			after.append(row.text, row.diffLineIndex, row.hunkIndex);
+		}
+	}
+
+	return {
+		sides: { before: before.finish(), after: after.finish() },
+		beforeExceeded: before.didExceedLimit,
+		afterExceeded: after.didExceedLimit,
+	};
+}
+
+export function waitForGitDiffSyntaxWorkSlot(signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return Promise.resolve();
+	return new Promise((resolve) => {
+		let idleId: number | null = null;
+		let timerId: ReturnType<typeof setTimeout> | null = null;
+		let settled = false;
+
+		const finish = (): void => {
+			if (settled) return;
+			settled = true;
+			if (idleId !== null) cancelIdleCallback(idleId);
+			if (timerId !== null) clearTimeout(timerId);
+			signal.removeEventListener('abort', finish);
+			resolve();
+		};
+
+		signal.addEventListener('abort', finish, { once: true });
+		if (typeof requestIdleCallback === 'function') {
+			idleId = requestIdleCallback(finish, {
+				timeout: GIT_DIFF_SYNTAX_LIMITS.workSlotTimeoutMs,
+			});
+		} else {
+			timerId = setTimeout(finish, 0);
+		}
+	});
+}

--- a/web/src/lib/git/review/git-review-performance.ts
+++ b/web/src/lib/git/review/git-review-performance.ts
@@ -6,7 +6,11 @@ export type GitReviewPerformancePhase =
 	| 'body-visible'
 	| 'body-prefetch'
 	| 'json-decode'
-	| 'patch-index';
+	| 'patch-index'
+	| 'syntax-reconstruct'
+	| 'syntax-language-load'
+	| 'syntax-parse'
+	| 'syntax-project';
 
 export interface GitReviewPerformanceSpan {
 	phase: GitReviewPerformancePhase;

--- a/web/src/lib/git/review/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/git/review/git-virtual-review-document.svelte.ts
@@ -13,6 +13,7 @@ import { type SplitDiffRowView, type UnifiedDiffRowView } from '$lib/git/review/
 import * as m from '$lib/paraglide/messages.js';
 import type { DiffMode, GitDiffActionTarget } from '$lib/git/workbench/git-workbench-types.js';
 import type { CommentComposerState } from '$lib/git/review/git-inline-comment.svelte.js';
+import type { GitDiffSyntaxResults } from '$lib/git/review/git-diff-syntax.js';
 import type { GitWorkbenchLoadGuard } from '$lib/git/workbench/git-workbench-types.js';
 import { GitReviewBodyScheduler } from './git-review-body-scheduler.js';
 import {
@@ -136,6 +137,7 @@ export interface BuildVirtualRowsOptions {
 	diffMode: DiffMode;
 	contextLines: number;
 	interaction: GitVirtualRowInteraction;
+	syntaxResults?: GitDiffSyntaxResults;
 	collapsedFilePaths?: ReadonlySet<string>;
 	placeholderLimit?: {
 		title: string;

--- a/web/src/lib/git/review/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/git/review/git-virtual-review-document.svelte.ts
@@ -274,7 +274,7 @@ export class GitVirtualReviewDocumentController {
 
 	focusFile(projectPath: string, filePath: string): void {
 		this.discardErrorBody(filePath);
-		this.requestBodies(projectPath, [filePath], 'visible');
+		this.requestNavigationBodies(projectPath, [filePath]);
 		this.requestScrollToFile(filePath);
 	}
 
@@ -285,7 +285,7 @@ export class GitVirtualReviewDocumentController {
 
 	requestInitialBodies(projectPath: string, filePaths: string[]): void {
 		const [priority, ...prefetch] = unique(filePaths);
-		if (priority) this.requestBodies(projectPath, [priority], 'visible');
+		if (priority) this.requestNavigationBodies(projectPath, [priority]);
 		this.requestBodies(projectPath, prefetch, 'prefetch');
 	}
 
@@ -301,13 +301,6 @@ export class GitVirtualReviewDocumentController {
 		this.ensureBodyScheduler(projectPath, guard);
 		if (!this.bodyScheduler) return 'not-ready';
 		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
-		if (purpose === 'visible' && uniquePaths.length > 0) {
-			this.syntax.handleDemand({
-				kind: 'navigation',
-				documentId: this.summary.documentId,
-				filePaths: uniquePaths,
-			});
-		}
 		this.seedCachedBodies(uniquePaths, purpose, guard);
 		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath, guard));
@@ -406,6 +399,21 @@ export class GitVirtualReviewDocumentController {
 	private requestDemandPaths(filePaths: readonly string[]): GitReviewDemandOutcome {
 		const projectPath = this.deps.targetProjectPath();
 		if (!projectPath) return 'not-ready';
+		return this.requestBodies(projectPath, filePaths, 'visible');
+	}
+
+	private requestNavigationBodies(
+		projectPath: string,
+		filePaths: readonly string[],
+	): GitReviewDemandOutcome {
+		const summary = this.summary;
+		if (summary) {
+			this.syntax.handleDemand({
+				kind: 'navigation',
+				documentId: summary.documentId,
+				filePaths,
+			});
+		}
 		return this.requestBodies(projectPath, filePaths, 'visible');
 	}
 

--- a/web/src/lib/git/review/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/git/review/git-virtual-review-document.svelte.ts
@@ -32,6 +32,7 @@ import {
 	type GitReviewDemandOutcome,
 } from './git-review-body-demand.js';
 import { GitReviewDemandReconciler } from './git-review-demand-reconciler.js';
+import { GitDiffSyntaxController } from './git-diff-syntax-controller.svelte.js';
 import {
 	assertGitReviewLoadingOwnership,
 	traceGitReviewDemand,
@@ -184,6 +185,7 @@ export class GitVirtualReviewDocumentController {
 			summary,
 			visibleFilePaths: this.deps.visibleFilePaths(),
 			fileBodies: this.fileBodies,
+			syntaxResults: this.syntax.results,
 			loadingBodies: this.loadingBodies,
 			focusedFilePath: this.deps.selectedFile(),
 			diffMode: this.diffMode,
@@ -198,7 +200,10 @@ export class GitVirtualReviewDocumentController {
 		});
 	});
 
-	constructor(private readonly deps: GitVirtualReviewDocumentDeps) {
+	constructor(
+		private readonly deps: GitVirtualReviewDocumentDeps,
+		private readonly syntax = new GitDiffSyntaxController(),
+	) {
 		this.demandReconciler = new GitReviewDemandReconciler({
 			currentDocumentId: () => this.summary?.documentId ?? null,
 			requestViewportPaths: (filePaths) => this.requestDemandPaths(filePaths),
@@ -224,6 +229,7 @@ export class GitVirtualReviewDocumentController {
 	}
 
 	applySummary(summary: GitReviewDocumentSummary | null): void {
+		const nextBodies = summary ? this.retainedBodiesForSummary(summary) : {};
 		this.clearBodyInFlightLoads();
 		this.loadingBodies = new Set();
 		this.loadGeneration++;
@@ -231,14 +237,18 @@ export class GitVirtualReviewDocumentController {
 		this.aggregateLimit = null;
 		this.prefetchStopped = false;
 		if (summary) {
-			this.pruneBodiesToSummary(summary);
+			this.fileBodies = nextBodies;
+			this.syntax.open({ documentId: summary.documentId, files: summary.files }, nextBodies);
+			this.replayViewportSyntaxDemand(summary.documentId);
 		} else {
 			this.fileBodies = {};
+			this.syntax.close({ preserveCache: true });
 		}
 		this.demandReconciler.markReadinessChanged();
 	}
 
 	handleBodyDemand(demand: GitReviewBodyDemand): void {
+		this.syntax.handleDemand(demand);
 		this.demandReconciler.handle(demand);
 	}
 
@@ -310,12 +320,14 @@ export class GitVirtualReviewDocumentController {
 	refreshAllData(): void {
 		this.bodyCache.clear();
 		this.bodyCacheBytes = 0;
+		this.syntax.reset();
 		this.applySummary(null);
 	}
 
 	clearForDisplayChange(): void {
 		this.summary = null;
 		this.fileBodies = {};
+		this.syntax.close({ preserveCache: true });
 		this.aggregateLimit = null;
 		this.prefetchStopped = false;
 		this.loadingBodies = new Set();
@@ -330,15 +342,21 @@ export class GitVirtualReviewDocumentController {
 				this.bodyCache.delete(key);
 			}
 		}
-		this.fileBodies = Object.fromEntries(
-			Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
+		this.replaceFileBodies(
+			Object.fromEntries(
+				Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
+			),
 		);
+		this.syntax.invalidateFile(filePath);
 	}
 
 	pruneToFilePaths(paths: Set<string>): void {
-		this.fileBodies = Object.fromEntries(
-			Object.entries(this.fileBodies).filter(([filePath]) => paths.has(filePath)),
+		this.replaceFileBodies(
+			Object.fromEntries(
+				Object.entries(this.fileBodies).filter(([filePath]) => paths.has(filePath)),
+			),
 		);
+		this.syntax.pruneToFilePaths(paths);
 		for (const key of Array.from(this.bodyCache.keys())) {
 			const filePath = key.split('|').slice(3).join('|');
 			if (!paths.has(filePath)) {
@@ -351,6 +369,7 @@ export class GitVirtualReviewDocumentController {
 	reset(): void {
 		this.summary = null;
 		this.fileBodies = {};
+		this.syntax.reset();
 		this.loadingBodies = new Set();
 		this.scrollRequest = null;
 		this.aggregateLimit = null;
@@ -360,6 +379,21 @@ export class GitVirtualReviewDocumentController {
 		this.loadGeneration++;
 		this.clearBodyInFlightLoads();
 		this.demandReconciler.clear();
+	}
+
+	private replaceFileBodies(next: Record<string, GitReviewFileBody>): void {
+		this.fileBodies = next;
+		this.syntax.replaceBodies(next);
+	}
+
+	private replayViewportSyntaxDemand(documentId: string): void {
+		const demand = this.demandReconciler.snapshot();
+		if (demand.documentId !== documentId) return;
+		this.syntax.handleDemand({
+			kind: 'viewport',
+			documentId,
+			filePaths: demand.filePaths,
+		});
 	}
 
 	private requestDemandPaths(filePaths: readonly string[]): GitReviewDemandOutcome {
@@ -387,9 +421,11 @@ export class GitVirtualReviewDocumentController {
 		return !targetProjectPath || targetProjectPath === guard.projectPath;
 	}
 
-	private pruneBodiesToSummary(summary: GitReviewDocumentSummary): void {
+	private retainedBodiesForSummary(
+		summary: GitReviewDocumentSummary,
+	): Record<string, GitReviewFileBody> {
 		const files = new Map(summary.files.map((file) => [file.path, file]));
-		this.fileBodies = Object.fromEntries(
+		return Object.fromEntries(
 			Object.entries(this.fileBodies).filter(([filePath, body]) => {
 				const file = files.get(filePath);
 				return Boolean(
@@ -401,8 +437,10 @@ export class GitVirtualReviewDocumentController {
 
 	private discardErrorBody(filePath: string): void {
 		if (this.fileBodies[filePath]?.bodyState !== 'error') return;
-		this.fileBodies = Object.fromEntries(
-			Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
+		this.replaceFileBodies(
+			Object.fromEntries(
+				Object.entries(this.fileBodies).filter(([candidate]) => candidate !== filePath),
+			),
 		);
 	}
 
@@ -450,7 +488,7 @@ export class GitVirtualReviewDocumentController {
 			next[filePath] = cached;
 			changed = true;
 		}
-		if (changed) this.fileBodies = next;
+		if (changed) this.replaceFileBodies(next);
 	}
 
 	private ensureBodyScheduler(projectPath: string, guard: GitWorkbenchLoadGuard): void {
@@ -541,7 +579,7 @@ export class GitVirtualReviewDocumentController {
 			if (body.bodyState !== 'error') this.cacheSet(file, guard, body);
 			next[filePath] = body;
 		}
-		this.fileBodies = next;
+		this.replaceFileBodies(next);
 	}
 
 	private collectionLimitBody(

--- a/web/src/lib/git/review/git-virtual-review-document.svelte.ts
+++ b/web/src/lib/git/review/git-virtual-review-document.svelte.ts
@@ -301,6 +301,13 @@ export class GitVirtualReviewDocumentController {
 		this.ensureBodyScheduler(projectPath, guard);
 		if (!this.bodyScheduler) return 'not-ready';
 		const uniquePaths = normalizeGitReviewDemandFilePaths(filePaths);
+		if (purpose === 'visible' && uniquePaths.length > 0) {
+			this.syntax.handleDemand({
+				kind: 'navigation',
+				documentId: this.summary.documentId,
+				filePaths: uniquePaths,
+			});
+		}
 		this.seedCachedBodies(uniquePaths, purpose, guard);
 		if (this.aggregateLimit) return 'limited';
 		const toFetch = uniquePaths.filter((filePath) => this.shouldLoadBody(filePath, guard));

--- a/web/src/lib/git/review/git-virtual-review-row-source.ts
+++ b/web/src/lib/git/review/git-virtual-review-row-source.ts
@@ -599,6 +599,9 @@ function interactionForFile(options: BuildVirtualRowsOptions, file: GitReviewFil
 		readOnly: !workbench,
 		selectedLineKeys: workbench?.selectedLineKeys ?? new Set<string>(),
 		composerTarget,
+		...(options.syntaxResults?.[file.path]
+			? { syntaxResult: options.syntaxResults[file.path] }
+			: {}),
 	};
 	const actionTarget: GitDiffActionTarget | null = workbench
 		? {

--- a/web/src/lib/highlighting/__tests__/code-highlight-types.logic.test.ts
+++ b/web/src/lib/highlighting/__tests__/code-highlight-types.logic.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { plainCodeSegments } from '../code-highlight-types';
+import { appendCodeHighlightSegment, plainCodeSegments } from '../code-highlight-types';
+
+describe('appendCodeHighlightSegment', () => {
+	it('merges adjacent segments with the same normalized class', () => {
+		const segments = [{ text: 'const', className: 'cm-code-keyword' }];
+
+		appendCodeHighlightSegment(segments, ' value', 'cm-code-keyword');
+		appendCodeHighlightSegment(segments, ' = 1', '');
+		appendCodeHighlightSegment(segments, ';', null);
+		appendCodeHighlightSegment(segments, '', 'cm-code-title');
+
+		expect(segments).toEqual([
+			{ text: 'const value', className: 'cm-code-keyword' },
+			{ text: ' = 1;', className: null },
+		]);
+	});
+});
 
 describe('plainCodeSegments', () => {
 	it('returns no segments for empty text', () => {

--- a/web/src/lib/highlighting/__tests__/codemirror-language-registry.test.ts
+++ b/web/src/lib/highlighting/__tests__/codemirror-language-registry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	canHighlightCodeFenceLanguage,
 	loadCodeFenceLanguage,
+	loadCodeMirrorLanguageForFile,
 	loadLanguageExtension,
 	normalizeCodeFenceLanguage,
 } from '../codemirror-language-registry';
@@ -102,5 +103,30 @@ describe('loadLanguageExtension', () => {
 		});
 
 		expect(extensions.length).toBeGreaterThan(0);
+	});
+});
+
+describe('loadCodeMirrorLanguageForFile', () => {
+	it.each([
+		['src/main.ts', 'typescript'],
+		['src/main.py', 'python'],
+		['Containerfile', 'dockerfile'],
+		['src/Counter.svelte', 'html'],
+	])('loads %s as %s', async (filePath, expectedKey) => {
+		const loaded = await loadCodeMirrorLanguageForFile(filePath);
+
+		expect(loaded?.key).toBe(expectedKey);
+		expect(loaded?.language.parser).toBeTruthy();
+		expect(loaded?.extensions.length).toBeGreaterThan(0);
+	});
+
+	it('preserves the extension-only compatibility API', async () => {
+		const loaded = await loadCodeMirrorLanguageForFile('src/main.ts');
+
+		await expect(loadLanguageExtension('src/main.ts')).resolves.toEqual(loaded?.extensions);
+	});
+
+	it('returns null for unsupported filenames', async () => {
+		await expect(loadCodeMirrorLanguageForFile('Makefile')).resolves.toBeNull();
 	});
 });

--- a/web/src/lib/highlighting/code-fence-highlighter.ts
+++ b/web/src/lib/highlighting/code-fence-highlighter.ts
@@ -1,109 +1,18 @@
-import { highlightCode, tagHighlighter, tags } from '@lezer/highlight';
+import { highlightCode } from '@lezer/highlight';
 
+import { codeTagHighlighter } from './codemirror-code-highlighter';
 import {
 	loadCodeFenceLanguage,
 	normalizeCodeFenceLanguage,
 } from './codemirror-language-registry';
-import { plainCodeSegments, type CodeHighlightSegment } from './code-highlight-types';
+import {
+	appendCodeHighlightSegment,
+	plainCodeSegments,
+	type CodeHighlightSegment,
+} from './code-highlight-types';
 
 const MAX_HIGHLIGHT_CHARS = 200_000;
 const MAX_HIGHLIGHT_LINES = 5_000;
-
-const codeHighlighter = tagHighlighter([
-	{
-		tag: [
-			tags.keyword,
-			tags.operatorKeyword,
-			tags.controlKeyword,
-			tags.definitionKeyword,
-			tags.moduleKeyword,
-			tags.modifier,
-			tags.self,
-			tags.null,
-		],
-		class: 'cm-code-keyword',
-	},
-	{
-		tag: [
-			tags.className,
-			tags.definition(tags.variableName),
-			tags.definition(tags.propertyName),
-			tags.function(tags.variableName),
-			tags.function(tags.propertyName),
-			tags.macroName,
-		],
-		class: 'cm-code-title',
-	},
-	{
-		tag: [
-			tags.number,
-			tags.bool,
-			tags.literal,
-			tags.operator,
-			tags.variableName,
-			tags.labelName,
-			tags.namespace,
-			tags.annotation,
-			tags.attributeName,
-		],
-		class: 'cm-code-meta',
-	},
-	{
-		tag: [
-			tags.string,
-			tags.docString,
-			tags.character,
-			tags.attributeValue,
-			tags.regexp,
-			tags.escape,
-			tags.special(tags.string),
-		],
-		class: 'cm-code-string',
-	},
-	{
-		tag: [tags.atom, tags.unit, tags.color, tags.url, tags.standard(tags.variableName)],
-		class: 'cm-code-symbol',
-	},
-	{
-		tag: [tags.comment, tags.lineComment, tags.blockComment, tags.docComment],
-		class: 'cm-code-comment',
-	},
-	{
-		tag: [
-			tags.name,
-			tags.typeName,
-			tags.tagName,
-			tags.propertyName,
-			tags.attributeName,
-			tags.processingInstruction,
-		],
-		class: 'cm-code-name',
-	},
-	{
-		tag: [tags.heading, tags.contentSeparator, tags.list, tags.quote],
-		class: 'cm-code-section',
-	},
-	{ tag: tags.inserted, class: 'cm-code-addition' },
-	{ tag: tags.deleted, class: 'cm-code-deletion' },
-	{ tag: tags.invalid, class: 'cm-code-invalid' },
-]);
-
-function pushSegment(
-	segments: CodeHighlightSegment[],
-	text: string,
-	className: string | null,
-): void {
-	if (!text) return;
-
-	const normalizedClassName = className || null;
-	const previous = segments.at(-1);
-	if (previous?.className === normalizedClassName) {
-		previous.text += text;
-		return;
-	}
-
-	segments.push({ text, className: normalizedClassName });
-}
 
 function exceedsHighlightLineLimit(text: string): boolean {
 	let lines = 1;
@@ -134,8 +43,8 @@ function highlightDiff(text: string): CodeHighlightSegment[] {
 		if (!line) continue;
 		const hasBreak = line.endsWith('\n');
 		const lineText = hasBreak ? line.slice(0, -1) : line;
-		pushSegment(segments, lineText, diffLineClass(lineText));
-		if (hasBreak) pushSegment(segments, '\n', null);
+		appendCodeHighlightSegment(segments, lineText, diffLineClass(lineText));
+		if (hasBreak) appendCodeHighlightSegment(segments, '\n', null);
 	}
 
 	return segments.length ? segments : plainCodeSegments(text);
@@ -161,9 +70,9 @@ export async function highlightCodeFence(
 		highlightCode(
 			text,
 			tree,
-			codeHighlighter,
-			(code, classes) => pushSegment(segments, code, classes),
-			() => pushSegment(segments, '\n', null),
+			codeTagHighlighter,
+			(code, classes) => appendCodeHighlightSegment(segments, code, classes),
+			() => appendCodeHighlightSegment(segments, '\n', null),
 		);
 		return segments.length ? segments : plainCodeSegments(text);
 	} catch {

--- a/web/src/lib/highlighting/code-highlight-types.ts
+++ b/web/src/lib/highlighting/code-highlight-types.ts
@@ -3,6 +3,23 @@ export interface CodeHighlightSegment {
 	className: string | null;
 }
 
+export function appendCodeHighlightSegment(
+	segments: CodeHighlightSegment[],
+	text: string,
+	className: string | null,
+): void {
+	if (!text) return;
+
+	const normalizedClassName = className || null;
+	const previous = segments.at(-1);
+	if (previous?.className === normalizedClassName) {
+		previous.text += text;
+		return;
+	}
+
+	segments.push({ text, className: normalizedClassName });
+}
+
 export function plainCodeSegments(text: string): CodeHighlightSegment[] {
 	return text ? [{ text, className: null }] : [];
 }

--- a/web/src/lib/highlighting/codemirror-code-highlighter.ts
+++ b/web/src/lib/highlighting/codemirror-code-highlighter.ts
@@ -1,0 +1,80 @@
+import { tagHighlighter, tags } from '@lezer/highlight';
+
+export const codeTagHighlighter = tagHighlighter([
+	{
+		tag: [
+			tags.keyword,
+			tags.operatorKeyword,
+			tags.controlKeyword,
+			tags.definitionKeyword,
+			tags.moduleKeyword,
+			tags.modifier,
+			tags.self,
+			tags.null,
+		],
+		class: 'cm-code-keyword',
+	},
+	{
+		tag: [
+			tags.className,
+			tags.definition(tags.variableName),
+			tags.definition(tags.propertyName),
+			tags.function(tags.variableName),
+			tags.function(tags.propertyName),
+			tags.macroName,
+		],
+		class: 'cm-code-title',
+	},
+	{
+		tag: [
+			tags.number,
+			tags.bool,
+			tags.literal,
+			tags.operator,
+			tags.variableName,
+			tags.labelName,
+			tags.namespace,
+			tags.annotation,
+			tags.attributeName,
+		],
+		class: 'cm-code-meta',
+	},
+	{
+		tag: [
+			tags.string,
+			tags.docString,
+			tags.character,
+			tags.attributeValue,
+			tags.regexp,
+			tags.escape,
+			tags.special(tags.string),
+		],
+		class: 'cm-code-string',
+	},
+	{
+		tag: [tags.atom, tags.unit, tags.color, tags.url, tags.standard(tags.variableName)],
+		class: 'cm-code-symbol',
+	},
+	{
+		tag: [tags.comment, tags.lineComment, tags.blockComment, tags.docComment],
+		class: 'cm-code-comment',
+	},
+	{
+		tag: [
+			tags.name,
+			tags.typeName,
+			tags.tagName,
+			tags.propertyName,
+			tags.attributeName,
+			tags.processingInstruction,
+		],
+		class: 'cm-code-name',
+	},
+	{
+		tag: [tags.heading, tags.contentSeparator, tags.list, tags.quote],
+		class: 'cm-code-section',
+	},
+	{ tag: tags.inserted, class: 'cm-code-addition' },
+	{ tag: tags.deleted, class: 'cm-code-deletion' },
+	{ tag: tags.invalid, class: 'cm-code-invalid' },
+]);

--- a/web/src/lib/highlighting/codemirror-language-registry.ts
+++ b/web/src/lib/highlighting/codemirror-language-registry.ts
@@ -106,14 +106,18 @@ export async function loadCodeFenceLanguage(
 export async function loadLanguageExtension(
 	input: LoadLanguageExtensionInput,
 ): Promise<Extension[]> {
+	const loaded = await loadCodeMirrorLanguageForFile(input);
+	return loaded?.extensions ?? [];
+}
+
+export async function loadCodeMirrorLanguageForFile(
+	input: LoadLanguageExtensionInput,
+): Promise<LoadedCodeMirrorLanguage | null> {
 	const filePath = typeof input === 'string' ? input : input.filePath;
 	const explicitLanguage = typeof input === 'string' ? null : input.language;
 	const description =
 		matchEditorExplicitLanguage(explicitLanguage) ??
 		matchEditorFilename(filePath) ??
 		matchEditorFallback(filePath);
-	if (!description) return [];
-
-	const loaded = await loadDescription(description);
-	return loaded?.extensions ?? [];
+	return description ? loadDescription(description) : null;
 }


### PR DESCRIPTION
Git diffs are easier to scan when source structure remains visible alongside additions and deletions. This adds best-effort, demand-driven syntax highlighting to workbench, compare, and history diff views using the existing CodeMirror and Lezer stack, with independent before/after parsing, bounded caching and scheduling, and plain-text fallback for unsupported or expensive inputs.