### PR TITLE
Distinguish CLI-originated user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,18 @@ repeatable tags with `--tag review --tag delegated`; every new chat receives the
 automatically, and `cli` records creation through `garcon-cli` and nothing else. `--title` sets
 an explicit title on either a new or resumed chat.
 
+Conversational start, resume, and `send-async` messages may add a visual CLI header with
+`--message-title <title>` and `--message-style notice|error`. A title alone uses `notice`; a
+style alone displays `CLI notice` or `CLI error`. These values distinguish the ordinary user
+message in Garcon and are not included in the prompt sent to the agent. `--title` remains the
+chat title.
+
+```bash
+garcon-cli --workspace default --resume 1785337200123456 \
+  --message-title "Deployment constraint" --message-style error \
+  "Do not deploy until the migration checksum matches."
+```
+
 The CLI supports write-capable delegation and does not force `plan` mode. Permission and reasoning values use the selected agent's live Garcon catalog; inherited bypass modes require the matching explicit `--permissions` flag. A single `-` prompt reads stdin. Use `--` before a positional prompt whose first word is `list`, `send-async`, `stop`, `status`, or `wait`. Interrupting the terminal detaches the CLI without stopping work in Garcon.
 
 Every accepted start or resume prints an exact handle before waiting:
@@ -225,7 +237,8 @@ If the chat is busy running another turn, `send-async` reports the busy state an
 
 ```bash
 garcon-cli --workspace default send-async 1785337200123456 \
-  --allow-steer "Also update the migration test."
+  --allow-steer --message-title "New blocker" --message-style error \
+  "Also update the migration test."
 ```
 
 ```text

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ Conversational start, resume, and `send-async` messages may add a visual CLI hea
 `--message-title <title>` and `--message-style notice|error`. A title alone uses `notice`; a
 style alone displays `CLI notice` or `CLI error`. These values distinguish the ordinary user
 message in Garcon and are not included in the prompt sent to the agent. `--title` remains the
-chat title.
+chat title. Ordinary restart, replay, shares, and frozen forks preserve this presentation;
+explicit native-history Reload and provider-native fork segments may drop it.
 
 ```bash
 garcon-cli --workspace default --resume 1785337200123456 \

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseCliArgs } from '../args.js';
+import { CLI_HELP, parseCliArgs } from '../args.js';
 import { CliError } from '../errors.js';
 
 const CHAT_ID = '1785337200123456';
