### PR TITLE
Stabilize executable build CI

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -78,7 +78,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: bun run check
 
-      - name: Run server tests
+      - name: Run server tests for release validation
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: bun run test:server
 
       - name: Run CLI checks

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/history-api-compatibility.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/history-api-compatibility.test.js
@@ -3,7 +3,7 @@ import { CodexAppServerClient, CodexAppServerRpcError } from '../client.ts';
 
 describe('bundled Codex history API compatibility', () => {
   it('recognizes thread/turns/list as a public method', async () => {
-    const client = new CodexAppServerClient();
+    const client = new CodexAppServerClient({ shutdownGraceMs: 100 });
     try {
       const initialized = await client.connect();
       expect(initialized.userAgent).toBeString();

--- a/server-agents/common/src/search/__tests__/transcript-search-service-v9.test.ts
+++ b/server-agents/common/src/search/__tests__/transcript-search-service-v9.test.ts
@@ -673,7 +673,7 @@ describe('transcript search service v9', () => {
     const service = new TranscriptSearchService({
       workspaceDirectory: workspace(),
       logger: logger(records),
-      readerRequestTimeoutMs: 20,
+      readerRequestTimeoutMs: 500,
       workerFactory: interceptingWorkerFactory((reader, event, deliver) => {
         if (reader === 0 && (event.data as { type?: unknown }).type === 'search-result') return;
         deliver(event);
@@ -688,14 +688,12 @@ describe('transcript search service v9', () => {
     await expect(service.search(searchRequest(
       'chat-grace', 'view-grace', 20, 'gracemarker',
     ))).resolves.toMatchObject({ results: [expect.objectContaining({ chatId: 'chat-grace' })] });
-    await Bun.sleep(300);
-    expect(service.status().phase).toBe('degraded');
-    await Bun.sleep(1_200);
-    expect(records.some((record) => (
+    await waitFor(() => service.status().phase === 'degraded');
+    await waitFor(() => records.some((record) => (
       (record.fields as { code?: string } | undefined)?.code === 'SEARCH_READER_RESTARTED'
-    ))).toBe(true);
+    )));
     await service.close();
-  });
+  }, 10_000);
 
   test('[TLV5-SEARCH.07-SVC-05] deletion sequences bounded maintenance after checkpoint', async () => {
     const requests: string[] = [];


### PR DESCRIPTION
Prevents the executable build workflow from rerunning the server suite already covered by Server Tests on ordinary pushes and pull requests, while retaining full validation for tags and manual releases. It also replaces load-sensitive shutdown and reader-recovery timing assumptions in the two recurring failures with bounded cleanup and state-based checks.