### PR TITLE
Fix chat feed navigation controls

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -2632,6 +2632,7 @@ async function verifyLaterPageReadingPosition(
   await initialPrompt.click();
   await waitForVirtualDataRevisionAfter(fixture.page, initialWindowRevision);
   await waitForTranscriptReady(fixture.page);
+  await initialPrompt.waitFor({ state: 'hidden' });
 
   await signalScrollIntent(fixture.page, 'earlier');
   const prefetchPosition = await positionNearLaterPageBoundary(fixture.page);
@@ -2654,9 +2655,35 @@ async function verifyLaterPageReadingPosition(
 
   const returnToLatest = fixture.page.locator('button[title="Scroll to bottom"]');
   await returnToLatest.waitFor({ state: 'visible' });
-  const latestWindowRevision = await virtualDataRevision(fixture.page);
-  await returnToLatest.click();
-  await waitForVirtualDataRevisionAfter(fixture.page, latestWindowRevision);
+  let releaseLatestRequest!: () => void;
+  const latestRequestGate = new Promise<void>((resolve) => (releaseLatestRequest = resolve));
+  let resolveLatestRequestStarted!: () => void;
+  const latestRequestStarted = new Promise<void>((resolve) => (resolveLatestRequestStarted = resolve));
+  let heldLatestRequest = false;
+  await fixture.page.route('**/api/v1/chats/messages?**', async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      !heldLatestRequest
+      && url.searchParams.get('chatId') === chatId
+      && !url.searchParams.has('beforeOrdinal')
+    ) {
+      heldLatestRequest = true;
+      resolveLatestRequestStarted();
+      await latestRequestGate;
+    }
+    await route.continue();
+  });
+  try {
+    const latestWindowRevision = await virtualDataRevision(fixture.page);
+    await returnToLatest.click();
+    await withDiagnosticTimeout('the held latest-window request', latestRequestStarted);
+    await returnToLatest.locator('svg.animate-spin').waitFor({ state: 'visible' });
+    releaseLatestRequest();
+    await waitForVirtualDataRevisionAfter(fixture.page, latestWindowRevision);
+  } finally {
+    releaseLatestRequest();
+    await fixture.page.unroute('**/api/v1/chats/messages?**');
+  }
   await waitForStablePinnedTranscriptLayout(fixture.page, 'return-to-latest');
   await appendTurn(fixture.integration, chatId, 'chromium-later-window-live-append');
   await fixture.page

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -98,6 +98,9 @@ interface FakeViewport extends ConversationViewportPort {
 	>;
 	cancelPendingLayoutMutation: ReturnType<typeof vi.fn<() => void>>;
 	cancelForUserIntent: ReturnType<typeof vi.fn<ConversationViewportPort['cancelForUserIntent']>>;
+	noteNativeTouchLifecycle: ReturnType<
+		typeof vi.fn<ConversationViewportPort['noteNativeTouchLifecycle']>
+	>;
 	scrollToTarget: ReturnType<typeof vi.fn<ConversationViewportPort['scrollToTarget']>>;
 }
 
@@ -114,7 +117,8 @@ function fakeViewport(overrides: Partial<ConversationViewportPort> = {}): FakeVi
 		measureViewportFill: vi.fn(async () => 'overflow'),
 		restoreHiddenReadingPosition: vi.fn(async () => 'restored'),
 		cancelPendingLayoutMutation: vi.fn(),
-		cancelForUserIntent: vi.fn(),
+		cancelForUserIntent: vi.fn(() => 'cancelled'),
+		noteNativeTouchLifecycle: vi.fn(),
 		scrollToTarget: vi.fn(async () => 'completed'),
 		...overrides,
 	} as FakeViewport;
@@ -445,6 +449,58 @@ describe('ConversationScrollController', () => {
 		now.mockRestore();
 	});
 
