### PR TITLE
Terminate expired detached terminals

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -2,16 +2,16 @@
 // variables and CLI flags. Other server modules use getters from here instead
 // of reading process.env or process.argv directly.
 
-import path from 'path';
-import os from 'os';
+import path from "path";
+import os from "os";
 
 const CLI_VALUE_FLAGS = {
-  '--config-dir': '<directory>',
-  '--workspace-dir': '<directory>',
-  '--workspace': '<name>',
-  '--port': '<number>',
-  '--bind-address': '<hostname-or-ip>',
-  '--project-base-dir': '<directory>',
+  "--config-dir": "<directory>",
+  "--workspace-dir": "<directory>",
+  "--workspace": "<name>",
+  "--port": "<number>",
+  "--bind-address": "<hostname-or-ip>",
+  "--project-base-dir": "<directory>",
 } as const;
 
 type CliValueFlag = keyof typeof CLI_VALUE_FLAGS;
@@ -34,6 +34,7 @@ export interface ServerConfig {
   wsMaxPayloadLength: number;
   httpIdleTimeoutSeconds: number;
   maxSessions: number;
+  terminalDetachedTtlSeconds: number;
   authDisabled: boolean;
   trustProxyEnabled: boolean;
   httpCompressionEnabled: boolean;
@@ -57,7 +58,7 @@ function currentConfig(): Readonly<ServerConfig> {
 
 function envValue(name: string): string | null {
   const value = process.env[name];
-  return value === undefined || value === '' ? null : value;
+  return value === undefined || value === "" ? null : value;
 }
 
 function cliValue(flag: CliValueFlag): string | null {
@@ -76,14 +77,14 @@ function nonEmptyValue(
   errorMessage: string,
 ): string | null {
   if (value === null) return null;
-  if (value.trim() === '') {
+  if (value.trim() === "") {
     throw new Error(errorMessage);
   }
   return value;
 }
 
 function parsePort(value: string, source: string): number {
-  if (value.trim() === '') {
+  if (value.trim() === "") {
     throw new Error(
       `Invalid ${source} value: must be an integer between 0 and 65535.`,
     );
@@ -100,9 +101,9 @@ function parsePort(value: string, source: string): number {
 function parseServerConfig(): ServerConfig {
   const configDir = parseConfigDir();
   const workspace = parseWorkspace(configDir);
-  const maxWsClients = envInt('MAX_WS_CLIENTS', 128);
+  const maxWsClients = envInt("MAX_WS_CLIENTS", 128);
   if (maxWsClients < 1) {
-    throw new Error('Invalid GARCON_MAX_WS_CLIENTS value: must be at least 1.');
+    throw new Error("Invalid GARCON_MAX_WS_CLIENTS value: must be at least 1.");
   }
   return {
     configDir,
@@ -110,55 +111,66 @@ function parseServerConfig(): ServerConfig {
     workspaceName: workspace.workspaceName,
     port: parsePortConfig(),
     bindAddress: parseBindAddress(),
-    jwtTokenExpiry: envValue('GARCON_JWT_TOKEN_EXPIRY') ?? '30d',
-    testEnvironment: envValue('NODE_ENV') === 'test',
+    jwtTokenExpiry: envValue("GARCON_JWT_TOKEN_EXPIRY") ?? "30d",
+    testEnvironment: envValue("NODE_ENV") === "test",
     projectBasePath: parseProjectBasePath(),
     userShell: parseUserShell(),
-    maxRequestBodySize: envInt('MAX_REQUEST_BODY_SIZE', 50 * 1024 * 1024),
-    maxConnections: envInt('MAX_CONNECTIONS', 1024),
+    maxRequestBodySize: envInt("MAX_REQUEST_BODY_SIZE", 50 * 1024 * 1024),
+    maxConnections: envInt("MAX_CONNECTIONS", 1024),
     maxWsClients,
-    wsIdleTimeoutSeconds: envInt('WS_IDLE_TIMEOUT_SECONDS', 60 * 16),
-    wsBackpressureLimit: envInt('WS_BACKPRESSURE_LIMIT', 2 * 1024 * 1024),
-    wsMaxPayloadLength: envInt('WS_MAX_PAYLOAD_LENGTH', 16 * 1024 * 1024),
-    httpIdleTimeoutSeconds: envInt('HTTP_IDLE_TIMEOUT_SECONDS', 60 * 2),
-    maxSessions: envInt('MAX_SESSIONS', 50),
+    wsIdleTimeoutSeconds: envInt("WS_IDLE_TIMEOUT_SECONDS", 60 * 16),
+    wsBackpressureLimit: envInt("WS_BACKPRESSURE_LIMIT", 2 * 1024 * 1024),
+    wsMaxPayloadLength: envInt("WS_MAX_PAYLOAD_LENGTH", 16 * 1024 * 1024),
+    httpIdleTimeoutSeconds: envInt("HTTP_IDLE_TIMEOUT_SECONDS", 60 * 2),
+    maxSessions: envInt("MAX_SESSIONS", 50),
+    terminalDetachedTtlSeconds: envInt("TERMINAL_DETACHED_TTL_SECONDS", 0),
     authDisabled: parseAuthDisabled(),
-    trustProxyEnabled: envBool('TRUST_PROXY', false),
-    httpCompressionEnabled: envBool('HTTP_COMPRESSION', true),
-    rollbackCarryOverMigration: process.argv.includes('--rollback-carryover-migration'),
+    trustProxyEnabled: envBool("TRUST_PROXY", false),
+    httpCompressionEnabled: envBool("HTTP_COMPRESSION", true),
+    rollbackCarryOverMigration: process.argv.includes(
+      "--rollback-carryover-migration",
+    ),
   };
 }
 
 function parseConfigDir(): string {
-  const envConfigDir = envValue('GARCON_CONFIG_DIR');
+  const envConfigDir = envValue("GARCON_CONFIG_DIR");
   if (envConfigDir !== null) return envConfigDir;
 
-  const configDir = cliValue('--config-dir');
+  const configDir = cliValue("--config-dir");
   if (configDir !== null) return configDir;
 
-  return path.join(os.homedir(), '.garcon');
+  return path.join(os.homedir(), ".garcon");
 }
 
-function parseWorkspace(configDir: string): Pick<ServerConfig, 'workspaceDir' | 'workspaceName'> {
+function parseWorkspace(
+  configDir: string,
+): Pick<ServerConfig, "workspaceDir" | "workspaceName"> {
   const workspaceDir = nonEmptyValue(
-    envValue('GARCON_WORKSPACE_DIR') ?? cliValue('--workspace-dir'),
-    'Invalid --workspace-dir value: must be a non-empty directory path.',
+    envValue("GARCON_WORKSPACE_DIR") ?? cliValue("--workspace-dir"),
+    "Invalid --workspace-dir value: must be a non-empty directory path.",
   );
   if (workspaceDir !== null) return { workspaceDir, workspaceName: null };
 
   let workspaceName: string;
-  const envWorkspace = envValue('GARCON_WORKSPACE');
+  const envWorkspace = envValue("GARCON_WORKSPACE");
   if (envWorkspace !== null) {
     workspaceName = envWorkspace;
   } else {
     const cliWorkspaceName = nonEmptyValue(
-      cliValue('--workspace'),
-      'Invalid --workspace value: must be a non-empty name.',
+      cliValue("--workspace"),
+      "Invalid --workspace value: must be a non-empty name.",
     );
-    workspaceName = cliWorkspaceName ?? 'default';
+    workspaceName = cliWorkspaceName ?? "default";
   }
-  if (workspaceName === '.' || workspaceName === '..' || /[\\/\0]/.test(workspaceName)) {
-    throw new Error('Invalid workspace name: must not contain path separators.');
+  if (
+    workspaceName === "." ||
+    workspaceName === ".." ||
+    /[\\/\0]/.test(workspaceName)
+  ) {
+    throw new Error(
+      "Invalid workspace name: must not contain path separators.",
+    );
   }
   return {
     workspaceDir: path.join(configDir, `workspace-${workspaceName}`),
@@ -167,29 +179,29 @@ function parseWorkspace(configDir: string): Pick<ServerConfig, 'workspaceDir' | 
 }
 
 function parsePortConfig(): number {
-  const envPort = envValue('GARCON_PORT');
-  if (envPort !== null) return parsePort(envPort, 'GARCON_PORT');
+  const envPort = envValue("GARCON_PORT");
+  if (envPort !== null) return parsePort(envPort, "GARCON_PORT");
 
-  const port = cliValue('--port');
-  if (port !== null) return parsePort(port, '--port');
+  const port = cliValue("--port");
+  if (port !== null) return parsePort(port, "--port");
 
   return 8080;
 }
 
 function parseBindAddress(): string {
   const bindAddress = nonEmptyValue(
-    envValue('GARCON_BIND_ADDRESS') ?? cliValue('--bind-address'),
-    'Invalid --bind-address value: must be a non-empty hostname or IP address.',
+    envValue("GARCON_BIND_ADDRESS") ?? cliValue("--bind-address"),
+    "Invalid --bind-address value: must be a non-empty hostname or IP address.",
   );
   if (bindAddress !== null) return bindAddress;
 
-  return '127.0.0.1';
+  return "127.0.0.1";
 }
 
 function parseProjectBasePath(): string {
   const projectBaseDir = nonEmptyValue(
-    envValue('GARCON_PROJECT_BASE_DIR') ?? cliValue('--project-base-dir'),
-    'Invalid --project-base-dir value: must be a non-empty directory path.',
+    envValue("GARCON_PROJECT_BASE_DIR") ?? cliValue("--project-base-dir"),
+    "Invalid --project-base-dir value: must be a non-empty directory path.",
   );
   if (projectBaseDir !== null) return path.resolve(projectBaseDir);
 
@@ -197,19 +209,19 @@ function parseProjectBasePath(): string {
 }
 
 function parseUserShell(): string {
-  return os.platform() === 'win32'
-    ? 'powershell.exe'
-    : (envValue('GARCON_TERMINAL_SHELL') ?? envValue('SHELL') ?? '/bin/bash');
+  return os.platform() === "win32"
+    ? "powershell.exe"
+    : (envValue("GARCON_TERMINAL_SHELL") ?? envValue("SHELL") ?? "/bin/bash");
 }
 
 function parseAuthDisabled(): boolean {
   if (
     process.env.GARCON_DISABLE_AUTH !== undefined &&
-    process.env.GARCON_DISABLE_AUTH.trim() !== ''
+    process.env.GARCON_DISABLE_AUTH.trim() !== ""
   ) {
-    return envBool('DISABLE_AUTH', false);
+    return envBool("DISABLE_AUTH", false);
   }
-  return process.argv.includes('--disable-auth');
+  return process.argv.includes("--disable-auth");
 }
 
 export function getConfigDir(): string {
@@ -280,6 +292,10 @@ export function getMaxSessions(): number {
   return currentConfig().maxSessions;
 }
 
+export function getTerminalDetachedTtlSeconds(): number {
+  return currentConfig().terminalDetachedTtlSeconds;
+}
+
 export function isAuthDisabled(): boolean {
   return currentConfig().authDisabled;
 }
@@ -294,9 +310,9 @@ export function isHttpCompressionEnabled(): boolean {
 
 // Parses an integer from an environment variable, returning the fallback when absent.
 function envInt(name: string, fallback: number): number {
-  const varName = 'GARCON_' + name;
+  const varName = "GARCON_" + name;
   const raw = process.env[varName];
-  if (raw === undefined || raw === '') {
+  if (raw === undefined || raw === "") {
     return fallback;
   }
   const normalized = raw.trim();
@@ -310,14 +326,14 @@ function envInt(name: string, fallback: number): number {
 }
 
 function envBool(name: string, fallback: boolean): boolean {
-  const varName = 'GARCON_' + name;
+  const varName = "GARCON_" + name;
   const raw = process.env[varName];
-  if (raw === undefined || raw === '') {
+  if (raw === undefined || raw === "") {
     return fallback;
   }
   const normalized = String(raw).trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
   throw new Error(
     `Invalid ${varName} value: ${raw}. Must be a boolean-like value.`,
   );

--- a/server/lib/__tests__/config.test.js
+++ b/server/lib/__tests__/config.test.js
@@ -1,17 +1,20 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from "bun:test";
 import {
   getPort,
   initializeServerConfig,
   resetServerConfigForTests,
   isAuthDisabled,
   isHttpCompressionEnabled,
-} from '../../config.js';
+  getTerminalDetachedTtlSeconds,
+} from "../../config.js";
 
 const originalArgv = [...process.argv];
 const originalPort = process.env.GARCON_PORT;
 const originalMaxWsClients = process.env.GARCON_MAX_WS_CLIENTS;
 const originalHttpCompression = process.env.GARCON_HTTP_COMPRESSION;
 const originalDisableAuth = process.env.GARCON_DISABLE_AUTH;
+const originalTerminalDetachedTtl =
+  process.env.GARCON_TERMINAL_DETACHED_TTL_SECONDS;
 
 afterEach(() => {
   resetServerConfigForTests();
@@ -36,100 +39,133 @@ afterEach(() => {
   } else {
     process.env.GARCON_DISABLE_AUTH = originalDisableAuth;
   }
+  if (originalTerminalDetachedTtl === undefined) {
+    delete process.env.GARCON_TERMINAL_DETACHED_TTL_SECONDS;
+  } else {
+    process.env.GARCON_TERMINAL_DETACHED_TTL_SECONDS =
+      originalTerminalDetachedTtl;
+  }
 });
 
-describe('getPort', () => {
-  it('preserves env port 0 for OS-assigned binding', () => {
-    process.env.GARCON_PORT = '0';
+describe("getPort", () => {
+  it("preserves env port 0 for OS-assigned binding", () => {
+    process.env.GARCON_PORT = "0";
     process.argv = [...originalArgv];
 
     expect(getPort()).toBe(0);
   });
 
-  it('preserves CLI port 0 for OS-assigned binding', () => {
+  it("preserves CLI port 0 for OS-assigned binding", () => {
     delete process.env.GARCON_PORT;
-    process.argv = [...originalArgv, '--port', '0'];
+    process.argv = [...originalArgv, "--port", "0"];
 
     expect(getPort()).toBe(0);
   });
 
-  it('rejects missing CLI port values', () => {
+  it("rejects missing CLI port values", () => {
     delete process.env.GARCON_PORT;
-    process.argv = [...originalArgv, '--port'];
+    process.argv = [...originalArgv, "--port"];
 
-    expect(() => getPort()).toThrow('--port requires a value');
+    expect(() => getPort()).toThrow("--port requires a value");
   });
 
-  it('rejects empty CLI port values', () => {
+  it("rejects empty CLI port values", () => {
     delete process.env.GARCON_PORT;
-    process.argv = [...originalArgv, '--port', ''];
+    process.argv = [...originalArgv, "--port", ""];
 
-    expect(() => getPort()).toThrow('Invalid --port value');
+    expect(() => getPort()).toThrow("Invalid --port value");
   });
 
-  it('rejects non-integer ports', () => {
-    process.env.GARCON_PORT = '3000.5';
+  it("rejects non-integer ports", () => {
+    process.env.GARCON_PORT = "3000.5";
     process.argv = [...originalArgv];
 
-    expect(() => getPort()).toThrow('Invalid GARCON_PORT value');
+    expect(() => getPort()).toThrow("Invalid GARCON_PORT value");
   });
 
-  it('freezes initialized config against later env changes', () => {
-    process.env.GARCON_PORT = '9001';
+  it("freezes initialized config against later env changes", () => {
+    process.env.GARCON_PORT = "9001";
     process.argv = [...originalArgv];
 
     const config = initializeServerConfig();
-    process.env.GARCON_PORT = '9002';
+    process.env.GARCON_PORT = "9002";
 
     expect(Object.isFrozen(config)).toBe(true);
     expect(getPort()).toBe(9001);
   });
 
-  it('validates websocket client limits during initialization', () => {
-    process.env.GARCON_MAX_WS_CLIENTS = 'many';
+  it("validates websocket client limits during initialization", () => {
+    process.env.GARCON_MAX_WS_CLIENTS = "many";
 
-    expect(() => initializeServerConfig()).toThrow('Invalid GARCON_MAX_WS_CLIENTS value');
+    expect(() => initializeServerConfig()).toThrow(
+      "Invalid GARCON_MAX_WS_CLIENTS value",
+    );
   });
 
-  it('parses the explicit carryover rollback startup flag', () => {
-    process.argv = [...originalArgv, '--rollback-carryover-migration'];
+  it("parses the explicit carryover rollback startup flag", () => {
+    process.argv = [...originalArgv, "--rollback-carryover-migration"];
 
     expect(initializeServerConfig().rollbackCarryOverMigration).toBe(true);
   });
 
-  it('rejects negative websocket client limits during initialization', () => {
-    process.env.GARCON_MAX_WS_CLIENTS = '-1';
+  it("rejects negative websocket client limits during initialization", () => {
+    process.env.GARCON_MAX_WS_CLIENTS = "-1";
 
-    expect(() => initializeServerConfig()).toThrow('non-negative integer');
+    expect(() => initializeServerConfig()).toThrow("non-negative integer");
   });
-
 });
 
-describe('isAuthDisabled', () => {
-  it('treats empty GARCON_DISABLE_AUTH as unset so the CLI flag can apply', () => {
-    process.env.GARCON_DISABLE_AUTH = '';
-    process.argv = [...originalArgv, '--disable-auth'];
+describe("getTerminalDetachedTtlSeconds", () => {
+  it("defaults to disabled", () => {
+    delete process.env.GARCON_TERMINAL_DETACHED_TTL_SECONDS;
+    initializeServerConfig();
+
+    expect(getTerminalDetachedTtlSeconds()).toBe(0);
+  });
+
+  it("parses a one-day ttl", () => {
+    process.env.GARCON_TERMINAL_DETACHED_TTL_SECONDS = "86400";
+    initializeServerConfig();
+
+    expect(getTerminalDetachedTtlSeconds()).toBe(86_400);
+  });
+
+  it("rejects negative ttl values", () => {
+    process.env.GARCON_TERMINAL_DETACHED_TTL_SECONDS = "-1";
+
+    expect(() => initializeServerConfig()).toThrow(
+      "Invalid GARCON_TERMINAL_DETACHED_TTL_SECONDS value",
+    );
+  });
+});
+
+describe("isAuthDisabled", () => {
+  it("treats empty GARCON_DISABLE_AUTH as unset so the CLI flag can apply", () => {
+    process.env.GARCON_DISABLE_AUTH = "";
+    process.argv = [...originalArgv, "--disable-auth"];
     initializeServerConfig();
 
     expect(isAuthDisabled()).toBe(true);
   });
 });
 
-describe('isHttpCompressionEnabled', () => {
-  it('defaults to enabled', () => {
+describe("isHttpCompressionEnabled", () => {
+  it("defaults to enabled", () => {
     delete process.env.GARCON_HTTP_COMPRESSION;
     initializeServerConfig();
     expect(isHttpCompressionEnabled()).toBe(true);
   });
 
-  it('disables on false-like env values', () => {
-    process.env.GARCON_HTTP_COMPRESSION = 'false';
+  it("disables on false-like env values", () => {
+    process.env.GARCON_HTTP_COMPRESSION = "false";
     initializeServerConfig();
     expect(isHttpCompressionEnabled()).toBe(false);
   });
 
-  it('throws on invalid values', () => {
-    process.env.GARCON_HTTP_COMPRESSION = 'maybe';
-    expect(() => initializeServerConfig()).toThrow('Invalid GARCON_HTTP_COMPRESSION value');
+  it("throws on invalid values", () => {
+    process.env.GARCON_HTTP_COMPRESSION = "maybe";
+    expect(() => initializeServerConfig()).toThrow(
+      "Invalid GARCON_HTTP_COMPRESSION value",
+    );
   });
 });

--- a/server/main.ts
+++ b/server/main.ts
@@ -28,6 +28,8 @@ Environment Variables:
   GARCON_JWT_TOKEN_EXPIRY          JWT expiry for auth tokens. Default: 30d
   GARCON_PROJECT_BASE_DIR          Restricts project file access to this resolved path.
   GARCON_TERMINAL_SHELL            Shell executable for PTY sessions (non-Windows).
+  GARCON_TERMINAL_DETACHED_TTL_SECONDS
+                                     Seconds before detached PTY sessions are terminated. Default: 0.
   GARCON_MAX_REQUEST_BODY_SIZE     HTTP request body size limit (bytes). Default: 52428800
   GARCON_MAX_CONNECTIONS           Max concurrent HTTP connections. Default: 1024
   GARCON_MAX_WS_CLIENTS            Max pending websocket clients. Default: 128
@@ -45,10 +47,10 @@ Notes:
   process.stdout.write(helpText);
 }
 
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
   printHelp();
 } else {
-  const { startServer } = await import('./server.js');
+  const { startServer } = await import("./server.js");
   await startServer();
 }
 

--- a/server/terminals/__tests__/terminal-manager.test.js
+++ b/server/terminals/__tests__/terminal-manager.test.js
@@ -284,11 +284,7 @@ describe("TerminalManager", () => {
 
     pty.emitExit(23);
 
-    for (const browser of [
-      displacedBrowser,
-      passiveBrowser,
-      attachedBrowser,
-    ]) {
+    for (const browser of [displacedBrowser, passiveBrowser, attachedBrowser]) {
       expect(browser.messages.at(-1)).toMatchObject({
         type: "terminal-status",
         terminal: {
@@ -445,9 +441,9 @@ describe("TerminalManager", () => {
       code: "terminal-backpressure",
       status: 429,
     });
-    expect(
-      await manager.terminate(alice, "missing-1", "terminate-1"),
-    ).toEqual(first);
+    expect(await manager.terminate(alice, "missing-1", "terminate-1")).toEqual(
+      first,
+    );
     await expect(
       manager.terminate(bob, "missing-1", "terminate-1"),
     ).resolves.toMatchObject({
@@ -476,8 +472,16 @@ describe("TerminalManager", () => {
     const firstTerminalId = firstTerminal.terminal.terminalId;
     const secondTerminalId = secondTerminal.terminal.terminalId;
 
-    const first = await manager.terminate(alice, firstTerminalId, "shared-request");
-    const second = await manager.terminate(alice, secondTerminalId, "shared-request");
+    const first = await manager.terminate(
+      alice,
+      firstTerminalId,
+      "shared-request",
+    );
+    const second = await manager.terminate(
+      alice,
+      secondTerminalId,
+      "shared-request",
+    );
 
     expect(first.terminalId).toBe(firstTerminalId);
     expect(second.terminalId).toBe(secondTerminalId);
@@ -554,6 +558,138 @@ describe("TerminalManager", () => {
       expect.objectContaining({
         terminalId: second.terminal.terminalId,
         attachmentStatus: "attached",
+      }),
+    ]);
+  });
+
+  it("terminates only expired detached terminals", async () => {
+    let now = 1_000;
+    const ptys = [];
+    const manager = new TerminalManager({
+      now: () => now,
+      detachedTerminalTtlMs: 86_400_000,
+      spawnPty: () => {
+        const pty = new FakePty();
+        ptys.push(pty);
+        return pty;
+      },
+    });
+    const alice = principal("alice");
+    const first = await manager.create(alice, {
+      requestId: "create-1",
+      requestedInitialWorkingDirectory: projectPath,
+    });
+    const second = await manager.create(alice, {
+      requestId: "create-2",
+      requestedInitialWorkingDirectory: projectPath,
+    });
+    const firstPeer = peer("socket-1");
+    const secondPeer = peer("socket-2");
+    manager.attach(alice, firstPeer, {
+      type: "terminal-attach",
+      terminalId: first.terminal.terminalId,
+      clientId: "client-1",
+      afterSequence: 0,
+      intent: "restore",
+    });
+    manager.attach(alice, secondPeer, {
+      type: "terminal-attach",
+      terminalId: second.terminal.terminalId,
+      clientId: "client-2",
+      afterSequence: 0,
+      intent: "restore",
+    });
+    manager.detachTerminal(alice, firstPeer, first.terminal.terminalId);
+
+    now += 86_400_000;
+    manager.pruneExpiredDetachedTerminals();
+
+    expect(ptys.map((pty) => pty.killCount)).toEqual([1, 0]);
+    expect(manager.list(alice)).toEqual([
+      expect.objectContaining({
+        terminalId: second.terminal.terminalId,
+        attachmentStatus: "attached",
+      }),
+    ]);
+    expect(firstPeer.ownedTerminalIds.has(first.terminal.terminalId)).toBe(
+      false,
+    );
+    expect(secondPeer.ownedTerminalIds.has(second.terminal.terminalId)).toBe(
+      true,
+    );
+  });
+
+  it("resets detached terminal expiry after reconnection", async () => {
+    let now = 1_000;
+    const pty = new FakePty();
+    const manager = new TerminalManager({
+      now: () => now,
+      detachedTerminalTtlMs: 86_400_000,
+      spawnPty: () => pty,
+    });
+    const alice = principal("alice");
+    const created = await manager.create(alice, {
+      requestId: "create-1",
+      requestedInitialWorkingDirectory: projectPath,
+    });
+    const terminalId = created.terminal.terminalId;
+    const firstPeer = peer("socket-1");
+    const secondPeer = peer("socket-2");
+    manager.attach(alice, firstPeer, {
+      type: "terminal-attach",
+      terminalId,
+      clientId: "client-1",
+      afterSequence: 0,
+      intent: "restore",
+    });
+    manager.detachTerminal(alice, firstPeer, terminalId);
+    now += 86_399_999;
+    manager.attach(alice, secondPeer, {
+      type: "terminal-attach",
+      terminalId,
+      clientId: "client-1",
+      afterSequence: 0,
+      intent: "restore",
+    });
+    manager.detachTerminal(alice, secondPeer, terminalId);
+
+    manager.pruneExpiredDetachedTerminals();
+    expect(pty.killCount).toBe(0);
+    expect(manager.list(alice)).toHaveLength(1);
+
+    now += 1;
+    manager.pruneExpiredDetachedTerminals();
+    expect(pty.killCount).toBe(0);
+    expect(manager.list(alice)).toHaveLength(1);
+
+    now += 86_399_999;
+    manager.pruneExpiredDetachedTerminals();
+    expect(pty.killCount).toBe(1);
+    expect(manager.list(alice)).toEqual([]);
+  });
+
+  it("leaves detached terminals alone when the ttl is disabled", async () => {
+    let now = 1_000;
+    const pty = new FakePty();
+    const manager = new TerminalManager({
+      now: () => now,
+      detachedTerminalTtlMs: 0,
+      spawnPty: () => pty,
+    });
+    const alice = principal("alice");
+    const created = await manager.create(alice, {
+      requestId: "create-1",
+      requestedInitialWorkingDirectory: projectPath,
+    });
+
+    now += 86_400_000;
+    manager.pruneExpiredDetachedTerminals();
+
+    expect(pty.killCount).toBe(0);
+    expect(manager.list(alice)).toEqual([
+      expect.objectContaining({
+        terminalId: created.terminal.terminalId,
+        attachmentStatus: "detached",
       }),
     ]);
   });

--- a/server/terminals/terminal-manager.ts
+++ b/server/terminals/terminal-manager.ts
@@ -10,7 +10,11 @@ import {
   type TerminalStreamServerMessage,
   type TerminalTerminateResponse,
 } from "../../common/terminal.js";
-import { getProjectBasePath, getUserShell } from "../config.js";
+import {
+  getProjectBasePath,
+  getTerminalDetachedTtlSeconds,
+  getUserShell,
+} from "../config.js";
 import { KeyedPromiseLock } from "../lib/keyed-lock.js";
 import { assertRealWithinProjectBase } from "../lib/path-boundary.js";
 import type { ServerPrincipal } from "../lib/http-route-types.js";
@@ -21,6 +25,7 @@ import { TerminalReplayBuffer } from "./terminal-replay-buffer.js";
 const logger = createLogger("terminals:manager");
 const CREATE_RESULT_TTL_MS = 10 * 60 * 1000;
 const MAX_PENDING_OPERATIONS = 1024;
+const DETACHED_TERMINAL_PRUNE_INTERVAL_MS = 5 * 60 * 1000;
 export const MAX_TERMINAL_REQUEST_RESULTS_PER_PRINCIPAL = 256;
 export const MAX_TERMINAL_REQUEST_RESULTS = 4096;
 
@@ -43,6 +48,7 @@ interface TerminalSession {
   attachment: TerminalAttachment | null;
   subscribers: Set<TerminalStreamPeer>;
   attachmentGeneration: number;
+  detachedAtMs: number | null;
   pendingOperations: number;
   operationChain: Promise<void>;
   pendingResize: {
@@ -88,6 +94,8 @@ type PtySpawner = (
   },
 ) => IPty;
 
+type UnrefTimer = ReturnType<typeof setInterval> & { unref?: () => void };
+
 interface TerminalManagerOptions {
   spawnPty?: PtySpawner;
   now?: () => number;
@@ -95,6 +103,8 @@ interface TerminalManagerOptions {
   replayBytes?: number;
   requestResultsPerPrincipal?: number;
   requestResultsTotal?: number;
+  detachedTerminalTtlMs?: number;
+  detachedTerminalPruneIntervalMs?: number;
 }
 
 function ptyEnvironment(): Record<string, string> {
@@ -147,8 +157,10 @@ export class TerminalManager {
   readonly #spawnPty?: PtySpawner;
   readonly #requestResultsPerPrincipal: number;
   readonly #requestResultsTotal: number;
+  readonly #detachedTerminalTtlMs: number;
   #requestResultCount = 0;
   readonly #resultCleanupTimer: ReturnType<typeof setInterval>;
+  readonly #detachedTerminalCleanupTimer: ReturnType<typeof setInterval> | null;
 
   constructor(options: TerminalManagerOptions = {}) {
     this.#now = options.now ?? Date.now;
@@ -160,11 +172,29 @@ export class TerminalManager {
       MAX_TERMINAL_REQUEST_RESULTS_PER_PRINCIPAL;
     this.#requestResultsTotal =
       options.requestResultsTotal ?? MAX_TERMINAL_REQUEST_RESULTS;
+    this.#detachedTerminalTtlMs =
+      options.detachedTerminalTtlMs ?? getTerminalDetachedTtlSeconds() * 1000;
     this.#resultCleanupTimer = setInterval(
       () => this.#pruneRequestResults(),
       Math.max(1_000, Math.min(this.#createResultTtlMs, 60_000)),
     );
-    this.#resultCleanupTimer.unref?.();
+    (this.#resultCleanupTimer as UnrefTimer).unref?.();
+    if (this.#detachedTerminalTtlMs > 0) {
+      this.#detachedTerminalCleanupTimer = setInterval(
+        () => this.pruneExpiredDetachedTerminals(),
+        Math.max(
+          1_000,
+          Math.min(
+            options.detachedTerminalPruneIntervalMs ??
+              DETACHED_TERMINAL_PRUNE_INTERVAL_MS,
+            this.#detachedTerminalTtlMs,
+          ),
+        ),
+      );
+      (this.#detachedTerminalCleanupTimer as UnrefTimer).unref?.();
+    } else {
+      this.#detachedTerminalCleanupTimer = null;
+    }
   }
 
   list(principal: ServerPrincipal): TerminalMetadata[] {
@@ -270,6 +300,7 @@ export class TerminalManager {
         attachment: null,
         subscribers: new Set(),
         attachmentGeneration: 0,
+        detachedAtMs: this.#now(),
         pendingOperations: 0,
         operationChain: Promise.resolve(),
         pendingResize: null,
@@ -327,35 +358,11 @@ export class TerminalManager {
         );
         return response;
       }
-      session.terminating = true;
-      const finalMetadata = cloneTerminalMetadata(session.metadata);
-      for (const subscriber of session.subscribers) {
-        try {
-          subscriber.sendTerminalMessage({
-            type: "terminal-terminated",
-            terminalId,
-          });
-        } catch (error) {
-          logger.warn(
-            `terminal termination notification failed id=${terminalId} connection=${subscriber.connectionId}:`,
-            errorMessage(error),
-          );
-        }
-        subscriber.ownedTerminalIds.delete(terminalId);
-      }
-      session.subscribers.clear();
-      session.attachment = null;
-      sessions.delete(terminalId);
-      if (session.metadata.processStatus === "running") {
-        try {
-          session.pty.kill();
-        } catch (error) {
-          logger.warn(
-            `terminal kill failed id=${terminalId}:`,
-            errorMessage(error),
-          );
-        }
-      }
+      const finalMetadata = this.#terminateSession(
+        sessions,
+        session,
+        "request",
+      );
       logger.info(
         `terminal terminated id=${terminalId} principal=${principal.key}`,
       );
@@ -415,6 +422,7 @@ export class TerminalManager {
 
     session.attachment = { clientId: request.clientId, peer };
     session.attachmentGeneration += 1;
+    session.detachedAtMs = null;
     peer.ownedTerminalIds.add(session.metadata.terminalId);
     session.metadata.attachmentStatus = "attached";
     const firstSequence = session.replay.firstRetainedSequence;
@@ -500,6 +508,7 @@ export class TerminalManager {
       if (session.attachment?.peer === peer) {
         session.attachment = null;
         session.attachmentGeneration += 1;
+        session.detachedAtMs = this.#now();
         session.metadata.attachmentStatus = "detached";
       }
       if (wasSubscribed) peer.ownedTerminalIds.delete(terminalId);
@@ -518,6 +527,7 @@ export class TerminalManager {
     if (session.attachment?.peer === peer) {
       session.attachment = null;
       session.attachmentGeneration += 1;
+      session.detachedAtMs = this.#now();
       session.metadata.attachmentStatus = "detached";
     }
     peer.ownedTerminalIds.delete(terminalId);
@@ -525,6 +535,8 @@ export class TerminalManager {
 
   shutdown(): void {
     clearInterval(this.#resultCleanupTimer);
+    if (this.#detachedTerminalCleanupTimer)
+      clearInterval(this.#detachedTerminalCleanupTimer);
     for (const sessions of this.#sessionsByPrincipal.values()) {
       for (const session of sessions.values()) {
         session.terminating = true;
@@ -539,6 +551,25 @@ export class TerminalManager {
     this.#createResults.clear();
     this.#terminateResults.clear();
     this.#requestResultCount = 0;
+  }
+
+  pruneExpiredDetachedTerminals(): void {
+    if (this.#detachedTerminalTtlMs <= 0) return;
+    const now = this.#now();
+    for (const sessions of this.#sessionsByPrincipal.values()) {
+      for (const session of [...sessions.values()]) {
+        if (session.attachment !== null) continue;
+        if (session.detachedAtMs === null) continue;
+        const detachedAgeMs = now - session.detachedAtMs;
+        if (detachedAgeMs < this.#detachedTerminalTtlMs) continue;
+        this.#terminateSession(
+          sessions,
+          session,
+          "detached-ttl",
+          detachedAgeMs,
+        );
+      }
+    }
   }
 
   #sessionsFor(principalKey: string): Map<string, TerminalSession> {
@@ -626,6 +657,50 @@ export class TerminalManager {
         `terminal exited id=${session.metadata.terminalId} principal=${session.principalKey} code=${exitCode}`,
       );
     });
+  }
+
+  #terminateSession(
+    sessions: Map<string, TerminalSession>,
+    session: TerminalSession,
+    reason: "request" | "detached-ttl",
+    detachedAgeMs?: number,
+  ): TerminalMetadata {
+    session.terminating = true;
+    const terminalId = session.metadata.terminalId;
+    const finalMetadata = cloneTerminalMetadata(session.metadata);
+    for (const subscriber of session.subscribers) {
+      try {
+        subscriber.sendTerminalMessage({
+          type: "terminal-terminated",
+          terminalId,
+        });
+      } catch (error) {
+        logger.warn(
+          `terminal termination notification failed id=${terminalId} connection=${subscriber.connectionId}:`,
+          errorMessage(error),
+        );
+      }
+      subscriber.ownedTerminalIds.delete(terminalId);
+    }
+    session.subscribers.clear();
+    session.attachment = null;
+    sessions.delete(terminalId);
+    if (session.metadata.processStatus === "running") {
+      try {
+        session.pty.kill();
+      } catch (error) {
+        logger.warn(
+          `terminal kill failed id=${terminalId}:`,
+          errorMessage(error),
+        );
+      }
+    }
+    const detachedAgeLog =
+      detachedAgeMs === undefined ? "" : ` detachedAgeMs=${detachedAgeMs}`;
+    logger.info(
+      `terminal cleanup id=${terminalId} principal=${session.principalKey} reason=${reason}${detachedAgeLog}`,
+    );
+    return finalMetadata;
   }
 
   #enqueue(


### PR DESCRIPTION
## Summary
- add opt-in `GARCON_TERMINAL_DETACHED_TTL_SECONDS` cleanup for detached PTY sessions
- leave attached terminals and disabled TTL behavior unchanged
- reset detached expiry when a browser reconnects

## Tests
- `bun test server/terminals/__tests__/terminal-manager.test.js server/lib/__tests__/config.test.js`
- `bun run check`
- `bun run build`
- `timeout 300s bun run test` reaches existing `server-agents/common/src/search/__tests__/reader-worker.test.ts` timeout after prior suites pass

## Deploy note
- production value for YK Garcon: `GARCON_TERMINAL_DETACHED_TTL_SECONDS=86400`