### PR TITLE
Harden fork refusals, route error logging, and live-lane prompts

### DIFF
--- a/docs/transcript-ledger-v5-cts.md
+++ b/docs/transcript-ledger-v5-cts.md
@@ -10,7 +10,7 @@ repair, the revision 20 OpenCode legacy-absence correction, and the revision
 Governing artifact:
 
 - `docs/transcript-ledger-v5-design.md`, revision 21, SHA-256
-  `287987bb8cf07c099b04143a75682a02fca4de9e3f06fce8d01502d0b71055a4`
+  `01c4a81993a3e2b219d5afe2a7713d032539d29690f9223936468f0839463e60`
 
 Current inventory: 367 discovered stable IDs, validated by
 `scripts/validate-transcript-ledger-v5-cases.js` against

--- a/docs/transcript-ledger-v5-design.md
+++ b/docs/transcript-ledger-v5-design.md
@@ -1675,10 +1675,14 @@ relevant-entry definition under the 10.2 obligation.
 - **Claude**: persist-before-notify append-only JSONL native format.
   Micro-compaction re-appends dedupe at translation by uuid; uuid is
   stamped into `providerMeta` for native-fidelity fork and import dedup.
-  Probe: last conversation entry timestamp (creation-stamped, satisfying
-  the obligation), excluding file-history snapshots, queue operations,
-  and summary bookkeeping. Importer excludes carryover seed context by
-  seed receipt.
+  The session file itself may materialize asynchronously after a turn's
+  result — the CLI has been observed with no JSONL on disk moments after
+  a completed turn — so a fork point resolved before the file exists
+  refuses as not settled and the client retries or asks for handoff
+  consent. Probe: last conversation entry timestamp (creation-stamped,
+  satisfying the obligation), excluding file-history snapshots, queue
+  operations, and summary bookkeeping. Importer excludes carryover seed
+  context by seed receipt.
 - **Codex**: the live app-server stream is the display truth and does
   not match the rollout row-for-row; the rollout is resume state and the
   reload source for the current binding. Item ids dedupe redelivery at