+	it('hands a preserved prepend to its first matching native scroll', () => {
+		const cancelForUserIntent = vi
+			.fn<ConversationViewportPort['cancelForUserIntent']>()
+			.mockReturnValueOnce('preserved-earlier-prepend')
+			.mockReturnValue('cancelled');
+		const fixture = controllerFixture({
+			scroller: { clientHeight: 400, scrollTop: 2_000 },
+			viewport: fakeViewport({ cancelForUserIntent, ownsScrollPosition: vi.fn(() => true) }),
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		fixture.scroller.scrollTop = 1_900;
+		fixture.controller.handleScroll();
+		fixture.scroller.scrollTop = 1_800;
+		fixture.controller.handleScroll();
+
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledTimes(2);
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenLastCalledWith('earlier');
+	});
+
+	it('does not hand ordinary cancellation to a later viewport-owned scroll', () => {
+		const fixture = controllerFixture({
+			scroller: { clientHeight: 400, scrollTop: 2_000 },
+			viewport: fakeViewport({ ownsScrollPosition: vi.fn(() => true) }),
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		fixture.scroller.scrollTop = 1_900;
+		fixture.controller.handleScroll();
+
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+	});
+
+	it('discards a preserved prepend handoff on opposite native movement', () => {
+		const cancelForUserIntent = vi
+			.fn<ConversationViewportPort['cancelForUserIntent']>()
+			.mockReturnValueOnce('preserved-earlier-prepend')
+			.mockReturnValue('cancelled');
+		const fixture = controllerFixture({
+			scroller: { clientHeight: 400, scrollTop: 2_000 },
+			viewport: fakeViewport({ cancelForUserIntent, ownsScrollPosition: vi.fn(() => true) }),
+		});
+
+		fixture.controller.noteUserScrollIntent('earlier');
+		fixture.scroller.scrollTop = 2_100;
+		fixture.controller.handleScroll();
+		fixture.scroller.scrollTop = 1_900;
+		fixture.controller.handleScroll();
+
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+	});
+
 	it('pages after viewport scroll ownership releases inside the intent window', async () => {
 		const now = vi.spyOn(performance, 'now').mockReturnValue(100);
 		const loadEarlierPage = vi.fn(async () => 'exhausted' as const);
@@ -628,8 +684,15 @@ describe('ConversationScrollController', () => {
 		);
 		const loadEarlierPage = vi.fn(async () => 'loaded' as const);
 		const invalidatePendingWindowNavigation = vi.fn();
+		const cancelForUserIntent = vi.fn<ConversationViewportPort['cancelForUserIntent']>(() =>
+			'cancelled',
+		);
 		const fixture = controllerFixture({
-			viewport: fakeViewport({ waitForLayout }),
+			viewport: fakeViewport({
+				cancelForUserIntent,
+				ownsScrollPosition: vi.fn(() => true),
+				waitForLayout,
+			}),
 			state: {
 				canLoadEarlier: true,
 				invalidatePendingWindowNavigation,
@@ -642,16 +705,22 @@ describe('ConversationScrollController', () => {
 		const request = fixture.controller.requestPage('earlier', 'scroll');
 		await vi.waitFor(() => expect(waitForLayout).toHaveBeenCalledOnce());
 		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
-		fixture.viewport.cancelForUserIntent.mockClear();
-		const invalidationCount = invalidatePendingWindowNavigation.mock.calls.length;
 
 		fixture.scroller.scrollTop = 8_490;
 		fixture.controller.handleScroll();
-		expect(fixture.viewport.cancelForUserIntent).not.toHaveBeenCalled();
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+
+		fixture.viewport.cancelForUserIntent.mockClear();
+		fixture.viewport.cancelForUserIntent
+			.mockReturnValueOnce('preserved-earlier-prepend')
+			.mockReturnValue('cancelled');
+		fixture.controller.noteUserScrollIntent('earlier');
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+		const invalidationCount = invalidatePendingWindowNavigation.mock.calls.length;
 
 		fixture.scroller.scrollTop = 8_484;
 		fixture.controller.handleScroll();
-		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledOnce();
+		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledTimes(2);
 		expect(fixture.viewport.cancelForUserIntent).toHaveBeenCalledWith('earlier');
 		expect(invalidatePendingWindowNavigation).toHaveBeenCalledTimes(invalidationCount);
 		expect(loadEarlierPage).toHaveBeenCalledOnce();
@@ -1328,6 +1397,35 @@ describe('ConversationScrollController', () => {
 		fixture.scroller.scrollTop = 20;
 		fixture.controller.handleScroll();
 		expect(fixture.controller.canScrollToTop).toBe(true);
+	});
+
+	it('publishes feed-start state only after an active page mutation settles', async () => {
+		let resolveLayout!: (result: 'settled') => void;
+		const waitForLayout = vi.fn(
+			() => new Promise<'settled'>((resolve) => (resolveLayout = resolve)),
+		);
+		const fixture = controllerFixture({
+			scroller: { scrollTop: 240 },
+			state: {
+				canLoadEarlier: true,
+				loadEarlierPage: vi.fn(async () => {
+					fixture.state.feedMutationClock = mutationClock(1, 1);
+					return 'loaded' as const;
+				}),
+			},
+			viewport: fakeViewport({ waitForLayout }),
+		});
+
+		const pageRequest = fixture.controller.requestPage('earlier', 'button');
+		await vi.waitFor(() => expect(waitForLayout).toHaveBeenCalledOnce());
+		fixture.state.canLoadEarlier = false;
+		fixture.scroller.scrollTop = 0;
+		fixture.controller.handleScroll();
+		expect(fixture.controller.canScrollToTop).toBe(true);
+
+		resolveLayout('settled');
+		await expect(pageRequest).resolves.toBe('loaded');
+		expect(fixture.controller.canScrollToTop).toBe(false);
 	});
 
 	it('preserves committed initial-window policy when layout settling is superseded', async () => {

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-controller.test.ts
@@ -1305,6 +1305,31 @@ describe('ConversationScrollController', () => {
 		expect(state.isUserScrolledUp).toBe(true);
 	});
 
+	it('stops offering top navigation after reaching the initial viewport start', async () => {
+		let resolveNavigation!: (result: 'loaded') => void;
+		const navigateToWindow = vi.fn(
+			() => new Promise<'loaded'>((resolve) => (resolveNavigation = resolve)),
+		);
+		const fixture = controllerFixture({
+			scroller: { scrollTop: 240 },
+			state: { canLoadEarlier: true, isUserScrolledUp: true, navigateToWindow },
+		});
+		fixture.controller.setPinnedToBottom(false);
+
+		const navigation = fixture.controller.scrollToTop();
+		await vi.waitFor(() => expect(navigateToWindow).toHaveBeenCalledOnce());
+		expect(fixture.controller.canScrollToTop).toBe(true);
+
+		fixture.state.canLoadEarlier = false;
+		resolveNavigation('loaded');
+		await navigation;
+
+		expect(fixture.controller.canScrollToTop).toBe(false);
+		fixture.scroller.scrollTop = 20;
+		fixture.controller.handleScroll();
+		expect(fixture.controller.canScrollToTop).toBe(true);
+	});
+
 	it('preserves committed initial-window policy when layout settling is superseded', async () => {
 		const observed: {
 			controller: ConversationScrollController | null;
@@ -1349,6 +1374,37 @@ describe('ConversationScrollController', () => {
 		expect(navigateToWindow).toHaveBeenCalledWith('chat-1', 'latest');
 		expect(viewport.scrollToEnd).toHaveBeenCalledOnce();
 		expect(chatState.entries.map((entry) => entry.ordinal)).toEqual(expectedOrdinals);
+	});
+
+	it('reports bottom navigation busy until the latest viewport is filled', async () => {
+		let resolveNavigation!: (result: 'loaded') => void;
+		let resolveFill!: (result: 'overflow') => void;
+		const navigateToWindow = vi.fn(
+			() => new Promise<'loaded'>((resolve) => (resolveNavigation = resolve)),
+		);
+		const viewport = fakeViewport({
+			measureViewportFill: vi.fn(
+				() => new Promise<'overflow'>((resolve) => (resolveFill = resolve)),
+			),
+		});
+		const fixture = controllerFixture({
+			viewport,
+			state: { hasLaterMessages: true, isUserScrolledUp: true, navigateToWindow },
+		});
+		fixture.controller.setPinnedToBottom(false);
+
+		const navigation = fixture.controller.scrollToLatestAndFill();
+		await vi.waitFor(() => expect(navigateToWindow).toHaveBeenCalledOnce());
+		expect(fixture.controller.isScrollingToBottom).toBe(true);
+
+		fixture.state.hasLaterMessages = false;
+		resolveNavigation('loaded');
+		await vi.waitFor(() => expect(viewport.measureViewportFill).toHaveBeenCalledOnce());
+		expect(fixture.controller.isScrollingToBottom).toBe(true);
+
+		resolveFill('overflow');
+		await navigation;
+		expect(fixture.controller.isScrollingToBottom).toBe(false);
 	});
 
 	it('scrolls to an already-loaded latest edge without trimming the expanded interval', async () => {

--- a/web/src/lib/chat/transcript/__tests__/conversation-scroll-gesture.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-scroll-gesture.test.ts
@@ -3,7 +3,7 @@ import { observeConversationViewportScrollGestures } from '../conversation-scrol
 
 function dispatchTouch(
 	node: HTMLElement,
-	type: 'touchstart' | 'touchmove' | 'touchend',
+	type: 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel',
 	touches: readonly { identifier: number; clientY: number }[],
 ): void {
 	const event = new Event(type, { bubbles: true });
@@ -29,9 +29,47 @@ describe('conversation viewport scroll gestures', () => {
 		dispatchTouch(node, 'touchend', [{ identifier: 2, clientY: 300 }]);
 		dispatchTouch(node, 'touchmove', [{ identifier: 2, clientY: 280 }]);
 
-		expect(report.mock.calls).toEqual([[null], ['earlier'], ['later']]);
+		expect(report.mock.calls).toEqual([
+			[{ direction: null, touch: 'start' }],
+			[{ direction: 'earlier', touch: 'move' }],
+			[{ direction: 'later', touch: 'move' }],
+		]);
 		cleanup();
 		node.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
 		expect(report).toHaveBeenCalledTimes(3);
+	});
+
+	it('delivers the terminal end signal when the last finger lifts', () => {
+		const node = document.createElement('div');
+		const report = vi.fn();
+		const cleanup = observeConversationViewportScrollGestures(node, report);
+
+		dispatchTouch(node, 'touchstart', [{ identifier: 1, clientY: 100 }]);
+		dispatchTouch(node, 'touchmove', [{ identifier: 1, clientY: 120 }]);
+		dispatchTouch(node, 'touchend', []);
+
+		expect(report.mock.calls).toEqual([
+			[{ direction: null, touch: 'start' }],
+			[{ direction: 'earlier', touch: 'move' }],
+			[{ direction: null, touch: 'end' }],
+		]);
+		cleanup();
+	});
+
+	it('delivers the terminal cancel signal as an end', () => {
+		const node = document.createElement('div');
+		const report = vi.fn();
+		const cleanup = observeConversationViewportScrollGestures(node, report);
+
+		dispatchTouch(node, 'touchstart', [{ identifier: 1, clientY: 100 }]);
+		dispatchTouch(node, 'touchmove', [{ identifier: 1, clientY: 120 }]);
+		dispatchTouch(node, 'touchcancel', []);
+
+		expect(report.mock.calls).toEqual([
+			[{ direction: null, touch: 'start' }],
+			[{ direction: 'earlier', touch: 'move' }],
+			[{ direction: null, touch: 'end' }],
+		]);
+		cleanup();
 	});
 });

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -5,7 +5,10 @@ import type {
 	TranscriptPageLoadResult,
 	TranscriptWindowTarget,
 } from '$lib/chat/transcript/transcript-page-progress.js';
-import type { ConversationViewportPort } from '$lib/chat/transcript/conversation-viewport-port.js';
+import type {
+	ConversationViewportIntentCancellationResult,
+	ConversationViewportPort,
+} from '$lib/chat/transcript/conversation-viewport-port.js';
 import type {
 	UserMessageNavigatorSelectionResult,
 	UserMessageNavigatorTarget,
@@ -35,6 +38,12 @@ interface UserScrollIntent {
 interface DeferredLiveEdgeIntent {
 	chatId: string;
 	epoch: number;
+}
+
+interface NativeScrollHandoff {
+	chatId: string;
+	epoch: number;
+	direction: TranscriptPageDirection | null;
 }
 
 export type ConversationScrollState = Pick<
@@ -83,6 +92,7 @@ export class ConversationScrollController {
 	#previousScrollTop: number | null = null;
 	#viewportOperationEpoch = 0;
 	#deferredLiveEdgeIntent: DeferredLiveEdgeIntent | null = null;
+	#nativeScrollHandoff: NativeScrollHandoff | null = null;
 	#isPageMutationInProgress = false;
 	#activeTargetNavigations = $state(0);
 	#resumeAutoFillAfterTargets = false;
@@ -195,7 +205,8 @@ export class ConversationScrollController {
 
 	noteUserScrollIntent(direction: TranscriptPageDirection | null = null): void {
 		this.#deferredLiveEdgeIntent = null;
-		this.deps.getViewport()?.cancelForUserIntent(direction);
+		this.#nativeScrollHandoff = null;
+		const cancellation = this.deps.getViewport()?.cancelForUserIntent(direction);
 		// Continued scrolling owns the page's viewport position without cancelling its
 		// data request. Explicit navigation still advances the shared operation epoch.
 		if (this.#isPageMutationInProgress) {
@@ -211,6 +222,7 @@ export class ConversationScrollController {
 			direction,
 			receivedAt: performance.now(),
 		};
+		this.#recordNativeScrollHandoff(cancellation, intentEpoch, direction);
 		// Evaluates a clamped edge after the gesture because another wheel or key input
 		// at that edge may not produce the usual scroll event.
 		if (direction) {
@@ -287,24 +299,15 @@ export class ConversationScrollController {
 	handleScroll(): void {
 		const node = this.deps.getScrollContainer();
 		if (!node || !this.#isViewportVisible || node.clientHeight <= 0) return;
-		const isViewportAtStart = node.scrollTop <= FEED_START_THRESHOLD_PX;
-		if (this.#isViewportAtStart !== isViewportAtStart) {
-			this.#isViewportAtStart = isViewportAtStart;
-		}
 		const inferredDirection = this.#inferScrollDirection(node.scrollTop);
+		const viewport = this.deps.getViewport();
+		const resumedNativeScroll = this.#resumeNativeScrollHandoff(inferredDirection, viewport);
 		if (this.#isPageMutationInProgress) {
-			const shouldReaffirmUserOwnership =
-				inferredDirection !== null &&
-				this.#userScrollIntent.direction === inferredDirection &&
-				this.#hasRecentUserScrollIntent();
-			this.#applyInferredIntentDirection(inferredDirection);
-			if (shouldReaffirmUserOwnership) {
-				this.deps.getViewport()?.cancelForUserIntent(inferredDirection);
-			}
+			this.#applyInferredIntentDirection(inferredDirection, resumedNativeScroll);
 			this.#preserveHistoryBrowsing();
 			return;
 		}
-		if (this.deps.getViewport()?.ownsScrollPosition()) {
+		if (viewport?.ownsScrollPosition()) {
 			const chatId = this.deps.sessions.selectedChatId;
 			if (
 				chatId
@@ -321,6 +324,7 @@ export class ConversationScrollController {
 			}
 			return;
 		}
+		this.#syncViewportStart();
 		this.#deferredLiveEdgeIntent = null;
 		this.#reconcileUserScroll(inferredDirection);
 	}
@@ -407,6 +411,7 @@ export class ConversationScrollController {
 				),
 			};
 			this.#isPageMutationInProgress = false;
+			if (this.deps.sessions.selectedChatId === chatId) this.#syncViewportStart();
 		}
 		if (this.deps.sessions.selectedChatId !== chatId) return 'invalidated';
 		if (
@@ -682,10 +687,22 @@ export class ConversationScrollController {
 		return scrollTop < previousTop ? 'earlier' : 'later';
 	}
 
-	#applyInferredIntentDirection(direction: TranscriptPageDirection | null): void {
+	#syncViewportStart(): void {
+		const scrollTop = this.deps.getScrollContainer()?.scrollTop;
+		if (scrollTop === undefined) return;
+		const isViewportAtStart = scrollTop <= FEED_START_THRESHOLD_PX;
+		if (this.#isViewportAtStart !== isViewportAtStart) {
+			this.#isViewportAtStart = isViewportAtStart;
+		}
+	}
+
+	#applyInferredIntentDirection(
+		direction: TranscriptPageDirection | null,
+		cancellationAlreadyApplied = false,
+	): void {
 		if (!direction || !this.#hasRecentUserScrollIntent()) return;
 		if (this.#userScrollIntent.direction === null) {
-			this.deps.getViewport()?.cancelForUserIntent(direction);
+			if (!cancellationAlreadyApplied) this.deps.getViewport()?.cancelForUserIntent(direction);
 			this.#userScrollIntent = { ...this.#userScrollIntent, direction };
 		}
 		if (this.#userScrollIntent.direction === direction) {
@@ -765,12 +782,14 @@ export class ConversationScrollController {
 
 	#beginViewportOperation(): number {
 		this.#deferredLiveEdgeIntent = null;
+		this.#nativeScrollHandoff = null;
 		this.deps.chatState.invalidatePendingWindowNavigation();
 		return ++this.#viewportOperationEpoch;
 	}
 
 	#cancelViewportOperations(): void {
 		this.#deferredLiveEdgeIntent = null;
+		this.#nativeScrollHandoff = null;
 		this.deps.chatState.invalidatePendingWindowNavigation();
 		this.#viewportOperationEpoch += 1;
 	}
@@ -808,6 +827,7 @@ export class ConversationScrollController {
 	}
 
 	#resetPagingContext(): void {
+		this.#nativeScrollHandoff = null;
 		const epoch = this.#userScrollIntent.epoch;
 		this.#consumedIntentEpoch = { earlier: epoch, later: epoch };
 		this.#laterBoundaryArmed = true;
@@ -834,6 +854,41 @@ export class ConversationScrollController {
 			this.#userScrollIntent.direction === direction &&
 			this.#hasRecentUserScrollIntent()
 		);
+	}
+
+	#recordNativeScrollHandoff(
+		cancellation: ConversationViewportIntentCancellationResult | undefined,
+		epoch: number,
+		direction: TranscriptPageDirection | null,
+	): void {
+		const chatId = this.deps.sessions.selectedChatId;
+		if (cancellation !== 'preserved-earlier-prepend' || !chatId) return;
+		this.#nativeScrollHandoff = { chatId, epoch, direction };
+	}
+
+	#resumeNativeScrollHandoff(
+		direction: TranscriptPageDirection | null,
+		viewport: ConversationViewportPort | null,
+	): boolean {
+		const handoff = this.#nativeScrollHandoff;
+		if (!handoff) return false;
+		if (
+			handoff.chatId !== this.deps.sessions.selectedChatId ||
+			handoff.epoch !== this.#userScrollIntent.epoch
+		) {
+			this.#nativeScrollHandoff = null;
+			return false;
+		}
+		if (!direction) return false;
+		this.#nativeScrollHandoff = null;
+		if (
+			(handoff.direction !== null && handoff.direction !== direction) ||
+			!viewport?.ownsScrollPosition()
+		) {
+			return false;
+		}
+		viewport.cancelForUserIntent(direction);
+		return true;
 	}
 
 	async #restoreVisibleViewport(): Promise<void> {

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -287,7 +287,10 @@ export class ConversationScrollController {
 	handleScroll(): void {
 		const node = this.deps.getScrollContainer();
 		if (!node || !this.#isViewportVisible || node.clientHeight <= 0) return;
-		this.#isViewportAtStart = node.scrollTop <= FEED_START_THRESHOLD_PX;
+		const isViewportAtStart = node.scrollTop <= FEED_START_THRESHOLD_PX;
+		if (this.#isViewportAtStart !== isViewportAtStart) {
+			this.#isViewportAtStart = isViewportAtStart;
+		}
 		const inferredDirection = this.#inferScrollDirection(node.scrollTop);
 		if (this.#isPageMutationInProgress) {
 			const shouldReaffirmUserOwnership =

--- a/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-controller.svelte.ts
@@ -15,6 +15,7 @@ const USER_SCROLL_INTENT_WINDOW_MS = 2_000;
 const MIN_PAGE_PREFETCH_DISTANCE_PX = 100;
 const EARLIER_PAGE_PREFETCH_VIEWPORTS = 2;
 const LIVE_END_REPIN_THRESHOLD_PX = 50;
+const FEED_START_THRESHOLD_PX = 1;
 
 // Buffers extra earlier history while preserving one-viewport later paging.
 function pagePrefetchDistance(direction: TranscriptPageDirection, viewportHeight: number): number {
@@ -67,7 +68,9 @@ export interface ScrollControllerDeps {
 export class ConversationScrollController {
 	isPinnedToBottom = $state(true);
 	isScrollingToTop = $state(false);
+	isScrollingToBottom = $state(false);
 	#isAutoFillingViewport = $state(false);
+	#isViewportAtStart = $state(true);
 	#refillViewportAfterCurrentFill = false;
 	#isViewportVisible = true;
 	#initialBottomRestoreChatId = $state<string | null>(null);
@@ -91,6 +94,8 @@ export class ConversationScrollController {
 		this.#lastObservedFeedChatId = deps.sessions.selectedChatId;
 		this.#lastObservedTranscriptViewId = deps.chatState.transcriptViewId;
 		this.#lastObservedFeedDataRevision = deps.chatState.feedMutationClock.dataRevision;
+		const scrollTop = deps.getScrollContainer()?.scrollTop;
+		if (scrollTop !== undefined) this.#isViewportAtStart = scrollTop <= FEED_START_THRESHOLD_PX;
 	}
 
 	isNearBottom(): boolean {
@@ -105,10 +110,15 @@ export class ConversationScrollController {
 		);
 	}
 
+	get canScrollToTop(): boolean {
+		return this.isScrollingToTop || this.deps.chatState.canLoadEarlier || !this.#isViewportAtStart;
+	}
+
 	scrollToBottom(): void {
 		const viewport = this.deps.getViewport();
 		if (!viewport) return;
 		viewport.scrollToEnd();
+		this.#isViewportAtStart = false;
 		this.#previousScrollTop = this.deps.getScrollContainer()?.scrollTop ?? this.#previousScrollTop;
 		this.deps.chatState.isUserScrolledUp = false;
 		this.setPinnedToBottom(true);
@@ -126,6 +136,17 @@ export class ConversationScrollController {
 		);
 		if (result === 'invalidated') return;
 		this.scrollToBottom();
+	}
+
+	async scrollToLatestAndFill(): Promise<void> {
+		if (this.isScrollingToBottom) return;
+		this.isScrollingToBottom = true;
+		try {
+			await this.scrollToLatest();
+			await this.fillUnderfilledViewport();
+		} finally {
+			this.isScrollingToBottom = false;
+		}
 	}
 
 	async restoreLatestWindow(chatId: string): Promise<boolean> {
@@ -246,7 +267,7 @@ export class ConversationScrollController {
 
 	async scrollToTop(): Promise<void> {
 		const chatId = this.deps.sessions.selectedChatId;
-		if (!chatId) return;
+		if (!chatId || this.isScrollingToTop) return;
 
 		this.isScrollingToTop = true;
 		try {
@@ -256,6 +277,7 @@ export class ConversationScrollController {
 			if (result === 'invalidated') return;
 			this.noteUserScrollIntent('earlier');
 			this.deps.getViewport()?.scrollToStart();
+			this.#isViewportAtStart = true;
 			await this.fillUnderfilledViewport();
 		} finally {
 			this.isScrollingToTop = false;
@@ -265,6 +287,7 @@ export class ConversationScrollController {
 	handleScroll(): void {
 		const node = this.deps.getScrollContainer();
 		if (!node || !this.#isViewportVisible || node.clientHeight <= 0) return;
+		this.#isViewportAtStart = node.scrollTop <= FEED_START_THRESHOLD_PX;
 		const inferredDirection = this.#inferScrollDirection(node.scrollTop);
 		if (this.#isPageMutationInProgress) {
 			const shouldReaffirmUserOwnership =

--- a/web/src/lib/chat/transcript/conversation-scroll-gesture.ts
+++ b/web/src/lib/chat/transcript/conversation-scroll-gesture.ts
@@ -5,7 +5,15 @@ export interface ConversationTouchPoint {
 	clientY: number;
 }
 
-export type ConversationScrollIntentReporter = (direction: TranscriptPageDirection | null) => void;
+export type ConversationNativeTouchPhase = 'start' | 'move' | 'end';
+
+export interface ConversationScrollIntent {
+	direction: TranscriptPageDirection | null;
+	// Carries the native touch lifetime; a directionless start stays stateless for settlement.
+	touch: ConversationNativeTouchPhase | null;
+}
+
+export type ConversationScrollIntentReporter = (intent: ConversationScrollIntent) => void;
 
 export class ConversationTouchScrollGesture {
 	#identifier: number | null = null;
@@ -82,28 +90,30 @@ export function observeConversationViewportScrollGestures(
 		}));
 	const handleWheel = (event: WheelEvent) => {
 		const direction = conversationWheelScrollDirection(event.deltaY);
-		if (direction) report(direction);
+		if (direction) report({ direction, touch: null });
 	};
 	const handleTouchStart = (event: TouchEvent) => {
-		if (touchGesture.begin(touchPoints(event))) report(null);
+		if (touchGesture.begin(touchPoints(event))) report({ direction: null, touch: 'start' });
 	};
 	const handleTouchMove = (event: TouchEvent) => {
 		const direction = touchGesture.move(touchPoints(event));
-		if (direction) report(direction);
+		if (direction) report({ direction, touch: 'move' });
 	};
 	const handleTouchEnd = (event: TouchEvent) => {
 		touchGesture.end(touchPoints(event));
+		// Ownership ends only when the last finger lifts; a partial lift keeps the gesture alive.
+		if (event.touches.length === 0) report({ direction: null, touch: 'end' });
 	};
 	const handlePointerDown = (event: PointerEvent) => {
-		if (event.button === 0 && event.pointerType !== 'touch') report(null);
+		if (event.button === 0 && event.pointerType !== 'touch') report({ direction: null, touch: null });
 	};
 	const handleKeydown = (event: KeyboardEvent) => {
 		if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
-			report('earlier');
+			report({ direction: 'earlier', touch: null });
 		} else if (event.key === ' ') {
-			report(event.shiftKey ? 'earlier' : 'later');
+			report({ direction: event.shiftKey ? 'earlier' : 'later', touch: null });
 		} else if (event.key === 'ArrowDown' || event.key === 'PageDown' || event.key === 'End') {
-			report('later');
+			report({ direction: 'later', touch: null });
 		}
 	};
 

--- a/web/src/lib/chat/transcript/conversation-viewport-port.ts
+++ b/web/src/lib/chat/transcript/conversation-viewport-port.ts
@@ -1,6 +1,12 @@
+import type { ConversationNativeTouchPhase } from './conversation-scroll-gesture.js';
+
 export type ConversationViewportTarget =
 	{ kind: 'row'; id: string } | { kind: 'dom-anchor'; id: string };
 export type ConversationViewportIntentSource = 'viewport' | 'scrollbar-drag';
+export type ConversationViewportIntentCancellationResult =
+	| 'cancelled'
+	| 'preserved-earlier-prepend'
+	| 'blocked-scrollbar-drag';
 
 export type HiddenReadingRestoreResult = 'restored' | 'missing-anchor' | 'not-ready';
 export type ConversationLayoutWaitResult = 'settled' | 'superseded' | 'not-ready';
@@ -23,7 +29,8 @@ export interface ConversationViewportPort {
 	cancelForUserIntent(
 		direction: 'earlier' | 'later' | null,
 		source?: ConversationViewportIntentSource,
-	): boolean;
+	): ConversationViewportIntentCancellationResult;
+	noteNativeTouchLifecycle(phase: ConversationNativeTouchPhase): void;
 	scrollToTarget(
 		target: ConversationViewportTarget,
 		options?: { align?: 'center' | 'start' | 'end' },

--- a/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedVirtualController.svelte.ts
@@ -4,12 +4,14 @@ import type { Readable, Unsubscriber } from 'svelte/store';
 import { createVirtualizer, type Range, type SvelteVirtualizer } from '@tanstack/svelte-virtual';
 import type {
 	ConversationLayoutWaitResult,
+	ConversationViewportIntentCancellationResult,
 	ConversationViewportFillResult,
 	ConversationViewportPort,
 	ConversationViewportTarget,
 	ConversationViewportTargetResult,
 	HiddenReadingRestoreResult,
 } from '$lib/chat/transcript/conversation-viewport-port.js';
+import type { ConversationNativeTouchPhase } from '$lib/chat/transcript/conversation-scroll-gesture.js';
 import type { ConversationVirtualGeometrySnapshot } from './ConversationFeedProjectionState.svelte.js';
 import {
 	CHAT_GEOMETRY_END_THRESHOLD_PX,
@@ -97,6 +99,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 	#initialEndRestoreEpoch = 0;
 	#activeTargetScrolls = 0;
 	#userIntentEpoch = 0;
+	#activeNativeTouch = false;
 	#scrollMargin = 0;
 	#observeElementRect = createConversationElementRectObserver({
 		width: 0,
@@ -444,6 +447,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		this.#layoutMutationToken += 1;
 		this.#readingRestoreGeneration += 1;
 		this.#pendingReadingAnchor = null;
+		this.#preCommitAnchorBuffer.clear();
 		this.#earlierPrependAnchor.clear();
 		this.#programmaticScroll.cancel();
 	}
@@ -451,7 +455,7 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 	cancelForUserIntent(
 		direction: 'earlier' | 'later' | null,
 		source: 'viewport' | 'scrollbar-drag' = 'viewport',
-	): boolean {
+	): ConversationViewportIntentCancellationResult {
 		this.#userIntentEpoch += 1;
 		this.#initialEndRestoreEpoch += 1;
 		this.#cancelTargetScroll();
@@ -465,12 +469,20 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 		);
 		if (preservesEarlierPrepend) {
 			this.options.onInitialEndRestored?.();
-			return this.#earlierPrependAnchor.blocksViewportMutation(source);
+			return this.#earlierPrependAnchor.blocksViewportMutation(source)
+				? 'blocked-scrollbar-drag'
+				: 'preserved-earlier-prepend';
 		}
 		this.cancelPendingLayoutMutation();
 		this.#instance().cancelScroll();
 		this.options.onInitialEndRestored?.();
-		return false;
+		return 'cancelled';
+	}
+
+	noteNativeTouchLifecycle(phase: ConversationNativeTouchPhase): void {
+		// Only a direction-bearing move owns settlement; a fresh stateless press or a terminal
+		// end/cancel explicitly releases it so no stale ownership survives a rebinding.
+		this.#activeNativeTouch = phase === 'move';
 	}
 
 	async scrollToTarget(
@@ -791,7 +803,8 @@ export class ConversationFeedVirtualController implements ConversationViewportPo
 				isCurrent: () =>
 					token === this.#layoutMutationToken &&
 					this.#programmaticScroll.isCurrent(operationEpoch) &&
-					this.isReady(),
+					this.isReady() &&
+					!this.#activeNativeTouch,
 			});
 		} finally {
 			release();

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -518,10 +518,18 @@
 	// Marks real scroll gestures on the actual viewport element without wrapper event forwarding.
 	$effect(() => {
 		const node = scrollContainer;
+		// The synchronous port read binds this effect to port changes, so teardown releases
+		// native-touch ownership on the captured old port before rebinding.
+		const viewport = conversationViewport;
 		if (!node) return;
-		return observeConversationViewportScrollGestures(node, (direction) =>
-			scroll.noteUserScrollIntent(direction),
-		);
+		const stop = observeConversationViewportScrollGestures(node, (intent) => {
+			if (intent.touch !== null) viewport?.noteNativeTouchLifecycle(intent.touch);
+			if (intent.touch !== 'end') scroll.noteUserScrollIntent(intent.direction);
+		});
+		return () => {
+			stop();
+			viewport?.noteNativeTouchLifecycle('end');
+		};
 	});
 
 	// Scrolls to bottom when the scroll container becomes available.

--- a/web/src/lib/components/chat/ConversationWorkspace.svelte
+++ b/web/src/lib/components/chat/ConversationWorkspace.svelte
@@ -384,7 +384,7 @@
 		sessions,
 	});
 	function scrollToBottomAndFill(): void {
-		void scroll.scrollToLatest().then(() => scroll.fillUnderfilledViewport());
+		void scroll.scrollToLatestAndFill();
 	}
 
 	// Session controller.
@@ -764,29 +764,36 @@
 			{/snippet}
 		</svelte:boundary>
 
-		{#if chatState.isUserScrolledUp && chatState.displayMessageCount > 0}
-			<Button
-				variant="outline"
-				size="icon"
-				class={scrollToTopButtonClass}
-				onclick={() => scroll.scrollToTop()}
-				disabled={scroll.isScrollingToTop}
-				title={m.workspace_scroll_to_initial_prompt()}
-			>
-				{#if scroll.isScrollingToTop}
-					<Loader2 class="w-5 h-5 animate-spin" />
-				{:else}
-					<ArrowUp class="w-5 h-5" />
-				{/if}
-			</Button>
+		{#if (chatState.isUserScrolledUp || scroll.isScrollingToBottom) && chatState.displayMessageCount > 0}
+			{#if scroll.canScrollToTop && !scroll.isScrollingToBottom}
+				<Button
+					variant="outline"
+					size="icon"
+					class={scrollToTopButtonClass}
+					onclick={() => scroll.scrollToTop()}
+					disabled={scroll.isScrollingToTop}
+					title={m.workspace_scroll_to_initial_prompt()}
+				>
+					{#if scroll.isScrollingToTop}
+						<Loader2 class="w-5 h-5 animate-spin" />
+					{:else}
+						<ArrowUp class="w-5 h-5" />
+					{/if}
+				</Button>
+			{/if}
 			<Button
 				variant="outline"
 				size="icon"
 				class="absolute bottom-14 right-5 sm:right-6 z-20 w-11 h-11 rounded-full shadow-md hover:shadow-lg"
 				onclick={scrollToBottomAndFill}
+				disabled={scroll.isScrollingToBottom}
 				title={m.workspace_scroll_to_bottom()}
 			>
-				<ArrowDown class="w-5 h-5" />
+				{#if scroll.isScrollingToBottom}
+					<Loader2 class="w-5 h-5 animate-spin" />
+				{:else}
+					<ArrowDown class="w-5 h-5" />
+				{/if}
 			</Button>
 		{/if}
 	</div>

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualController.test.ts
@@ -631,6 +631,8 @@ interface ControllerExposure {
 	controller: ConversationFeedVirtualController;
 	instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>;
 	initialEndRestoredCount(): number;
+	prepareClampedScrollbarPrepend(): void;
+	publishPreparedEarlierPrependAfterUserIntent(): Promise<void>;
 	prepareHiddenOffsetWithMissingAnchor(): Promise<void>;
 	prepareHiddenOffsetWithoutAnchor(): Promise<void>;
 	prependWithRetainedWithheldAnchor(index: number): Promise<void>;
@@ -842,6 +844,32 @@ describe('ConversationFeedVirtualController', () => {
 		expect(scrollToOffset).not.toHaveBeenCalled();
 	});
 
+	it('does not restore a pre-commit anchor cancelled by newer user intent', async () => {
+		const { exposure } = await renderController();
+		const viewport = document.querySelector<HTMLDivElement>('[data-controller-viewport]');
+		if (!viewport) throw new Error('Expected the controller viewport');
+		await fireEvent.click(screen.getByRole('button', { name: 'Toggle pinned' }));
+		viewport.scrollTop = 86;
+		viewport.dispatchEvent(new Event('scroll'));
+		await nextFrame();
+		const scrollToOffset = vi.spyOn(exposure.instance, 'scrollToOffset');
+
+		await exposure.publishPreparedEarlierPrependAfterUserIntent();
+		for (let frame = 0; frame < 10; frame += 1) await nextFrame();
+
+		expect(scrollToOffset).not.toHaveBeenCalled();
+		expect(exposure.controller.ownsScrollPosition()).toBe(false);
+	});
+
+	it('reports a blocked scrollbar drag while preserving its clamped prepend', async () => {
+		const { exposure } = await renderController();
+		exposure.prepareClampedScrollbarPrepend();
+
+		expect(exposure.controller.cancelForUserIntent('earlier', 'scrollbar-drag')).toBe(
+			'blocked-scrollbar-drag',
+		);
+	});
+
 	it('keeps a clamped prepend latched through a tail publication', async () => {
 		const { exposure, viewport, scrollToIndex, scrollToOffset, expectedScrollOffset } =
 			await preparePendingEarlierPrepend((current, index) =>
@@ -851,7 +879,9 @@ describe('ConversationFeedVirtualController', () => {
 		scrollToIndex.mockClear();
 		scrollToOffset.mockClear();
 		viewport.scrollTop = 80;
-		exposure.controller.cancelForUserIntent('earlier');
+		expect(exposure.controller.cancelForUserIntent('earlier')).toBe(
+			'preserved-earlier-prepend',
+		);
 		expect(cancelScroll).not.toHaveBeenCalled();
 		await exposure.releaseWithheldEndItem();
 
@@ -868,7 +898,10 @@ describe('ConversationFeedVirtualController', () => {
 		scrollToIndex.mockClear();
 		scrollToOffset.mockClear();
 		viewport.scrollTop = 0;
-		exposure.controller.cancelForUserIntent('earlier');
+		expect(exposure.controller.cancelForUserIntent('earlier')).toBe(
+			'preserved-earlier-prepend',
+		);
+		exposure.controller.noteNativeTouchLifecycle('start');
 		await exposure.releaseWithheldEndItem();
 
 		await waitFor(() =>
@@ -884,13 +917,34 @@ describe('ConversationFeedVirtualController', () => {
 		scrollToIndex.mockClear();
 		scrollToOffset.mockClear();
 		viewport.scrollTop = 80;
-		exposure.controller.cancelForUserIntent(null);
+		expect(exposure.controller.cancelForUserIntent(null)).toBe('preserved-earlier-prepend');
 		exposure.controller.cancelForUserIntent('earlier');
 		scrollToIndex.mockClear();
 		scrollToOffset.mockClear();
 		await exposure.releaseWithheldEndItem();
 		for (let frame = 0; frame < 10; frame += 1) await nextFrame();
 
+		expect(scrollToIndex).not.toHaveBeenCalled();
+		expect(scrollToOffset).not.toHaveBeenCalled();
+	});
+
+	it('suppresses the counter-direction settle write while a native touch owns the viewport', async () => {
+		const { exposure, viewport, scrollToIndex, scrollToOffset } =
+			await preparePendingEarlierPrepend((current, index) =>
+				current.stageEarlierPrependWithTail(index),
+			);
+		scrollToIndex.mockClear();
+		scrollToOffset.mockClear();
+		viewport.scrollTop = 0;
+		exposure.controller.noteNativeTouchLifecycle('move');
+		await exposure.releaseWithheldEndItem();
+		for (let frame = 0; frame < 10; frame += 1) await nextFrame();
+
+		expect(scrollToIndex).not.toHaveBeenCalled();
+		expect(scrollToOffset).not.toHaveBeenCalled();
+
+		exposure.controller.noteNativeTouchLifecycle('end');
+		for (let frame = 0; frame < 10; frame += 1) await nextFrame();
 		expect(scrollToIndex).not.toHaveBeenCalled();
 		expect(scrollToOffset).not.toHaveBeenCalled();
 	});
@@ -1021,7 +1075,7 @@ describe('ConversationFeedVirtualController', () => {
 		const scrollToIndex = vi.spyOn(exposure.instance, 'scrollToIndex');
 
 		exposure.controller.restoreInitialEnd();
-		exposure.controller.cancelForUserIntent(null);
+		expect(exposure.controller.cancelForUserIntent(null)).toBe('cancelled');
 		await nextFrame();
 		await nextFrame();
 		await nextFrame();

--- a/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedVirtualControllerTestHost.svelte
@@ -14,6 +14,8 @@
 		controller: ConversationFeedVirtualController;
 		instance: SvelteVirtualizer<HTMLElement, HTMLDivElement>;
 		initialEndRestoredCount(): number;
+		prepareClampedScrollbarPrepend(): void;
+		publishPreparedEarlierPrependAfterUserIntent(): Promise<void>;
 		prepareHiddenOffsetWithMissingAnchor(): Promise<void>;
 		prepareHiddenOffsetWithoutAnchor(): Promise<void>;
 		releaseWithheldEndItem(): Promise<void>;
@@ -131,6 +133,8 @@
 			controller,
 			instance,
 			initialEndRestoredCount: () => initialEndRestoredCount,
+			prepareClampedScrollbarPrepend,
+			publishPreparedEarlierPrependAfterUserIntent,
 			prepareHiddenOffsetWithMissingAnchor,
 			prepareHiddenOffsetWithoutAnchor,
 			releaseWithheldEndItem,
@@ -203,6 +207,11 @@
 		geometryRevision += 1;
 	}
 
+	function prepareClampedScrollbarPrepend(): void {
+		if (viewport) viewport.scrollTop = 0;
+		controller.prepareForGeometryPublication(geometryRevision + 1, true, true);
+	}
+
 	function prependItems(): void {
 		controller.prepareForGeometryPublication(geometryRevision + 1);
 		historyEarlierMutation = true;
@@ -210,6 +219,18 @@
 		itemCount += 4;
 		measurementReset = 'none';
 		geometryRevision += 1;
+	}
+
+	async function publishPreparedEarlierPrependAfterUserIntent(): Promise<void> {
+		controller.prepareForGeometryPublication(geometryRevision + 1, true);
+		controller.cancelForUserIntent('earlier');
+		historyEarlierMutation = true;
+		firstItemNumber -= 4;
+		itemCount += 4;
+		measurementReset = 'none';
+		geometryRevision += 1;
+		await tick();
+		await tick();
 	}
 
 	function toggleScale(): void {


### PR DESCRIPTION
Chat feed navigation could leave Top visible at the physical start, drop Bottom feedback while navigation was still settling, and let paged prepends fight an active native scroll gesture. This change tracks the physical feed start independently, keeps Bottom pending through loading, layout settlement, scrolling, and viewport filling, and coordinates prepend settlement with touch, scrollbar, and keyboard ownership so navigation remains responsive and stable.