@@ -180,6 +180,17 @@ describe('parseCliArgs', () => {
 
   test('returns help without requiring submission arguments', () => {
     expect(parseCliArgs(['--help'], ENV)).toEqual({ kind: 'help' });
+  });
+
+  test('documents presentation on conversational commands and its native-history boundary', () => {
+    expect(CLI_HELP).toContain(
+      'garcon-cli [options] [--message-title <title>] [--message-style <notice|error>] <prompt>',
+    );
+    expect(CLI_HELP).toContain(
+      '--resume <chat-id> [--message-title <title>] [--message-style <notice|error>] <prompt>',
+    );
+    expect(CLI_HELP).toContain('Native-history\nReload');
+    expect(CLI_HELP).toContain('provider-native fork segments may drop');
   });
 
   test('parses an exact turn wait with connection options and JSON output', () => {

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -42,6 +42,33 @@ describe('parseCliArgs', () => {
     });
   });
 
+  test('canonicalizes conversational message presentation independently of chat title', () => {
+    expect(parseCliArgs([
+      '--agent', 'codex',
+      '--model', 'gpt',
+      '--title', 'Chat title',
+      '--message-title', '  Operator context  ',
+      'prompt',
+    ], ENV)).toMatchObject({
+      kind: 'start',
+      title: 'Chat title',
+      userMessagePresentation: {
+        origin: 'cli',
+        style: 'notice',
+        title: 'Operator context',
+      },
+    });
+
+    expect(parseCliArgs([
+      '--resume', CHAT_ID,
+      '--message-style', 'error',
+      'prompt',
+    ], ENV)).toMatchObject({
+      kind: 'resume',
+      userMessagePresentation: { origin: 'cli', style: 'error' },
+    });
+  });
+
   test('parses live catalog queries without submission arguments', () => {
     expect(parseCliArgs([
       'list', 'models',
@@ -283,6 +310,19 @@ describe('parseCliArgs', () => {
     });
   });
 
+  test('parses send-async message presentation', () => {
+    expect(parseCliArgs([
+      'send-async', CHAT_ID,
+      '--message-title', 'Blocker',
+      '--message-style', 'error',
+      'Do not deploy',
+    ], ENV)).toMatchObject({
+      kind: 'send-async',
+      message: 'Do not deploy',
+      userMessagePresentation: { origin: 'cli', style: 'error', title: 'Blocker' },
+    });
+  });
+
   test('parses a connection-qualified send-async with --allow-steer before or after the chat ID', () => {
     expect(parseCliArgs([
       '--workspace', 'work',
@@ -402,6 +442,10 @@ describe('parseCliArgs', () => {
     { args: ['--resume', CHAT_ID, '--allow-steer', 'prompt'], message: '--allow-steer can only be used with send-async' },
     { args: ['--agent', 'codex', '--model', 'gpt', '--allow-steer', '--', 'prompt'], message: '--allow-steer can only be used with send-async' },
     { args: ['send-async', CHAT_ID, '--tag', '!!!', 'message'], message: 'letters or numbers' },
+    { args: ['send-async', CHAT_ID, '--message-style', 'ERROR', 'message'], message: 'must be notice or error' },
+    { args: ['stop', CHAT_ID, '--message-title', 'Heading'], message: 'message presentation cannot be used with stop' },
+    { args: ['status', CHAT_ID, '--message-style', 'notice'], message: '--message-style cannot be used with status' },
+    { args: ['list', 'agents', '--message-title', 'Heading'], message: '--message-title cannot be used with list' },
   ])('rejects invalid control arguments: $message', ({ args, message }) => {
     expect(() => parseCliArgs(args, ENV)).toThrow(message);
     try {

--- a/cli/__tests__/chat-control.test.ts
+++ b/cli/__tests__/chat-control.test.ts
@@ -210,6 +210,30 @@ describe('sendChatAsync', () => {
     expect(testOutput.sentRecords).toEqual([[CHAT_ID, 'new-turn', 'turn-1']]);
   });
 
+  test('preserves presentation across run and steer route switches', async () => {
+    let runCalls = 0;
+    const testClient = client({
+      async runChat() {
+        runCalls += 1;
+        if (runCalls === 1) throw busyError();
+        return acceptedTurn();
+      },
+      async steerChat() { throw steerError('STEER_TURN_UNAVAILABLE'); },
+    });
+    const presentation = { origin: 'cli', style: 'error', title: 'Blocker' } as const;
+    await sendChatAsync({
+      chatId: CHAT_ID,
+      content: 'Message',
+      allowSteer: true,
+      userMessagePresentation: presentation,
+    }, testClient, output(), undefined, noDelayDependencies());
+
+    expect(testClient.runs).toHaveLength(2);
+    expect(testClient.runs[0]).toEqual(testClient.runs[1]);
+    expect(testClient.runs[0]?.userMessagePresentation).toEqual(presentation);
+    expect(testClient.steers[0]?.userMessagePresentation).toEqual(presentation);
+  });
+
   test('reports bounded exhaustion after run-steer-run with a second busy rejection', async () => {
     const testClient = client({
       async runChat() { throw busyError(); },

--- a/cli/__tests__/chat-status.test.ts
+++ b/cli/__tests__/chat-status.test.ts
@@ -249,6 +249,32 @@ describe('chat status', () => {
     expect(value).not.toContain(`[3] ${TIMESTAMP} error (CLI)`);
   });
 
+  test('labels presented user messages without printing presentation JSON', () => {
+    const value = formatChatStatus(snapshot({
+      transcript: {
+        availability: 'available',
+        transcriptViewId: 'view-1',
+        messages: [{
+          ordinal: 1,
+          message: new UserMessage(
+            TIMESTAMP,
+            'Do not deploy.',
+            undefined,
+            undefined,
+            { origin: 'cli', style: 'error', title: 'Blocker' },
+          ),
+        }],
+        lastOrdinal: 1,
+        pageOldestOrdinal: 1,
+        pageNewestOrdinal: 1,
+        hasMore: false,
+      },
+    }));
+
+    expect(value).toContain(`[1] ${TIMESTAMP} user-message (CLI error) — Blocker\nDo not deploy.`);
+    expect(value).not.toContain('"presentation"');
+  });
+
   test('shows a plain notice title without CLI provenance', () => {
     const value = formatChatStatus(snapshot({
       transcript: {

--- a/cli/__tests__/consultation.test.ts
+++ b/cli/__tests__/consultation.test.ts
@@ -156,6 +156,7 @@ describe('runConsultation', () => {
       kind: 'start', workspace: 'default', configDir: '/config', cwd: '/repo',
       agentId: 'codex', model: 'gpt-5.4', prompt: 'Implement it', readsPromptFromStdin: false,
       title: 'Implementation review',
+      userMessagePresentation: { origin: 'cli', style: 'notice', title: 'Operator context' },
       additionalTags: ['review-needed'],
     };
     const testClient = client();
@@ -166,6 +167,7 @@ describe('runConsultation', () => {
     expect(testClient.starts[0]).toMatchObject({
       chatId: CHAT_ID, agentId: 'codex', projectPath: '/repo', command: 'Implement it',
       permissionMode: 'acceptEdits', thinkingMode: 'high', tags: ['cli', 'review-needed'],
+      userMessagePresentation: { origin: 'cli', style: 'notice', title: 'Operator context' },
     });
     expect(testOutput.acceptedHandles).toEqual([{ chatId: CHAT_ID, turnId: 'turn-1' }]);
     expect(testClient.titles).toEqual([{ chatId: CHAT_ID, title: 'Implementation review' }]);
@@ -228,6 +230,7 @@ describe('runConsultation', () => {
       kind: 'resume', workspace: 'default', configDir: '/config', chatId: CHAT_ID,
       prompt: 'Continue', readsPromptFromStdin: false,
       title: 'Follow-up review',
+      userMessagePresentation: { origin: 'cli', style: 'error' },
       additionalTags: ['follow-up'],
     };
     const testClient = client();
@@ -239,6 +242,7 @@ describe('runConsultation', () => {
       transcriptViewId: 'view-1',
       command: 'Continue', tagsToAdd: ['follow-up'],
       permissionFallbackPolicy: 'require-explicit-bypass',
+      userMessagePresentation: { origin: 'cli', style: 'error' },
     });
     expect(testClient.titles).toEqual([{ chatId: CHAT_ID, title: 'Follow-up review' }]);
   });

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -15,6 +15,7 @@ import {
   type ChatRowType,
 } from '@garcon/common/chat-row-contracts';
 import { isCommandCorrelationIdWithinLimit } from '@garcon/common/chat-command-contracts';
+import type { UserMessagePresentation } from '@garcon/common/chat-types';
 import {
   CHAT_SNAPSHOT_DEFAULT_MESSAGE_LIMIT,
   CHAT_SNAPSHOT_MAX_MESSAGE_LIMIT,
@@ -26,7 +27,7 @@ export const CLI_HELP = `Usage:
   garcon-cli [options] <prompt>
   garcon-cli [options] --resume <chat-id> <prompt>
   garcon-cli [options] list <resource>
-  garcon-cli [options] send-async <chat-id> [--allow-steer] <message>
+  garcon-cli [options] send-async <chat-id> [--allow-steer] [--message-title <title>] [--message-style <notice|error>] <message>
   garcon-cli [options] stop <chat-id>
   garcon-cli [connection options] add-row <chat-id> --type <notice|error> [--title <title>] <content>
   garcon-cli [connection options] status <chat-id> [--messages <count>] [--json]
@@ -41,6 +42,8 @@ Stop button and interrupts the active turn. If queued messages exist, stop
 pauses the queue; resume it in Garcon before sending a new direct turn.
 add-row appends one durable presentation-only notice or error to chat history.
 It never sends, queues, or exposes the row to the agent.
+Message presentation is not sent as prompt text. A message title without a style
+uses notice; a style without a title displays CLI notice or CLI error.
 
 List resources:
   agents
@@ -62,6 +65,8 @@ Options:
   --permissions <mode>         Permission mode: ${PERMISSION_MODE_VALUES.join(', ')}
   --reasoning-effort <mode>    Reasoning effort: ${THINKING_MODE_VALUES.join(', ')}
   --title <title>              Set a new-chat title or add-row heading
+  --message-title <title>      Add a heading to this conversational CLI user message
+  --message-style <style>      Style this CLI user message: notice or error
   --tag <name>                 Add a tag; repeatable. New chats always receive cli
   --resume <chat-id>           Resume an existing chat
   --allow-steer                With send-async, steer the active turn when busy; never queues
@@ -103,6 +108,7 @@ interface CliInvocationBase extends CliSelectionOptions, CliConnectionOptions {
   additionalTags?: string[];
   prompt: string | null;
   readsPromptFromStdin: boolean;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface StartCliInvocation extends CliInvocationBase {
@@ -145,6 +151,7 @@ export interface SendAsyncCliCommand extends CliConnectionOptions {
   allowSteer: boolean;
   message: string | null;
   readsMessageFromStdin: boolean;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface StopCliCommand extends CliConnectionOptions {
@@ -198,6 +205,8 @@ const SINGLE_STRING_OPTIONS = [
   'permissions',
   'reasoning-effort',
   'title',
+  'message-title',
+  'message-style',
   'resume',
   'turn',
   'messages',
@@ -250,6 +259,29 @@ function parseAdditionalTags(value: ParsedOptionValue): string[] | undefined {
   }
   const tags = normalizeTags(rawTags).filter((tag) => tag !== 'cli');
   return tags.length > 0 ? tags : undefined;
+}
+
+function parseUserMessagePresentationOptions(
+  values: Record<string, ParsedOptionValue>,
+): UserMessagePresentation | undefined {
+  const rawStyle = values['message-style'];
+  if (rawStyle !== undefined && rawStyle !== 'notice' && rawStyle !== 'error') {
+    throw argumentError('--message-style must be notice or error');
+  }
+  let title: string | undefined;
+  try {
+    title = parseChatRowTitle(values['message-title']);
+  } catch (error) {
+    throw argumentError(error instanceof Error ? error.message : 'message title is invalid', {
+      cause: error,
+    });
+  }
+  if (rawStyle === undefined && title === undefined) return undefined;
+  return {
+    origin: 'cli',
+    style: rawStyle === 'error' ? 'error' : 'notice',
+    ...(title === undefined ? {} : { title }),
+  };
 }
 
 function isListResource(value: string): value is ListResource {
@@ -324,6 +356,7 @@ function parseSendAsync(
   if (message !== null && message.trim().length === 0) {
     throw argumentError('the message must not be empty');
   }
+  const userMessagePresentation = parseUserMessagePresentationOptions(values);
   return {
     kind: 'send-async',
     ...connection,
@@ -331,6 +364,7 @@ function parseSendAsync(
     allowSteer: values['allow-steer'] === true,
     message,
     readsMessageFromStdin,
+    ...(userMessagePresentation === undefined ? {} : { userMessagePresentation }),
   };
 }
 
@@ -345,6 +379,9 @@ function parseStop(
     throw argumentError('--allow-steer cannot be used with stop');
   }
   if (values.type !== undefined) throw argumentError('--type cannot be used with stop');
+  if (values['message-title'] !== undefined || values['message-style'] !== undefined) {
+    throw argumentError('message presentation cannot be used with stop');
+  }
   if (parsed.positionals.length !== 2) {
     throw argumentError('stop requires exactly one chat ID');
   }
@@ -363,6 +400,9 @@ function parseAddRow(
   rejectControlForbiddenOptions(values, 'add-row');
   if (values['allow-steer'] !== undefined) {
     throw argumentError('--allow-steer cannot be used with add-row');
+  }
+  if (values['message-title'] !== undefined || values['message-style'] !== undefined) {
+    throw argumentError('message presentation cannot be used with add-row');
   }
   if (parsed.positionals.length !== 3) {
     throw argumentError('add-row requires a chat ID and one content argument');
@@ -409,6 +449,8 @@ const OBSERVATION_FORBIDDEN_OPTIONS: ReadonlyArray<readonly [string, string]> = 
   ['resume', '--resume'],
   ['allow-steer', '--allow-steer'],
   ['type', '--type'],
+  ['message-title', '--message-title'],
+  ['message-style', '--message-style'],
 ] as const;
 
 function rejectObservationMutationOptions(
@@ -521,6 +563,8 @@ export function parseCliArgs(
         permissions: { type: 'string' },
         'reasoning-effort': { type: 'string' },
         title: { type: 'string' },
+        'message-title': { type: 'string' },
+        'message-style': { type: 'string' },
         tag: { type: 'string', multiple: true },
         resume: { type: 'string' },
         turn: { type: 'string' },
@@ -616,6 +660,8 @@ export function parseCliArgs(
     rejectListOption(values.turn, '--turn');
     rejectListOption(values.messages, '--messages');
     rejectListOption(values.type, '--type');
+    rejectListOption(values['message-title'], '--message-title');
+    rejectListOption(values['message-style'], '--message-style');
     if (endpointId !== undefined && providerId === undefined) {
       throw argumentError('--endpoint requires --provider');
     }
@@ -661,6 +707,7 @@ export function parseCliArgs(
   }
   if (values.type !== undefined) throw argumentError('--type can only be used with add-row');
   const title = nonEmptyOption(values.title as string | undefined, '--title')?.trim();
+  const userMessagePresentation = parseUserMessagePresentationOptions(values);
   const modes = parseModeOptions(values);
 
   if (endpointId !== undefined && providerId === undefined) {
@@ -688,6 +735,7 @@ export function parseCliArgs(
     ...(model === undefined ? {} : { model }),
     ...(title === undefined ? {} : { title }),
     ...(additionalTags === undefined ? {} : { additionalTags }),
+    ...(userMessagePresentation === undefined ? {} : { userMessagePresentation }),
     ...modes,
     prompt,
     readsPromptFromStdin,

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -24,8 +24,8 @@ import { normalizeTags, normalizeTagSlug } from '@garcon/common/tags';
 import { argumentError } from './errors.js';
 
 export const CLI_HELP = `Usage:
-  garcon-cli [options] <prompt>
-  garcon-cli [options] --resume <chat-id> <prompt>
+  garcon-cli [options] [--message-title <title>] [--message-style <notice|error>] <prompt>
+  garcon-cli [options] --resume <chat-id> [--message-title <title>] [--message-style <notice|error>] <prompt>
   garcon-cli [options] list <resource>
   garcon-cli [options] send-async <chat-id> [--allow-steer] [--message-title <title>] [--message-style <notice|error>] <message>
   garcon-cli [options] stop <chat-id>
@@ -44,6 +44,8 @@ add-row appends one durable presentation-only notice or error to chat history.
 It never sends, queues, or exposes the row to the agent.
 Message presentation is not sent as prompt text. A message title without a style
 uses notice; a style without a title displays CLI notice or CLI error.
+Ordinary restart, replay, shares, and frozen forks preserve it. Native-history
+Reload and provider-native fork segments may drop Garcon-only presentation.
 
 List resources:
   agents

--- a/cli/chat-control.ts
+++ b/cli/chat-control.ts
@@ -8,6 +8,7 @@ import type {
   SteerCommandResponse,
 } from '@garcon/common/chat-command-contracts';
 import type { ChatSnapshotResponse } from '@garcon/common/chat-snapshot';
+import type { UserMessagePresentation } from '@garcon/common/chat-types';
 import { abortableDelay } from './abortable-delay.js';
 import { CliError } from './errors.js';
 import { GarconHttpError } from './garcon-client.js';
@@ -63,7 +64,12 @@ function isSafeSteerStateFlip(error: unknown): boolean {
 // reused byte-for-byte when returning to /run, because the server's pre-schedule
 // failure replay path resets an exact failed run identity.
 export async function sendChatAsync(
-  input: { chatId: string; content: string; allowSteer: boolean },
+  input: {
+    chatId: string;
+    content: string;
+    allowSteer: boolean;
+    userMessagePresentation?: UserMessagePresentation;
+  },
   client: ChatControlClient,
   output: CliOutput,
   signal?: AbortSignal,
@@ -78,6 +84,9 @@ export async function sendChatAsync(
     chatId: input.chatId,
     transcriptViewId,
     command: input.content,
+    ...(input.userMessagePresentation === undefined
+      ? {}
+      : { userMessagePresentation: input.userMessagePresentation }),
   };
   let operation: 'run' | 'steer' = 'run';
   let lastStateFlip: GarconHttpError | undefined;
@@ -98,6 +107,9 @@ export async function sendChatAsync(
         chatId: input.chatId,
         transcriptViewId,
         content: input.content,
+        ...(input.userMessagePresentation === undefined
+          ? {}
+          : { userMessagePresentation: input.userMessagePresentation }),
       };
       const response = await client.steerChat(request, signal);
       output.sent(response.chatId, 'steer', response.turnId);

--- a/cli/chat-status.ts
+++ b/cli/chat-status.ts
@@ -105,17 +105,25 @@ function formatMessage(entry: TranscriptMessage): string {
   const textPayload = { ...payload } as Record<string, unknown>;
   delete textPayload.images;
   delete textPayload.title;
+  delete textPayload.presentation;
   let content = typeof textPayload.content === 'string'
     ? redactDataUrl(textPayload.content)
     : JSON.stringify(textPayload, redactDataUrls, 2) ?? '{}';
   if (images && images.length > 0) {
     content += `\n[${images.length} image attachments omitted from text output]`;
   }
-  const title = 'title' in entry.message
-    && typeof entry.message.title === 'string' && entry.message.title
-    ? ` — ${entry.message.title}`
-    : '';
-  return `[${entry.ordinal}] ${timestamp} ${type}${cliDetail ? ' (CLI)' : ''}${title}\n`
+  const userPresentation = entry.message.type === 'user-message'
+    ? entry.message.presentation
+    : undefined;
+  const titleValue = userPresentation?.title
+    ?? ('title' in entry.message && typeof entry.message.title === 'string'
+      ? entry.message.title
+      : undefined);
+  const title = titleValue ? ` — ${titleValue}` : '';
+  const cliLabel = userPresentation
+    ? ` (CLI ${userPresentation.style})`
+    : cliDetail ? ' (CLI)' : '';
+  return `[${entry.ordinal}] ${timestamp} ${type}${cliLabel}${title}\n`
     + truncateStatusText(content);
 }
 

--- a/cli/consultation.ts
+++ b/cli/consultation.ts
@@ -104,6 +104,9 @@ async function submitStart(
       ...selection,
       command: prompt,
       tags: startTags(invocation.additionalTags),
+      ...(invocation.userMessagePresentation === undefined
+        ? {}
+        : { userMessagePresentation: invocation.userMessagePresentation }),
     };
     try {
       return await client.startChat(request, signal);
@@ -146,6 +149,9 @@ async function submitResume(
     command: prompt,
     ...(tagsToAdd === undefined ? {} : { tagsToAdd }),
     permissionFallbackPolicy: 'require-explicit-bypass',
+    ...(invocation.userMessagePresentation === undefined
+      ? {}
+      : { userMessagePresentation: invocation.userMessagePresentation }),
   };
   const needsCatalog = invocation.model !== undefined
     || invocation.permissionMode !== undefined

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -178,6 +178,9 @@ export async function main(
         chatId: command.chatId,
         content: message,
         allowSteer: command.allowSteer,
+        ...(command.userMessagePresentation === undefined
+          ? {}
+          : { userMessagePresentation: command.userMessagePresentation }),
       }, client, output, options.signal);
       return 0;
     }

--- a/common/__tests__/chat-command-contracts.test.js
+++ b/common/__tests__/chat-command-contracts.test.js
@@ -222,6 +222,32 @@ describe('chat command request parsers', () => {
     })).toThrow(CommandRequestValidationError);
   });
 
+  it('validates presentation on run and steer requests', () => {
+    const run = parseAgentRunCommandRequest({
+      clientRequestId: 'request-presentation',
+      clientMessageId: 'message-presentation',
+      chatId: CHAT_ID,
+      transcriptViewId: TRANSCRIPT_VIEW_ID,
+      command: 'continue',
+      userMessagePresentation: { origin: 'cli', style: 'notice', title: '  Context  ' },
+    });
+    expect(run.userMessagePresentation).toEqual({
+      origin: 'cli', style: 'notice', title: 'Context',
+    });
+    expect(parseSteerCommandRequest({
+      clientRequestId: 'request-steer-presentation',
+      clientMessageId: 'message-steer-presentation',
+      chatId: CHAT_ID,
+      transcriptViewId: TRANSCRIPT_VIEW_ID,
+      content: 'stop here',
+      userMessagePresentation: { origin: 'cli', style: 'error' },
+    }).userMessagePresentation).toEqual({ origin: 'cli', style: 'error' });
+    expect(() => parseAgentRunCommandRequest({
+      ...run,
+      userMessagePresentation: { origin: 'cli', style: 'notice', extra: true },
+    })).toThrow('unsupported field');
+  });
+
   it('parses queue steering with explicit entry concurrency preconditions', () => {
     expect(parseQueueEntrySteerCommandRequest({
       clientRequestId: ' request-steer-queue ',

--- a/common/__tests__/user-message-presentation.test.js
+++ b/common/__tests__/user-message-presentation.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  ErrorMessage,
   parseChatMessage,
   parseUserMessagePresentation,
   UserMessage,
 } from '../chat-types.ts';
+import { parseTranscriptMessage } from '../chat-view.ts';
 
 describe('user message presentation', () => {
   it('parses and normalizes the closed CLI presentation shape', () => {
@@ -35,5 +37,17 @@ describe('user message presentation', () => {
       undefined,
       { origin: 'cli', style: 'error', title: 'Blocker' },
     ));
+  });
+
+  it('degrades malformed serialized presentation without throwing', () => {
+    const message = {
+      type: 'user-message',
+      timestamp: '2026-08-22T00:00:00.000Z',
+      content: 'Body only',
+      presentation: { origin: 'cli', style: 'notice', title: 'invalid\ntitle' },
+    };
+
+    expect(parseChatMessage(message)).toBeNull();
+    expect(parseTranscriptMessage({ ordinal: 1, message })?.message).toBeInstanceOf(ErrorMessage);
   });
 });

--- a/common/__tests__/user-message-presentation.test.js
+++ b/common/__tests__/user-message-presentation.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  parseChatMessage,
+  parseUserMessagePresentation,
+  UserMessage,
+} from '../chat-types.ts';
+
+describe('user message presentation', () => {
+  it('parses and normalizes the closed CLI presentation shape', () => {
+    expect(parseUserMessagePresentation({
+      origin: 'cli',
+      style: 'notice',
+      title: '  Operator context  ',
+    })).toEqual({ origin: 'cli', style: 'notice', title: 'Operator context' });
+    expect(parseUserMessagePresentation(undefined)).toBeUndefined();
+    expect(() => parseUserMessagePresentation({ origin: 'spa', style: 'notice' }))
+      .toThrow('origin must be cli');
+    expect(() => parseUserMessagePresentation({ origin: 'cli', style: 'warning' }))
+      .toThrow('style must be notice or error');
+    expect(() => parseUserMessagePresentation({ origin: 'cli', style: 'notice', extra: true }))
+      .toThrow('unsupported field');
+  });
+
+  it('round-trips presentation as a first-class user message field', () => {
+    const parsed = parseChatMessage({
+      type: 'user-message',
+      timestamp: '2026-08-22T00:00:00.000Z',
+      content: 'Body only',
+      presentation: { origin: 'cli', style: 'error', title: 'Blocker' },
+    });
+    expect(parsed).toEqual(new UserMessage(
+      '2026-08-22T00:00:00.000Z',
+      'Body only',
+      undefined,
+      undefined,
+      { origin: 'cli', style: 'error', title: 'Blocker' },
+    ));
+  });
+});

--- a/common/chat-command-contracts.ts
+++ b/common/chat-command-contracts.ts
@@ -16,7 +16,11 @@ import type { HttpErrorResponse } from './http-error.js';
 import type { ChatListEntry } from './chat-list.js';
 import type { ErrorCode } from './error-codes.js';
 import { normalizeTags } from './tags.js';
-import type { ChatStopOutcome } from './chat-types.js';
+import {
+  parseUserMessagePresentation,
+  type ChatStopOutcome,
+  type UserMessagePresentation,
+} from './chat-types.js';
 import {
   CommandRequestValidationError,
   optionalNonEmptyString,
@@ -155,6 +159,7 @@ export interface StartChatCommandRequest {
   command: string;
   images?: AgentCommandImage[];
   tags?: string[];
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface AgentRunCommandRequest {
@@ -176,6 +181,7 @@ export interface AgentRunCommandRequest {
   tagsToAdd?: string[];
   permissionFallbackPolicy?: 'require-explicit-bypass';
   handoff?: AgentHandoffRequest;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface AgentHandoffTarget {
@@ -263,6 +269,7 @@ export interface SteerCommandRequest {
   chatId: string;
   transcriptViewId: string;
   content: string;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface SteerCommandResponse extends CommandAcceptedResponse {
@@ -450,6 +457,7 @@ export function parseStartChatCommandRequest(value: unknown): StartChatCommandRe
   const images = optionalImages(body.images);
   const command = contentOrImages(body, 'command', images).trim();
   const agentSettings = requiredAgentSettings(body.agentSettings, 'agentSettings');
+  const userMessagePresentation = parseCommandUserMessagePresentation(body.userMessagePresentation);
   if (agentSettings.ownerId !== agentId) {
     throw new CommandRequestValidationError('agentSettings must be owned by agentId');
   }
@@ -469,12 +477,14 @@ export function parseStartChatCommandRequest(value: unknown): StartChatCommandRe
     command,
     ...(images === undefined ? {} : { images }),
     tags: normalizeTags(Array.isArray(body.tags) ? body.tags : []),
+    ...(userMessagePresentation === undefined ? {} : { userMessagePresentation }),
   };
 }
 
 export function parseAgentRunCommandRequest(value: unknown): AgentRunCommandRequest {
   const body = requestRecord(value);
   const handoff = optionalAgentHandoffRequest(body.handoff);
+  const userMessagePresentation = parseCommandUserMessagePresentation(body.userMessagePresentation);
   const images = optionalImages(body.images);
   const model = optionalNonEmptyString(body, 'model');
   const apiProviderId = optionalNullableString(body, 'apiProviderId');
@@ -543,6 +553,7 @@ export function parseAgentRunCommandRequest(value: unknown): AgentRunCommandRequ
       ? { permissionFallbackPolicy }
       : {}),
     ...(handoff === undefined ? {} : { handoff }),
+    ...(userMessagePresentation === undefined ? {} : { userMessagePresentation }),
   };
 }
 
@@ -745,13 +756,25 @@ export function parseQueueEntryMoveCommandRequest(value: unknown): QueueEntryMov
 
 export function parseSteerCommandRequest(value: unknown): SteerCommandRequest {
   const body = requestRecord(value);
+  const userMessagePresentation = parseCommandUserMessagePresentation(body.userMessagePresentation);
   return {
     clientRequestId: requiredCommandCorrelationId(body, 'clientRequestId'),
     clientMessageId: requiredCommandCorrelationId(body, 'clientMessageId'),
     chatId: requiredChatId(body, 'chatId'),
     transcriptViewId: requiredString(body, 'transcriptViewId'),
     content: requiredContent(body, 'content'),
+    ...(userMessagePresentation === undefined ? {} : { userMessagePresentation }),
   };
+}
+
+function parseCommandUserMessagePresentation(value: unknown): UserMessagePresentation | undefined {
+  try {
+    return parseUserMessagePresentation(value);
+  } catch (error) {
+    throw new CommandRequestValidationError(
+      error instanceof Error ? error.message : 'userMessagePresentation is invalid',
+    );
+  }
 }
 
 export function parseQueueEntrySteerCommandRequest(value: unknown): QueueEntrySteerCommandRequest {

--- a/common/chat-types.ts
+++ b/common/chat-types.ts
@@ -18,6 +18,7 @@ import {
   parseChatMessageMetadata,
   str,
 } from './chat-message-coercion.js';
+import { parseChatRowTitle } from './chat-row-contracts.js';
 
 export interface ChatImage {
   data: string;
@@ -40,6 +41,34 @@ export interface ChatMessageMetadata {
   clientMessageId?: string;
   upstreamRequestId?: string;
   turnId?: string;
+}
+
+export const USER_MESSAGE_PRESENTATION_STYLES = ['notice', 'error'] as const;
+export type UserMessagePresentationStyle = typeof USER_MESSAGE_PRESENTATION_STYLES[number];
+
+export interface UserMessagePresentation {
+  readonly origin: 'cli';
+  readonly style: UserMessagePresentationStyle;
+  readonly title?: string;
+}
+
+export function parseUserMessagePresentation(value: unknown): UserMessagePresentation | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('user message presentation must be an object');
+  }
+  const body = value as Record<string, unknown>;
+  for (const key of Object.keys(body)) {
+    if (key !== 'origin' && key !== 'style' && key !== 'title') {
+      throw new TypeError(`user message presentation contains unsupported field: ${key}`);
+    }
+  }
+  if (body.origin !== 'cli') throw new TypeError('user message presentation origin must be cli');
+  if (body.style !== 'notice' && body.style !== 'error') {
+    throw new TypeError('user message presentation style must be notice or error');
+  }
+  const title = parseChatRowTitle(body.title);
+  return { origin: 'cli', style: body.style, ...(title === undefined ? {} : { title }) };
 }
 
 // Canonical shape for a single todo/plan item. All provider-specific
@@ -78,6 +107,7 @@ export class UserMessage {
     public content: string,
     public images?: ChatImage[],
     public metadata?: ChatMessageMetadata,
+    public presentation?: UserMessagePresentation,
   ) {}
 }
 
@@ -1165,6 +1195,7 @@ export function parseChatMessage(data: Record<string, unknown>): ChatMessage | n
 	        str(data.content),
 	        asChatImages(data.images),
 	        parseChatMessageMetadata(data.metadata),
+	        parseUserMessagePresentation(data.presentation),
 	      );
     case 'assistant-message':
       return new AssistantMessage(str(data.timestamp), str(data.content));

--- a/common/chat-types.ts
+++ b/common/chat-types.ts
@@ -1189,14 +1189,21 @@ export function parseChatMessage(data: Record<string, unknown>): ChatMessage | n
   if (toolUseMessage) return toolUseMessage;
 
   switch (data.type) {
-	    case 'user-message':
-	      return new UserMessage(
-	        str(data.timestamp),
-	        str(data.content),
-	        asChatImages(data.images),
-	        parseChatMessageMetadata(data.metadata),
-	        parseUserMessagePresentation(data.presentation),
-	      );
+    case 'user-message': {
+      let presentation: UserMessagePresentation | undefined;
+      try {
+        presentation = parseUserMessagePresentation(data.presentation);
+      } catch {
+        return null;
+      }
+      return new UserMessage(
+        str(data.timestamp),
+        str(data.content),
+        asChatImages(data.images),
+        parseChatMessageMetadata(data.metadata),
+        presentation,
+      );
+    }
     case 'assistant-message':
       return new AssistantMessage(str(data.timestamp), str(data.content));
     case 'thinking':

--- a/common/transcript-seed.ts
+++ b/common/transcript-seed.ts
@@ -461,6 +461,7 @@ export function sanitizeRecordedCarriedContext(input: {
       original.content.slice(receipt.codeUnitLength),
       original.images,
       original.metadata,
+      original.presentation,
     );
     return { kind: 'stripped-exact', messages: next };
   }
@@ -505,7 +506,13 @@ export function stripFirstUserSeed(messages: ChatMessage[]): ChatMessage[] {
   const stripped = stripTranscriptSeed(original.content);
   if (stripped === original.content) return messages;
   const next = messages.slice();
-  next[index] = new UserMessage(original.timestamp, stripped, original.images, original.metadata);
+  next[index] = new UserMessage(
+    original.timestamp,
+    stripped,
+    original.images,
+    original.metadata,
+    original.presentation,
+  );
   return next;
 }
 
@@ -534,6 +541,7 @@ export function boundProjectedMessage(message: ChatMessage): ChatMessage {
       message.content.slice(0, PROJECTED_BODY_MAX_CHARS),
       undefined,
       message.metadata,
+      message.presentation,
     );
   }
   if (message.type === 'assistant-message') {

--- a/server/agents/agent-run-command-input.ts
+++ b/server/agents/agent-run-command-input.ts
@@ -4,6 +4,7 @@ import type {
   ForkRunCommandRequest,
 } from '../../common/chat-command-contracts.js';
 import type { RunAgentTurnOptions } from './session-types.js';
+import type { UserMessagePresentation } from '../../common/chat-types.js';
 
 export interface NormalizedAgentRunCommandInput {
   readonly chatId: string;
@@ -15,6 +16,7 @@ export interface NormalizedAgentRunCommandInput {
   readonly tagsToAdd?: string[];
   readonly permissionFallbackPolicy?: 'require-explicit-bypass';
   readonly handoff?: AgentHandoffRequest;
+  readonly userMessagePresentation?: UserMessagePresentation;
 }
 
 export function runOptionsForCommand(
@@ -54,5 +56,6 @@ export function agentRunCommandPayload(
     tagsToAdd: input.tagsToAdd,
     permissionFallbackPolicy: input.permissionFallbackPolicy,
     handoff: input.handoff,
+    userMessagePresentation: input.userMessagePresentation ?? null,
   };
 }

--- a/server/chat-execution/__tests__/accepted-input-handler.test.js
+++ b/server/chat-execution/__tests__/accepted-input-handler.test.js
@@ -235,6 +235,28 @@ describe('AcceptedInputHandler', () => {
     expect(settle.markScheduled).not.toHaveBeenCalled();
   });
 
+  test('admits direct presentation without exposing it to provider run options', async () => {
+    const presentation = { origin: 'cli', style: 'notice', title: 'Context' };
+    const { handler, m } = scaffold();
+    await handler.schedule({
+      command: command(),
+      content: 'body only',
+      options: { clientRequestId: 'request-1', turnId: 'turn-1' },
+      userMessagePresentation: presentation,
+      settlement: settlement(),
+    });
+
+    expect(m.admitInput).toHaveBeenCalledWith('chat-1', 'body only', {
+      clientRequestId: 'request-1',
+      turnId: 'turn-1',
+      userMessagePresentation: presentation,
+    });
+    expect(m.runDirect.mock.calls[0][2]).toEqual({
+      clientRequestId: 'request-1',
+      turnId: 'turn-1',
+    });
+  });
+
   test('rolls back preparation before releasing admission on pre-schedule failure', async () => {
     const events = [];
     const registrationError = new Error('append failed');
@@ -442,6 +464,7 @@ describe('AcceptedInputHandler', () => {
       providerContent: 'focus here\n\nresolved context',
       clientMessageId: 'message-steer',
       transcriptViewId: 'view-1',
+      userMessagePresentation: { origin: 'cli', style: 'error', title: 'Stop condition' },
       target: { attempt: {}, identity: { turnId: 'turn-current' } },
       settlement: settle,
     })).resolves.toEqual({ turnId: 'turn-current', duplicate: false });
@@ -454,6 +477,7 @@ describe('AcceptedInputHandler', () => {
       expect.any(Object),
       expect.any(Object),
       expect.any(Function),
+      { origin: 'cli', style: 'error', title: 'Stop condition' },
     );
     expect(m.create).not.toHaveBeenCalled();
   });

--- a/server/chat-execution/accepted-input-handler.ts
+++ b/server/chat-execution/accepted-input-handler.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import type { CommandErrorCode } from '../../common/chat-command-contracts.ts';
+import type { UserMessagePresentation } from '../../common/chat-types.ts';
 import type {
   AgentExecutionAdmission,
   AgentSteerOptions,
@@ -74,6 +75,7 @@ export interface AcceptedInputCoordinator {
     options: AgentSteerOptions,
     target: CapturedSteerTarget,
     afterPendingRegistered: (turnId: string) => Promise<void>,
+    userMessagePresentation?: UserMessagePresentation,
   ): Promise<AcceptedSteerOutcome>;
 }
 
@@ -303,6 +305,7 @@ export class AcceptedInputHandler {
         },
         input.target,
         (turnId) => input.settlement.markScheduled(input.command, turnId),
+        input.userMessagePresentation,
       );
       if (outcome.duplicate) {
         await input.settlement.settleDuplicateInput(input.command);
@@ -563,7 +566,10 @@ export class AcceptedInputHandler {
         })));
       const inserted = await this.#checkpointAfter(
         reservation,
-        this.#coordinator.admitInput(input.command.chatId, input.content, input.options),
+        this.#coordinator.admitInput(input.command.chatId, input.content, {
+          ...input.options,
+          userMessagePresentation: input.userMessagePresentation,
+        }),
       );
       if (inserted === false) {
         await input.settlement.settleDuplicateInput(input.command);

--- a/server/chat-execution/accepted-input-handler.ts
+++ b/server/chat-execution/accepted-input-handler.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import type { CommandErrorCode } from '../../common/chat-command-contracts.ts';
-import type { UserMessagePresentation } from '../../common/chat-types.ts';
 import type {
   AgentExecutionAdmission,
   AgentSteerOptions,
@@ -75,7 +74,7 @@ export interface AcceptedInputCoordinator {
     options: AgentSteerOptions,
     target: CapturedSteerTarget,
     afterPendingRegistered: (turnId: string) => Promise<void>,
-    userMessagePresentation?: UserMessagePresentation,
+    userMessagePresentation?: UserInputAdmissionOptions['userMessagePresentation'],
   ): Promise<AcceptedSteerOutcome>;
 }
 
@@ -566,10 +565,7 @@ export class AcceptedInputHandler {
         })));
       const inserted = await this.#checkpointAfter(
         reservation,
-        this.#coordinator.admitInput(input.command.chatId, input.content, {
-          ...input.options,
-          userMessagePresentation: input.userMessagePresentation,
-        }),
+        this.#coordinator.admitInput(input.command.chatId, input.content, { ...input.options, userMessagePresentation: input.userMessagePresentation }),
       );
       if (inserted === false) {
         await input.settlement.settleDuplicateInput(input.command);

--- a/server/chat-execution/accepted-input-transcript.ts
+++ b/server/chat-execution/accepted-input-transcript.ts
@@ -40,13 +40,7 @@ export class AcceptedInputTranscript {
     const images = normalizeChatImages(options.images);
     const result = await this.transcript.admitInput(
       chatId,
-      new UserMessage(
-        options.createdAt ?? new Date().toISOString(),
-        content,
-        images,
-        undefined,
-        options.userMessagePresentation,
-      ),
+      new UserMessage(options.createdAt ?? new Date().toISOString(), content, images, undefined, options.userMessagePresentation),
       { ...options, clientRequestId: options.clientRequestId },
     );
     return result.inserted !== false;

--- a/server/chat-execution/accepted-input-transcript.ts
+++ b/server/chat-execution/accepted-input-transcript.ts
@@ -40,7 +40,13 @@ export class AcceptedInputTranscript {
     const images = normalizeChatImages(options.images);
     const result = await this.transcript.admitInput(
       chatId,
-      new UserMessage(options.createdAt ?? new Date().toISOString(), content, images),
+      new UserMessage(
+        options.createdAt ?? new Date().toISOString(),
+        content,
+        images,
+        undefined,
+        options.userMessagePresentation,
+      ),
       { ...options, clientRequestId: options.clientRequestId },
     );
     return result.inserted !== false;

--- a/server/chat-execution/chat-execution-coordinator.ts
+++ b/server/chat-execution/chat-execution-coordinator.ts
@@ -5,6 +5,7 @@ import {
   isStopSatisfied,
   type ChatStopIntent,
   type ChatStopOutcome,
+  type UserMessagePresentation,
 } from '../../common/chat-types.ts';
 import {
   type AgentExecutionAdmission,
@@ -388,6 +389,7 @@ export class ChatExecutionCoordinator extends EventEmitter<ChatExecutionCoordina
     options: AgentSteerOptions,
     target: CapturedSteerTarget,
     afterPendingRegistered: (turnId: string) => Promise<void>,
+    userMessagePresentation?: UserMessagePresentation,
   ): Promise<AcceptedSteerOutcome> {
     return this.#steerInputDelivery.deliver(
       chatId,
@@ -396,6 +398,7 @@ export class ChatExecutionCoordinator extends EventEmitter<ChatExecutionCoordina
       options,
       target,
       afterPendingRegistered,
+      userMessagePresentation,
     );
   }
 

--- a/server/chat-execution/chat-execution-coordinator.ts
+++ b/server/chat-execution/chat-execution-coordinator.ts
@@ -5,7 +5,6 @@ import {
   isStopSatisfied,
   type ChatStopIntent,
   type ChatStopOutcome,
-  type UserMessagePresentation,
 } from '../../common/chat-types.ts';
 import {
   type AgentExecutionAdmission,
@@ -389,7 +388,7 @@ export class ChatExecutionCoordinator extends EventEmitter<ChatExecutionCoordina
     options: AgentSteerOptions,
     target: CapturedSteerTarget,
     afterPendingRegistered: (turnId: string) => Promise<void>,
-    userMessagePresentation?: UserMessagePresentation,
+    userMessagePresentation?: UserInputAdmissionOptions['userMessagePresentation'],
   ): Promise<AcceptedSteerOutcome> {
     return this.#steerInputDelivery.deliver(
       chatId,

--- a/server/chat-execution/steer-input-delivery.ts
+++ b/server/chat-execution/steer-input-delivery.ts
@@ -3,6 +3,7 @@ import type {
   AgentSteerResult,
 } from '@garcon/server-agent-interface';
 import type { AgentSteerOptions } from '../agents/session-types.ts';
+import type { UserMessagePresentation } from '../../common/chat-types.ts';
 import { DomainError, SteerDeliveryError } from '../lib/domain-error.ts';
 import type { ExecutionOwnership } from './execution-ownership.ts';
 import type {
@@ -48,6 +49,7 @@ export class SteerInputDelivery {
     options: AgentSteerOptions,
     target: CapturedSteerTarget,
     afterPendingRegistered: (turnId: string) => Promise<void>,
+    userMessagePresentation?: UserMessagePresentation,
   ): Promise<AcceptedSteerOutcome> {
     let deliveryPrepared = false;
     let inserted = false;
@@ -60,6 +62,7 @@ export class SteerInputDelivery {
         transcriptViewId: options.transcriptViewId,
         turnId: target.identity.turnId,
         commandType: 'steer',
+        userMessagePresentation,
       });
       if (!inserted) return { turnId: target.identity.turnId, duplicate: true };
       await afterPendingRegistered(target.identity.turnId);

--- a/server/chat-execution/steer-input-delivery.ts
+++ b/server/chat-execution/steer-input-delivery.ts
@@ -3,7 +3,6 @@ import type {
   AgentSteerResult,
 } from '@garcon/server-agent-interface';
 import type { AgentSteerOptions } from '../agents/session-types.ts';
-import type { UserMessagePresentation } from '../../common/chat-types.ts';
 import { DomainError, SteerDeliveryError } from '../lib/domain-error.ts';
 import type { ExecutionOwnership } from './execution-ownership.ts';
 import type {
@@ -49,7 +48,7 @@ export class SteerInputDelivery {
     options: AgentSteerOptions,
     target: CapturedSteerTarget,
     afterPendingRegistered: (turnId: string) => Promise<void>,
-    userMessagePresentation?: UserMessagePresentation,
+    userMessagePresentation?: UserInputAdmissionOptions['userMessagePresentation'],
   ): Promise<AcceptedSteerOutcome> {
     let deliveryPrepared = false;
     let inserted = false;

--- a/server/chat-execution/types.ts
+++ b/server/chat-execution/types.ts
@@ -7,6 +7,7 @@ import type { AutomaticQueuePauseKind, QueueEntry } from '../../common/queue-sta
 import type {
   ChatStopIntent,
   ChatStopOutcome,
+  UserMessagePresentation,
 } from '../../common/chat-types.ts';
 import type {
   AgentGoalControlHandoff,
@@ -44,6 +45,7 @@ export type UserInputAdmissionOptions = Pick<
 > & {
   commandType?: AgentExecutionCommandType | 'steer';
   createdAt?: string;
+  userMessagePresentation?: UserMessagePresentation;
 };
 
 export class QueueEntryMutationError extends DomainError {
@@ -145,6 +147,7 @@ export interface AcceptedDirectInput {
   settlement: CommandSettlementPort;
   preparation?: DirectInputPreparation;
   dispatch?: (admission: AgentExecutionAdmission) => Promise<void>;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface AcceptedDirectOperation {
@@ -212,6 +215,7 @@ export interface AcceptedSteerInput {
   transcriptViewId: string;
   target: CapturedSteerTarget;
   settlement: CommandSettlementPort;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface AcceptedQueueEntrySteer extends AcceptedSteerInput {

--- a/server/chat-execution/types.ts
+++ b/server/chat-execution/types.ts
@@ -44,8 +44,7 @@ export type UserInputAdmissionOptions = Pick<
   | 'excludedResendOrdinals'
 > & {
   commandType?: AgentExecutionCommandType | 'steer';
-  createdAt?: string;
-  userMessagePresentation?: UserMessagePresentation;
+  createdAt?: string; userMessagePresentation?: UserMessagePresentation;
 };
 
 export class QueueEntryMutationError extends DomainError {
@@ -146,8 +145,7 @@ export interface AcceptedDirectInput {
   options: RunAgentTurnOptions;
   settlement: CommandSettlementPort;
   preparation?: DirectInputPreparation;
-  dispatch?: (admission: AgentExecutionAdmission) => Promise<void>;
-  userMessagePresentation?: UserMessagePresentation;
+  dispatch?: (admission: AgentExecutionAdmission) => Promise<void>; userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface AcceptedDirectOperation {
@@ -214,8 +212,7 @@ export interface AcceptedSteerInput {
   clientMessageId: string;
   transcriptViewId: string;
   target: CapturedSteerTarget;
-  settlement: CommandSettlementPort;
-  userMessagePresentation?: UserMessagePresentation;
+  settlement: CommandSettlementPort; userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface AcceptedQueueEntrySteer extends AcceptedSteerInput {

--- a/server/chats/__tests__/share-transcript.test.js
+++ b/server/chats/__tests__/share-transcript.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   ErrorMessage,
   TranscriptNoticeMessage,
+  UserMessage,
 } from '../../../common/chat-types.ts';
 import { renderSharedChatText } from '../share-transcript.ts';
 
@@ -34,5 +35,28 @@ describe('shared transcript chat rows', () => {
     expect(rendered).toContain(`[CLI Error] ${AT}\nShared error.`);
     expect(rendered).toContain(`[Notice] ${AT}\nInternal notice.`);
     expect(rendered).toContain(`[Error] ${AT}\nProvider error.`);
+  });
+
+  it('distinguishes presented user messages from presentation-only CLI rows', () => {
+    const rendered = renderSharedChatText({
+      shareToken: 'synthetic-share-token',
+      chatId: 'synthetic-chat',
+      title: 'Presented users',
+      agentId: 'codex',
+      model: 'gpt',
+      projectPath: '/synthetic/workspace',
+      sharedAt: AT,
+      messages: [
+        new UserMessage(AT, 'Body', undefined, undefined, {
+          origin: 'cli', style: 'notice', title: 'Operator context',
+        }),
+        new UserMessage(AT, 'Stop', undefined, undefined, {
+          origin: 'cli', style: 'error',
+        }),
+      ],
+    });
+
+    expect(rendered).toContain(`[User (CLI Notice) — Operator context] ${AT}\nBody`);
+    expect(rendered).toContain(`[User (CLI Error)] ${AT}\nStop`);
   });
 });

--- a/server/chats/chat-carryover-migration.ts
+++ b/server/chats/chat-carryover-migration.ts
@@ -465,6 +465,7 @@ function stripExactLegacyPrefix(
     original.content.slice(prefix.length),
     original.images,
     original.metadata,
+    original.presentation,
   );
   return { messages: next, stripped: true };
 }

--- a/server/chats/share-transcript.ts
+++ b/server/chats/share-transcript.ts
@@ -189,8 +189,12 @@ function normalizeImages(images: UserMessage['images']): string {
 
 function formatMessage(message: ChatMessage, raw: unknown): TranscriptEntry {
   if (message instanceof UserMessage) {
+    const presentation = message.presentation;
+    const role = presentation
+      ? `User (CLI ${presentation.style === 'error' ? 'Error' : 'Notice'})${presentation.title ? ` — ${presentation.title}` : ''}`
+      : 'User';
     return {
-      role: 'User',
+      role,
       timestamp: message.timestamp,
       content: `${message.content}${normalizeImages(message.images)}`.trim(),
     };

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -4182,6 +4182,7 @@ describe('ChatCommandService', () => {
         transcriptViewId: 'view-1',
         content: input.content,
         clientMessageId: input.clientMessageId,
+        userMessagePresentation: null,
       },
     });
     await ledger.settleTerminal(accepted.record.key, 'finished', { turnId: 'turn-compact' });

--- a/server/commands/command-support.ts
+++ b/server/commands/command-support.ts
@@ -20,6 +20,7 @@ import {
 } from '../../common/chat-command-contracts.js';
 import { InvalidChatIdError, parseChatId, type ChatId } from '../../common/chat-id.js';
 import type { PermissionMode, ThinkingMode } from '../../common/chat-modes.js';
+import type { UserMessagePresentation } from '../../common/chat-types.js';
 import type { AgentRegistryServiceContract } from '../agents/registry.js';
 import type {
   AgentExecutionCommandType,
@@ -179,6 +180,7 @@ export interface NormalizedSubmitRunInput {
   tagsToAdd?: string[];
   permissionFallbackPolicy?: 'require-explicit-bypass';
   handoff?: AgentHandoffRequest;
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface NormalizedSubmitForkRunInput extends NormalizedSubmitRunInput {
@@ -221,6 +223,7 @@ export interface NormalizedChatStart {
   thinkingMode: ThinkingMode;
   agentSettings: AgentSettingsEnvelope;
   tags: string[];
+  userMessagePresentation?: UserMessagePresentation;
 }
 
 export interface ScheduledExistingChatInput {
@@ -532,6 +535,7 @@ export class CommandSupport {
         },
         content: input.command,
         options,
+        userMessagePresentation: input.userMessagePresentation,
         settlement: this.settlement,
         preparation,
       });

--- a/server/commands/session-commands.ts
+++ b/server/commands/session-commands.ts
@@ -67,6 +67,7 @@ export class SessionCommands {
       tagsToAdd: input.tagsToAdd,
       permissionFallbackPolicy: input.permissionFallbackPolicy,
       handoff: input.handoff,
+      userMessagePresentation: input.userMessagePresentation,
     };
     const replay = await this.support.replayHttpRun(normalizedInput);
     if (replay) {

--- a/server/commands/start-commands.ts
+++ b/server/commands/start-commands.ts
@@ -90,6 +90,7 @@ export class StartCommands {
       thinkingMode: input.thinkingMode,
       agentSettings: input.agentSettings,
       tags: input.tags ?? [],
+      userMessagePresentation: input.userMessagePresentation,
     };
   }
 
@@ -131,6 +132,7 @@ export class StartCommands {
         images: input.images.length > 0 ? input.images : undefined,
         agentSettings: input.agentSettings,
       },
+      userMessagePresentation: input.userMessagePresentation,
       settlement: this.support.settlement,
       preparation: {
         operation: 'chat-start',
@@ -289,6 +291,7 @@ function startPayload(input: NormalizedChatStart): Record<string, unknown> {
     thinkingMode: input.thinkingMode,
     agentSettings: input.agentSettings,
     tags: input.tags,
+    userMessagePresentation: input.userMessagePresentation ?? null,
   };
 }
 
@@ -311,5 +314,6 @@ function startReplayPayload(
     thinkingMode: input.thinkingMode,
     agentSettings: input.agentSettings,
     tags: input.tags ?? [],
+    userMessagePresentation: input.userMessagePresentation ?? null,
   };
 }

--- a/server/commands/start-commands.ts
+++ b/server/commands/start-commands.ts
@@ -89,8 +89,7 @@ export class StartCommands {
       permissionMode: input.permissionMode,
       thinkingMode: input.thinkingMode,
       agentSettings: input.agentSettings,
-      tags: input.tags ?? [],
-      userMessagePresentation: input.userMessagePresentation,
+      tags: input.tags ?? [], userMessagePresentation: input.userMessagePresentation,
     };
   }
 

--- a/server/commands/steer-commands.ts
+++ b/server/commands/steer-commands.ts
@@ -65,6 +65,7 @@ export class SteerCommands {
         transcriptViewId: input.transcriptViewId,
         content: input.content,
         clientMessageId,
+        userMessagePresentation: input.userMessagePresentation ?? null,
       },
     };
     let outcomeTurnId = target?.identity.turnId;
@@ -137,6 +138,7 @@ export class SteerCommands {
           providerContent,
           clientMessageId,
           transcriptViewId: input.transcriptViewId,
+          userMessagePresentation: input.userMessagePresentation,
           target,
           settlement: this.support.settlement,
         });

--- a/server/ledger/__tests__/codec-user-presentation.test.js
+++ b/server/ledger/__tests__/codec-user-presentation.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { UserMessage } from '../../../common/chat-types.ts';
+import { submissionFingerprint } from '../codec.ts';
+
+describe('transcript submission presentation fingerprint', () => {
+  const detail = (presentation) => ({
+    message: new UserMessage('2026-08-22T00:00:00.000Z', 'Body', undefined, undefined, presentation),
+    attachments: [],
+    steer: false,
+  });
+
+  it('conflicts on presentation presence, style, and title', () => {
+    expect(submissionFingerprint(detail(undefined))).not.toBe(submissionFingerprint(detail({
+      origin: 'cli', style: 'notice',
+    })));
+    expect(submissionFingerprint(detail({ origin: 'cli', style: 'notice' })))
+      .not.toBe(submissionFingerprint(detail({ origin: 'cli', style: 'error' })));
+    expect(submissionFingerprint(detail({ origin: 'cli', style: 'notice', title: 'A' })))
+      .not.toBe(submissionFingerprint(detail({ origin: 'cli', style: 'notice', title: 'B' })));
+  });
+});

--- a/server/ledger/codec.ts
+++ b/server/ledger/codec.ts
@@ -135,6 +135,7 @@ export function submissionFingerprint(detail: LedgerUserInputDetail): string {
   return stableJsonStringify({
     content: detail.message.content,
     images: detail.message.images ?? null,
+    presentation: detail.message.presentation ?? null,
     attachments: detail.attachments,
     steer: detail.steer,
   });

--- a/server/ledger/presentation.ts
+++ b/server/ledger/presentation.ts
@@ -42,6 +42,7 @@ export function ledgerRowToMessage(row: LedgerRow): ChatMessage | null {
             ...row.detail.message.metadata,
             clientMessageId: row.detail.clientMessageId,
           },
+          row.detail.message.presentation,
         )
         : row.detail.message;
     case 'provider-row':

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1537,7 +1537,7 @@
 	"sidebar_chats_reload": "Reload from native history",
 	"sidebar_chats_reload_failed": "Failed to reload chat.",
 	"sidebar_chats_reload_confirm_title": "Replace this transcript?",
-	"sidebar_chats_reload_confirm_description": "This replaces the displayed history with the provider's native history. This cannot be undone.",
+	"sidebar_chats_reload_confirm_description": "This replaces the displayed history with the provider's native history. CLI message titles and styles in the current native segment may be lost. This cannot be undone.",
 	"sidebar_chats_reload_confirm_resend": "These unsent messages will be removed from the current transcript:",
 	"sidebar_chats_reload_confirm_button": "Replace transcript",
 	"sidebar_chats_try_different_search": "Try a different search term.",

--- a/web/src/lib/chat/transcript/user-message-navigator-controller.svelte.ts
+++ b/web/src/lib/chat/transcript/user-message-navigator-controller.svelte.ts
@@ -1,4 +1,5 @@
 import { UserMessage } from '$shared/chat-types';
+import type { UserMessagePresentation } from '$shared/chat-types';
 import type { ChatDisplayRow, ChatLoadStatus } from './active-transcript-state.svelte.js';
 import type { TranscriptPageLoadResult } from './transcript-page-progress.js';
 
@@ -8,6 +9,7 @@ export interface UserMessageNavigatorItem {
 	content: string;
 	timestamp: string;
 	attachmentCount: number;
+	presentation?: UserMessagePresentation;
 }
 
 export interface UserMessageNavigatorTarget {
@@ -79,6 +81,9 @@ export class UserMessageNavigatorController implements UserMessageNavigatorDialo
 						content: row.message.content,
 						timestamp: row.message.timestamp,
 						attachmentCount: row.message.images?.length ?? 0,
+						...(row.message.presentation === undefined
+							? {}
+							: { presentation: row.message.presentation }),
 					},
 				];
 			})

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -36,6 +36,7 @@
 	import AgentSwitchRow from './AgentSwitchRow.svelte';
 	import ChatEventCard from './rows/ChatEventCard.svelte';
 	import CliRowMessage from './rows/CliRowMessage.svelte';
+	import UserMessagePresentationHeader from './UserMessagePresentationHeader.svelte';
 	import ChatToolEventRenderer from './tools/ChatToolEventRenderer.svelte';
 	import {
 		ContextMenu,
@@ -493,6 +494,9 @@
 						class="user-message-context-target chat-message-context-target message-context-menu-trigger relative block bg-user-bubble text-user-bubble-foreground data-[state=open]:bg-user-bubble-selected rounded-xl border border-border px-3 py-2 shadow-sm flex-1 sm:flex-initial min-w-0 max-w-full"
 					>
 						<div>
+							{#if asUser.presentation}
+								<UserMessagePresentationHeader presentation={asUser.presentation} />
+							{/if}
 							<div class="text-sm">
 								<Markdown
 									source={asUser.content}

--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -17,6 +17,7 @@
 	import ChatToolEventRenderer from '$lib/components/chat/tools/ChatToolEventRenderer.svelte';
 	import ChatEventCard from '$lib/components/chat/rows/ChatEventCard.svelte';
 	import CliRowMessage from '$lib/components/chat/rows/CliRowMessage.svelte';
+	import UserMessagePresentationHeader from '$lib/components/chat/UserMessagePresentationHeader.svelte';
 	import { getAppTitle } from '$lib/context';
 	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Loader2 from '@lucide/svelte/icons/loader-2';
@@ -274,6 +275,9 @@
 									<div
 										class="mt-1 bg-user-bubble text-user-bubble-foreground rounded-xl border border-border px-3 py-2 shadow-sm"
 									>
+										{#if message.presentation}
+											<UserMessagePresentationHeader presentation={message.presentation} />
+										{/if}
 										<div class="text-sm">
 											<Markdown source={message.content} variant="user" />
 										</div>

--- a/web/src/lib/components/chat/UserMessageNavigatorDialog.svelte
+++ b/web/src/lib/components/chat/UserMessageNavigatorDialog.svelte
@@ -4,6 +4,7 @@
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import type { UserMessageNavigatorDialogController } from '$lib/chat/transcript/user-message-navigator-controller.svelte.js';
+	import UserMessagePresentationHeader from './UserMessagePresentationHeader.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
 	const LOAD_THRESHOLD_PX = 96;
@@ -125,10 +126,13 @@
 						<svelte:boundary {failed}>
 							<button
 								type="button"
-								class="flex min-h-16 w-full items-center px-5 py-3 text-start hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-6"
+								class="flex min-h-16 w-full flex-col items-stretch px-5 py-3 text-start hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-6"
 								onclick={() => void controller.select(item)}
 								data-user-message-navigator-row={item.id}
 							>
+								{#if item.presentation}
+									<UserMessagePresentationHeader presentation={item.presentation} />
+								{/if}
 								<span
 									class="line-clamp-2 w-full whitespace-pre-wrap break-words text-sm leading-5 text-foreground"
 								>

--- a/web/src/lib/components/chat/UserMessageNavigatorDialog.svelte
+++ b/web/src/lib/components/chat/UserMessageNavigatorDialog.svelte
@@ -126,7 +126,7 @@
 						<svelte:boundary {failed}>
 							<button
 								type="button"
-								class="flex min-h-16 w-full flex-col items-stretch px-5 py-3 text-start hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-6"
+								class="flex min-h-16 w-full flex-col items-stretch justify-center px-5 py-3 text-start hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-6"
 								onclick={() => void controller.select(item)}
 								data-user-message-navigator-row={item.id}
 							>

--- a/web/src/lib/components/chat/UserMessagePresentationHeader.svelte
+++ b/web/src/lib/components/chat/UserMessagePresentationHeader.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import SquareTerminal from '@lucide/svelte/icons/square-terminal';
+	import type { UserMessagePresentation } from '$shared/chat-types';
+	import * as m from '$lib/paraglide/messages.js';
+
+	let { presentation }: { presentation: UserMessagePresentation } = $props();
+	const label = $derived(
+		presentation.style === 'error' ? m.chat_message_cli_error() : m.chat_message_cli_notice(),
+	);
+</script>
+
+<div
+	class={[
+		'mb-1.5 flex min-w-0 items-center gap-1.5 border-b pb-1 text-xs font-medium',
+		presentation.style === 'error'
+			? 'border-status-error-border text-status-error-foreground'
+			: 'border-status-info-border text-status-info-foreground',
+	]}
+	data-user-message-presentation={presentation.style}
+>
+	<SquareTerminal class="size-3.5 shrink-0" aria-hidden="true" />
+	<span class="shrink-0">{label}</span>
+	{#if presentation.title}
+		<span aria-hidden="true">·</span>
+		<span class="min-w-0 truncate">{presentation.title}</span>
+	{/if}
+</div>

--- a/web/src/lib/components/chat/UserMessagePresentationHeader.svelte
+++ b/web/src/lib/components/chat/UserMessagePresentationHeader.svelte
@@ -9,12 +9,12 @@
 	);
 </script>
 
-<div
+<span
 	class={[
-		'mb-1.5 flex min-w-0 items-center gap-1.5 border-b pb-1 text-xs font-medium',
+		'mb-1.5 flex min-w-0 items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium',
 		presentation.style === 'error'
-			? 'border-status-error-border text-status-error-foreground'
-			: 'border-status-info-border text-status-info-foreground',
+			? 'border-status-error-border bg-status-error text-status-error-foreground'
+			: 'border-status-info-border bg-status-info text-status-info-foreground',
 	]}
 	data-user-message-presentation={presentation.style}
 >
@@ -24,4 +24,4 @@
 		<span aria-hidden="true">·</span>
 		<span class="min-w-0 truncate">{presentation.title}</span>
 	{/if}
-</div>
+</span>

--- a/web/src/lib/components/chat/__tests__/ConversationMessage.actions.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.actions.test.ts
@@ -100,6 +100,8 @@ describe('ConversationMessage actions', () => {
 		const header = container.querySelector('[data-user-message-presentation="error"]');
 		expect(header?.textContent).toContain('CLI error');
 		expect(header?.textContent).toContain('Deployment blocker');
+		expect(header?.classList.contains('bg-status-error')).toBe(true);
+		expect(header?.classList.contains('text-status-error-foreground')).toBe(true);
 		expect(container.querySelector('.user-message-context-target')?.contains(header)).toBe(true);
 		expect(container.querySelector('.cli-row-message')).toBeNull();
 		expect(container.querySelector('[role="alert"]')).toBeNull();

--- a/web/src/lib/components/chat/__tests__/ConversationMessage.actions.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.actions.test.ts
@@ -86,6 +86,26 @@ describe('ConversationMessage actions', () => {
 		expect(await screen.findByRole('menuitem', { name: 'Copy text' })).toBeTruthy();
 	});
 
+	it('renders CLI presentation inside the ordinary user message bubble', () => {
+		const { container } = render(ConversationMessageHost, {
+			message: new UserMessage(
+				'2026-06-27T00:00:00.000Z',
+				'**Body** only',
+				undefined,
+				undefined,
+				{ origin: 'cli', style: 'error', title: 'Deployment blocker' },
+			),
+		});
+
+		const header = container.querySelector('[data-user-message-presentation="error"]');
+		expect(header?.textContent).toContain('CLI error');
+		expect(header?.textContent).toContain('Deployment blocker');
+		expect(container.querySelector('.user-message-context-target')?.contains(header)).toBe(true);
+		expect(container.querySelector('.cli-row-message')).toBeNull();
+		expect(container.querySelector('[role="alert"]')).toBeNull();
+		expect(screen.getByText('Body')).toBeTruthy();
+	});
+
 	it('renders tool rows synchronously without an await placeholder', () => {
 		render(ConversationMessageHost, {
 			message: new BashToolUseMessage('2026-06-27T00:00:00.000Z', 'tool-1', 'echo hello'),

--- a/web/src/lib/components/chat/__tests__/UserMessageNavigatorDialog.test.ts
+++ b/web/src/lib/components/chat/__tests__/UserMessageNavigatorDialog.test.ts
@@ -43,8 +43,24 @@ describe('UserMessageNavigatorDialog', () => {
 			'Oldest message',
 		]);
 		expect(rows[0]?.classList.contains('min-h-16')).toBe(true);
+		expect(rows[0]?.classList.contains('justify-center')).toBe(true);
 		expect(rows[0]?.querySelector('span')?.classList.contains('line-clamp-2')).toBe(true);
 		expect(rows[0]?.querySelector('span')?.classList.contains('break-words')).toBe(true);
+	});
+
+	it('renders presented messages with valid semantic button content', () => {
+		render(UserMessageNavigatorDialogTestHost, {
+			initialItems: [{
+				...item('generation-1:1', 'Deployment context'),
+				presentation: { origin: 'cli', style: 'notice', title: 'Operator note' },
+			}],
+		});
+
+		const row = document.querySelector<HTMLButtonElement>('[data-user-message-navigator-row]');
+		const header = row?.querySelector<HTMLElement>('[data-user-message-presentation="notice"]');
+		expect(header?.tagName).toBe('SPAN');
+		expect(header?.classList.contains('bg-status-info')).toBe(true);
+		expect(header?.textContent).toContain('Operator note');
 	});
 
 	it('renders the attachment fallback and selects the exact stable item', async () => {

--- a/web/src/lib/components/chat/__tests__/conversation-feed-virtual-items.test.ts
+++ b/web/src/lib/components/chat/__tests__/conversation-feed-virtual-items.test.ts
@@ -14,7 +14,9 @@ import {
 	estimateConversationFeedItemSize,
 } from '../conversation-feed-virtual-items.js';
 
-function userItem(index: number): ConversationFeedRenderItem {
+function userItem(
+	index: number,
+): Extract<ConversationFeedRenderItem, { kind: 'message' }> {
 	const rowId = `generation-1:${index}`;
 	return {
 		kind: 'message',
@@ -145,6 +147,22 @@ describe('conversation virtual feed model', () => {
 
 		expect(estimateConversationFeedItemSize(transcript, 0.7)).toBeCloseTo(86.8);
 		expect(estimateConversationFeedItemSize(boundary, 0.7)).toBe(44);
+	});
+
+	it('reserves header geometry for presented user messages', () => {
+		const ordinary = build([userItem(1)]).items[1]!;
+		const presentedItem = userItem(2);
+		presentedItem.message = new UserMessage(
+			'2026-08-03T00:00:00.000Z',
+			'message 2',
+			undefined,
+			undefined,
+			{ origin: 'cli', style: 'notice' },
+		);
+		const presented = build([presentedItem]).items[1]!;
+
+		expect(estimateConversationFeedItemSize(ordinary, 1)).toBe(124);
+		expect(estimateConversationFeedItemSize(presented, 1)).toBe(156);
 	});
 
 	it('includes viewport geometry and established floating permission spacing', () => {

--- a/web/src/lib/components/chat/conversation-feed-announcer.ts
+++ b/web/src/lib/components/chat/conversation-feed-announcer.ts
@@ -128,6 +128,14 @@ export function announcementForAppendedRow(
 ): string | null {
 	if (row.kind === 'local-notice') return plainAnnouncementText(row.content) || null;
 	const message = row.message;
+	if (message instanceof UserMessage && message.presentation) {
+		const label = message.presentation.style === 'error'
+			? m.chat_message_cli_error()
+			: m.chat_message_cli_notice();
+		const title = message.presentation.title ? `: ${message.presentation.title}` : '';
+		const body = plainAnnouncementText(String(message.content ?? ''));
+		return `${label}${title}.${body ? ` ${body}` : ''}`;
+	}
 	if (message instanceof AssistantMessage || message instanceof UserMessage) {
 		return plainAnnouncementText(String(message.content ?? '')) || null;
 	}

--- a/web/src/lib/components/chat/conversation-feed-virtual-items.ts
+++ b/web/src/lib/components/chat/conversation-feed-virtual-items.ts
@@ -291,7 +291,9 @@ export function estimateConversationFeedItemSize(
 	if (layout === 'hidden') return 0;
 	if (layout === 'permission') return 240 * scale + spacing;
 	if (renderItem.kind === 'local-notice') return 52 * scale + spacing;
-	if (renderItem.message.type === 'user-message') return 112 * scale + spacing;
+	if (renderItem.message.type === 'user-message') {
+		return (renderItem.message.presentation ? 144 : 112) * scale + spacing;
+	}
 	if (renderItem.message.type === 'assistant-message') return 180 * scale + spacing;
 	if (renderItem.message.type === 'thinking') return 160 * scale + spacing;
 	return 96 * scale + spacing;


### PR DESCRIPTION
CLI-driven consultations and delegated work need to remain visible as ordinary conversation while still being recognizable in Garcon. This adds optional message title and notice/error styling to new-chat, resume, and send-async commands, persists the presentation metadata through the transcript ledger, renders it in chat, navigation, status, and shared views, and documents the native-history boundaries; the field is optional, so existing messages require no migration.