### PR TITLE
Fix Commit sidebar hangs on large worktrees

### DIFF
--- a/web/src/lib/components/git/CommitFileTree.svelte
+++ b/web/src/lib/components/git/CommitFileTree.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+	import AlertTriangle from '@lucide/svelte/icons/triangle-alert';
+	import FileIcon from '@lucide/svelte/icons/file';
+	import FolderIcon from '@lucide/svelte/icons/folder';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import Plus from '@lucide/svelte/icons/plus';
+	import type { GitTreeNode } from '$lib/api/git.js';
+	import { FixedVirtualWindow } from '$lib/components/virtual/fixed-virtual-window.svelte';
+	import type { CommitController } from '$lib/git/commit/commit-controller.svelte.js';
+	import {
+		buildCommitTreeRows,
+		COMMIT_TREE_ROW_HEIGHT,
+		COMMIT_TREE_ROW_OVERSCAN,
+		type CommitDirectoryTreeRow,
+		type CommitFileTreeRow,
+		type CommitTreeRow,
+	} from '$lib/git/commit/commit-tree-rows.js';
+	import * as m from '$lib/paraglide/messages.js';
+	import { nativeWorkspaceScrollRegion } from '$lib/workspace/workspace-scroll-region.js';
+
+	interface Props {
+		controller: CommitController;
+	}
+
+	let { controller }: Props = $props();
+	let viewportRef = $state<HTMLElement | null>(null);
+	const primaryScrollRegion = nativeWorkspaceScrollRegion('primary');
+	const rootFontSize = (() => {
+		if (typeof window === 'undefined') return 16;
+		const value = Number.parseFloat(window.getComputedStyle(document.documentElement).fontSize);
+		return Number.isFinite(value) && value > 0 ? value : 16;
+	})();
+	const rowHeight = COMMIT_TREE_ROW_HEIGHT * Math.max(1, rootFontSize / 16);
+	let rows = $derived(buildCommitTreeRows(controller.tree, controller.intents));
+	const virtualWindow = new FixedVirtualWindow({
+		get itemCount() {
+			return rows.length;
+		},
+		get rowHeight() {
+			return rowHeight;
+		},
+		get overscan() {
+			return COMMIT_TREE_ROW_OVERSCAN;
+		},
+		get viewportRef() {
+			return viewportRef;
+		},
+		defaultViewportHeight: 640,
+	});
+	let visibleRows = $derived.by(() =>
+		virtualWindow.visibleIndexes
+			.map((index) => ({ index, row: rows[index] }))
+			.filter((entry): entry is { index: number; row: CommitTreeRow } => Boolean(entry.row)),
+	);
+
+	$effect(() => {
+		return virtualWindow.bindViewport();
+	});
+
+	$effect(() => {
+		return virtualWindow.observeViewport();
+	});
+
+	$effect(() => {
+		const viewport = viewportRef;
+		const maxScrollTop = Math.max(0, virtualWindow.totalHeight - virtualWindow.viewportHeight);
+		if (!viewport || virtualWindow.scrollTop <= maxScrollTop) return;
+		viewport.scrollTop = maxScrollTop;
+		virtualWindow.scrollTop = viewport.scrollTop;
+	});
+
+	function fileBadge(node: GitTreeNode): string {
+		if (node.staged && node.hasUnstaged) return 'mixed';
+		if (node.changeKind === 'untracked') return 'untracked';
+		if (node.staged) return 'staged';
+		return 'unstaged';
+	}
+
+	function indeterminate(
+		node: HTMLInputElement,
+		value: boolean,
+	): { update(nextValue: boolean): void } {
+		node.indeterminate = value;
+		return {
+			update(nextValue: boolean) {
+				node.indeterminate = nextValue;
+			},
+		};
+	}
+</script>
+
+<div class="relative flex h-full min-w-0 flex-col overflow-hidden">
+	<div
+		bind:this={viewportRef}
+		class="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden py-1 {controller.treeErrorMessage
+			? 'pb-12'
+			: ''}"
+		{@attach primaryScrollRegion}
+		data-commit-file-scroll
+	>
+		{#if controller.isLoadingTree}
+			<div class="flex items-center justify-center gap-2 px-3 py-8 text-xs text-muted-foreground">
+				<LoaderCircle class="h-3.5 w-3.5 animate-spin" />
+				<span>{m.filetree_loading()}</span>
+			</div>
+		{:else if rows.length === 0}
+			<div class="px-3 py-8 text-center text-xs text-muted-foreground">
+				{m.git_quick_commit_no_changed_files()}
+			</div>
+		{:else}
+			<div
+				class="relative w-full"
+				style={`height:${virtualWindow.totalHeight}px;`}
+				data-commit-file-virtual-list
+			>
+				{#each visibleRows as entry (entry.row.node.path)}
+					<div
+						class="absolute left-0 right-0 top-0 overflow-hidden"
+						style={`height:${rowHeight}px; transform:translateY(${virtualWindow.getOffset(entry.index)}px);`}
+						data-commit-tree-row={entry.row.node.path}
+						data-commit-tree-index={entry.index}
+						data-commit-tree-depth={entry.row.depth}
+					>
+						<svelte:boundary>
+							{#if entry.row.kind === 'directory'}
+								{@render directoryRow(entry.row)}
+							{:else}
+								{@render fileRow(entry.row)}
+							{/if}
+
+							{#snippet failed()}
+								<div
+									class="flex h-full items-center gap-2 px-3 text-xs text-status-error-foreground"
+								>
+									<AlertTriangle class="h-3.5 w-3.5 shrink-0" />
+									<span class="truncate">{m.git_diff_document_file_row_failed()}</span>
+								</div>
+							{/snippet}
+						</svelte:boundary>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+	{#if controller.treeErrorMessage}
+		<div
+			class="absolute inset-x-0 bottom-0 border-t border-status-error-border bg-status-error px-3 py-2 text-xs text-status-error-foreground shadow-sm"
+		>
+			<div class="flex min-w-0 items-center gap-2">
+				<AlertTriangle class="h-3.5 w-3.5 shrink-0" />
+				<span class="min-w-0 flex-1 truncate" title={controller.treeErrorMessage}>
+					{controller.treeErrorMessage}
+				</span>
+			</div>
+		</div>
+	{/if}
+</div>
+
+{#snippet directoryRow(row: CommitDirectoryTreeRow)}
+	{@const selection = row.selection}
+	<div
+		class="group flex h-full min-w-0 max-w-full items-center gap-2 overflow-hidden px-2 text-xs text-muted-foreground hover:bg-muted/50"
+		style:padding-left={`${row.depth * 14 + 10}px`}
+	>
+		<input
+			type="checkbox"
+			checked={selection.checked}
+			use:indeterminate={selection.mixed}
+			onchange={() =>
+				controller.toggleDirectory(row.node.path, selection.mixed ? true : !selection.checked)}
+			disabled={selection.fileCount === 0}
+			class="size-3.5 shrink-0 accent-current"
+			aria-checked={selection.mixed ? 'mixed' : selection.checked}
+			aria-label={selection.checked && !selection.mixed
+				? m.git_quick_commit_unstage_path({ path: row.node.path })
+				: m.git_quick_commit_stage_path({ path: row.node.path })}
+		/>
+		{#if selection.isRunning}
+			<LoaderCircle class="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+		{:else}
+			<FolderIcon class="h-3.5 w-3.5 shrink-0" />
+		{/if}
+		<span class="min-w-0 flex-1 truncate" title={row.node.path}>{row.node.name}</span>
+		{#if row.node.additions || row.node.deletions}
+			<span class="flex shrink-0 gap-1 tabular-nums">
+				{#if row.node.additions}
+					<span class="text-git-added">+{row.node.additions}</span>
+				{/if}
+				{#if row.node.deletions}
+					<span class="text-git-deleted">-{row.node.deletions}</span>
+				{/if}
+			</span>
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet fileRow(row: CommitFileTreeRow)}
+	<div
+		class="group flex h-full min-w-0 max-w-full items-center gap-2 overflow-hidden px-2 text-xs hover:bg-muted/50"
+		style:padding-left={`${row.depth * 14 + 10}px`}
+	>
+		<input
+			type="checkbox"
+			checked={row.intent?.desiredSelected ?? false}
+			onchange={(event) => controller.togglePath(row.node.path, event.currentTarget.checked)}
+			class="size-3.5 shrink-0 accent-current"
+			aria-label={controller.operationLabelForPath(row.node.path)}
+		/>
+		{#if row.intent?.isRunning}
+			<LoaderCircle
+				class="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground"
+				aria-label={controller.operationLabelForPath(row.node.path)}
+			/>
+		{:else}
+			<FileIcon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+		{/if}
+		<span class="min-w-0 flex-1 truncate text-foreground" title={row.node.path}
+			>{row.node.name}</span
+		>
+		{#if row.stats.additions > 0 || row.stats.deletions > 0}
+			<span class="flex shrink-0 gap-1 tabular-nums">
+				{#if row.stats.additions > 0}
+					<span class="text-git-added">+{row.stats.additions}</span>
+				{/if}
+				{#if row.stats.deletions > 0}
+					<span class="text-git-deleted">-{row.stats.deletions}</span>
+				{/if}
+			</span>
+		{/if}
+		<span class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+			{fileBadge(row.node)}
+		</span>
+		{#if row.node.staged && row.node.hasUnstaged}
+			<button
+				type="button"
+				onclick={() => controller.includeUnstaged(row.node.path)}
+				class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:hidden"
+				title={m.git_quick_commit_include_unstaged()}
+				aria-label={m.git_quick_commit_include_unstaged()}
+			>
+				<Plus class="h-3 w-3" />
+			</button>
+			<button
+				type="button"
+				onclick={() => controller.includeUnstaged(row.node.path)}
+				class="hidden shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:inline-flex sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
+			>
+				{m.git_quick_commit_include_unstaged()}
+			</button>
+		{/if}
+	</div>
+{/snippet}

--- a/web/src/lib/components/git/CommitSurface.svelte
+++ b/web/src/lib/components/git/CommitSurface.svelte
@@ -2,21 +2,16 @@
 	import { onDestroy, untrack } from 'svelte';
 	import Sparkles from '@lucide/svelte/icons/sparkles';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
-	import FileIcon from '@lucide/svelte/icons/file';
-	import FolderIcon from '@lucide/svelte/icons/folder';
 	import GripHorizontal from '@lucide/svelte/icons/grip-horizontal';
-	import Plus from '@lucide/svelte/icons/plus';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import GitCommitHorizontal from '@lucide/svelte/icons/git-commit-horizontal';
-	import AlertTriangle from '@lucide/svelte/icons/triangle-alert';
-	import type { GitTreeNode } from '$lib/api/git.js';
 	import type { CommitController } from '$lib/git/commit/commit-controller.svelte.js';
 	import * as m from '$lib/paraglide/messages.js';
 	import { cn } from '$lib/utils/cn';
 	import type { ResponsiveSurfaceAction } from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
 	import GitSurfaceToolbar from './GitSurfaceToolbar.svelte';
+	import CommitFileTree from './CommitFileTree.svelte';
 	import { gitProjectInvalidations } from '$lib/git/surface/git-project-invalidation.svelte.js';
-	import { nativeWorkspaceScrollRegion } from '$lib/workspace/workspace-scroll-region.js';
 
 	interface Props {
 		controller: CommitController;
@@ -28,7 +23,6 @@
 	let dialogBodyEl = $state<HTMLDivElement | null>(null);
 	let messagePanePercent = $state(28);
 	let resizeCleanup: (() => void) | null = null;
-	const primaryScrollRegion = nativeWorkspaceScrollRegion('primary');
 
 	const dialogBodyGridStyle = $derived(
 		isMobile
@@ -79,13 +73,6 @@
 		untrack(() => void controller.target.refreshForInvalidation(key, version));
 	});
 
-	function fileBadge(node: GitTreeNode): string {
-		if (node.staged && node.hasUnstaged) return 'mixed';
-		if (node.changeKind === 'untracked') return 'untracked';
-		if (node.staged) return 'staged';
-		return 'unstaged';
-	}
-
 	function clampMessagePanePercent(value: number): number {
 		return Math.max(18, Math.min(52, value));
 	}
@@ -125,18 +112,6 @@
 		resizeCleanup = null;
 	}
 
-	function indeterminate(
-		node: HTMLInputElement,
-		value: boolean,
-	): { update(nextValue: boolean): void } {
-		node.indeterminate = value;
-		return {
-			update(nextValue: boolean) {
-				node.indeterminate = nextValue;
-			},
-		};
-	}
-
 	onDestroy(() => {
 		cleanupResize();
 	});
@@ -148,44 +123,7 @@
 
 		<div bind:this={dialogBodyEl} class="grid min-h-0 min-w-0 flex-1" style={dialogBodyGridStyle}>
 			<section class="min-h-0 min-w-0 overflow-hidden" data-commit-file-tree>
-				<div class="relative flex h-full min-w-0 flex-col overflow-hidden">
-					<div
-						class="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden py-1 {controller.treeErrorMessage
-							? 'pb-12'
-							: ''}"
-						{@attach primaryScrollRegion}
-						data-commit-file-scroll
-					>
-						{#if controller.isLoadingTree}
-							<div
-								class="flex items-center justify-center gap-2 px-3 py-8 text-xs text-muted-foreground"
-							>
-								<LoaderCircle class="h-3.5 w-3.5 animate-spin" />
-								<span>{m.filetree_loading()}</span>
-							</div>
-						{:else if controller.tree.length === 0}
-							<div class="px-3 py-8 text-center text-xs text-muted-foreground">
-								{m.git_quick_commit_no_changed_files()}
-							</div>
-						{:else}
-							{#each controller.tree as node (node.path)}
-								{@render treeNode(node, 0)}
-							{/each}
-						{/if}
-					</div>
-					{#if controller.treeErrorMessage}
-						<div
-							class="absolute inset-x-0 bottom-0 border-t border-status-error-border bg-status-error px-3 py-2 text-xs text-status-error-foreground shadow-sm"
-						>
-							<div class="flex min-w-0 items-center gap-2">
-								<AlertTriangle class="h-3.5 w-3.5 shrink-0" />
-								<span class="min-w-0 flex-1 truncate" title={controller.treeErrorMessage}>
-									{controller.treeErrorMessage}
-								</span>
-							</div>
-						</div>
-					{/if}
-				</div>
+				<CommitFileTree {controller} />
 			</section>
 
 			{#if !isMobile}
@@ -277,103 +215,3 @@
 		</div>
 	</div>
 </div>
-
-{#snippet treeNode(node: GitTreeNode, depth: number)}
-	{#if node.kind === 'directory'}
-		{@const selection = controller.directorySelection(node.path)}
-		<div
-			class="group flex min-w-0 max-w-full items-center gap-2 overflow-hidden px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50"
-			style="padding-left: {depth * 14 + 10}px"
-		>
-			<input
-				type="checkbox"
-				checked={selection.checked}
-				use:indeterminate={selection.mixed}
-				onchange={() =>
-					controller.toggleDirectory(node.path, selection.mixed ? true : !selection.checked)}
-				disabled={selection.fileCount === 0}
-				class="size-3.5 shrink-0 accent-current"
-				aria-checked={selection.mixed ? 'mixed' : selection.checked}
-				aria-label={selection.checked && !selection.mixed
-					? m.git_quick_commit_unstage_path({ path: node.path })
-					: m.git_quick_commit_stage_path({ path: node.path })}
-			/>
-			{#if selection.isRunning}
-				<LoaderCircle class="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-			{:else}
-				<FolderIcon class="h-3.5 w-3.5 shrink-0" />
-			{/if}
-			<span class="min-w-0 flex-1 truncate" title={node.path}>{node.name}</span>
-			{#if node.additions || node.deletions}
-				<span class="flex shrink-0 gap-1 tabular-nums">
-					{#if node.additions}
-						<span class="text-git-added">+{node.additions}</span>
-					{/if}
-					{#if node.deletions}
-						<span class="text-git-deleted">-{node.deletions}</span>
-					{/if}
-				</span>
-			{/if}
-		</div>
-		{#if node.children}
-			{#each node.children as child (child.path)}
-				{@render treeNode(child, depth + 1)}
-			{/each}
-		{/if}
-	{:else}
-		{@const intent = controller.intentFor(node.path)}
-		{@const stats = controller.nodeStats(node.path)}
-		<div
-			class="group flex min-w-0 max-w-full items-center gap-2 overflow-hidden px-2 py-1.5 text-xs hover:bg-muted/50"
-			style="padding-left: {depth * 14 + 10}px"
-		>
-			<input
-				type="checkbox"
-				checked={intent?.desiredSelected ?? false}
-				onchange={(event) => controller.togglePath(node.path, event.currentTarget.checked)}
-				class="size-3.5 shrink-0 accent-current"
-				aria-label={controller.operationLabelForPath(node.path)}
-			/>
-			{#if intent?.isRunning}
-				<LoaderCircle
-					class="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground"
-					aria-label={controller.operationLabelForPath(node.path)}
-				/>
-			{:else}
-				<FileIcon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-			{/if}
-			<span class="min-w-0 flex-1 truncate text-foreground" title={node.path}>{node.name}</span>
-			{#if stats.additions > 0 || stats.deletions > 0}
-				<span class="flex shrink-0 gap-1 tabular-nums">
-					{#if stats.additions > 0}
-						<span class="text-git-added">+{stats.additions}</span>
-					{/if}
-					{#if stats.deletions > 0}
-						<span class="text-git-deleted">-{stats.deletions}</span>
-					{/if}
-				</span>
-			{/if}
-			<span class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-				{fileBadge(node)}
-			</span>
-			{#if node.staged && node.hasUnstaged}
-				<button
-					type="button"
-					onclick={() => controller.includeUnstaged(node.path)}
-					class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:hidden"
-					title={m.git_quick_commit_include_unstaged()}
-					aria-label={m.git_quick_commit_include_unstaged()}
-				>
-					<Plus class="h-3 w-3" />
-				</button>
-				<button
-					type="button"
-					onclick={() => controller.includeUnstaged(node.path)}
-					class="hidden shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:inline-flex sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
-				>
-					{m.git_quick_commit_include_unstaged()}
-				</button>
-			{/if}
-		</div>
-	{/if}
-{/snippet}

--- a/web/src/lib/components/git/__tests__/CommitSurface.test.ts
+++ b/web/src/lib/components/git/__tests__/CommitSurface.test.ts
@@ -1,14 +1,36 @@
-import { render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
 import CommitSurfaceTestHost from './CommitSurfaceTestHost.svelte';
 import { CommitController } from '$lib/git/commit/commit-controller.svelte.js';
 import { createGitSurfaceTestDeps } from '$lib/git/__tests__/git-surface-test-deps.js';
+import type { GitTreeNode } from '$lib/api/git.js';
 import * as m from '$lib/paraglide/messages.js';
 
 function makeController(): CommitController {
 	const controller = new CommitController(createGitSurfaceTestDeps());
 	void controller.setContext('/project', '/project');
 	return controller;
+}
+
+function installTree(controller: CommitController, tree: GitTreeNode[]): void {
+	controller.tree = tree;
+	controller.intents = Object.fromEntries(
+		tree
+			.flatMap((node) => node.children ?? [node])
+			.filter((node) => node.kind === 'file')
+			.map((node) => [
+				node.path,
+				{
+					path: node.path,
+					desiredSelected: node.staged,
+					actualSelected: node.staged,
+					isRunning: false,
+					runningMode: null,
+					error: null,
+				},
+			]),
+	);
 }
 
 describe('CommitSurface', () => {
@@ -74,6 +96,91 @@ describe('CommitSurface', () => {
 		expect(
 			summary.compareDocumentPosition(message) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
+	});
+
+	it('bounds mounted rows while allowing a large tree to reach its final file', async () => {
+		const controller = makeController();
+		const fileCount = 80;
+		const children: GitTreeNode[] = Array.from({ length: fileCount }, (_, index) => ({
+			path: `src/file-${index.toString().padStart(4, '0')}.ts`,
+			name: `file-${index.toString().padStart(4, '0')}.ts`,
+			kind: 'file',
+			staged: false,
+			hasUnstaged: true,
+			changeKind: 'modified',
+			additions: 1,
+			deletions: 0,
+		}));
+		installTree(controller, [
+			{
+				path: 'src',
+				name: 'src',
+				kind: 'directory',
+				staged: false,
+				hasUnstaged: true,
+				children,
+				additions: fileCount,
+				deletions: 0,
+			},
+		]);
+
+		const { container } = render(CommitSurfaceTestHost, {
+			controller,
+			presentation: 'sidebar',
+		});
+		const viewport = container.querySelector<HTMLElement>('[data-commit-file-scroll]');
+		expect(viewport).toBeTruthy();
+		if (!viewport) return;
+
+		const mountedCheckboxes = () =>
+			viewport.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+		expect(mountedCheckboxes().length).toBeLessThan(50);
+		expect(viewport.querySelector('[title="src/file-0079.ts"]')).toBeNull();
+
+		viewport.scrollTop = fileCount * 28;
+		await fireEvent.scroll(viewport);
+		await tick();
+
+		expect(mountedCheckboxes().length).toBeLessThan(50);
+		expect(viewport.querySelector('[title="src/file-0079.ts"]')).toBeTruthy();
+	});
+
+	it('preserves directory and file selection actions in the virtual tree', async () => {
+		const controller = makeController();
+		installTree(controller, [
+			{
+				path: 'src',
+				name: 'src',
+				kind: 'directory',
+				staged: false,
+				hasUnstaged: true,
+				children: [
+					{
+						path: 'src/file.ts',
+						name: 'file.ts',
+						kind: 'file',
+						staged: false,
+						hasUnstaged: true,
+					},
+				],
+			},
+		]);
+		const toggleDirectory = vi.spyOn(controller, 'toggleDirectory');
+		const togglePath = vi.spyOn(controller, 'togglePath');
+		const { container } = render(CommitSurfaceTestHost, {
+			controller,
+			presentation: 'sidebar',
+		});
+		const checkboxes = container.querySelectorAll<HTMLInputElement>(
+			'[data-commit-file-scroll] input[type="checkbox"]',
+		);
+		expect(checkboxes).toHaveLength(2);
+
+		await fireEvent.click(checkboxes[0] as HTMLInputElement);
+		await fireEvent.click(checkboxes[1] as HTMLInputElement);
+
+		expect(toggleDirectory).toHaveBeenCalledWith('src', true);
+		expect(togglePath).toHaveBeenCalledWith('src/file.ts', true);
 	});
 
 	it('owns branch state independently from another Commit controller', () => {

--- a/web/src/lib/git/commit/__tests__/commit-controller.test.ts
+++ b/web/src/lib/git/commit/__tests__/commit-controller.test.ts
@@ -487,12 +487,6 @@ describe('CommitController', () => {
 		await controller.setContext('/project', '/project');
 		await controller.setPresentationVisible(true);
 
-		expect(controller.directorySelection('src')).toMatchObject({
-			checked: false,
-			mixed: false,
-			fileCount: 2,
-		});
-
 		controller.toggleDirectory('src', true);
 		expect(await controller.waitForQueue()).toBe(true);
 
@@ -502,11 +496,7 @@ describe('CommitController', () => {
 			['src/a.ts', 'src/b.ts'],
 			'stage',
 		);
-		expect(controller.directorySelection('src')).toMatchObject({
-			checked: true,
-			mixed: false,
-			fileCount: 2,
-		});
+		expect(Object.values(controller.intents).every((intent) => intent.desiredSelected)).toBe(true);
 	});
 
 	it('unstages staged descendant files in one batch when a directory is cleared', async () => {
@@ -540,11 +530,7 @@ describe('CommitController', () => {
 			['src/a.ts', 'src/b.ts'],
 			'unstage',
 		);
-		expect(controller.directorySelection('src')).toMatchObject({
-			checked: false,
-			mixed: false,
-			fileCount: 2,
-		});
+		expect(Object.values(controller.intents).every((intent) => !intent.desiredSelected)).toBe(true);
 	});
 
 	it('does not restage already staged mixed files during directory staging', async () => {
@@ -603,10 +589,10 @@ describe('CommitController', () => {
 		});
 		mockedApi.getGitWorkbenchSnapshot.mockImplementation(async (projectPath) =>
 			snapshot([
-				fileNode(
-					projectPath === '/project' ? 'project.ts' : 'worktree.ts',
-					{ staged: true, hasUnstaged: false },
-				),
+				fileNode(projectPath === '/project' ? 'project.ts' : 'worktree.ts', {
+					staged: true,
+					hasUnstaged: false,
+				}),
 			]),
 		);
 		const controller = makeController();

--- a/web/src/lib/git/commit/__tests__/commit-tree-rows.logic.test.ts
+++ b/web/src/lib/git/commit/__tests__/commit-tree-rows.logic.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { GitTreeNode } from '$lib/api/git.js';
+import type { QuickCommitPathIntent } from '../commit-controller.svelte.js';
+import { buildCommitTreeRows } from '../commit-tree-rows.js';
+
+function fileNode(path: string, overrides: Partial<GitTreeNode> = {}): GitTreeNode {
+	return {
+		path,
+		name: path.split('/').at(-1) ?? path,
+		kind: 'file',
+		staged: false,
+		hasUnstaged: true,
+		additions: 1,
+		deletions: 0,
+		...overrides,
+	};
+}
+
+function directoryNode(path: string, children: GitTreeNode[]): GitTreeNode {
+	return {
+		path,
+		name: path.split('/').at(-1) ?? path,
+		kind: 'directory',
+		staged: children.some((child) => child.staged),
+		hasUnstaged: children.some((child) => child.hasUnstaged),
+		children,
+	};
+}
+
+function intent(
+	path: string,
+	overrides: Partial<QuickCommitPathIntent> = {},
+): QuickCommitPathIntent {
+	return {
+		path,
+		desiredSelected: false,
+		actualSelected: false,
+		isRunning: false,
+		runningMode: null,
+		error: null,
+		...overrides,
+	};
+}
+
+describe('buildCommitTreeRows', () => {
+	it('builds exact preorder depth, file stats, and descendant directory selection', () => {
+		const tree = [
+			directoryNode('src', [
+				fileNode('src/a.ts', {
+					staged: true,
+					hasUnstaged: false,
+					stagedFacet: {
+						status: 'M',
+						changeKind: 'modified',
+						stats: { additions: 7, deletions: 2 },
+					},
+				}),
+				directoryNode('src/nested', [fileNode('src/nested/b.ts')]),
+			]),
+			fileNode('root.ts'),
+		];
+		const rows = buildCommitTreeRows(tree, {
+			'src/a.ts': intent('src/a.ts', {
+				desiredSelected: true,
+				actualSelected: true,
+			}),
+			'src/nested/b.ts': intent('src/nested/b.ts', {
+				isRunning: true,
+				error: 'stage failed',
+			}),
+			'root.ts': intent('root.ts', { desiredSelected: true, actualSelected: true }),
+		});
+
+		expect(rows.map((row) => [row.kind, row.node.path, row.depth])).toEqual([
+			['directory', 'src', 0],
+			['file', 'src/a.ts', 1],
+			['directory', 'src/nested', 1],
+			['file', 'src/nested/b.ts', 2],
+			['file', 'root.ts', 0],
+		]);
+		expect(rows[0]).toMatchObject({
+			kind: 'directory',
+			selection: {
+				checked: false,
+				mixed: true,
+				isRunning: true,
+				error: 'stage failed',
+				fileCount: 2,
+			},
+		});
+		expect(rows[2]).toMatchObject({
+			kind: 'directory',
+			selection: {
+				checked: false,
+				mixed: false,
+				isRunning: true,
+				error: 'stage failed',
+				fileCount: 1,
+			},
+		});
+		expect(rows[1]).toMatchObject({
+			kind: 'file',
+			stats: { additions: 7, deletions: 2 },
+		});
+	});
+
+	it('reads each directory child collection once while emitting one row per node', () => {
+		let childReads = 0;
+		const children = Array.from({ length: 500 }, (_, index) => fileNode(`src/${index}.ts`));
+		const directory = {
+			path: 'src',
+			name: 'src',
+			kind: 'directory',
+			staged: false,
+			hasUnstaged: true,
+			get children() {
+				childReads += 1;
+				return children;
+			},
+		} satisfies GitTreeNode;
+		const intents = Object.fromEntries(children.map((node) => [node.path, intent(node.path)]));
+
+		const rows = buildCommitTreeRows([directory], intents);
+
+		expect(rows).toHaveLength(501);
+		expect(rows.at(-1)?.node.path).toBe('src/499.ts');
+		expect(childReads).toBe(1);
+	});
+});

--- a/web/src/lib/git/commit/commit-controller.svelte.ts
+++ b/web/src/lib/git/commit/commit-controller.svelte.ts
@@ -3,7 +3,6 @@ import {
 	getGitWorkbenchSnapshot,
 	gitCommitIndex,
 	gitStagePaths,
-	type GitChangeStats,
 	type GitTreeNode,
 } from '$lib/api/git.js';
 import { ApiError } from '$lib/api/client.js';
@@ -31,14 +30,6 @@ export interface QuickCommitPathIntent {
 	isRunning: boolean;
 	runningMode: QuickCommitStageMode | null;
 	error: string | null;
-}
-
-export interface QuickCommitDirectorySelection {
-	checked: boolean;
-	mixed: boolean;
-	isRunning: boolean;
-	error: string | null;
-	fileCount: number;
 }
 
 export interface CommitControllerDeps extends GitSurfaceControllerDeps {
@@ -71,6 +62,7 @@ export class CommitController implements PortableSingletonController {
 	readonly target: GitTargetSessionController;
 	tree = $state<GitTreeNode[]>([]);
 	intents = $state<Record<string, QuickCommitPathIntent>>({});
+	readonly fileNodes = $derived.by(() => flattenCommitFileNodes(this.tree));
 	message = $state('');
 	treeLoadState = $state<QuickCommitTreeLoadState>('idle');
 	isProcessingQueue = $state(false);
@@ -91,6 +83,18 @@ export class CommitController implements PortableSingletonController {
 	private disposed = false;
 	private contextGeneration = 0;
 	private loadedTargetIdentity: string | null = null;
+	private selectedChangeStats = $derived.by(() => {
+		let additions = 0;
+		let deletions = 0;
+		for (const node of this.fileNodes) {
+			const intent = this.intentFor(node.path);
+			if (!intent?.desiredSelected) continue;
+			const stats = commitStatsForNode(node);
+			additions += stats.additions;
+			deletions += stats.deletions;
+		}
+		return { additions, deletions };
+	});
 
 	constructor(private readonly deps: CommitControllerDeps) {
 		this.target = new GitTargetSessionController({
@@ -98,8 +102,7 @@ export class CommitController implements PortableSingletonController {
 			createBranchSelector: deps.createGitBranchSelector,
 			invalidationVersion: deps.invalidationVersion,
 			canChangeTarget: () =>
-				this.canClose &&
-				deps.gitMutations.pendingCount(singletonSurfaceId('commit')) === 0,
+				this.canClose && deps.gitMutations.pendingCount(singletonSurfaceId('commit')) === 0,
 			onTargetChanged: (_target, identity, reason, identityChanged) =>
 				this.setTargetIdentity(identity, reason, identityChanged),
 		});
@@ -115,10 +118,6 @@ export class CommitController implements PortableSingletonController {
 
 	get projectIdentityPending(): boolean {
 		return this.target.projectIdentityPending;
-	}
-
-	get fileNodes(): GitTreeNode[] {
-		return flattenCommitFileNodes(this.tree);
 	}
 
 	get isLoadingTree(): boolean {
@@ -173,11 +172,11 @@ export class CommitController implements PortableSingletonController {
 	}
 
 	get totalAdditions(): number {
-		return this.selectedStats().additions;
+		return this.selectedChangeStats.additions;
 	}
 
 	get totalDeletions(): number {
-		return this.selectedStats().deletions;
+		return this.selectedChangeStats.deletions;
 	}
 
 	get canCommit(): boolean {
@@ -269,28 +268,6 @@ export class CommitController implements PortableSingletonController {
 
 	intentFor(path: string): QuickCommitPathIntent | null {
 		return this.intents[path] ?? null;
-	}
-
-	directorySelection(path: string): QuickCommitDirectorySelection {
-		const node = findCommitTreeNode(this.tree, path);
-		const files = node ? flattenCommitFileNodes([node]) : [];
-		const intents = files
-			.map((file) => this.intentFor(file.path))
-			.filter((item): item is QuickCommitPathIntent => Boolean(item));
-		const selectedCount = intents.filter((item) => item.desiredSelected).length;
-		const checked = intents.length > 0 && selectedCount === intents.length;
-		return {
-			checked,
-			mixed: selectedCount > 0 && selectedCount < intents.length,
-			isRunning: intents.some((item) => item.isRunning),
-			error: intents.find((item) => item.error)?.error ?? null,
-			fileCount: intents.length,
-		};
-	}
-
-	nodeStats(path: string): GitChangeStats {
-		const node = this.fileNodes.find((candidate) => candidate.path === path);
-		return node ? commitStatsForNode(node) : { additions: 0, deletions: 0 };
 	}
 
 	togglePath(path: string, desiredSelected: boolean): void {
@@ -693,19 +670,6 @@ export class CommitController implements PortableSingletonController {
 		});
 	}
 
-	private selectedStats(): GitChangeStats {
-		let additions = 0;
-		let deletions = 0;
-		for (const node of this.fileNodes) {
-			const intent = this.intentFor(node.path);
-			if (!intent?.desiredSelected) continue;
-			const stats = commitStatsForNode(node);
-			additions += stats.additions;
-			deletions += stats.deletions;
-		}
-		return { additions, deletions };
-	}
-
 	private fileErrorSummary(errors: string[]): string {
 		const first = errors[0] ?? '';
 		if (errors.length <= 1) return first;
@@ -740,11 +704,7 @@ export class CommitController implements PortableSingletonController {
 	}
 
 	private reconcilePathsAfterStage(paths: string[], desiredSelected: boolean): void {
-		const result = reconcileCommitTreeAfterStage(
-			this.tree,
-			new Set(paths),
-			desiredSelected,
-		);
+		const result = reconcileCommitTreeAfterStage(this.tree, new Set(paths), desiredSelected);
 		if (result.changed) this.tree = result.nodes;
 	}
 
@@ -810,10 +770,7 @@ export class CommitController implements PortableSingletonController {
 		if (reason === 'invalidation' && this.isPresentationVisible) {
 			const generation = this.contextGeneration;
 			await this.waitForQueue();
-			if (
-				generation === this.contextGeneration &&
-				identity === this.target.identity
-			) {
+			if (generation === this.contextGeneration && identity === this.target.identity) {
 				await this.refreshTreeSnapshot();
 			}
 		}

--- a/web/src/lib/git/commit/commit-tree-rows.ts
+++ b/web/src/lib/git/commit/commit-tree-rows.ts
@@ -1,0 +1,118 @@
+import type { GitChangeStats, GitTreeNode } from '$lib/api/git.js';
+import type { QuickCommitPathIntent } from './commit-controller.svelte.js';
+import { commitStatsForNode } from './commit-tree-reconciliation.js';
+
+export const COMMIT_TREE_ROW_HEIGHT = 28;
+export const COMMIT_TREE_ROW_OVERSCAN = 8;
+
+export interface CommitDirectorySelection {
+	readonly checked: boolean;
+	readonly mixed: boolean;
+	readonly isRunning: boolean;
+	readonly error: string | null;
+	readonly fileCount: number;
+}
+
+interface CommitTreeRowBase {
+	readonly node: GitTreeNode;
+	readonly depth: number;
+}
+
+export interface CommitDirectoryTreeRow extends CommitTreeRowBase {
+	readonly kind: 'directory';
+	readonly selection: CommitDirectorySelection;
+}
+
+export interface CommitFileTreeRow extends CommitTreeRowBase {
+	readonly kind: 'file';
+	readonly intent: QuickCommitPathIntent | null;
+	readonly stats: GitChangeStats;
+}
+
+export type CommitTreeRow = CommitDirectoryTreeRow | CommitFileTreeRow;
+
+interface DirectoryAggregate {
+	fileCount: number;
+	selectedCount: number;
+	isRunning: boolean;
+	error: string | null;
+}
+
+function emptyAggregate(): DirectoryAggregate {
+	return {
+		fileCount: 0,
+		selectedCount: 0,
+		isRunning: false,
+		error: null,
+	};
+}
+
+function mergeAggregate(target: DirectoryAggregate, source: DirectoryAggregate): void {
+	target.fileCount += source.fileCount;
+	target.selectedCount += source.selectedCount;
+	target.isRunning ||= source.isRunning;
+	target.error ??= source.error;
+}
+
+export function buildCommitTreeRows(
+	nodes: readonly GitTreeNode[],
+	intents: Readonly<Record<string, QuickCommitPathIntent>>,
+): CommitTreeRow[] {
+	const rows: CommitTreeRow[] = [];
+
+	function visit(node: GitTreeNode, depth: number): DirectoryAggregate {
+		if (node.kind === 'file') {
+			const intent = intents[node.path] ?? null;
+			rows.push({
+				kind: 'file',
+				node,
+				depth,
+				intent,
+				stats: commitStatsForNode(node),
+			});
+			return intent
+				? {
+						fileCount: 1,
+						selectedCount: intent.desiredSelected ? 1 : 0,
+						isRunning: intent.isRunning,
+						error: intent.error,
+					}
+				: emptyAggregate();
+		}
+
+		const rowIndex = rows.length;
+		const aggregate = emptyAggregate();
+		rows.push({
+			kind: 'directory',
+			node,
+			depth,
+			selection: {
+				checked: false,
+				mixed: false,
+				isRunning: false,
+				error: null,
+				fileCount: 0,
+			},
+		});
+		const children = node.children ?? [];
+		for (const child of children) {
+			mergeAggregate(aggregate, visit(child, depth + 1));
+		}
+		rows[rowIndex] = {
+			kind: 'directory',
+			node,
+			depth,
+			selection: {
+				checked: aggregate.fileCount > 0 && aggregate.selectedCount === aggregate.fileCount,
+				mixed: aggregate.selectedCount > 0 && aggregate.selectedCount < aggregate.fileCount,
+				isRunning: aggregate.isRunning,
+				error: aggregate.error,
+				fileCount: aggregate.fileCount,
+			},
+		};
+		return aggregate;
+	}
+
+	for (const node of nodes) visit(node, 0);
+	return rows;
+}


### PR DESCRIPTION
Virtualizes the Commit file tree and computes row, selection, and statistics state in linear passes, preventing large worktrees from blocking the browser while preserving existing staging and commit behavior.