### PR TITLE
Fix dependency setup and dark theme startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bun run start
 
 Open `http://127.0.0.1:8080`. On first launch, create an account at `/setup`, then connect agents and API providers in Settings.
 
-`bun run setup` installs the root workspace and integration-test dependencies. Authentication is enabled by default.
+`bun run setup` installs the root, server, web, and integration-test dependencies. Authentication is enabled by default.
 
 ### Requirements
 

--- a/integration-tests/tests/chromium/theme-bootstrap.test.ts
+++ b/integration-tests/tests/chromium/theme-bootstrap.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { chromium } from "playwright";
+
+const APP_URL = "http://theme-bootstrap.test/";
+const LOCAL_SETTINGS_KEY = "pref_local_settings";
+const STARTUP_MARKER = `<script>
+globalThis.__themeBeforeApplicationStartup = {
+  dark: document.documentElement.classList.contains('dark'),
+  colorScheme: document.documentElement.style.colorScheme,
+};
+</script>`;
+
+interface ThemeScenario {
+  name: string;
+  storedSettings: string | null;
+  systemColorScheme: "dark" | "light";
+  expectedDark: boolean;
+}
+
+const scenarios: ThemeScenario[] = [
+  {
+    name: "stored dark overrides a light system",
+    storedSettings: JSON.stringify({ theme: "dark" }),
+    systemColorScheme: "light",
+    expectedDark: true,
+  },
+  {
+    name: "stored light overrides a dark system",
+    storedSettings: JSON.stringify({ theme: "light" }),
+    systemColorScheme: "dark",
+    expectedDark: false,
+  },
+  {
+    name: "system follows dark",
+    storedSettings: JSON.stringify({ theme: "system" }),
+    systemColorScheme: "dark",
+    expectedDark: true,
+  },
+  {
+    name: "system follows light",
+    storedSettings: JSON.stringify({ theme: "system" }),
+    systemColorScheme: "light",
+    expectedDark: false,
+  },
+  {
+    name: "missing settings follow the system",
+    storedSettings: null,
+    systemColorScheme: "dark",
+    expectedDark: true,
+  },
+  {
+    name: "malformed settings follow the system",
+    storedSettings: "{",
+    systemColorScheme: "dark",
+    expectedDark: true,
+  },
+];
+
+describe("theme bootstrap", () => {
+  test("applies the resolved theme before application startup", async () => {
+    const appTemplate = await readFile(
+      new URL("../../../web/src/app.html", import.meta.url),
+      "utf8",
+    );
+    expect(appTemplate.indexOf("pref_local_settings")).toBeLessThan(
+      appTemplate.indexOf("%sveltekit.head%"),
+    );
+    const testDocument = appTemplate
+      .replace("%sveltekit.head%", STARTUP_MARKER)
+      .replace("%sveltekit.body%", "");
+    const browser = await chromium.launch({ headless: true });
+
+    try {
+      for (const scenario of scenarios) {
+        const context = await browser.newContext({
+          colorScheme: scenario.systemColorScheme,
+        });
+        await context.addInitScript(
+          ({ key, storedSettings }) => {
+            if (storedSettings === null) localStorage.removeItem(key);
+            else localStorage.setItem(key, storedSettings);
+          },
+          { key: LOCAL_SETTINGS_KEY, storedSettings: scenario.storedSettings },
+        );
+        const page = await context.newPage();
+        await page.route(`${APP_URL}**`, async (route) => {
+          if (new URL(route.request().url()).pathname === "/") {
+            await route.fulfill({
+              contentType: "text/html",
+              body: testDocument,
+            });
+            return;
+          }
+          await route.fulfill({ status: 204 });
+        });
+
+        const response = await page.goto(APP_URL);
+        expect(response?.ok(), scenario.name).toBe(true);
+        const startupTheme = await page.evaluate(() => {
+          const annotatedGlobal = globalThis as typeof globalThis & {
+            __themeBeforeApplicationStartup?: {
+              dark: boolean;
+              colorScheme: string;
+            };
+          };
+          return annotatedGlobal.__themeBeforeApplicationStartup;
+        });
+        expect(startupTheme, scenario.name).toEqual({
+          dark: scenario.expectedDark,
+          colorScheme: scenario.expectedDark ? "dark" : "light",
+        });
+
+        await context.close();
+      }
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/cfal/garcon/issues"
   },
   "scripts": {
-    "setup": "bun install && bun install --cwd integration-tests",
+    "setup": "bun scripts/setup.js",
     "build": "bun scripts/build-web.js",
     "build-exe:compile": "bun scripts/build-exe.js",
     "build-exe:smoke": "bun scripts/smoke-exe.js",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,96 @@
+import { lstat, rm } from "node:fs/promises";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dir, "..");
+const integrationTestsRoot = path.join(repositoryRoot, "integration-tests");
+
+async function findWorkspaceRoots() {
+  const manifest = await Bun.file(
+    path.join(repositoryRoot, "package.json"),
+  ).json();
+  const roots = new Set();
+
+  for (const workspace of manifest.workspaces) {
+    const packages = new Bun.Glob(`${workspace}/package.json`);
+    for await (const packagePath of packages.scan({
+      cwd: repositoryRoot,
+      onlyFiles: true,
+    })) {
+      roots.add(path.dirname(path.join(repositoryRoot, packagePath)));
+    }
+  }
+
+  return [...roots].sort();
+}
+
+async function hasNonIsolatedDependencies(workspaceRoot) {
+  const manifest = await Bun.file(
+    path.join(workspaceRoot, "package.json"),
+  ).json();
+  const dependencies = Object.keys({
+    ...manifest.dependencies,
+    ...manifest.devDependencies,
+  });
+
+  for (const dependency of dependencies) {
+    try {
+      const entry = await lstat(
+        path.join(workspaceRoot, "node_modules", dependency),
+      );
+      if (!entry.isSymbolicLink()) {
+        return true;
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  return false;
+}
+
+async function resetNonIsolatedDependencies(workspaceRoot) {
+  if (!(await hasNonIsolatedDependencies(workspaceRoot))) {
+    return;
+  }
+
+  console.log(
+    `Resetting non-isolated dependencies in ${path.relative(repositoryRoot, workspaceRoot)}`,
+  );
+  await rm(path.join(workspaceRoot, "node_modules"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+async function installDependencies(installRoot) {
+  const label = path.relative(repositoryRoot, installRoot) || "root workspace";
+  console.log(`Installing dependencies in ${label}`);
+  const install = Bun.spawn(
+    [process.execPath, "install", "--frozen-lockfile"],
+    {
+      cwd: installRoot,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+  const exitCode = await install.exited;
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+}
+
+const workspaceRoots = await findWorkspaceRoots();
+await Promise.all(workspaceRoots.map(resetNonIsolatedDependencies));
+
+const installRoots = [
+  repositoryRoot,
+  path.join(repositoryRoot, "server"),
+  path.join(repositoryRoot, "web"),
+  integrationTestsRoot,
+];
+for (const installRoot of installRoots) {
+  await installDependencies(installRoot);
+}

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -20,6 +20,23 @@
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<link rel="manifest" href="/site.webmanifest" />
 		<title>Garcon</title>
+		<script>
+			(() => {
+				let theme = 'system';
+				try {
+					const stored = JSON.parse(localStorage.getItem('pref_local_settings') ?? '{}');
+					if (stored?.theme === 'dark' || stored?.theme === 'light') theme = stored.theme;
+				} catch {
+					// Falls back to the system preference when persisted settings are unavailable.
+				}
+
+				const isDark =
+					theme === 'dark' ||
+					(theme === 'system' && matchMedia('(prefers-color-scheme: dark)').matches);
+				document.documentElement.classList.toggle('dark', isDark);
+				document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
Dependency upgrades can leave stale nested installs and dark-mode users can see a light first paint; this updates setup to refresh incompatible workspace dependency trees and applies the persisted or system theme before SvelteKit loads.