--- a/integration-tests/support/live-agent.ts
+++ b/integration-tests/support/live-agent.ts
@@ -16,14 +16,14 @@ export function liveMarker(label: string): string {
 }
 
 export function exactReplyPrompt(value: string): string {
-  return `Reply with exactly ${value}. Do not use tools.`;
+  return `Reply with exactly this text: ${value}. Copy it character for character. Do not use tools.`;
 }
 
 // A prompt that may still be unanswered when the next one is dispatched gets folded into it, so
 // it must not forbid what that successor asks for. Otherwise the merged instruction contradicts
 // itself and the answer depends on which half the model picks.
 export function foldableReplyPrompt(value: string): string {
-  return `Reply with exactly ${value}.`;
+  return `Reply with exactly this text: ${value}. Copy it character for character.`;
 }
 
 export function expectFinished(type: string): void {

--- a/integration-tests/tests/live/claude/lifecycle.test.ts
+++ b/integration-tests/tests/live/claude/lifecycle.test.ts
@@ -129,8 +129,8 @@ describe('live Claude lifecycle', () => {
       const firstMarker = marker('PARENT_FIRST');
       const secondMarker = marker('PARENT_SECOND');
       const firstPrompt = [
-        'Use the Bash tool now to run exactly `sleep 2`.',
-        `After it succeeds, reply with exactly ${firstMarker}.`,
+        'Use the Bash tool immediately, as your first action, to run exactly `sleep 2`.',
+        `After it succeeds, reply with exactly this text: ${firstMarker}. Copy it character for character.`,
         'Do not run any other command.',
       ].join(' ');
       const secondPrompt = foldableReplyPrompt(secondMarker);
@@ -148,8 +148,8 @@ describe('live Claude lifecycle', () => {
       const childChatId = fixture.newChatId();
       const childMarker = marker('CHILD');
       const childPrompt = [
-        'Use the Bash tool now to run exactly `sleep 2`.',
-        `After it succeeds, reply with exactly ${childMarker}.`,
+        'Use the Bash tool immediately, as your first action, to run exactly `sleep 2`.',
+        `After it succeeds, reply with exactly this text: ${childMarker}. Copy it character for character.`,
         'Do not run any other command.',
       ].join(' ');
       const childCursor = fixture.client.markEvents();
@@ -580,7 +580,7 @@ describe('live Claude lifecycle', () => {
     await withIntegrationFixture('live-claude-interrupt-and-send', async (fixture) => {
       const chatId = fixture.newChatId();
       const interruptedPrompt = [
-        'Use the Bash tool now to run exactly `sleep 30`.',
+        'Use the Bash tool immediately, as your first action, to run exactly `sleep 30`.',
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly SHOULD_NOT_COMPLETE.',
       ].join(' ');
@@ -651,7 +651,7 @@ describe('live Claude lifecycle', () => {
       const stoppedStarted = join(fixture.dirs.project, '.claude-stop-started');
       const stoppedCommand = 'touch .claude-stop-started && sleep 30';
       const stoppedPrompt = [
-        `Use the Bash tool now to run exactly \`${stoppedCommand}\`.`,
+        `Use the Bash tool immediately, as your first action, to run exactly \`${stoppedCommand}\`.`,
         'Do not perform other work before the command finishes.',
         'After it finishes, reply with exactly STOPPED_TURN_SHOULD_NOT_COMPLETE.',
       ].join(' ');
@@ -783,7 +783,7 @@ describe('live Claude lifecycle', () => {
 });
 
 async function waitForFile(path: string): Promise<void> {
-  const deadline = Date.now() + 60_000;
+  const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
     if (await Bun.file(path).exists()) return;
     await Bun.sleep(25);

--- a/integration-tests/tests/live/codex/lifecycle.test.ts
+++ b/integration-tests/tests/live/codex/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { ChatMessagesMessage } from '../../../../common/ws-events.js';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
@@ -319,6 +320,7 @@ describe('live Codex lifecycle', () => {
       ].join(' ');
       const successorMarker = liveMarker('CODEX_INTERRUPT_SUCCESSOR');
       const successorPrompt = exactReplyPrompt(successorMarker);
+      const activeCursor = fixture.client.markEvents();
       const active = await fixture.client.startChat(liveCodexStartRequest({
         chatId,
         projectPath: fixture.dirs.project,
@@ -327,6 +329,18 @@ describe('live Codex lifecycle', () => {
       }));
 
       await waitForFile(interruptedStarted);
+      // The interrupt must land after the tool row is committed, or the resend
+      // scan folds the interrupted prompt into the successor.
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'bash-tool-use'
+            && entry.message.command.includes('.codex-interrupt-started')),
+        'live Codex interrupted shell tool use',
+        { afterIndex: activeCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
       const queued = await fixture.client.enqueueNew(chatId, successorPrompt);
       expect(queued.control.queue.entries.map((entry) => entry.content)).toEqual([successorPrompt]);
 
@@ -377,6 +391,16 @@ describe('live Codex lifecycle', () => {
         permissionMode: 'bypassPermissions',
       }));
       await waitForFile(stoppedStarted);
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage =>
+          event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) =>
+            entry.message.type === 'bash-tool-use'
+            && entry.message.command.includes('.codex-stop-started')),
+        'live Codex stopped shell tool use',
+        { afterIndex: stoppedCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
       const stopCommandCursor = fixture.client.markEvents();
       const stopRequestId = crypto.randomUUID();
       const stopped = await Promise.all([

--- a/server-agents/common/src/forking/__tests__/jsonl-forking.test.ts
+++ b/server-agents/common/src/forking/__tests__/jsonl-forking.test.ts
@@ -253,14 +253,14 @@ describe('createJsonlNativeForking prefix protection', () => {
     });
   });
 
-  it('refuses a point in a source the provider has not written yet as not settled', async () => {
+  it('refuses a point in a source the provider has not written yet as source-missing', async () => {
     const fixture = await createFixture();
     await rm(fixture.sourcePath, { force: true });
 
     await expect(fixture.forking.fork(fixture.request)).rejects.toMatchObject({
       code: 'TRANSCRIPT_UNAVAILABLE',
       retryable: true,
-      details: { nativeForkReason: 'not-settled' },
+      details: { nativeForkReason: 'source-missing' },
     });
   });
 

--- a/server-agents/common/src/forking/jsonl-forking.ts
+++ b/server-agents/common/src/forking/jsonl-forking.ts
@@ -157,9 +157,9 @@ async function resolveProviderPoint(
     signal: request.admission.signal,
   }).catch((error) => {
     // A source file the provider has not written yet holds no native
-    // positions; refusing as not settled keeps the retry and
+    // positions; the typed source-level refusal keeps the retry and
     // handoff-consent flow instead of surfacing a raw filesystem error.
-    if (hasNodeErrorCode(error, 'ENOENT')) throw missingNativePoint();
+    if (hasNodeErrorCode(error, 'ENOENT')) throw missingNativeSource();
     throw error;
   });
   for (const message of native.messages) {
@@ -207,6 +207,15 @@ function positiveSafeInteger(value: unknown): number | null {
 
 function nonNegativeSafeInteger(value: unknown): number | null {
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function missingNativeSource(): AgentIntegrationError {
+  return new AgentIntegrationError(
+    'TRANSCRIPT_UNAVAILABLE',
+    'The source native transcript is unavailable',
+    true,
+    { nativeForkReason: 'source-missing' },
+  );
 }
 
 function missingNativePoint(): AgentIntegrationError {

--- a/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
@@ -117,7 +117,7 @@ describe('OpenCodeRuntime fork', () => {
     expect(failure?.retryable).toBe(true);
   });
 
-  it('refuses a fork of a session the provider cannot return as not settled', async () => {
+  it('refuses a fork of a session the provider cannot return as source-missing', async () => {
     const fork = mock(() => Promise.resolve({ error: { name: 'NotFoundError' } }));
     const { runtime } = createRuntimeWithClient({
       session: { fork },
@@ -126,7 +126,7 @@ describe('OpenCodeRuntime fork', () => {
     const failure = await runtime.forkSession('missing-session').then(() => null, (error) => error);
     expect(failure?.code).toBe('TRANSCRIPT_UNAVAILABLE');
     expect(failure?.retryable).toBe(true);
-    expect(failure?.details).toEqual({ nativeForkReason: 'not-settled' });
+    expect(failure?.details).toEqual({ nativeForkReason: 'source-missing' });
   });
 
   it('creates new sessions and submits the first prompt in the project directory', async () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
@@ -157,6 +157,20 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
     expect(sessionDelete.mock.calls[0][0]).toEqual({ sessionID: 'forked-session' });
   });
 
+  it('refuses a point fork of a session with no stored messages as source-missing', async () => {
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const messages = mock(() => Promise.resolve({ error: { name: 'NotFoundError' } }));
+    const { forking } = createForking({ fork, messages });
+
+    const failure = await forking.fork(forkRequest({
+      providerMeta: { entryId: 'prt_b1' },
+    })).then(() => null, (error) => error);
+
+    expect(failure?.details).toEqual({ nativeForkReason: 'source-missing' });
+    expect(failure?.retryable).toBe(true);
+    expect(fork).not.toHaveBeenCalled();
+  });
+
   it('refuses an anchor the provider has not persisted as not settled', async () => {
     const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
     const messages = mock(() => Promise.resolve({ data: STORED_SOURCE_MESSAGES }));

--- a/server-agents/opencode/src/agents/opencode/endpoint-coordinator.ts
+++ b/server-agents/opencode/src/agents/opencode/endpoint-coordinator.ts
@@ -99,14 +99,14 @@ export class OpenCodeEndpointCoordinator {
       ),
     ));
     // A source session the provider cannot return has no native fork position;
-    // the typed refusal keeps the handoff-fork consent flow reachable instead
-    // of dead-ending the request in an untyped failure.
+    // the typed source-level refusal keeps the handoff-fork consent flow
+    // reachable instead of dead-ending the request in an untyped failure.
     if (isOpenCodeNotFoundResult(result)) {
       throw new AgentIntegrationError(
         'TRANSCRIPT_UNAVAILABLE',
-        'The OpenCode source session has no provider-native fork position',
+        'The OpenCode source session is unavailable',
         true,
-        { nativeForkReason: 'not-settled' },
+        { nativeForkReason: 'source-missing' },
       );
     }
     if (result?.error) {

--- a/server-agents/opencode/src/agents/opencode/forking.ts
+++ b/server-agents/opencode/src/agents/opencode/forking.ts
@@ -105,6 +105,7 @@ async function resolveAnchorMessageId(
       true,
     );
   });
+  if (messages.length === 0) throw missingSource();
   const anchor = messages.find((message) => ownsEntry(message, entryId));
   const anchorMessageId = anchor?.info?.id;
   if (typeof anchorMessageId !== 'string' || !anchorMessageId) throw notSettled();
@@ -135,6 +136,15 @@ function ownsEntry(message: OpenCodeMessage, entryId: string): boolean {
     && typeof part === 'object'
     && (part as { id?: unknown }).id === entryId
   ));
+}
+
+function missingSource(): AgentIntegrationError {
+  return new AgentIntegrationError(
+    'TRANSCRIPT_UNAVAILABLE',
+    'The OpenCode source session is unavailable',
+    true,
+    { nativeForkReason: 'source-missing' },
+  );
 }
 
 function notSettled(): AgentIntegrationError {

--- a/server/agents/__tests__/runtime-router-fork.test.js
+++ b/server/agents/__tests__/runtime-router-fork.test.js
@@ -182,6 +182,31 @@ describe('AgentRuntimeRouter forks', () => {
     });
   });
 
+  it('names an unavailable source while keeping the consent-capable refusal code', async () => {
+    const fork = mock(async () => {
+      throw new AgentIntegrationError(
+        'TRANSCRIPT_UNAVAILABLE',
+        'The source native transcript is unavailable',
+        true,
+        { nativeForkReason: 'source-missing' },
+      );
+    });
+    const { router, entry } = makeRouter(fork);
+
+    await expect(router.forkAgentSession({
+      sourceSession: entry,
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      messageOrdinal: 1,
+      providerMeta: { lineNumber: 1 },
+    })).rejects.toMatchObject({
+      code: 'TRANSCRIPT_NOT_YET_PERSISTED',
+      status: 409,
+      retryable: true,
+      message: expect.stringContaining('native session for this chat is unavailable'),
+    });
+  });
+
   it('maps a changed selected prefix to a retryable conflict', async () => {
     const fork = mock(async () => {
       throw new AgentIntegrationError(

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -578,10 +578,15 @@ export class AgentRuntimeRouter {
         // A refusal means the row exists in the ledger but the provider has not written it
         // to native history yet. Reporting it lets the caller retry once it settles;
         // returning null here would silently hand back a fork with no native session.
-        if (error.details?.nativeForkReason === 'not-settled') {
+        // A missing source shares the refusal code so the handoff-consent flow
+        // applies, but names the source rather than promising the row will settle.
+        const forkReason = error.details?.nativeForkReason;
+        if (forkReason === 'not-settled' || forkReason === 'source-missing') {
           throw new DomainError(
             'TRANSCRIPT_NOT_YET_PERSISTED',
-            'The selected message is not in the agent\'s native history yet. Try again shortly.',
+            forkReason === 'source-missing'
+              ? 'The agent\'s native session for this chat is unavailable right now. Retry, or fork without it.'
+              : 'The selected message is not in the agent\'s native history yet. Try again shortly.',
             409,
             true,
           );

--- a/server/lib/http-error.ts
+++ b/server/lib/http-error.ts
@@ -1,6 +1,9 @@
 import { AgentIntegrationError } from '@garcon/server-agent-interface';
 import type { HttpErrorResponse } from '../../common/http-error.ts';
 import { isDomainError, transcriptUnavailableMessage } from './domain-error.js';
+import { createLogger } from './log.js';
+
+const logger = createLogger('http:error');
 
 export const DEFAULT_VALIDATION_ERROR_CODE = 'VALIDATION_FAILED';
 export const DEFAULT_INTERNAL_ERROR_CODE = 'INTERNAL_ERROR';
@@ -47,6 +50,11 @@ export function jsonErrorFromUnknown(
   }
   if (isDomainError(error)) {
     return jsonError(error.message, error.status, error.code, error.retryable);
+  }
+  // An untyped failure answered with an opaque 500 would otherwise leave no
+  // server-side trace at all.
+  if (status >= 500) {
+    logger.error('Unhandled route error:', error as Error);
   }
   const message = status >= 500
     ? DEFAULT_INTERNAL_ERROR_MESSAGE

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -40,11 +40,9 @@ import { jsonError, jsonErrorFromUnknown } from '../lib/http-error.js';
 import {
   GoalControlDeliveryError,
   DomainError,
-  isDomainError,
   QueueEntrySteerError,
   ValidationDomainError,
 } from '../lib/domain-error.js';
-import { AgentIntegrationError } from '@garcon/server-agent-interface';
 import { AttachmentValidationError, validateCommandAttachments } from '../attachments/validation.js';
 import { TranscriptHistoryUnavailableError } from '../chats/errors.js';
 import type { ChatReorderResult } from '../settings/types.js';
@@ -740,11 +738,6 @@ export default function createChatRoutes({
       if (error instanceof CommandValidationError) {
         return jsonError(error.message, error.status, error.code, error.retryable);
       }
-      // An untyped fork failure otherwise leaves no server-side trace behind
-      // its opaque 500.
-      if (!isDomainError(error) && !(error instanceof AgentIntegrationError)) {
-        logger.error('fork: chat fork failed:', error as Error);
-      }
       return jsonErrorFromUnknown(error);
     }
   }
@@ -820,9 +813,6 @@ export default function createChatRoutes({
     } catch (error: unknown) {
       if (error instanceof CommandValidationError) {
         return jsonError(error.message, error.status, error.code, error.retryable);
-      }
-      if (!isDomainError(error) && !(error instanceof AgentIntegrationError)) {
-        logger.error('fork: chat fork-run failed:', error as Error);
       }
       return jsonErrorFromUnknown(error);
     }


### PR DESCRIPTION
An untyped exception on any route surfaced as an opaque 500 with no server-side trace, every fork refusal claimed the selected row would settle shortly even when the source session or file was gone entirely, and the live conformance lanes failed intermittently because the DeepSeek models now behind them follow instructions less literally than Claude models. Unhandled route errors are now logged at the shared error boundary before the 500 is returned; source-level unavailability (a missing Claude or Codex session file, a missing OpenCode session, or a provider-reported NotFound on the fork call) refuses with its own source-missing reason and honest wording while keeping the same consent-capable 409, so retry and handoff-fork behavior are unchanged; the transcript design document records that Claude's session file can materialize asynchronously after a turn's result; and the live-lane prompts now demand character-for-character marker copies and immediate command execution with a longer command-marker wait, which takes the previously flaky suite to consecutive clean runs on the exact CI model.