### PR TITLE
Improve responsive branch name visibility

### DIFF
--- a/web/src/lib/components/chat/GitQuickStatusTray.svelte
+++ b/web/src/lib/components/chat/GitQuickStatusTray.svelte
@@ -76,7 +76,7 @@
 							isLoading={branchSelector.isLoading}
 							{isMobile}
 							side="top"
-							menuClass="w-[min(18rem,calc(100vw-2rem))]"
+							menuClass="w-[min(36rem,calc(100vw-2rem))]"
 							triggerClass="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-md border border-border bg-background/65 px-2 py-1 text-xs text-muted-foreground hover:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							iconClass="h-3.5 w-3.5 shrink-0"
 							labelClass="max-w-32 text-xs font-medium text-foreground"

--- a/web/src/lib/components/chat/GitQuickStatusTray.svelte
+++ b/web/src/lib/components/chat/GitQuickStatusTray.svelte
@@ -77,7 +77,7 @@
 							{isMobile}
 							side="top"
 							menuClass="w-[min(36rem,calc(100vw-2rem))]"
-							triggerClass="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-md border border-border bg-background/65 px-2 py-1 text-xs text-muted-foreground hover:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							triggerClass="inline-flex h-7 min-w-0 max-w-44 items-center gap-1.5 rounded-md border border-border bg-background/65 px-2 py-1 text-xs text-muted-foreground hover:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:max-w-80"
 							iconClass="h-3.5 w-3.5 shrink-0"
 							labelClass="max-w-32 text-xs font-medium text-foreground"
 							chevronClass="h-3.5 w-3.5"

--- a/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
+++ b/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
@@ -167,6 +167,9 @@ describe('GitQuickStatusTray', () => {
 			},
 		});
 
+		const menuClass = document.querySelector('[data-slot="popover-content"]')?.className ?? '';
+		expect(menuClass).toContain('w-[min(36rem,calc(100vw-2rem))]');
+
 		const search = screen.getByRole('combobox', { name: 'Find a ref' });
 		await fireEvent.input(search, { target: { value: 'feature' } });
 		expect(screen.queryByText('Branches')).toBeNull();

--- a/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
+++ b/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
@@ -212,6 +212,37 @@ describe('GitQuickStatusTray', () => {
 		expect(onToggle).toHaveBeenCalledOnce();
 	});
 
