### PR TITLE
Style Bash tool rows as compact cards

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -29,6 +29,7 @@
 	--color-chat-tabs-active: hsl(var(--chat-tabs-active-bg));
 	--color-chat-tabs-active-foreground: hsl(var(--chat-tabs-active-foreground));
 	--color-chat-tabs-active-border: hsl(var(--chat-tabs-active-border));
+	--color-chat-bash-row: hsl(var(--chat-bash-row-bg));
 
 	--color-sidebar: hsl(var(--sidebar-background));
 	--color-sidebar-foreground: hsl(var(--sidebar-foreground));
@@ -221,6 +222,7 @@
 	--chat-tabs-active-bg: 0 0% 18%;
 	--chat-tabs-active-foreground: 0 0% 98%;
 	--chat-tabs-active-border: 0 0% 18%;
+	--chat-bash-row-bg: 0 0% 94%;
 
 	--sidebar-background: 0 0% 98%;
 	--sidebar-foreground: 0 0% 5%;
@@ -437,6 +439,7 @@
 	--chat-tabs-active-bg: 0 0% 84%;
 	--chat-tabs-active-foreground: 0 0% 8%;
 	--chat-tabs-active-border: 0 0% 84%;
+	--chat-bash-row-bg: 0 0% 0%;
 
 	--sidebar-background: 0 0% 8%;
 	--sidebar-foreground: 0 0% 95%;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -439,7 +439,7 @@
 	--chat-tabs-active-bg: 0 0% 84%;
 	--chat-tabs-active-foreground: 0 0% 8%;
 	--chat-tabs-active-border: 0 0% 84%;
-	--chat-bash-row-bg: 0 0% 0%;
+	--chat-bash-row-bg: 0 0% 6%;
 
 	--sidebar-background: 0 0% 8%;
 	--sidebar-foreground: 0 0% 95%;

--- a/web/src/lib/components/chat/rows/ChatEventCard.svelte
+++ b/web/src/lib/components/chat/rows/ChatEventCard.svelte
@@ -4,7 +4,15 @@
 
 	import type { Snippet } from 'svelte';
 
-	type Variant = 'default' | 'info' | 'success' | 'warning' | 'error' | 'neutral' | 'thinking';
+	type Variant =
+		| 'default'
+		| 'bash'
+		| 'info'
+		| 'success'
+		| 'warning'
+		| 'error'
+		| 'neutral'
+		| 'thinking';
 
 	interface Props {
 		variant?: Variant;
@@ -26,6 +34,8 @@
 
 	const variantClass = $derived.by(() => {
 		switch (variant) {
+			case 'bash':
+				return 'border-border bg-chat-bash-row text-foreground';
 			case 'info':
 				return 'border-status-info-border bg-status-info/20 text-status-info-foreground';
 			case 'success':

--- a/web/src/lib/components/chat/tools/ChatBashToolEvent.svelte
+++ b/web/src/lib/components/chat/tools/ChatBashToolEvent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ChatEventCard from '../rows/ChatEventCard.svelte';
 	import HighlightedCodeText from '../HighlightedCodeText.svelte';
 
 	interface Props {
@@ -9,12 +10,16 @@
 	let { command, anchorId }: Props = $props();
 </script>
 
-<code
-	id={anchorId}
-	class="code-highlight scroll-mt-16 block whitespace-pre-wrap break-all font-mono text-xs text-foreground"
-	data-chat-bash-command
-	><span class="text-muted-foreground">{'$ '}</span><HighlightedCodeText
-		text={command}
-		language="bash"
-	/></code
->
+<div class="group my-0.5">
+	<ChatEventCard variant="bash" compact>
+		{#snippet body()}
+			<code
+				id={anchorId}
+				class="code-highlight scroll-mt-16 block whitespace-pre-wrap break-all font-mono text-xs leading-[1.25] text-foreground"
+				data-chat-bash-command
+				><span class="inline-block w-5 text-center text-muted-foreground">{'$ '}</span
+				><HighlightedCodeText text={command} language="bash" /></code
+			>
+		{/snippet}
+	</ChatEventCard>
+</div>

--- a/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
+++ b/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
@@ -252,7 +252,7 @@ describe('ChatToolEventRenderer', () => {
 		expect(container.childElementCount).toBe(0);
 	});
 
-	it('renders Bash as one unframed highlighted shell command', async () => {
+	it('renders Bash as a highlighted shell command on the shared card surface', async () => {
 		const command = 'if true; then echo "ready"; fi';
 		const { container } = render(ChatToolEventRenderer, {
 			toolMessage: new BashToolUseMessage('', 'bash-1', command),
@@ -264,15 +264,24 @@ describe('ChatToolEventRenderer', () => {
 		expect(code?.classList.contains('text-xs')).toBe(true);
 		expect(code?.classList.contains('font-mono')).toBe(true);
 		expect(code?.classList.contains('block')).toBe(true);
+		expect(code?.classList.contains('leading-[1.25]')).toBe(true);
 		expect(code?.classList.contains('whitespace-pre-wrap')).toBe(true);
 		expect(code?.classList.contains('break-all')).toBe(true);
+		expect(code?.querySelector('span')?.classList.contains('w-5')).toBe(true);
+
+		const card = code?.closest('article');
+		expect(card?.classList.contains('rounded-xl')).toBe(true);
+		expect(card?.classList.contains('border')).toBe(true);
+		expect(card?.classList.contains('shadow-sm')).toBe(true);
+		expect(card?.classList.contains('bg-chat-bash-row')).toBe(true);
+		expect(card?.classList.contains('px-3')).toBe(true);
+		expect(card?.classList.contains('py-2')).toBe(true);
 		expect(container.querySelector('.markdown-code-block')).toBeNull();
 		expect(container.querySelector('pre')).toBeNull();
-		expect(container.querySelector('div')).toBeNull();
 		expect(container.querySelector('button')).toBeNull();
 		expect(screen.queryByText('Bash')).toBeNull();
 		expect(container.children).toHaveLength(1);
-		expect(container.firstElementChild?.tagName).toBe('CODE');
+		expect(container.firstElementChild?.classList.contains('my-0.5')).toBe(true);
 
 		await waitFor(
 			() => {


### PR DESCRIPTION
Make Bash tool activity easier to distinguish in the conversation feed while preserving the compact rhythm shared by other tool rows. Bash rows now use the shared event-card treatment with a light gray surface in light mode and a black surface in dark mode, alongside focused rendering coverage for the new presentation.