### PR TITLE
Stabilize editor readiness in browser tests

### DIFF
--- a/integration-tests/tests/e2e/file-viewer-scrolling.test.ts
+++ b/integration-tests/tests/e2e/file-viewer-scrolling.test.ts
@@ -205,6 +205,7 @@ async function waitForActiveTarget(
     { timeout: 20_000 },
     { expectedFileName: fileName, expectedTarget: target },
   );
+  if (target === "editor") await waitForAnimationFrames(page, 1);
 }
 
 async function setScrollOffset(

--- a/web/src/lib/components/chat/__tests__/ComposerEditor.test.ts
+++ b/web/src/lib/components/chat/__tests__/ComposerEditor.test.ts
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { EditorView } from '@codemirror/view';
 import { afterEach, describe, expect, it } from 'vitest';
+// Keeps the lifecycle assertion independent of lazy-module transform latency.
+import '../ComposerEditor.svelte';
 import PromptComposerTestHost from './PromptComposerTestHost.svelte';
 
 describe('ComposerEditor integration', () => {


### PR DESCRIPTION
Waits for CodeMirror’s initial animation-frame measurement before synthetic Lightpanda scrolling and preloads the lazy composer editor in its lifecycle test, preventing transient layout resets and cold-transform delays from causing false CI failures while preserving exact scroll and EditorView assertions.