+	it('expands the branch control on wide screens without wrapping on narrow screens', () => {
+		const longBranch = 'feature/a-long-current-branch-name';
+		render(GitQuickStatusTray, {
+			props: {
+				isVisible: true,
+				summary: summary({ branch: longBranch }),
+				isRefreshing: false,
+				branchSelector: {
+					refs: refsFromNames([longBranch]),
+					isOpen: false,
+					isLoading: false,
+					onToggle: vi.fn(),
+					onClose: vi.fn(),
+					onCreateBranch: vi.fn(),
+					onSwitchBranch: vi.fn(),
+				},
+				onCommit: vi.fn(),
+			},
+		});
+
+		const trigger = screen.getByRole('button', {
+			name: new RegExp(`current ref ${longBranch}`, 'i'),
+		});
+		const label = within(trigger).getByText(longBranch);
+		expect(trigger.className).toContain('max-w-44');
+		expect(trigger.className).toContain('sm:max-w-80');
+		expect(label.className).toContain('max-w-32');
+		expect(label.className).toContain('sm:max-w-64');
+		expect(label.className).toContain('truncate');
+	});
+
 	it('widens the switch confirmation dialog while preserving narrow-screen truncation', async () => {
 		const longBranch =
 			'feature/some-extremely-long-branch-name-that-should-never-wrap-the-confirmation-dialog';

--- a/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
+++ b/web/src/lib/components/chat/__tests__/GitQuickStatusTray.test.ts
@@ -209,7 +209,7 @@ describe('GitQuickStatusTray', () => {
 		expect(onToggle).toHaveBeenCalledOnce();
 	});
 
-	it('truncates long branch names in the switch confirmation dialog', async () => {
+	it('widens the switch confirmation dialog while preserving narrow-screen truncation', async () => {
 		const longBranch =
 			'feature/some-extremely-long-branch-name-that-should-never-wrap-the-confirmation-dialog';
 		render(GitQuickStatusTray, {
@@ -236,6 +236,13 @@ describe('GitQuickStatusTray', () => {
 			name: `Switch to branch ${longBranch}?`,
 		});
 		const branchText = within(heading).getByText(longBranch);
+		const dialogClass = heading.closest('[data-slot="dialog-content"]')?.className ?? '';
+		const headerClass = heading.closest('[data-slot="dialog-header"]')?.className ?? '';
+		expect(dialogClass).toContain('w-[calc(100%-2rem)]');
+		expect(dialogClass).toContain('sm:max-w-2xl');
+		expect(headerClass).toContain('min-w-0');
+		expect(headerClass).toContain('max-w-full');
+		expect(heading.className).toContain('max-w-full');
 		expect(branchText.className).toContain('truncate');
 	});
 

--- a/web/src/lib/components/git/GitBranchSelector.svelte
+++ b/web/src/lib/components/git/GitBranchSelector.svelte
@@ -138,7 +138,7 @@
 	);
 	const resolvedMenuClass = $derived(
 		cn(
-			'w-72 max-w-[calc(100vw-1rem)] max-h-[min(28rem,var(--bits-popover-content-available-height))] overflow-hidden rounded-lg border-border p-0 shadow-lg',
+			'w-[min(36rem,calc(100vw-1rem))] max-h-[min(28rem,var(--bits-popover-content-available-height))] overflow-hidden rounded-lg border-border p-0 shadow-lg',
 			menuClass,
 		),
 	);

--- a/web/src/lib/components/git/GitBranchSelector.svelte
+++ b/web/src/lib/components/git/GitBranchSelector.svelte
@@ -435,18 +435,19 @@
 	}}
 >
 	<Dialog.Content
+		class="w-[calc(100%-2rem)] sm:max-w-2xl"
 		showCloseButton={!isSwitchingBranch}
 		onCloseAutoFocus={handleSwitchDialogCloseAutoFocus}
 	>
 		{#if pendingSwitchRef}
-			<Dialog.Header>
-				<div class="flex min-w-0 items-center">
+			<Dialog.Header class="min-w-0 max-w-full">
+				<div class="flex min-w-0 max-w-full items-center">
 					<div class="mr-3 shrink-0 rounded-full bg-diff-modified p-2">
 						<GitBranch class="h-5 w-5 text-diff-modified-foreground" />
 					</div>
 					<Dialog.Title
 						aria-label={switchBranchTitle}
-						class="flex min-w-0 flex-1 items-baseline overflow-hidden text-left whitespace-nowrap"
+						class="flex min-w-0 max-w-full flex-1 items-baseline overflow-hidden text-left whitespace-nowrap"
 					>
 						<span aria-hidden="true" class="shrink-0"
 							>{pendingSwitchRef.kind === 'local-branch'

--- a/web/src/lib/components/git/GitBranchSelector.svelte
+++ b/web/src/lib/components/git/GitBranchSelector.svelte
@@ -127,7 +127,11 @@
 	);
 	const resolvedIconClass = $derived(cn('text-muted-foreground w-4 h-4', iconClass));
 	const resolvedLabelClass = $derived(
-		cn('text-sm font-medium truncate', isMobile ? 'max-w-[6rem]' : 'max-w-[140px]', labelClass),
+		cn(
+			'text-sm font-medium truncate sm:max-w-64',
+			isMobile ? 'max-w-[6rem]' : 'max-w-[140px]',
+			labelClass,
+		),
 	);
 	const resolvedChevronClass = $derived(
 		cn(

--- a/web/src/lib/components/git/GitTargetSelector.svelte
+++ b/web/src/lib/components/git/GitTargetSelector.svelte
@@ -92,7 +92,7 @@
 		isLoading={target.branches.isLoadingBranches}
 		{disabled}
 		{isMobile}
-		triggerClass="h-8 max-w-40 px-2 text-xs"
+		triggerClass="h-8 max-w-40 px-2 text-xs sm:max-w-80"
 		labelClass="max-w-24 text-xs"
 		onToggle={toggleBranchSelector}
 		onClose={() => target.branches.closeBranchDropdown()}

--- a/web/src/lib/components/git/__tests__/GitBranchSelector.test.ts
+++ b/web/src/lib/components/git/__tests__/GitBranchSelector.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import GitBranchSelector from '../GitBranchSelector.svelte';
 
@@ -74,6 +74,27 @@ describe('GitBranchSelector switch-confirmation dialog', () => {
 		expect(screen.getByRole('option', { name: /branch-0/ })).toBeTruthy();
 		expect(screen.queryByRole('option', { name: /branch-119/ })).toBeNull();
 		expect(document.querySelectorAll('[data-git-ref-virtual-row]').length).toBeLessThan(40);
+	});
+
+	it('expands the ref list within the viewport without wrapping long names', () => {
+		const longBranch = 'feature/a-branch-name-that-benefits-from-the-available-screen-width';
+		renderSelector({
+			refs: [
+				{ name: 'main', ref: 'refs/heads/main', kind: 'local-branch', isCurrent: true },
+				{
+					name: longBranch,
+					ref: `refs/heads/${longBranch}`,
+					kind: 'local-branch',
+				},
+			],
+		});
+
+		const menuClass = document.querySelector('[data-slot="popover-content"]')?.className ?? '';
+		const branchText = within(
+			screen.getByRole('option', { name: new RegExp(longBranch) }),
+		).getByText(longBranch);
+		expect(menuClass).toContain('w-[min(36rem,calc(100vw-1rem))]');
+		expect(branchText.className).toContain('truncate');
 	});
 
 	it('reclaims focus when the switch is cancelled', async () => {

--- a/web/src/lib/components/git/__tests__/GitSurfaceToolbar.test.ts
+++ b/web/src/lib/components/git/__tests__/GitSurfaceToolbar.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import GitSurfaceToolbarTestHost from './GitSurfaceToolbarTestHost.svelte';
 import { GitTargetSessionController } from '$lib/git/targets/git-target-session.svelte.js';
@@ -47,6 +47,28 @@ describe('GitSurfaceToolbar', () => {
 		expect(folder.getAttribute('title')).toBe('/very/long/workspace/project/path');
 		expect(folder.textContent).toContain('...');
 		expect(screen.getByRole('button', { name: /current ref HEAD/i })).toBeTruthy();
+	});
+
+	it('expands the branch control on wide screens without wrapping on narrow screens', () => {
+		const longBranch = 'feature/a-long-current-branch-name';
+		const controller = target();
+		controller.branches.currentBranch = longBranch;
+		render(GitSurfaceToolbarTestHost, {
+			props: {
+				target: controller,
+				presentation: 'main',
+			},
+		});
+
+		const trigger = screen.getByRole('button', {
+			name: new RegExp(`current ref ${longBranch}`, 'i'),
+		});
+		const label = within(trigger).getByText(longBranch);
+		expect(trigger.className).toContain('max-w-40');
+		expect(trigger.className).toContain('sm:max-w-80');
+		expect(label.className).toContain('max-w-24');
+		expect(label.className).toContain('sm:max-w-64');
+		expect(label.className).toContain('truncate');
 	});
 
 	it('opens the shared target dialog from the folder control', async () => {


### PR DESCRIPTION
Long branch names were unnecessarily truncated on wide screens and could overflow the switch confirmation dialog. This widens branch selectors, ref lists, and the switch dialog when space is available while preserving single-line truncation and viewport bounds on narrow screens.