### PR TITLE
Fix OpenCode compaction and tool blockers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
   server-integration:
     name: Server protocol integration
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository

--- a/integration-tests/support/scripted-opencode.ts
+++ b/integration-tests/support/scripted-opencode.ts
@@ -128,13 +128,14 @@ export function openCodePaths(directories: IntegrationDirectories): OpenCodePath
   };
 }
 
-function openCodeConfig(modelBaseUrl: string): Record<string, unknown> {
+function openCodeConfig(modelBaseUrl: string, modelId: string): Record<string, unknown> {
+  const agentModel = `${OPENCODE_TEST_PROVIDER}/${modelId}`;
   return {
     formatter: false,
     lsp: false,
     enabled_providers: [OPENCODE_TEST_PROVIDER],
-    model: OPENCODE_TEST_MODEL,
-    small_model: OPENCODE_TEST_MODEL,
+    model: agentModel,
+    small_model: agentModel,
     agent: {
       title: { disable: true },
       summary: { disable: true },
@@ -146,8 +147,8 @@ function openCodeConfig(modelBaseUrl: string): Record<string, unknown> {
         env: [],
         npm: '@ai-sdk/openai-compatible',
         models: {
-          [OPENCODE_TEST_MODEL_ID]: {
-            id: OPENCODE_TEST_MODEL_ID,
+          [modelId]: {
+            id: modelId,
             name: 'Garcon Fake Model',
             attachment: true,
             // The image input modality is what unsupportedParts() gates on;
@@ -196,6 +197,7 @@ export function assertScriptedOpenCodePlatform(platform: NodeJS.Platform = proce
 
 export interface ScriptedOpenCodeTestEnvironment {
   readonly model: FakeChatCompletionsModel;
+  readonly agentModel: string;
   resolveServerEnvironment(directories: IntegrationDirectories): Record<string, string>;
   prepareWorkspace(directories: IntegrationDirectories): Promise<void>;
   afterGarconStop(directories: IntegrationDirectories): Promise<void>;
@@ -205,11 +207,14 @@ export interface ScriptedOpenCodeTestEnvironment {
 
 export function startScriptedOpenCodeTestEnvironment(options: {
   autoCompact?: boolean;
+  modelId?: string;
   proxy?: boolean;
   platform?: NodeJS.Platform;
 } = {}): ScriptedOpenCodeTestEnvironment {
   assertScriptedOpenCodePlatform(options.platform);
   const model = FakeChatCompletionsModel.start();
+  const modelId = options.modelId ?? OPENCODE_TEST_MODEL_ID;
+  const agentModel = `${OPENCODE_TEST_PROVIDER}/${modelId}`;
   const preparedRoots = new Set<string>();
   const cleanedRoots = new Set<string>();
 
@@ -259,6 +264,7 @@ export function startScriptedOpenCodeTestEnvironment(options: {
 
   return {
     model,
+    agentModel,
     resolveServerEnvironment,
     async prepareWorkspace(directories) {
       preparedRoots.add(directories.root);
@@ -279,7 +285,7 @@ export function startScriptedOpenCodeTestEnvironment(options: {
       ]) {
         await mkdir(directory, { recursive: true });
       }
-      await writeFile(paths.config, JSON.stringify(openCodeConfig(model.baseUrl), null, 2), {
+      await writeFile(paths.config, JSON.stringify(openCodeConfig(model.baseUrl, modelId), null, 2), {
         mode: 0o600,
       });
       await writeOpenCodePluginSeed(paths.globalConfig);
@@ -302,6 +308,7 @@ export function startScriptedOpenCodeTestEnvironment(options: {
       return {
         opencode: {
           version: OPENCODE_VERSION,
+          model: agentModel,
           configPath: paths.config,
           databasePath: paths.database,
           mode: options.proxy ? 'proxy' : 'direct',
@@ -524,6 +531,7 @@ export function scriptedOpenCodeStartRequest(input: {
   command: string;
   permissionMode?: StartChatCommandRequest['permissionMode'];
   images?: StartChatCommandRequest['images'];
+  model?: StartChatCommandRequest['model'];
 }): StartChatCommandRequest {
   return {
     clientRequestId: crypto.randomUUID(),
@@ -531,7 +539,7 @@ export function scriptedOpenCodeStartRequest(input: {
     chatId: input.chatId,
     agentId: 'opencode',
     projectPath: input.projectPath,
-    model: OPENCODE_TEST_MODEL,
+    model: input.model ?? OPENCODE_TEST_MODEL,
     permissionMode: input.permissionMode ?? 'bypassPermissions',
     thinkingMode: OPENCODE_TEST_THINKING_MODE,
     agentSettings: OPENCODE_AGENT_SETTINGS,
@@ -544,6 +552,7 @@ export function scriptedOpenCodeRunRequest(input: {
   chatId: string;
   command: string;
   permissionMode?: AgentRunCommandRequest['permissionMode'];
+  model?: AgentRunCommandRequest['model'];
 }): Omit<AgentRunCommandRequest, 'transcriptViewId'> {
   return {
     clientRequestId: crypto.randomUUID(),
@@ -553,7 +562,7 @@ export function scriptedOpenCodeRunRequest(input: {
     permissionMode: input.permissionMode ?? 'bypassPermissions',
     thinkingMode: OPENCODE_TEST_THINKING_MODE,
     agentSettings: OPENCODE_AGENT_SETTINGS,
-    model: OPENCODE_TEST_MODEL,
+    model: input.model ?? OPENCODE_TEST_MODEL,
   };
 }
 

--- a/integration-tests/support/scripted-opencode.ts
+++ b/integration-tests/support/scripted-opencode.ts
@@ -221,6 +221,7 @@ export interface ScriptedOpenCodeTestEnvironment {
 
 export function startScriptedOpenCodeTestEnvironment(options: {
   autoCompact?: boolean;
+  experimentalPlanMode?: boolean;
   modelId?: string;
   nestedTaskAgent?: boolean;
   proxy?: boolean;
@@ -271,6 +272,9 @@ export function startScriptedOpenCodeTestEnvironment(options: {
     };
     if (!options.autoCompact) {
       environment.OPENCODE_DISABLE_AUTOCOMPACT = '1';
+    }
+    if (options.experimentalPlanMode) {
+      environment.OPENCODE_EXPERIMENTAL_PLAN_MODE = '1';
     }
     if (options.proxy) {
       environment.GARCON_TEST_OPENCODE_PROXY_DIR = paths.proxy;

--- a/integration-tests/support/scripted-opencode.ts
+++ b/integration-tests/support/scripted-opencode.ts
@@ -128,17 +128,31 @@ export function openCodePaths(directories: IntegrationDirectories): OpenCodePath
   };
 }
 
-function openCodeConfig(modelBaseUrl: string, modelId: string): Record<string, unknown> {
+function openCodeConfig(
+  modelBaseUrl: string,
+  modelId: string,
+  options: { nestedTaskAgent?: boolean; subagentDepth?: number } = {},
+): Record<string, unknown> {
   const agentModel = `${OPENCODE_TEST_PROVIDER}/${modelId}`;
   return {
     formatter: false,
     lsp: false,
+    ...(options.subagentDepth === undefined ? {} : { subagent_depth: options.subagentDepth }),
     enabled_providers: [OPENCODE_TEST_PROVIDER],
     model: agentModel,
     small_model: agentModel,
     agent: {
       title: { disable: true },
       summary: { disable: true },
+      ...(options.nestedTaskAgent
+        ? {
+            'scripted-nested': {
+              mode: 'subagent',
+              description: 'Exercises deterministic nested task behavior.',
+              permission: { task: 'allow' },
+            },
+          }
+        : {}),
     },
     provider: {
       [OPENCODE_TEST_PROVIDER]: {
@@ -208,8 +222,10 @@ export interface ScriptedOpenCodeTestEnvironment {
 export function startScriptedOpenCodeTestEnvironment(options: {
   autoCompact?: boolean;
   modelId?: string;
+  nestedTaskAgent?: boolean;
   proxy?: boolean;
   platform?: NodeJS.Platform;
+  subagentDepth?: number;
 } = {}): ScriptedOpenCodeTestEnvironment {
   assertScriptedOpenCodePlatform(options.platform);
   const model = FakeChatCompletionsModel.start();
@@ -285,7 +301,10 @@ export function startScriptedOpenCodeTestEnvironment(options: {
       ]) {
         await mkdir(directory, { recursive: true });
       }
-      await writeFile(paths.config, JSON.stringify(openCodeConfig(model.baseUrl, modelId), null, 2), {
+      await writeFile(paths.config, JSON.stringify(openCodeConfig(model.baseUrl, modelId, {
+        nestedTaskAgent: options.nestedTaskAgent,
+        subagentDepth: options.subagentDepth,
+      }), null, 2), {
         mode: 0o600,
       });
       await writeOpenCodePluginSeed(paths.globalConfig);

--- a/integration-tests/tests/live/opencode/lifecycle.test.ts
+++ b/integration-tests/tests/live/opencode/lifecycle.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import {
   assistantContents,
+  messagesOfType,
   userContents,
 } from '../../../support/chat-assertions.js';
 import { withIntegrationFixture } from '../../../support/integration-fixture.js';
 import {
   exactReplyPrompt,
   expectAssistantMarker,
+  LIVE_TURN_TIMEOUT_MS,
   liveMarker,
   waitForVisibleResponse,
 } from '../../../support/live-agent.js';
@@ -20,6 +22,99 @@ import { openCodeNativeSession } from '../../../support/scripted-opencode.js';
 const describeOnLinux = process.platform === 'linux' ? describe : describe.skip;
 
 describeOnLinux('live OpenCode lifecycle', () => {
+  test('renders a real tool call and continues after an answered question', async () => {
+    const fixtureOptions = await liveOpenCodeFixtureOptions();
+    await withIntegrationFixture('live-opencode-tool-question', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const questionMarker = liveMarker('OPENCODE_QUESTION');
+      const toolMarker = liveMarker('OPENCODE_BASH');
+      const replyMarker = liveMarker('OPENCODE_TOOL_REPLY');
+      const questionPrompt = `Which mode should ${questionMarker} use?`;
+      const command = `printf '%s' '${toolMarker}'`;
+      const prompt = [
+        'Use the question tool immediately as your first action.',
+        `Ask exactly one single-select question with header "Integration", question "${questionPrompt}", and exactly two options: "Careful" described as "Run the compatibility check." and "Stop" described as "Do not run it.".`,
+        'Do not answer the question yourself or use another tool before the user answers.',
+        `Only if the answer is "Careful", use the bash tool exactly once to run exactly \`${command}\`.`,
+        `After bash succeeds, reply with exactly ${replyMarker}.`,
+        'Do not use any other tools.',
+      ].join(' ');
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(liveOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: prompt,
+      }));
+
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        (row) => row.message.type === 'permission-request'
+          && row.message.requestedTool.type === 'ask-user-question-tool-use'
+          && row.message.requestedTool.questions.some((question) =>
+            question.prompt.includes(questionMarker)),
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (
+        permission.message.type !== 'permission-request'
+        || permission.message.requestedTool.type !== 'ask-user-question-tool-use'
+      ) {
+        throw new Error('Live OpenCode question request was not rendered.');
+      }
+      const questions = permission.message.requestedTool.questions;
+      expect(questions).toHaveLength(1);
+      const question = questions[0]!;
+      expect(question.prompt).toContain(questionMarker);
+      expect(question.allowMultiple).toBe(false);
+      const selected = question.options.find((option) => option.label === 'Careful');
+      if (!selected) throw new Error('Live OpenCode question omitted the Careful option.');
+
+      expect((await fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: true,
+        alwaysAllow: false,
+        response: {
+          type: 'ask-user-question-response',
+          outcome: 'answered',
+          answers: [{ questionId: question.id, selectedOptionIds: [selected.id] }],
+        },
+      })).status).toBe('accepted');
+
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: replyMarker,
+        afterIndex: cursor,
+      });
+
+      const transcript = await fixture.client.getMessages(chatId);
+      const questionTools = messagesOfType(
+        transcript.messages,
+        'ask-user-question-tool-use',
+      );
+      expect(questionTools).toHaveLength(1);
+      const bash = messagesOfType(transcript.messages, 'bash-tool-use').find(
+        (message) => message.command.includes(toolMarker),
+      );
+      if (!bash) throw new Error('Live OpenCode Bash tool use was not rendered.');
+      const result = messagesOfType(transcript.messages, 'tool-result').find(
+        (message) => message.toolId === bash.toolId,
+      );
+      expect(result?.isError).toBe(false);
+      expect(JSON.stringify(result?.content)).toContain(toolMarker);
+      expect(messagesOfType(transcript.messages, 'permission-resolved')).toContainEqual(
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+          allowed: true,
+        }),
+      );
+      expect(messagesOfType(transcript.messages, 'unknown-tool-use')).toEqual([]);
+      expectAssistantMarker(assistantContents(transcript.messages), replyMarker);
+    }, fixtureOptions);
+  }, 180_000);
+
   test('restores archived history and resumes the native session after restart', async () => {
     const fixtureOptions = await liveOpenCodeFixtureOptions();
     await withIntegrationFixture('live-opencode-restart', async (fixture) => {

--- a/integration-tests/tests/server/opencode-scripted-fork-while-running.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-fork-while-running.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { TranscriptMessage } from '../../../common/chat-view.js';
+import { userContents } from '../../support/chat-assertions.js';
+import { chatCompletionsText } from '../../support/fake-chat-completions-model.js';
+import {
+  withIntegrationFixture,
+  type IntegrationFixtureOptions,
+} from '../../support/integration-fixture.js';
+import {
+  LIVE_TURN_TIMEOUT_MS,
+  waitForVisibleResponse,
+} from '../../support/live-agent.js';
+import {
+  openCodeNativeSession,
+  readOpenCodeSessionRows,
+  scriptedOpenCodeRunRequest,
+  scriptedOpenCodeStartRequest,
+  startScriptedOpenCodeTestEnvironment,
+  type OpenCodeSessionRows,
+  type ScriptedOpenCodeTestEnvironment,
+} from '../../support/scripted-opencode.js';
+
+let environment: ScriptedOpenCodeTestEnvironment | undefined;
+
+const describeOnLinux = process.platform === 'linux' ? describe : describe.skip;
+
+describeOnLinux('scripted OpenCode fork while running', () => {
+  beforeEach(() => {
+    environment = startScriptedOpenCodeTestEnvironment();
+  });
+
+  afterEach(() => {
+    environment?.dispose();
+    environment = undefined;
+  });
+
+  test('seeds point and whole-session forks from their native prefixes', async () => {
+    const testEnvironment = requireEnvironment();
+    const firstPrompt = marker('FIRST_PROMPT');
+    const firstReply = marker('FIRST_REPLY');
+    const secondPrompt = marker('SECOND_PROMPT');
+    const secondReply = marker('SECOND_REPLY');
+    testEnvironment.model.scriptTurn([chatCompletionsText(firstReply)]);
+    const heldSecondReply = testEnvironment.model.scriptHeldTurn([
+      chatCompletionsText(secondReply),
+    ]);
+
+    await withIntegrationFixture('opencode-scripted-fork-running', async (fixture) => {
+      const catalog = await fixture.client.listAgentCatalog();
+      const opencode = catalog.agents.find((agent) => agent.id === 'opencode');
+      if (!opencode) throw new Error('OpenCode integration is missing from the agent catalog.');
+      expect(opencode.supportsForkWhileRunning).toBe(true);
+
+      const sourceChatId = fixture.newChatId();
+      const firstCursor = fixture.client.markEvents();
+      const firstTurn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId: sourceChatId,
+        projectPath: fixture.dirs.project,
+        command: firstPrompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: sourceChatId,
+        turnId: firstTurn.turnId,
+        marker: firstReply,
+        afterIndex: firstCursor,
+      });
+
+      const settled = await fixture.client.getMessages(sourceChatId);
+      const settledReply = settled.messages.find((entry) =>
+        entry.message.type === 'assistant-message'
+        && entry.message.content.includes(firstReply));
+      if (!settledReply) throw new Error('OpenCode first reply was not persisted.');
+      const sourceNative = await openCodeNativeSession(fixture, sourceChatId);
+      const settledNativeConversation = nativeConversation(readOpenCodeSessionRows(sourceNative));
+      expect(settledNativeConversation).toEqual([
+        ['user', firstPrompt],
+        ['assistant', firstReply],
+      ]);
+
+      const secondCursor = fixture.client.markEvents();
+      const secondTurn = await fixture.client.runChat(scriptedOpenCodeRunRequest({
+        chatId: sourceChatId,
+        command: secondPrompt,
+      }));
+      await heldSecondReply.requested;
+      await fixture.client.waitForProcessing(sourceChatId, true, {
+        afterIndex: secondCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      const running = await fixture.client.getMessages(sourceChatId);
+      expect(userContents(running.messages)).toEqual([firstPrompt, secondPrompt]);
+      const runningNativeConversation = nativeConversation(readOpenCodeSessionRows(sourceNative));
+      expect(runningNativeConversation).toEqual([
+        ...settledNativeConversation,
+        ['user', secondPrompt],
+      ]);
+
+      let pointForkChatId = '';
+      let wholeForkChatId = '';
+      let pointForkConversation: ConversationLine[] = [];
+      let wholeForkConversation: ConversationLine[] = [];
+      try {
+        pointForkChatId = fixture.newChatId();
+        await fixture.client.forkChat({
+          sourceChatId,
+          chatId: pointForkChatId,
+          transcriptViewId: running.transcriptViewId,
+          upToOrdinal: settledReply.ordinal,
+        });
+        const pointForkNative = await openCodeNativeSession(fixture, pointForkChatId);
+        expect(pointForkNative.agentSessionId).not.toBe(sourceNative.agentSessionId);
+        pointForkConversation = nativeConversation(readOpenCodeSessionRows(pointForkNative));
+        expect(pointForkConversation).toEqual(settledNativeConversation);
+        expect(renderedConversation(
+          (await fixture.client.getMessages(pointForkChatId)).messages,
+        )).toEqual(pointForkConversation);
+
+        wholeForkChatId = fixture.newChatId();
+        await fixture.client.forkChat({ sourceChatId, chatId: wholeForkChatId });
+        const wholeForkNative = await openCodeNativeSession(fixture, wholeForkChatId);
+        expect(wholeForkNative.agentSessionId).not.toBe(sourceNative.agentSessionId);
+        expect(wholeForkNative.agentSessionId).not.toBe(pointForkNative.agentSessionId);
+        wholeForkConversation = nativeConversation(readOpenCodeSessionRows(wholeForkNative));
+        expect(wholeForkConversation).toEqual(runningNativeConversation);
+        expect(renderedConversation(
+          (await fixture.client.getMessages(wholeForkChatId)).messages,
+        )).toEqual(wholeForkConversation);
+        expect(nativeConversation(readOpenCodeSessionRows(sourceNative)))
+          .toEqual(runningNativeConversation);
+      } finally {
+        heldSecondReply.release();
+      }
+
+      await waitForVisibleResponse({
+        fixture,
+        chatId: sourceChatId,
+        turnId: secondTurn.turnId,
+        marker: secondReply,
+        afterIndex: secondCursor,
+      });
+      const completedSourceConversation: ConversationLine[] = [
+        ...runningNativeConversation,
+        ['assistant', secondReply],
+      ];
+      expect(nativeConversation(readOpenCodeSessionRows(sourceNative)))
+        .toEqual(completedSourceConversation);
+      expect(renderedConversation((await fixture.client.getMessages(sourceChatId)).messages))
+        .toEqual(completedSourceConversation);
+      expect(nativeConversation(readOpenCodeSessionRows(
+        await openCodeNativeSession(fixture, pointForkChatId),
+      ))).toEqual(pointForkConversation);
+      expect(renderedConversation((await fixture.client.getMessages(pointForkChatId)).messages))
+        .toEqual(pointForkConversation);
+      expect(nativeConversation(readOpenCodeSessionRows(
+        await openCodeNativeSession(fixture, wholeForkChatId),
+      ))).toEqual(wholeForkConversation);
+      expect(renderedConversation((await fixture.client.getMessages(wholeForkChatId)).messages))
+        .toEqual(wholeForkConversation);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+});
+
+type ConversationLine = ['user' | 'assistant', string];
+
+function nativeConversation(rows: OpenCodeSessionRows): ConversationLine[] {
+  const lines: ConversationLine[] = [];
+  for (const message of rows.messages) {
+    const parts = rows.parts.filter((part) => part.message_id === message.id);
+    if (message.data.role === 'user') {
+      const text = parts
+        .filter((part) => part.data.type === 'text' && part.data.synthetic !== true)
+        .map((part) => typeof part.data.text === 'string' ? part.data.text : '')
+        .join('\n');
+      if (text.trim()) lines.push(['user', text]);
+      continue;
+    }
+    if (message.data.role !== 'assistant') continue;
+    for (const part of parts) {
+      if (part.data.type === 'text' && typeof part.data.text === 'string'
+        && part.data.text.trim()) {
+        lines.push(['assistant', part.data.text]);
+      }
+    }
+  }
+  return lines;
+}
+
+function renderedConversation(messages: readonly TranscriptMessage[]): ConversationLine[] {
+  return messages.flatMap((entry): ConversationLine[] => {
+    if (entry.message.type === 'user-message') return [['user', entry.message.content]];
+    if (entry.message.type === 'assistant-message') {
+      return [['assistant', entry.message.content]];
+    }
+    return [];
+  });
+}
+
+function requireEnvironment(): ScriptedOpenCodeTestEnvironment {
+  if (!environment) throw new Error('Scripted OpenCode environment was not initialized.');
+  return environment;
+}
+
+function withScriptedOpenCode(): IntegrationFixtureOptions {
+  const testEnvironment = requireEnvironment();
+  return {
+    resolveServerEnvironment: testEnvironment.resolveServerEnvironment,
+    prepareWorkspace: testEnvironment.prepareWorkspace,
+    afterGarconStop: testEnvironment.afterGarconStop,
+    extraDiagnostics: testEnvironment.extraDiagnostics,
+  };
+}
+
+function marker(label: string): string {
+  return `SCRIPTED_OPENCODE_FORK_RUNNING_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+}

--- a/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../../support/integration-fixture.js';
 import {
   LIVE_TURN_TIMEOUT_MS,
+  reloadFromNativeHistory,
   waitForVisibleResponse,
 } from '../../support/live-agent.js';
 import {
@@ -239,6 +240,13 @@ describeOnLinux('scripted OpenCode interrupt lifecycle', () => {
       expect(assistantContents(restored).join('\n')).not.toContain(stoppedReply);
       expect(messagesOfType(restored, 'error')).toEqual([]);
       expectAbortedToolRows(restored, command);
+
+      await reloadFromNativeHistory(fixture, chatId);
+      const reloaded = (await fixture.client.getMessages(chatId)).messages;
+      expect(userContents(reloaded)).toContain(stoppedPrompt);
+      expect(assistantContents(reloaded).join('\n')).not.toContain(stoppedReply);
+      expect(messagesOfType(reloaded, 'error')).toEqual([]);
+      expectAbortedToolRows(reloaded, command);
 
       testEnvironment.model.reset();
       testEnvironment.model.scriptTurn([chatCompletionsText(recoveryReply)]);

--- a/integration-tests/tests/server/opencode-scripted-model.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-model.test.ts
@@ -54,6 +54,54 @@ describeOnLinux('OpenCode against a scripted model', () => {
     environment = undefined;
   });
 
+  test('pins the real binary default tool inventory exposed to the model', async () => {
+    const testEnvironment = requireEnvironment();
+    testEnvironment.model.scriptTurn([chatCompletionsText(marker('TOOL_INVENTORY_REPLY'))]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-scripted-tool-inventory', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: marker('TOOL_INVENTORY_PROMPT'),
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        afterIndex: cursor,
+      });
+
+      const requests = testEnvironment.model.requestsSince(requestCursor);
+      expect(requests).toHaveLength(1);
+      const tools = requests[0]?.body.tools;
+      if (!Array.isArray(tools)) throw new Error('OpenCode omitted its model tool inventory.');
+      const names = tools.map((entry) => {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
+        const fn = 'function' in entry ? entry.function : null;
+        if (!fn || typeof fn !== 'object' || Array.isArray(fn) || !('name' in fn)) return null;
+        return typeof fn.name === 'string' ? fn.name : null;
+      });
+      expect(names.every((name): name is string => name !== null)).toBe(true);
+      expect(names.toSorted()).toEqual([
+        'bash',
+        'edit',
+        'glob',
+        'grep',
+        'question',
+        'read',
+        'skill',
+        'task',
+        'todowrite',
+        'webfetch',
+        'write',
+      ]);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('lists only the fake model, rejects a non-catalog model, and keeps all provider paths inside the fixture', async () => {
     const testEnvironment = requireEnvironment();
     testEnvironment.model.scriptTurn([chatCompletionsText(marker('ISOLATION_REPLY'))]);
@@ -258,6 +306,123 @@ describeOnLinux('OpenCode against a scripted model', () => {
       expect(terminalIndex).toBeGreaterThan(lastMessages.index);
       testEnvironment.model.assertSettled();
     }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('renders every non-blocking default built-in through the real binary', async () => {
+    const testEnvironment = requireEnvironment();
+    const webMarker = marker('WEBFETCH_BODY');
+    const subagentReply = marker('TASK_REPLY');
+    const finalReply = marker('BUILTIN_MATRIX_REPLY');
+    const webServer = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: () => new Response(webMarker, {
+        headers: { 'content-type': 'text/plain' },
+      }),
+    });
+
+    try {
+      await withIntegrationFixture('opencode-scripted-builtin-matrix', async (fixture) => {
+        const filePath = join(fixture.dirs.project, 'opencode-tool-inventory.txt');
+        const skillDirectory = join(
+          openCodePaths(fixture.dirs).globalConfig,
+          'skills',
+          'inventory',
+        );
+        await mkdir(skillDirectory, { recursive: true });
+        await writeFile(join(skillDirectory, 'SKILL.md'), [
+          '---',
+          'name: inventory',
+          'description: Exercises the pinned skill tool.',
+          '---',
+          'Use deterministic fixture content.',
+          '',
+        ].join('\n'));
+
+        for (const block of [
+          chatCompletionsToolUse('call_builtin_write', 'write', {
+            filePath,
+            content: 'initial\n',
+          }),
+          chatCompletionsToolUse('call_builtin_read', 'read', { filePath }),
+          chatCompletionsToolUse('call_builtin_edit', 'edit', {
+            filePath,
+            oldString: 'initial',
+            newString: 'updated',
+          }),
+          chatCompletionsToolUse('call_builtin_glob', 'glob', {
+            pattern: '**/opencode-tool-inventory.txt',
+            path: fixture.dirs.project,
+          }),
+          chatCompletionsToolUse('call_builtin_grep', 'grep', {
+            pattern: 'updated',
+            path: fixture.dirs.project,
+            include: '*.txt',
+          }),
+          chatCompletionsToolUse('call_builtin_todo', 'todowrite', {
+            todos: [{
+              content: 'Verify built-in tools',
+              status: 'completed',
+              priority: 'high',
+            }],
+          }),
+          chatCompletionsToolUse('call_builtin_skill', 'skill', { name: 'inventory' }),
+          chatCompletionsToolUse('call_builtin_webfetch', 'webfetch', {
+            url: `http://127.0.0.1:${webServer.port}/fixture`,
+            format: 'text',
+          }),
+          chatCompletionsToolUse('call_builtin_task', 'task', {
+            subagent_type: 'general',
+            description: 'Return fixture marker',
+            prompt: `Reply exactly ${subagentReply}`,
+          }),
+        ]) {
+          testEnvironment.model.scriptTurn([block]);
+        }
+        testEnvironment.model.scriptTurn([chatCompletionsText(subagentReply)]);
+        testEnvironment.model.scriptTurn([chatCompletionsText(finalReply)]);
+
+        const chatId = fixture.newChatId();
+        const cursor = fixture.client.markEvents();
+        const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+          chatId,
+          projectPath: fixture.dirs.project,
+          command: marker('BUILTIN_MATRIX_PROMPT'),
+        }));
+        await waitForVisibleResponse({
+          fixture,
+          chatId,
+          turnId: turn.turnId,
+          marker: finalReply,
+          afterIndex: cursor,
+        });
+
+        const transcript = await fixture.client.getMessages(chatId);
+        const types = new Set(transcript.messages.map((entry) => entry.message.type));
+        const expectedTypes = [
+          'write-tool-use',
+          'read-tool-use',
+          'edit-tool-use',
+          'glob-tool-use',
+          'grep-tool-use',
+          'todo-write-tool-use',
+          'external-tool-use',
+          'web-fetch-tool-use',
+          'task-tool-use',
+        ] as const;
+        for (const type of expectedTypes) expect(types.has(type)).toBe(true);
+        expect(messagesOfType(transcript.messages, 'unknown-tool-use')).toEqual([]);
+        expect(messagesOfType(transcript.messages, 'external-tool-use')).toEqual([
+          expect.objectContaining({ name: 'skill', namespace: 'opencode' }),
+        ]);
+        expect(JSON.stringify(messagesOfType(transcript.messages, 'tool-result')))
+          .toContain(webMarker);
+        expect(await readFile(filePath, 'utf8')).toBe('updated\n');
+        testEnvironment.model.assertSettled();
+      }, withScriptedOpenCode());
+    } finally {
+      webServer.stop(true);
+    }
   }, 120_000);
 
   test('[TLV5-L07.03-OPENCODE-SCRIPTED-01] accumulates transcript and preview across a second turn', async () => {

--- a/integration-tests/tests/server/opencode-scripted-model.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-model.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   OPENCODE_PLUGIN_SEED_FILES,
   OPENCODE_TEST_MODEL,
+  OPENCODE_TEST_MODEL_ID,
   OPENCODE_VERSION,
   openCodeNativeSession,
   openCodePaths,
@@ -76,16 +77,9 @@ describeOnLinux('OpenCode against a scripted model', () => {
 
       const requests = testEnvironment.model.requestsSince(requestCursor);
       expect(requests).toHaveLength(1);
-      const tools = requests[0]?.body.tools;
-      if (!Array.isArray(tools)) throw new Error('OpenCode omitted its model tool inventory.');
-      const names = tools.map((entry) => {
-        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
-        const fn = 'function' in entry ? entry.function : null;
-        if (!fn || typeof fn !== 'object' || Array.isArray(fn) || !('name' in fn)) return null;
-        return typeof fn.name === 'string' ? fn.name : null;
-      });
-      expect(names.every((name): name is string => name !== null)).toBe(true);
-      expect(names.toSorted()).toEqual([
+      expect(testEnvironment.agentModel).toBe(OPENCODE_TEST_MODEL);
+      expect(requests[0]?.body.model).toBe(OPENCODE_TEST_MODEL_ID);
+      expect(modelToolNames(requests[0]?.body ?? {}).toSorted()).toEqual([
         'bash',
         'edit',
         'glob',
@@ -98,6 +92,78 @@ describeOnLinux('OpenCode against a scripted model', () => {
         'webfetch',
         'write',
       ]);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('executes the conditional apply_patch inventory through the real binary', async () => {
+    environment?.dispose();
+    const modelId = 'gpt-5-scripted';
+    environment = startScriptedOpenCodeTestEnvironment({ modelId });
+    const testEnvironment = requireEnvironment();
+    const toolCallId = 'call_conditional_apply_patch';
+    const fileName = 'opencode-conditional-apply-patch.txt';
+    const patchText = [
+      '*** Begin Patch',
+      `*** Add File: ${fileName}`,
+      '+conditional inventory content',
+      '*** End Patch',
+    ].join('\n');
+    const reply = marker('CONDITIONAL_APPLY_PATCH_REPLY');
+    testEnvironment.model.scriptTurn([
+      chatCompletionsToolUse(toolCallId, 'apply_patch', { patchText }),
+    ]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-scripted-conditional-tools', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: marker('CONDITIONAL_APPLY_PATCH_PROMPT'),
+        model: testEnvironment.agentModel,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+
+      const requests = testEnvironment.model.requestsSince(requestCursor);
+      expect(requests).toHaveLength(2);
+      expect(requests[0]?.body.model).toBe(modelId);
+      expect(modelToolNames(requests[0]?.body ?? {}).toSorted()).toEqual([
+        'apply_patch',
+        'bash',
+        'glob',
+        'grep',
+        'question',
+        'read',
+        'skill',
+        'task',
+        'todowrite',
+        'webfetch',
+      ]);
+      expect(requests[1]?.toolResults).toHaveLength(1);
+      expect(requests[1]?.toolResults[0]?.toolCallId).toBe(toolCallId);
+      expect(requests[1]?.toolResults[0]?.content).toContain('Success. Updated the following files:');
+
+      const transcript = await fixture.client.getMessages(chatId);
+      const applyPatch = messagesOfType(transcript.messages, 'apply-patch-tool-use').find(
+        (message) => message.patch === patchText,
+      );
+      if (!applyPatch) throw new Error('OpenCode apply_patch tool use was not rendered.');
+      const result = messagesOfType(transcript.messages, 'tool-result').find(
+        (message) => message.toolId === applyPatch.toolId,
+      );
+      expect(result?.isError).toBe(false);
+      expect(messagesOfType(transcript.messages, 'unknown-tool-use')).toEqual([]);
+      expect(await readFile(join(fixture.dirs.project, fileName), 'utf8'))
+        .toBe('conditional inventory content\n');
       testEnvironment.model.assertSettled();
     }, withScriptedOpenCode());
   }, 120_000);
@@ -700,6 +766,21 @@ function withScriptedOpenCode(): IntegrationFixtureOptions {
     afterGarconStop: testEnvironment.afterGarconStop,
     extraDiagnostics: testEnvironment.extraDiagnostics,
   };
+}
+
+function modelToolNames(body: Record<string, unknown>): string[] {
+  if (!Array.isArray(body.tools)) throw new Error('OpenCode omitted its model tool inventory.');
+  return body.tools.map((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error('OpenCode emitted a malformed model tool.');
+    }
+    const fn = 'function' in entry ? entry.function : null;
+    if (!fn || typeof fn !== 'object' || Array.isArray(fn) || !('name' in fn)
+      || typeof fn.name !== 'string') {
+      throw new Error('OpenCode emitted a malformed function tool.');
+    }
+    return fn.name;
+  });
 }
 
 function marker(label: string): string {

--- a/integration-tests/tests/server/opencode-scripted-model.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-model.test.ts
@@ -168,6 +168,39 @@ describeOnLinux('OpenCode against a scripted model', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
+  test('does not advertise experimental plan transitions without a route carrier', async () => {
+    environment?.dispose();
+    environment = startScriptedOpenCodeTestEnvironment({ experimentalPlanMode: true });
+    const testEnvironment = requireEnvironment();
+    testEnvironment.model.scriptTurn([
+      chatCompletionsText('SCRIPTED_OPENCODE_EXPERIMENTAL_PLAN_REPLY'),
+    ]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-scripted-plan-inventory', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_EXPERIMENTAL_PLAN_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: 'SCRIPTED_OPENCODE_EXPERIMENTAL_PLAN_REPLY',
+        afterIndex: cursor,
+      });
+
+      const requests = testEnvironment.model.requestsSince(requestCursor);
+      expect(requests).toHaveLength(1);
+      expect(modelToolNames(requests[0]?.body ?? {})).not.toContain('plan_exit');
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('lists only the fake model, rejects a non-catalog model, and keeps all provider paths inside the fixture', async () => {
     const testEnvironment = requireEnvironment();
     testEnvironment.model.scriptTurn([chatCompletionsText(marker('ISOLATION_REPLY'))]);

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -1,6 +1,7 @@
 import { access, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ChatMessagesMessage } from '../../../common/ws-events.js';
 import { messagesOfType } from '../../support/chat-assertions.js';
 import {
   chatCompletionsText,
@@ -13,6 +14,7 @@ import {
 } from '../../support/integration-fixture.js';
 import {
   LIVE_TURN_TIMEOUT_MS,
+  reloadFromNativeHistory,
   waitForVisibleResponse,
 } from '../../support/live-agent.js';
 import {
@@ -299,6 +301,260 @@ describeOnLinux('scripted OpenCode permissions', () => {
           allowed: true,
         }),
       ]);
+
+      await reloadFromNativeHistory(fixture, chatId);
+      const reloaded = await fixture.client.getMessages(chatId);
+      expect(reloaded.transcriptViewId).not.toBe(transcript.transcriptViewId);
+      expect(messagesOfType(reloaded.messages, 'ask-user-question-tool-use')).toHaveLength(1);
+      expect(messagesOfType(reloaded.messages, 'unknown-tool-use')).toEqual([]);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('cancels a pending question once on interrupt and leaves the next turn clean', async () => {
+    const testEnvironment = requireEnvironment();
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_interrupted',
+      'question',
+      {
+        questions: [{
+          header: 'Interrupt',
+          question: 'Continue this turn?',
+          options: [{ label: 'Continue', description: 'Continue the active turn.' }],
+        }],
+      },
+    )]);
+
+    await withIntegrationFixture('opencode-question-interrupt', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_QUESTION_INTERRUPT_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        (row) => row.message.type === 'permission-request'
+          && row.message.requestedTool.type === 'ask-user-question-tool-use',
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (permission.message.type !== 'permission-request') {
+        throw new Error('Interrupted OpenCode question request was not found.');
+      }
+
+      const stopCursor = fixture.client.markEvents();
+      expect(await fixture.client.stopChat({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+      })).toMatchObject({ outcome: 'interrupt-requested' });
+      await fixture.client.waitForProcessing(chatId, false, {
+        afterIndex: stopCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      await fixture.client.waitForSessionStopped(chatId, {
+        afterIndex: stopCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      await fixture.client.waitForEvent(
+        (event): event is ChatMessagesMessage => event.type === 'chat-messages'
+          && event.chatId === chatId
+          && event.messages.some((entry) => entry.message.type === 'permission-cancelled'
+            && entry.message.permissionOccurrenceId
+              === permission.message.permissionOccurrenceId),
+        'OpenCode question cancellation',
+        { afterIndex: stopCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+
+      const stopped = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(stopped.messages, 'permission-cancelled')).toEqual([
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        }),
+      ]);
+      expect(messagesOfType(stopped.messages, 'permission-resolved')).toEqual([]);
+
+      testEnvironment.model.reset();
+      const recoveryReply = 'SCRIPTED_OPENCODE_QUESTION_INTERRUPT_RECOVERY_REPLY';
+      testEnvironment.model.scriptTurn([chatCompletionsText(recoveryReply)]);
+      const recoveryCursor = fixture.client.markEvents();
+      const recovery = await fixture.client.runChat(scriptedOpenCodeRunRequest({
+        chatId,
+        command: 'SCRIPTED_OPENCODE_QUESTION_INTERRUPT_RECOVERY_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: recovery.turnId,
+        marker: recoveryReply,
+        afterIndex: recoveryCursor,
+      });
+
+      const recovered = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(recovered.messages, 'permission-cancelled')).toHaveLength(1);
+      expect(messagesOfType(recovered.messages, 'permission-resolved')).toEqual([]);
+      expect(messagesOfType(recovered.messages, 'unknown-tool-use')).toEqual([]);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('delivers steering accepted during a pending question exactly once', async () => {
+    const testEnvironment = requireEnvironment();
+    const reply = 'SCRIPTED_OPENCODE_QUESTION_STEER_REPLY';
+    const steering = 'SCRIPTED_OPENCODE_QUESTION_STEER_GUIDANCE';
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_steered',
+      'question',
+      {
+        questions: [{
+          header: 'Mode',
+          question: 'Which mode?',
+          options: [{ label: 'Careful', description: 'Check each boundary.' }],
+        }],
+      },
+    )]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-question-steer', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_QUESTION_STEER_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        (row) => row.message.type === 'permission-request'
+          && row.message.requestedTool.type === 'ask-user-question-tool-use',
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (permission.message.type !== 'permission-request') {
+        throw new Error('Steered OpenCode question request was not found.');
+      }
+
+      expect(await fixture.client.steer({
+        clientRequestId: crypto.randomUUID(),
+        clientMessageId: crypto.randomUUID(),
+        chatId,
+        content: steering,
+      })).toMatchObject({ status: 'accepted', turnId: turn.turnId });
+      expect(await fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: true,
+        alwaysAllow: false,
+        response: {
+          type: 'ask-user-question-response',
+          outcome: 'answered',
+          answers: [{
+            questionId: 'question-1',
+            selectedOptionIds: ['question-1-option-1'],
+          }],
+        },
+      })).toMatchObject({ status: 'accepted' });
+
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+      const requests = testEnvironment.model.requestsSince(requestCursor);
+      expect(requests).toHaveLength(2);
+      expect(requests[1]?.userTexts.filter((text) => text === steering)).toHaveLength(1);
+      expect(messagesOfType(
+        (await fixture.client.getMessages(chatId)).messages,
+        'permission-resolved',
+      )).toHaveLength(1);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('keeps a pending question inert after restart and rejects its stale control', async () => {
+    const testEnvironment = requireEnvironment();
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_stale',
+      'question',
+      {
+        questions: [{
+          header: 'Restart',
+          question: 'Keep this request active?',
+          options: [{ label: 'No', description: 'Leave the old request inert.' }],
+        }],
+      },
+    )]);
+
+    await withIntegrationFixture('opencode-question-restart', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_QUESTION_RESTART_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        (row) => row.message.type === 'permission-request'
+          && row.message.requestedTool.type === 'ask-user-question-tool-use',
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (permission.message.type !== 'permission-request') {
+        throw new Error('Restarted OpenCode question request was not found.');
+      }
+      const beforeRestart = await fixture.client.getChatSnapshot(chatId, 0);
+      const staleControl = {
+        serverInstanceId: beforeRestart.transientFeed.serverInstanceId,
+        chatId,
+        runId: permission.runId,
+        permissionOccurrenceId: permission.permissionOccurrenceId,
+      };
+
+      await fixture.restartGarcon();
+
+      const restarted = await fixture.client.getChatSnapshot(chatId, 0);
+      expect(restarted.transientFeed.serverInstanceId).not.toBe(staleControl.serverInstanceId);
+      expect(restarted.transientFeed.rows).toEqual([]);
+      const transcript = await fixture.client.getMessages(chatId);
+      const durableRequests = messagesOfType(transcript.messages, 'permission-request');
+      expect(durableRequests).toEqual([
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        }),
+      ]);
+      expect(durableRequests[0]?.requestedTool.type).toBe('ask-user-question-tool-use');
+      expect(messagesOfType(transcript.messages, 'permission-resolved')).toEqual([]);
+
+      await expect(fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: false,
+        alwaysAllow: false,
+        control: staleControl,
+        response: {
+          type: 'ask-user-question-response',
+          outcome: 'skipped',
+          reason: 'The server restarted',
+        },
+      })).rejects.toMatchObject({
+        status: 409,
+        body: {
+          errorCode: 'VALIDATION_FAILED',
+          retryable: false,
+        },
+      });
+      expect(messagesOfType(
+        (await fixture.client.getMessages(chatId)).messages,
+        'permission-resolved',
+      )).toEqual([]);
       testEnvironment.model.assertSettled();
     }, withScriptedOpenCode());
   }, 120_000);

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -387,6 +387,37 @@ describeOnLinux('scripted OpenCode permissions', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
+  test('rejects an empty question request instead of leaving the turn blocked', async () => {
+    const testEnvironment = requireEnvironment();
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_empty',
+      'question',
+      { questions: [] },
+    )]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-question-empty', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_EMPTY_QUESTION_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+
+      const terminal = await fixture.client.waitForTurnTerminal(chatId, turn.turnId, {
+        afterIndex: cursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      expect(terminal.type).toBe('agent-run-finished');
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'permission-request')).toEqual([]);
+      expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(1);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('auto-replies once in manualBypass without emitting a user permission row', async () => {
     const testEnvironment = requireEnvironment();
     const toolMarker = marker('MANUAL_BYPASS_OUTPUT');

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -418,6 +418,83 @@ describeOnLinux('scripted OpenCode permissions', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
+  test('surfaces a task child blocker without exposing its transcript', async () => {
+    const testEnvironment = requireEnvironment();
+    const childReply = marker('TASK_CHILD_REPLY');
+    const finalReply = marker('TASK_PARENT_REPLY');
+    const repeatedCommand = 'printf %s SCRIPTED_OPENCODE_TASK_CHILD_COMMAND';
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_parent_task',
+      'task',
+      {
+        subagent_type: 'general',
+        description: 'Exercise a child blocker',
+        prompt: 'Run the repeated command, then return the child marker.',
+      },
+    )]);
+    testEnvironment.model.scriptTurn([
+      chatCompletionsToolUse('call_child_bash_1', 'bash', { command: repeatedCommand }),
+      chatCompletionsToolUse('call_child_bash_2', 'bash', { command: repeatedCommand }),
+      chatCompletionsToolUse('call_child_bash_3', 'bash', { command: repeatedCommand }),
+    ]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(childReply)]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(finalReply)]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-task-child-permission', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: marker('TASK_CHILD_PROMPT'),
+        permissionMode: 'bypassPermissions',
+      }));
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        (row) => row.message.type === 'permission-request'
+          && row.message.requestedTool.type === 'request-permissions-tool-use'
+          && row.message.requestedTool.reason === 'DoomLoop',
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (permission.message.type !== 'permission-request') {
+        throw new Error('OpenCode task child permission request was not found.');
+      }
+      const decision = await fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: true,
+        alwaysAllow: false,
+      });
+      expect(decision.status).toBe('accepted');
+
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: finalReply,
+        afterIndex: cursor,
+      });
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'task-tool-use')).toHaveLength(1);
+      expect(messagesOfType(transcript.messages, 'bash-tool-use')).toEqual([]);
+      expect(JSON.stringify(transcript.messages)).toContain(childReply);
+      expect(messagesOfType(transcript.messages, 'permission-resolved')).toEqual([
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+          allowed: true,
+        }),
+      ]);
+      const serverLogs = fixture.diagnostics().processRuns.flatMap((run) => run.serverLogs);
+      expect(serverLogs.filter((line) => (
+        line.includes('Ignoring an OpenCode event without an operation identity')
+      ))).toHaveLength(1);
+      expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(4);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('auto-replies once in manualBypass without emitting a user permission row', async () => {
     const testEnvironment = requireEnvironment();
     const toolMarker = marker('MANUAL_BYPASS_OUTPUT');

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -16,17 +16,18 @@ import {
   waitForVisibleResponse,
 } from '../../support/live-agent.js';
 import {
+  scriptedOpenCodeRunRequest,
   scriptedOpenCodeStartRequest,
   startScriptedOpenCodeTestEnvironment,
   type ScriptedOpenCodeTestEnvironment,
 } from '../../support/scripted-opencode.js';
 
-// Permission flows through the real binary: OpenCode's permission.asked events cross Garcon's
-// public boundary, user decisions execute or refuse the real shell tool, and manualBypass
-// auto-replies without surfacing a user row.
+// Permission flows through the real binary: Garcon answers OpenCode's permission and question
+// blockers while manualBypass remains automatic only for ordinary tool approval.
 let environment: ScriptedOpenCodeTestEnvironment | undefined;
 
 const describeOnLinux = process.platform === 'linux' ? describe : describe.skip;
+const PERMISSION_OCCURRENCE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 describeOnLinux('scripted OpenCode permissions', () => {
   beforeEach(() => {
@@ -157,6 +158,211 @@ describeOnLinux('scripted OpenCode permissions', () => {
       );
       expect(rejectedResult?.isError).toBe(true);
       expect(messagesOfType(transcript.messages, 'error')).toEqual([]);
+      expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(2);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('answers the question tool through the permission channel in bypass mode', async () => {
+    const testEnvironment = requireEnvironment();
+    const reply = 'SCRIPTED_OPENCODE_QUESTION_ANSWERED_REPLY';
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_answered',
+      'question',
+      {
+        questions: [
+          {
+            header: 'Mode',
+            question: 'Which mode?',
+            options: [
+              { label: 'Fast', description: 'Complete quickly.' },
+              { label: 'Careful', description: 'Check boundaries.' },
+            ],
+          },
+          {
+            header: 'Checks',
+            question: 'Which checks?',
+            multiple: true,
+            options: [
+              { label: 'Unit', description: 'Run unit tests.' },
+              { label: 'Integration', description: 'Run integration tests.' },
+            ],
+          },
+        ],
+      },
+    )]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+
+    const requestCursor = testEnvironment.model.markRequests();
+    await withIntegrationFixture('opencode-question-answer', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_QUESTION_ANSWERED_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        () => true,
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (
+        permission.message.type !== 'permission-request'
+        || permission.message.requestedTool.type !== 'ask-user-question-tool-use'
+      ) {
+        throw new Error('OpenCode question permission request was not found.');
+      }
+      expect(permission.message.permissionOccurrenceId).toMatch(PERMISSION_OCCURRENCE_UUID);
+      expect(permission.message.permissionOccurrenceId).not.toBe('call_question_answered');
+      expect(permission.message.requestedTool.questions).toEqual([
+        {
+          id: 'Which mode?',
+          prompt: 'Which mode?',
+          header: 'Mode',
+          options: [
+            { id: 'Fast', label: 'Fast', description: 'Complete quickly.' },
+            { id: 'Careful', label: 'Careful', description: 'Check boundaries.' },
+          ],
+          allowMultiple: false,
+        },
+        {
+          id: 'Which checks?',
+          prompt: 'Which checks?',
+          header: 'Checks',
+          options: [
+            { id: 'Unit', label: 'Unit', description: 'Run unit tests.' },
+            { id: 'Integration', label: 'Integration', description: 'Run integration tests.' },
+          ],
+          allowMultiple: true,
+        },
+      ]);
+
+      const decision = await fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: true,
+        alwaysAllow: false,
+        response: {
+          type: 'ask-user-question-response',
+          outcome: 'answered',
+          answers: [
+            { questionId: 'Which mode?', selectedOptionIds: ['Careful'] },
+            { questionId: 'Which checks?', selectedOptionIds: ['Unit', 'Integration'] },
+          ],
+        },
+      });
+      expect(decision.status).toBe('accepted');
+
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+      const requests = testEnvironment.model.requestsSince(requestCursor);
+      expect(requests).toHaveLength(2);
+      expect(requests[1]?.toolResults).toEqual([{
+        toolCallId: 'call_question_answered',
+        content: expect.stringContaining('"Which mode?"="Careful"'),
+      }]);
+
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'ask-user-question-tool-use')).toHaveLength(1);
+      expect(messagesOfType(transcript.messages, 'unknown-tool-use')).toEqual([]);
+      expect(messagesOfType(transcript.messages, 'permission-resolved')).toEqual([
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+          allowed: true,
+        }),
+      ]);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  test('rejects Skip without letting manual bypass hide the question', async () => {
+    const testEnvironment = requireEnvironment();
+    const reply = 'SCRIPTED_OPENCODE_QUESTION_SKIPPED_REPLY';
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_skipped',
+      'question',
+      {
+        questions: [{
+          header: 'Continue',
+          question: 'Continue?',
+          options: [{ label: 'Yes', description: 'Continue.' }],
+        }],
+      },
+    )]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+
+    const requestCursor = testEnvironment.model.markRequests();
+    await withIntegrationFixture('opencode-question-skip', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_QUESTION_SKIPPED_PROMPT',
+        permissionMode: 'manualBypass',
+      }));
+
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        () => true,
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (
+        permission.message.type !== 'permission-request'
+        || permission.message.requestedTool.type !== 'ask-user-question-tool-use'
+      ) {
+        throw new Error('OpenCode question permission request was not found.');
+      }
+      await fixture.client.sendPermissionDecision({
+        clientRequestId: crypto.randomUUID(),
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: false,
+        alwaysAllow: false,
+        response: {
+          type: 'ask-user-question-response',
+          outcome: 'skipped',
+          reason: 'User skipped question',
+        },
+      });
+
+      const terminal = await fixture.client.waitForTurnTerminal(chatId, turn.turnId, {
+        afterIndex: cursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      expect(terminal.type).toBe('agent-run-finished');
+
+      const recoveryCursor = fixture.client.markEvents();
+      const recovery = await fixture.client.runChat(scriptedOpenCodeRunRequest({
+        chatId,
+        command: 'SCRIPTED_OPENCODE_QUESTION_SKIPPED_RECOVERY_PROMPT',
+        permissionMode: 'manualBypass',
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: recovery.turnId,
+        marker: reply,
+        afterIndex: recoveryCursor,
+      });
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'ask-user-question-tool-use')).toHaveLength(1);
+      expect(messagesOfType(transcript.messages, 'unknown-tool-use')).toEqual([]);
+      expect(messagesOfType(transcript.messages, 'permission-resolved')).toEqual([
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+          allowed: false,
+        }),
+      ]);
       expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(2);
       testEnvironment.model.assertSettled();
     }, withScriptedOpenCode());

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -799,6 +799,100 @@ describeOnLinux('scripted OpenCode permissions', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
+  test('surfaces a nested task blocker through its exact ancestor operation', async () => {
+    environment?.dispose();
+    environment = startScriptedOpenCodeTestEnvironment({
+      nestedTaskAgent: true,
+      subagentDepth: 2,
+    });
+    const testEnvironment = requireEnvironment();
+    const grandchildReply = 'SCRIPTED_OPENCODE_PERMISSION_TASK_GRANDCHILD_REPLY';
+    const childReply = 'SCRIPTED_OPENCODE_PERMISSION_TASK_NESTED_CHILD_REPLY';
+    const finalReply = 'SCRIPTED_OPENCODE_PERMISSION_TASK_NESTED_PARENT_REPLY';
+    const repeatedCommand = 'printf %s SCRIPTED_OPENCODE_PERMISSION_TASK_NESTED_COMMAND';
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_nested_parent_task',
+      'task',
+      {
+        subagent_type: 'scripted-nested',
+        description: 'Start nested child',
+        prompt: 'Start another scripted nested task and return only the child marker.',
+      },
+    )]);
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_nested_child_task',
+      'task',
+      {
+        subagent_type: 'scripted-nested',
+        description: 'Exercise nested blocker',
+        prompt: 'Run the repeated command, then return only the grandchild marker.',
+      },
+    )]);
+    testEnvironment.model.scriptTurn([
+      chatCompletionsToolUse('call_nested_bash_1', 'bash', { command: repeatedCommand }),
+      chatCompletionsToolUse('call_nested_bash_2', 'bash', { command: repeatedCommand }),
+      chatCompletionsToolUse('call_nested_bash_3', 'bash', { command: repeatedCommand }),
+    ]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(grandchildReply)]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(childReply)]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(finalReply)]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-task-nested-permission', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_PERMISSION_TASK_NESTED_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+      const permission = await fixture.client.waitForTransientPermission(
+        chatId,
+        (row) => row.message.type === 'permission-request'
+          && row.message.requestedTool.type === 'request-permissions-tool-use'
+          && row.message.requestedTool.reason === 'DoomLoop',
+        { afterIndex: cursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
+      );
+      if (permission.message.type !== 'permission-request') {
+        throw new Error('OpenCode nested task permission request was not found.');
+      }
+      const decision = await fixture.client.sendPermissionDecision({
+        clientRequestId: '00000000-0000-4000-8000-000000000731',
+        chatId,
+        permissionOccurrenceId: permission.message.permissionOccurrenceId,
+        allow: true,
+        alwaysAllow: false,
+      });
+      expect(decision.status).toBe('accepted');
+
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: finalReply,
+        afterIndex: cursor,
+      });
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'task-tool-use')).toHaveLength(1);
+      expect(messagesOfType(transcript.messages, 'bash-tool-use')).toEqual([]);
+      expect(JSON.stringify(transcript.messages)).toContain(childReply);
+      expect(JSON.stringify(transcript.messages)).not.toContain(grandchildReply);
+      expect(messagesOfType(transcript.messages, 'permission-resolved')).toEqual([
+        expect.objectContaining({
+          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+          allowed: true,
+        }),
+      ]);
+      const serverLogs = fixture.diagnostics().processRuns.flatMap((run) => run.serverLogs);
+      expect(serverLogs.filter((line) => (
+        line.includes('Ignoring an OpenCode event without an operation identity')
+      ))).toHaveLength(1);
+      expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(6);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('auto-replies once in manualBypass without emitting a user permission row', async () => {
     const testEnvironment = requireEnvironment();
     const toolMarker = marker('MANUAL_BYPASS_OUTPUT');

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -343,6 +343,7 @@ describeOnLinux('scripted OpenCode permissions', () => {
       if (permission.message.type !== 'permission-request') {
         throw new Error('Interrupted OpenCode question request was not found.');
       }
+      const permissionOccurrenceId = permission.message.permissionOccurrenceId;
 
       const stopCursor = fixture.client.markEvents();
       expect(await fixture.client.stopChat({
@@ -362,7 +363,7 @@ describeOnLinux('scripted OpenCode permissions', () => {
           && event.chatId === chatId
           && event.messages.some((entry) => entry.message.type === 'permission-cancelled'
             && entry.message.permissionOccurrenceId
-              === permission.message.permissionOccurrenceId),
+              === permissionOccurrenceId),
         'OpenCode question cancellation',
         { afterIndex: stopCursor, timeoutMs: LIVE_TURN_TIMEOUT_MS },
       );
@@ -370,7 +371,7 @@ describeOnLinux('scripted OpenCode permissions', () => {
       const stopped = await fixture.client.getMessages(chatId);
       expect(messagesOfType(stopped.messages, 'permission-cancelled')).toEqual([
         expect.objectContaining({
-          permissionOccurrenceId: permission.message.permissionOccurrenceId,
+          permissionOccurrenceId,
         }),
       ]);
       expect(messagesOfType(stopped.messages, 'permission-resolved')).toEqual([]);

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -675,6 +675,53 @@ describeOnLinux('scripted OpenCode permissions', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
+  test('rejects a partially unrenderable question request instead of shifting answers', async () => {
+    const testEnvironment = requireEnvironment();
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse(
+      'call_question_gap',
+      'question',
+      {
+        questions: [
+          {
+            header: 'Hidden',
+            question: '',
+            options: [{ label: 'Wrong answer', description: 'Must not receive a later answer.' }],
+          },
+          {
+            header: 'Visible',
+            question: 'SCRIPTED_OPENCODE_PERMISSION_QUESTION_GAP_VISIBLE',
+            options: [
+              { label: 'Yes', description: 'Choose yes.' },
+              { label: 'No', description: 'Choose no.' },
+            ],
+          },
+        ],
+      },
+    )]);
+    const requestCursor = testEnvironment.model.markRequests();
+
+    await withIntegrationFixture('opencode-question-gap', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: 'SCRIPTED_OPENCODE_PERMISSION_QUESTION_GAP_PROMPT',
+        permissionMode: 'bypassPermissions',
+      }));
+
+      const terminal = await fixture.client.waitForTurnTerminal(chatId, turn.turnId, {
+        afterIndex: cursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      expect(terminal.type).toBe('agent-run-finished');
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'permission-request')).toEqual([]);
+      expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(1);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('surfaces a task child blocker without exposing its transcript', async () => {
     const testEnvironment = requireEnvironment();
     const childReply = marker('TASK_CHILD_REPLY');

--- a/integration-tests/tests/server/opencode-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-permissions.test.ts
@@ -219,22 +219,38 @@ describeOnLinux('scripted OpenCode permissions', () => {
       expect(permission.message.permissionOccurrenceId).not.toBe('call_question_answered');
       expect(permission.message.requestedTool.questions).toEqual([
         {
-          id: 'Which mode?',
+          id: 'question-1',
           prompt: 'Which mode?',
           header: 'Mode',
           options: [
-            { id: 'Fast', label: 'Fast', description: 'Complete quickly.' },
-            { id: 'Careful', label: 'Careful', description: 'Check boundaries.' },
+            {
+              id: 'question-1-option-1',
+              label: 'Fast',
+              description: 'Complete quickly.',
+            },
+            {
+              id: 'question-1-option-2',
+              label: 'Careful',
+              description: 'Check boundaries.',
+            },
           ],
           allowMultiple: false,
         },
         {
-          id: 'Which checks?',
+          id: 'question-2',
           prompt: 'Which checks?',
           header: 'Checks',
           options: [
-            { id: 'Unit', label: 'Unit', description: 'Run unit tests.' },
-            { id: 'Integration', label: 'Integration', description: 'Run integration tests.' },
+            {
+              id: 'question-2-option-1',
+              label: 'Unit',
+              description: 'Run unit tests.',
+            },
+            {
+              id: 'question-2-option-2',
+              label: 'Integration',
+              description: 'Run integration tests.',
+            },
           ],
           allowMultiple: true,
         },
@@ -250,8 +266,11 @@ describeOnLinux('scripted OpenCode permissions', () => {
           type: 'ask-user-question-response',
           outcome: 'answered',
           answers: [
-            { questionId: 'Which mode?', selectedOptionIds: ['Careful'] },
-            { questionId: 'Which checks?', selectedOptionIds: ['Unit', 'Integration'] },
+            { questionId: 'question-1', selectedOptionIds: ['question-1-option-2'] },
+            {
+              questionId: 'question-2',
+              selectedOptionIds: ['question-2-option-1', 'question-2-option-2'],
+            },
           ],
         },
       });

--- a/server-agents/opencode/src/agents/opencode/__tests__/history-loader.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/history-loader.test.js
@@ -283,7 +283,7 @@ describe('OpenCode history loader', () => {
     expect(messages[0].content).toBe('real prompt');
   });
 
-  it('restores provider failures without turning an abort into an error row', async () => {
+  it('restores terminal tools from aborted assistants without turning an abort into an error row', async () => {
     const getClient = mock(() => Promise.resolve({
       session: {
         messages: mock(() => Promise.resolve({
@@ -320,11 +320,62 @@ describe('OpenCode history loader', () => {
 
     const messages = await loadOpenCodeChatMessages('session-1', getClient);
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(4);
     expect(messages[0]).toBeInstanceOf(AssistantMessage);
     expect(messages[0].content).toBe('partial reply');
     expect(messages[1]).toBeInstanceOf(ErrorMessage);
     expect(messages[1].content).toBe('invalid key');
+    expect(messages[2]).toBeInstanceOf(BashToolUseMessage);
+    expect(messages[2].command).toBe('sleep 30');
+    expect(messages[3]).toBeInstanceOf(ToolResultMessage);
+    expect(messages[3].toolId).toBe('interrupted-tool');
+    expect(JSON.stringify(messages[3].content)).toContain('User aborted the command');
+  });
+
+  it('omits pending and running tools from native history', async () => {
+    const getClient = mock(() => Promise.resolve({
+      session: {
+        messages: mock(() => Promise.resolve({
+          data: [{
+            info: {
+              role: 'assistant',
+              time: { created: '2026-07-04T00:00:00.000Z' },
+            },
+            parts: [
+              {
+                type: 'tool',
+                tool: 'bash',
+                callID: 'pending-tool',
+                state: { status: 'pending', input: { command: 'pending command' } },
+              },
+              {
+                type: 'tool',
+                tool: 'bash',
+                callID: 'running-tool',
+                state: { status: 'running', input: { command: 'running command' } },
+              },
+              {
+                type: 'tool',
+                tool: 'bash',
+                callID: 'completed-tool',
+                state: {
+                  status: 'completed',
+                  input: { command: 'completed command' },
+                  output: 'completed output',
+                },
+              },
+            ],
+          }],
+        })),
+      },
+    }));
+
+    const messages = await loadOpenCodeChatMessages('session-1', getClient);
+
+    expect(messages.map((message) => [message.type, message.toolId])).toEqual([
+      ['bash-tool-use', 'completed-tool'],
+      ['tool-result', 'completed-tool'],
+    ]);
   });
 
   it('restores a failed compaction error without exposing its internal summary', async () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routes.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routes.test.js
@@ -85,6 +85,28 @@ function compactionPartEvent(part = {}) {
   };
 }
 
+function taskPartEvent(childSessionId, part = {}) {
+  return {
+    id: 'event-task-part',
+    type: 'message.part.updated',
+    properties: {
+      sessionID: 'session-1',
+      part: {
+        id: 'part-task',
+        messageID: 'assistant-task',
+        type: 'tool',
+        tool: 'task',
+        state: {
+          status: 'running',
+          input: {},
+          metadata: { sessionId: childSessionId },
+        },
+        ...part,
+      },
+    },
+  };
+}
+
 describe('OpenCodeOperationRoutes', () => {
   it('does not let a delayed prompt binding replace a newer source route', () => {
     const { routes } = createFixture();
@@ -394,6 +416,55 @@ describe('OpenCodeOperationRoutes', () => {
         part: { id: 'steering-a', messageID: 'user-steering-a' },
       },
     })).toBeNull();
+  });
+
+  it('binds only a routed task part child session without a session fallback', () => {
+    const { logger, routes } = createFixture();
+    const parent = register(routes, {
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      runId: 'run-a',
+    });
+
+    expect(routes.resolveTaskChild('child-1')).toBeNull();
+    expect(routes.bindTaskChildSession(parent.route, taskPartEvent('child-1', {
+      tool: 'bash',
+    }))).toBe(false);
+    expect(routes.bindTaskChildSession(parent.route, taskPartEvent('child-1', {
+      state: { status: 'running', input: {}, metadata: {} },
+    }))).toBe(false);
+    expect(routes.bindTaskChildSession(parent.route, taskPartEvent('session-1'))).toBe(false);
+    expect(routes.bindTaskChildSession(parent.route, taskPartEvent('child-1'))).toBe(true);
+    expect(routes.resolveTaskChild('child-1')).toBe(parent.route);
+    expect(routes.resolveTaskChild('unknown-child')).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('refuses child-session collisions and retires affiliations with the route', () => {
+    const { logger, routes } = createFixture();
+    const first = register(routes, {
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      runId: 'run-a',
+    });
+    const second = register(routes, {
+      sessionId: 'session-2',
+      chatId: 'chat-2',
+      runId: 'run-b',
+    });
+
+    expect(routes.bindTaskChildSession(first.route, taskPartEvent('child-shared'))).toBe(true);
+    expect(routes.bindTaskChildSession(second.route, taskPartEvent('child-shared'))).toBe(false);
+    expect(routes.bindTaskChildSession(first.route, taskPartEvent('session-2'))).toBe(false);
+    expect(routes.resolveTaskChild('child-shared')).toBe(first.route);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+
+    routes.unregister(first.route);
+
+    expect(routes.resolveTaskChild('child-shared')).toBeNull();
+    expect(routes.bindTaskChildSession(second.route, taskPartEvent('child-shared'))).toBe(true);
+    routes.clear();
+    expect(routes.resolveTaskChild('child-shared')).toBeNull();
   });
 
   it('recognizes only provider-marked automatic compaction control parts', () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routes.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routes.test.js
@@ -107,6 +107,17 @@ function taskPartEvent(childSessionId, part = {}) {
   };
 }
 
+function taskChildCreatedEvent(childSessionId, parentSessionId) {
+  return {
+    id: `event-created-${childSessionId}`,
+    type: 'session.created',
+    properties: {
+      sessionID: childSessionId,
+      info: { id: childSessionId, parentID: parentSessionId },
+    },
+  };
+}
+
 describe('OpenCodeOperationRoutes', () => {
   it('does not let a delayed prompt binding replace a newer source route', () => {
     const { routes } = createFixture();
@@ -465,6 +476,32 @@ describe('OpenCodeOperationRoutes', () => {
     expect(routes.bindTaskChildSession(second.route, taskPartEvent('child-shared'))).toBe(true);
     routes.clear();
     expect(routes.resolveTaskChild('child-shared')).toBeNull();
+  });
+
+  it('affiliates task descendants only through an already bound child parent', () => {
+    const { logger, routes } = createFixture();
+    const parent = register(routes, {
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      runId: 'run-a',
+    });
+
+    expect(routes.bindTaskDescendantSession(taskChildCreatedEvent(
+      'unaffiliated-child',
+      'session-1',
+    ))).toBeNull();
+    expect(routes.bindTaskChildSession(parent.route, taskPartEvent('child-1'))).toBe(true);
+    expect(routes.bindTaskDescendantSession(taskChildCreatedEvent(
+      'grandchild-1',
+      'child-1',
+    ))).toBe(parent.route);
+    expect(routes.bindTaskDescendantSession(taskChildCreatedEvent(
+      'great-grandchild-1',
+      'grandchild-1',
+    ))).toBe(parent.route);
+    expect(routes.resolveTaskChild('grandchild-1')).toBe(parent.route);
+    expect(routes.resolveTaskChild('great-grandchild-1')).toBe(parent.route);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('recognizes only provider-marked automatic compaction control parts', () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -497,16 +497,24 @@ describe('OpenCode operation routing', () => {
       toolId: 'call-question',
       questions: [
         {
-          id: 'Which mode?',
+          id: 'question-1',
           prompt: 'Which mode?',
           allowMultiple: false,
           options: [
-            { id: 'Fast', label: 'Fast', description: 'Complete quickly.' },
-            { id: 'Careful', label: 'Careful', description: 'Check boundaries.' },
+            {
+              id: 'question-1-option-1',
+              label: 'Fast',
+              description: 'Complete quickly.',
+            },
+            {
+              id: 'question-1-option-2',
+              label: 'Careful',
+              description: 'Check boundaries.',
+            },
           ],
         },
         {
-          id: 'Which checks?',
+          id: 'question-2',
           prompt: 'Which checks?',
           allowMultiple: true,
         },
@@ -519,8 +527,11 @@ describe('OpenCode operation routing', () => {
         type: 'ask-user-question-response',
         outcome: 'answered',
         answers: [
-          { questionId: 'Which mode?', selectedOptionIds: ['Careful'] },
-          { questionId: 'Which checks?', selectedOptionIds: ['Unit', 'Integration'] },
+          { questionId: 'question-1', selectedOptionIds: ['question-1-option-2'] },
+          {
+            questionId: 'question-2',
+            selectedOptionIds: ['question-2-option-1', 'question-2-option-2'],
+          },
         ],
       },
     };

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -78,10 +78,13 @@ function createRuntime(sessionIds, options = {}) {
   });
   const create = mock(() => Promise.resolve({ data: { id: sessionIds.shift() } }));
   const permissionReply = mock(() => Promise.resolve({}));
+  const questionReply = mock(() => Promise.resolve({}));
+  const questionReject = mock(() => Promise.resolve({}));
   const runtime = new OpenCodeRuntime({
     createInstance: mock(() => Promise.resolve({
       client: {
         permission: { reply: permissionReply },
+        question: { reply: questionReply, reject: questionReject },
         global: { event: mock(() => Promise.resolve({ stream: eventStream.stream() })) },
         session: {
           create,
@@ -94,7 +97,15 @@ function createRuntime(sessionIds, options = {}) {
     })),
     ...options,
   });
-  return { create, eventStream, permissionReply, promptAsync, runtime };
+  return {
+    create,
+    eventStream,
+    permissionReply,
+    promptAsync,
+    questionReject,
+    questionReply,
+    runtime,
+  };
 }
 
 function operation(runId, events) {
@@ -357,6 +368,250 @@ describe('OpenCode operation routing', () => {
     ]]);
     expect(JSON.stringify(warnings)).not.toContain('sensitive-native-request-id');
     expect(JSON.stringify(warnings)).not.toContain('sensitive-command-must-not-be-logged');
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('logs and drops a question without an operation identity', async () => {
+    const warnings = [];
+    const { eventStream, runtime } = createRuntime(['session-1'], {
+      logger: {
+        debug() {},
+        info() {},
+        warn(...args) { warnings.push(args); },
+        error() {},
+      },
+    });
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: operation('run-a', events),
+    });
+
+    eventStream.push({
+      id: 'unowned-question-event',
+      type: 'question.asked',
+      properties: {
+        id: 'sensitive-native-question-id',
+        sessionID: 'session-1',
+        questions: [{
+          header: 'Private',
+          question: 'sensitive-question-must-not-be-logged',
+          options: [],
+        }],
+        tool: {
+          callID: 'sensitive-tool-call-id',
+          messageID: 'unowned-provider-message',
+        },
+      },
+    });
+    await waitFor(() => warnings.length === 1);
+
+    expect(events).toEqual([]);
+    expect(warnings).toEqual([[
+      'Ignoring an OpenCode event without an operation identity',
+      expect.objectContaining({
+        eventId: 'unowned-question-event',
+        eventType: 'question.asked',
+        sessionId: 'session-1',
+      }),
+    ]]);
+    expect(JSON.stringify(warnings)).not.toContain('sensitive-native-question-id');
+    expect(JSON.stringify(warnings)).not.toContain('sensitive-tool-call-id');
+    expect(JSON.stringify(warnings)).not.toContain('sensitive-question-must-not-be-logged');
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('routes an OpenCode question and retains its capability after a failed reply', async () => {
+    const {
+      eventStream,
+      promptAsync,
+      questionReject,
+      questionReply,
+      runtime,
+    } = createRuntime(['session-1']);
+    questionReply
+      .mockRejectedValueOnce(new Error('question reply failed'))
+      .mockResolvedValueOnce({});
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Preparing a question.',
+    });
+    eventStream.push({
+      id: 'event-question-asked',
+      type: 'question.asked',
+      properties: {
+        id: 'provider-question-request',
+        sessionID: 'session-1',
+        questions: [
+          {
+            header: 'Mode',
+            question: 'Which mode?',
+            options: [
+              { label: 'Fast', description: 'Complete quickly.' },
+              { label: 'Careful', description: 'Check boundaries.' },
+            ],
+          },
+          {
+            header: 'Checks',
+            question: 'Which checks?',
+            multiple: true,
+            options: [
+              { label: 'Unit', description: 'Run unit tests.' },
+              { label: 'Integration', description: 'Run integration tests.' },
+            ],
+          },
+        ],
+        tool: { callID: 'call-question', messageID: 'assistant-a' },
+      },
+    });
+    await waitFor(() => events.some((event) => event.type === 'permission'));
+
+    const request = events.find((event) => event.type === 'permission');
+    expect(request.lifecycle.permissionOccurrenceId).toMatch(PERMISSION_OCCURRENCE_UUID);
+    expect(request.lifecycle.permissionOccurrenceId).not.toBe('provider-question-request');
+    expect(request.lifecycle.requestedTool).toMatchObject({
+      type: 'ask-user-question-tool-use',
+      toolId: 'call-question',
+      questions: [
+        {
+          id: 'Which mode?',
+          prompt: 'Which mode?',
+          allowMultiple: false,
+          options: [
+            { id: 'Fast', label: 'Fast', description: 'Complete quickly.' },
+            { id: 'Careful', label: 'Careful', description: 'Check boundaries.' },
+          ],
+        },
+        {
+          id: 'Which checks?',
+          prompt: 'Which checks?',
+          allowMultiple: true,
+        },
+      ],
+    });
+
+    const decision = {
+      allow: true,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [
+          { questionId: 'Which mode?', selectedOptionIds: ['Careful'] },
+          { questionId: 'Which checks?', selectedOptionIds: ['Unit', 'Integration'] },
+        ],
+      },
+    };
+    await expect(request.decision.respond(decision)).rejects.toThrow('question reply failed');
+    await expect(request.decision.respond(decision)).resolves.toBeUndefined();
+    expect(questionReply).toHaveBeenCalledTimes(2);
+    expect(questionReply.mock.calls[1][0]).toMatchObject({
+      requestID: 'provider-question-request',
+      answers: [['Careful'], ['Unit', 'Integration']],
+    });
+    expect(questionReject).not.toHaveBeenCalled();
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('rejects an OpenCode question when the generic question response is skipped', async () => {
+    const {
+      eventStream,
+      promptAsync,
+      questionReject,
+      questionReply,
+      runtime,
+    } = createRuntime(['session-1']);
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Preparing a question.',
+    });
+    eventStream.push({
+      id: 'event-question-asked',
+      type: 'question.asked',
+      properties: {
+        id: 'provider-question-request',
+        sessionID: 'session-1',
+        questions: [{
+          header: 'Continue',
+          question: 'Continue?',
+          options: [{ label: 'Yes', description: 'Continue.' }],
+        }],
+        tool: { callID: 'call-question', messageID: 'assistant-a' },
+      },
+    });
+    await waitFor(() => events.some((event) => event.type === 'permission'));
+
+    const request = events.find((event) => event.type === 'permission');
+    await request.decision.respond({
+      allow: false,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'skipped',
+        reason: 'User skipped question',
+      },
+    });
+    expect(questionReject).toHaveBeenCalledTimes(1);
+    expect(questionReject.mock.calls[0][0]).toMatchObject({
+      requestID: 'provider-question-request',
+    });
+    expect(questionReply).not.toHaveBeenCalled();
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
     eventStream.close();
     await runtime.shutdown();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -182,6 +182,33 @@ function pushAssistant(eventStream, {
   });
 }
 
+function pushTaskChild(eventStream, {
+  childSessionId,
+  eventId,
+  messageId,
+  parentSessionId,
+}) {
+  eventStream.push({
+    id: eventId,
+    type: 'message.part.updated',
+    properties: {
+      sessionID: parentSessionId,
+      part: {
+        id: `part-task-${childSessionId}`,
+        messageID: messageId,
+        type: 'tool',
+        tool: 'task',
+        callID: `call-task-${childSessionId}`,
+        state: {
+          status: 'running',
+          input: { description: 'Run a deterministic child task' },
+          metadata: { sessionId: childSessionId },
+        },
+      },
+    },
+  });
+}
+
 function pushTerminal(eventStream, {
   eventId,
   messageId,
@@ -672,6 +699,177 @@ describe('OpenCode operation routing', () => {
       requestID: 'provider-question-empty',
     });
     expect(events.filter((event) => event.type === 'permission')).toEqual([]);
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('routes a task child permission through its exact parent operation and hides child output', async () => {
+    const diagnostics = diagnosticLogger();
+    const {
+      eventStream,
+      permissionReply,
+      promptAsync,
+      runtime,
+    } = createRuntime(['session-1'], { logger: diagnostics.logger });
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Starting a child task.',
+    });
+    pushTaskChild(eventStream, {
+      childSessionId: 'session-child',
+      eventId: 'event-04',
+      messageId: 'assistant-a',
+      parentSessionId: 'session-1',
+    });
+    eventStream.push({
+      id: 'event-child-user',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-child',
+        info: { id: 'child-user', role: 'user' },
+      },
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 6,
+      messageId: 'child-assistant',
+      parentId: 'child-user',
+      sessionId: 'session-child',
+      text: 'CHILD_OUTPUT_MUST_STAY_HIDDEN',
+    });
+    eventStream.push({
+      id: 'event-child-permission',
+      type: 'permission.asked',
+      properties: {
+        id: 'provider-child-permission',
+        sessionID: 'session-child',
+        permission: 'doom_loop',
+        patterns: ['bash'],
+        metadata: { tool: 'bash', input: { command: 'true' } },
+        tool: { callID: 'call-child-bash', messageID: 'child-assistant' },
+      },
+    });
+
+    await waitFor(() => events.some((event) => (
+      event.type === 'permission' && event.lifecycle.kind === 'requested'
+    )));
+    const requested = events.find((event) => (
+      event.type === 'permission' && event.lifecycle.kind === 'requested'
+    ));
+    expect(requested.runId).toBe('run-a');
+    await requested.decision.respond({ allow: true, alwaysAllow: false });
+    expect(permissionReply.mock.calls[0][0]).toMatchObject({
+      requestID: 'provider-child-permission',
+      reply: 'once',
+    });
+    expect(JSON.stringify(events)).not.toContain('CHILD_OUTPUT_MUST_STAY_HIDDEN');
+    expect(diagnostics.warnings).toEqual([]);
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('routes a task child question through its exact parent operation', async () => {
+    const {
+      eventStream,
+      promptAsync,
+      questionReply,
+      runtime,
+    } = createRuntime(['session-1']);
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Starting a child task.',
+    });
+    pushTaskChild(eventStream, {
+      childSessionId: 'session-child',
+      eventId: 'event-04',
+      messageId: 'assistant-a',
+      parentSessionId: 'session-1',
+    });
+    eventStream.push({
+      id: 'event-child-question',
+      type: 'question.asked',
+      properties: {
+        id: 'provider-child-question',
+        sessionID: 'session-child',
+        questions: [{
+          header: 'Choice',
+          question: 'Choose one',
+          options: [{ label: 'Alpha', description: 'First choice' }],
+        }],
+        tool: { callID: 'call-child-question', messageID: 'child-assistant' },
+      },
+    });
+
+    await waitFor(() => events.some((event) => (
+      event.type === 'permission' && event.lifecycle.kind === 'requested'
+    )));
+    const requested = events.find((event) => (
+      event.type === 'permission' && event.lifecycle.kind === 'requested'
+    ));
+    expect(requested.lifecycle.requestedTool.type).toBe('ask-user-question-tool-use');
+    await requested.decision.respond({
+      allow: true,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [{ questionId: 'question-1', selectedOptionIds: ['question-1-option-1'] }],
+      },
+    });
+    expect(questionReply.mock.calls[0][0]).toMatchObject({
+      requestID: 'provider-child-question',
+      answers: [['Alpha']],
+    });
 
     pushTerminal(eventStream, {
       eventId: 'event-terminal',

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -627,6 +627,63 @@ describe('OpenCode operation routing', () => {
     await runtime.shutdown();
   });
 
+  it('rejects an owned question that has no renderable prompts', async () => {
+    const {
+      eventStream,
+      promptAsync,
+      questionReject,
+      runtime,
+    } = createRuntime(['session-1']);
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Preparing a question.',
+    });
+    eventStream.push({
+      id: 'event-question-empty',
+      type: 'question.asked',
+      properties: {
+        id: 'provider-question-empty',
+        sessionID: 'session-1',
+        questions: [],
+        tool: { callID: 'call-question-empty', messageID: 'assistant-a' },
+      },
+    });
+
+    await waitFor(() => questionReject.mock.calls.length === 1);
+    expect(questionReject.mock.calls[0][0]).toMatchObject({
+      requestID: 'provider-question-empty',
+    });
+    expect(events.filter((event) => event.type === 'permission')).toEqual([]);
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
   it('[TLV5-L07.03-OPENCODE-UNIT-01] publishes late named rows and permissions through the operation that produced them', async () => {
     const { eventStream, permissionReply, promptAsync, runtime } = createRuntime(['session-1']);
     const firstEvents = [];

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -255,6 +255,16 @@ function diagnosticLogger() {
   };
 }
 
+function missingOpenCodeRequestResult() {
+  return {
+    error: {
+      name: 'NotFoundError',
+      data: { message: 'Question request not found' },
+    },
+    response: { status: 404 },
+  };
+}
+
 function compactionWarningCodes(warnings) {
   return warnings
     .filter(([message]) => message === 'Dropping an OpenCode compaction part')
@@ -707,6 +717,130 @@ describe('OpenCode operation routing', () => {
       sessionId: 'session-1',
     });
     await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('treats a missing unrenderable-question request as already settled', async () => {
+    const diagnostics = diagnosticLogger();
+    const {
+      eventStream,
+      promptAsync,
+      questionReject,
+      runtime,
+    } = createRuntime(['session-1'], { logger: diagnostics.logger });
+    questionReject.mockResolvedValueOnce(missingOpenCodeRequestResult());
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Preparing a question.',
+    });
+    eventStream.push({
+      id: 'event-question-missing',
+      type: 'question.asked',
+      properties: {
+        id: 'provider-question-missing',
+        sessionID: 'session-1',
+        questions: [],
+        tool: { callID: 'call-question-missing', messageID: 'assistant-a' },
+      },
+    });
+
+    await waitFor(() => (
+      diagnostics.debug.some(([message]) => (
+        message === 'Ignoring an OpenCode rejection for a missing question request'
+      ))
+      || events.some((event) => event.type === 'run-ended')
+    ));
+    expect(events.some((event) => event.type === 'run-ended')).toBe(false);
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    expect(events.at(-1)).toMatchObject({ type: 'run-ended', outcome: 'finished' });
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('treats a missing manual-bypass permission request as already settled', async () => {
+    const diagnostics = diagnosticLogger();
+    const {
+      eventStream,
+      permissionReply,
+      promptAsync,
+      runtime,
+    } = createRuntime(['session-1'], { logger: diagnostics.logger });
+    permissionReply.mockResolvedValueOnce(missingOpenCodeRequestResult());
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'manualBypass',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-01',
+      messageId: 'user-a',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushAssistant(eventStream, {
+      eventNumber: 2,
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+      text: 'Preparing a permission request.',
+    });
+    eventStream.push({
+      id: 'event-permission-missing',
+      type: 'permission.asked',
+      properties: {
+        sessionID: 'session-1',
+        requestID: 'provider-permission-missing',
+        permission: 'bash',
+        tool: { callID: 'call-permission-missing', messageID: 'assistant-a' },
+      },
+    });
+
+    await waitFor(() => (
+      diagnostics.debug.some(([message]) => (
+        message === 'Ignoring an OpenCode reply for a missing permission request'
+      ))
+      || events.some((event) => event.type === 'run-ended')
+    ));
+    expect(events.some((event) => event.type === 'run-ended')).toBe(false);
+
+    pushTerminal(eventStream, {
+      eventId: 'event-terminal',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      sessionId: 'session-1',
+    });
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+    expect(events.at(-1)).toMatchObject({ type: 'run-ended', outcome: 'finished' });
     eventStream.close();
     await runtime.shutdown();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/permissions.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/permissions.test.js
@@ -276,14 +276,14 @@ describe('convertOpencodePermissionTool', () => {
 });
 
 describe('mapPermissionMode', () => {
-  it('maps bypassPermissions to allow all OpenCode permission keys', () => {
+  it('maps bypassPermissions across all OpenCode permission keys', () => {
     const rules = mapPermissionMode('bypassPermissions');
     expect(rules).toHaveLength(OPENCODE_PERMISSION_KEYS.length);
     expect(rules).toEqual(
       OPENCODE_PERMISSION_KEYS.map((permission) => ({
         permission,
         pattern: '*',
-        action: 'allow',
+        action: permission === 'plan_enter' || permission === 'plan_exit' ? 'deny' : 'allow',
       })),
     );
   });
@@ -294,6 +294,20 @@ describe('mapPermissionMode', () => {
       permission: 'external_directory',
       pattern: '*',
       action: 'allow',
+    });
+  });
+
+  it('denies native plan transitions in bypassPermissions', () => {
+    const rules = mapPermissionMode('bypassPermissions');
+    expect(rules).toContainEqual({
+      permission: 'plan_enter',
+      pattern: '*',
+      action: 'deny',
+    });
+    expect(rules).toContainEqual({
+      permission: 'plan_exit',
+      pattern: '*',
+      action: 'deny',
     });
   });
 
@@ -360,7 +374,7 @@ describe('OpenCodeRuntime permissions', () => {
       permission: OPENCODE_PERMISSION_KEYS.map((permission) => ({
         permission,
         pattern: '*',
-        action: 'allow',
+        action: permission === 'plan_enter' || permission === 'plan_exit' ? 'deny' : 'allow',
       })),
     });
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/questions.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/questions.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  extractOpenCodeQuestionRequest,
+  mapOpenCodeQuestionDecision,
+} from '../questions.js';
+
+const QUESTIONS = [
+  {
+    id: 'Which mode?',
+    prompt: 'Which mode?',
+    options: [
+      { id: 'Fast', label: 'Fast' },
+      { id: 'Careful', label: 'Careful' },
+    ],
+    allowMultiple: false,
+  },
+  {
+    id: 'Which checks?',
+    prompt: 'Which checks?',
+    options: [
+      { id: 'Unit', label: 'Unit tests' },
+      { id: 'Integration', label: 'Integration tests' },
+    ],
+    allowMultiple: true,
+  },
+];
+
+describe('OpenCode questions', () => {
+  it('extracts the routed provider request fields', () => {
+    expect(extractOpenCodeQuestionRequest({
+      type: 'question.asked',
+      properties: {
+        id: 'provider-request',
+        sessionID: 'session-a',
+        questions: [{ question: 'Which mode?', header: 'Mode', options: [] }],
+        tool: { callID: 'call-question', messageID: 'assistant-a' },
+      },
+    })).toEqual({
+      requestId: 'provider-request',
+      toolCallId: 'call-question',
+      questions: [{ question: 'Which mode?', header: 'Mode', options: [] }],
+    });
+  });
+
+  it.each([
+    { type: 'message.updated', properties: {} },
+    { type: 'question.asked', properties: { questions: [], tool: { callID: 'call' } } },
+    { type: 'question.asked', properties: { id: 'request', questions: {}, tool: { callID: 'call' } } },
+    { type: 'question.asked', properties: { id: 'request', questions: [], tool: {} } },
+  ])('rejects malformed question events', (event) => {
+    expect(extractOpenCodeQuestionRequest(event)).toBeNull();
+  });
+
+  it('maps selected option identities to ordered OpenCode answer labels', () => {
+    expect(mapOpenCodeQuestionDecision(QUESTIONS, {
+      allow: true,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [
+          { questionId: 'Which checks?', selectedOptionIds: ['Unit', 'Integration'] },
+          { questionId: 'Which mode?', selectedOptionIds: ['Careful'] },
+        ],
+      },
+    })).toEqual({
+      kind: 'reply',
+      answers: [['Careful'], ['Unit tests', 'Integration tests']],
+    });
+  });
+
+  it.each([
+    { allow: false },
+    {
+      allow: true,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'skipped',
+        reason: 'User skipped question',
+      },
+    },
+  ])('maps denial and Skip to rejection', (decision) => {
+    expect(mapOpenCodeQuestionDecision(QUESTIONS, decision)).toEqual({ kind: 'reject' });
+  });
+
+  it('refuses an allow decision without canonical question answers', () => {
+    expect(() => mapOpenCodeQuestionDecision(QUESTIONS, { allow: true }))
+      .toThrow('missing an answered response');
+  });
+});

--- a/server-agents/opencode/src/agents/opencode/__tests__/questions.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/questions.test.js
@@ -89,4 +89,24 @@ describe('OpenCode questions', () => {
     expect(() => mapOpenCodeQuestionDecision(QUESTIONS, { allow: true }))
       .toThrow('missing an answered response');
   });
+
+  it.each([
+    {
+      answers: [{ questionId: 'unknown-question', selectedOptionIds: [] }],
+      expected: 'unknown question ID',
+    },
+    {
+      answers: [{ questionId: 'question-1', selectedOptionIds: ['unknown-option'] }],
+      expected: 'unknown option ID',
+    },
+  ])('refuses provider answers containing an $expected', ({ answers, expected }) => {
+    expect(() => mapOpenCodeQuestionDecision(QUESTIONS, {
+      allow: true,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers,
+      },
+    })).toThrow(expected);
+  });
 });

--- a/server-agents/opencode/src/agents/opencode/__tests__/questions.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/questions.test.js
@@ -6,20 +6,20 @@ import {
 
 const QUESTIONS = [
   {
-    id: 'Which mode?',
+    id: 'question-1',
     prompt: 'Which mode?',
     options: [
-      { id: 'Fast', label: 'Fast' },
-      { id: 'Careful', label: 'Careful' },
+      { id: 'question-1-option-1', label: 'Fast' },
+      { id: 'question-1-option-2', label: 'Careful' },
     ],
     allowMultiple: false,
   },
   {
-    id: 'Which checks?',
+    id: 'question-2',
     prompt: 'Which checks?',
     options: [
-      { id: 'Unit', label: 'Unit tests' },
-      { id: 'Integration', label: 'Integration tests' },
+      { id: 'question-2-option-1', label: 'Unit tests' },
+      { id: 'question-2-option-2', label: 'Integration tests' },
     ],
     allowMultiple: true,
   },
@@ -58,8 +58,11 @@ describe('OpenCode questions', () => {
         type: 'ask-user-question-response',
         outcome: 'answered',
         answers: [
-          { questionId: 'Which checks?', selectedOptionIds: ['Unit', 'Integration'] },
-          { questionId: 'Which mode?', selectedOptionIds: ['Careful'] },
+          {
+            questionId: 'question-2',
+            selectedOptionIds: ['question-2-option-1', 'question-2-option-2'],
+          },
+          { questionId: 'question-1', selectedOptionIds: ['question-1-option-2'] },
         ],
       },
     })).toEqual({

--- a/server-agents/opencode/src/agents/opencode/__tests__/tool-use-converter.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/tool-use-converter.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 import { convertOpenCodeToolUse } from '../tool-use-converter.js';
 import {
+  AskUserQuestionToolUseMessage,
   BashToolUseMessage,
   ReadToolUseMessage,
   EditToolUseMessage,
@@ -82,6 +83,54 @@ describe('convertOpenCodeToolUse', () => {
     });
     expect(msg).toBeInstanceOf(ExitPlanModeToolUseMessage);
     expect(msg.plan).toBe('Do X');
+  });
+
+  it('maps question into the generic ask-user-question tool-use type', () => {
+    const msg = convertOpenCodeToolUse(TS, {
+      tool: 'question',
+      callID: 'oc-question',
+      state: {
+        input: {
+          questions: [{
+            header: 'Mode',
+            question: 'Which mode should the task use?',
+            multiple: true,
+            options: [
+              { label: 'Fast', description: 'Complete the task quickly.' },
+              { label: 'Careful', description: 'Check every boundary.' },
+            ],
+          }],
+        },
+      },
+    });
+
+    expect(msg).toBeInstanceOf(AskUserQuestionToolUseMessage);
+    expect(msg).toEqual(new AskUserQuestionToolUseMessage(
+      TS,
+      'oc-question',
+      undefined,
+      [{
+        id: 'Which mode should the task use?',
+        prompt: 'Which mode should the task use?',
+        header: 'Mode',
+        allowMultiple: true,
+        options: [
+          { id: 'Fast', label: 'Fast', description: 'Complete the task quickly.' },
+          { id: 'Careful', label: 'Careful', description: 'Check every boundary.' },
+        ],
+      }],
+    ));
+  });
+
+  it('falls back to Unknown for malformed question input', () => {
+    const msg = convertOpenCodeToolUse(TS, {
+      tool: 'question',
+      callID: 'oc-question-malformed',
+      state: { input: { questions: [{ header: 'Missing prompt', options: [] }] } },
+    });
+
+    expect(msg).toBeInstanceOf(UnknownToolUseMessage);
+    expect(msg.rawName).toBe('question');
   });
 
   it('falls back to Unknown for unrecognized tools', () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/tool-use-converter.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/tool-use-converter.test.js
@@ -1,11 +1,18 @@
 import { describe, it, expect } from 'bun:test';
-import { convertOpenCodeToolUse } from '../tool-use-converter.js';
+import {
+  convertOpenCodeToolUse,
+  OPENCODE_BUILTIN_TOOL_IDS,
+} from '../tool-use-converter.js';
 import {
   AskUserQuestionToolUseMessage,
+  ApplyPatchToolUseMessage,
   BashToolUseMessage,
+  ExecToolUseMessage,
+  ExternalToolUseMessage,
   ReadToolUseMessage,
   EditToolUseMessage,
   WriteToolUseMessage,
+  TaskToolUseMessage,
   TodoWriteToolUseMessage,
   EnterPlanModeToolUseMessage,
   ExitPlanModeToolUseMessage,
@@ -110,16 +117,120 @@ describe('convertOpenCodeToolUse', () => {
       'oc-question',
       undefined,
       [{
-        id: 'Which mode should the task use?',
+        id: 'question-1',
         prompt: 'Which mode should the task use?',
         header: 'Mode',
         allowMultiple: true,
         options: [
-          { id: 'Fast', label: 'Fast', description: 'Complete the task quickly.' },
-          { id: 'Careful', label: 'Careful', description: 'Check every boundary.' },
+          {
+            id: 'question-1-option-1',
+            label: 'Fast',
+            description: 'Complete the task quickly.',
+          },
+          {
+            id: 'question-1-option-2',
+            label: 'Careful',
+            description: 'Check every boundary.',
+          },
         ],
       }],
     ));
+  });
+
+  it('keeps repeated question prompts and option labels independently addressable', () => {
+    const msg = convertOpenCodeToolUse(TS, {
+      tool: 'question',
+      callID: 'oc-question-repeated',
+      state: {
+        input: {
+          questions: [1, 2].map(() => ({
+            header: 'Mode',
+            question: 'Choose a mode',
+            options: [1, 2].map(() => ({
+              label: 'Same label',
+              description: 'A repeated provider label.',
+            })),
+          })),
+        },
+      },
+    });
+
+    expect(msg).toBeInstanceOf(AskUserQuestionToolUseMessage);
+    expect(msg.questions.map((question) => question.id)).toEqual(['question-1', 'question-2']);
+    expect(msg.questions.map((question) => question.options.map((option) => option.id))).toEqual([
+      ['question-1-option-1', 'question-1-option-2'],
+      ['question-2-option-1', 'question-2-option-2'],
+    ]);
+  });
+
+  it('maps every pinned OpenCode built-in to an explicit shared tool type', () => {
+    const cases = [
+      ['invalid', { tool: 'missing_tool', error: 'Tool does not exist.' }, 'external-tool-use'],
+      ['question', {
+        questions: [{
+          header: 'Mode',
+          question: 'Which mode?',
+          options: [{ label: 'Careful', description: 'Check boundaries.' }],
+        }],
+      }, 'ask-user-question-tool-use'],
+      ['bash', { command: 'printf done' }, 'bash-tool-use'],
+      ['read', { filePath: '/repo/input.ts' }, 'read-tool-use'],
+      ['glob', { pattern: '**/*.ts', path: '/repo' }, 'glob-tool-use'],
+      ['grep', { pattern: 'needle', path: '/repo' }, 'grep-tool-use'],
+      ['edit', { filePath: '/repo/input.ts', oldString: 'a', newString: 'b' }, 'edit-tool-use'],
+      ['write', { filePath: '/repo/output.ts', content: 'data' }, 'write-tool-use'],
+      ['task', {
+        subagent_type: 'reviewer',
+        description: 'Review change',
+        prompt: 'Review the implementation.',
+      }, 'task-tool-use'],
+      ['webfetch', { url: 'https://example.test' }, 'web-fetch-tool-use'],
+      ['todowrite', { todos: [{ content: 'Verify behavior', status: 'pending' }] }, 'todo-write-tool-use'],
+      ['websearch', { query: 'OpenCode tools' }, 'web-search-tool-use'],
+      ['skill', { name: 'testing' }, 'external-tool-use'],
+      ['apply_patch', { patchText: '*** Begin Patch\n*** End Patch' }, 'apply-patch-tool-use'],
+      ['execute', { code: 'return tools.example({})' }, 'exec-tool-use'],
+      ['lsp', { operation: 'hover', filePath: '/repo/input.ts', line: 1, character: 1 }, 'external-tool-use'],
+      ['plan_exit', {}, 'exit-plan-mode-tool-use'],
+    ];
+
+    expect(cases.map(([tool]) => tool)).toEqual(OPENCODE_BUILTIN_TOOL_IDS);
+    for (const [tool, input, expectedType] of cases) {
+      const message = convertOpenCodeToolUse(TS, {
+        tool,
+        callID: `call-${tool}`,
+        state: { input },
+      });
+      expect({ tool, type: message.type }).toEqual({ tool, type: expectedType });
+      expect(message).not.toBeInstanceOf(UnknownToolUseMessage);
+    }
+  });
+
+  it('preserves current OpenCode apply_patch, task resume, and execute inputs', () => {
+    const patch = convertOpenCodeToolUse(TS, {
+      tool: 'apply_patch',
+      callID: 'call-patch',
+      state: { input: { patchText: '*** Begin Patch\n*** End Patch' } },
+    });
+    expect(patch).toBeInstanceOf(ApplyPatchToolUseMessage);
+    expect(patch.patch).toBe('*** Begin Patch\n*** End Patch');
+
+    const task = convertOpenCodeToolUse(TS, {
+      tool: 'task',
+      callID: 'call-task',
+      state: { input: { task_id: 'task-42' } },
+    });
+    expect(task).toBeInstanceOf(TaskToolUseMessage);
+    expect(task.resume).toBe('task-42');
+
+    const execute = convertOpenCodeToolUse(TS, {
+      tool: 'execute',
+      callID: 'call-execute',
+      state: { input: { code: 'return tools.example({})' } },
+    });
+    expect(execute).toBeInstanceOf(ExecToolUseMessage);
+    expect(execute.code).toBe('return tools.example({})');
+    expect(execute.language).toBe('javascript');
   });
 
   it('falls back to Unknown for malformed question input', () => {
@@ -133,14 +244,16 @@ describe('convertOpenCodeToolUse', () => {
     expect(msg.rawName).toBe('question');
   });
 
-  it('falls back to Unknown for unrecognized tools', () => {
+  it('maps custom and plugin tools to the explicit external tool contract', () => {
     const msg = convertOpenCodeToolUse(TS, {
       tool: 'CustomTool',
       callID: 'oc-8',
       state: { input: { key: 'val' } },
     });
-    expect(msg).toBeInstanceOf(UnknownToolUseMessage);
-    expect(msg.rawName).toBe('CustomTool');
+    expect(msg).toBeInstanceOf(ExternalToolUseMessage);
+    expect(msg.name).toBe('CustomTool');
+    expect(msg.namespace).toBe('opencode');
+    expect(msg.input).toEqual({ key: 'val' });
   });
 
   it('uses fallback id from part.id when callID is missing', () => {
@@ -173,7 +286,7 @@ describe('convertOpenCodeToolUse', () => {
       callID: 'oc-10',
       state: { input: 'some string payload' },
     });
-    expect(msg).toBeInstanceOf(UnknownToolUseMessage);
+    expect(msg).toBeInstanceOf(ExternalToolUseMessage);
     expect(msg.input).toEqual({ raw: 'some string payload' });
   });
 
@@ -183,7 +296,7 @@ describe('convertOpenCodeToolUse', () => {
       callID: 'oc-11',
       state: { input: '{"key":"val"}' },
     });
-    expect(msg).toBeInstanceOf(UnknownToolUseMessage);
+    expect(msg).toBeInstanceOf(ExternalToolUseMessage);
     expect(msg.input).toEqual({ key: 'val' });
   });
 

--- a/server-agents/opencode/src/agents/opencode/__tests__/tool-use-converter.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/tool-use-converter.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import {
+  convertOpenCodeQuestionToolUse,
   convertOpenCodeToolUse,
   OPENCODE_BUILTIN_TOOL_IDS,
 } from '../tool-use-converter.js';
@@ -242,6 +243,21 @@ describe('convertOpenCodeToolUse', () => {
 
     expect(msg).toBeInstanceOf(UnknownToolUseMessage);
     expect(msg.rawName).toBe('question');
+  });
+
+  it('refuses a question array when any provider prompt is unrenderable', () => {
+    expect(convertOpenCodeQuestionToolUse(TS, 'oc-question-gap', [
+      {
+        header: 'Hidden',
+        question: '',
+        options: [{ label: 'Wrong answer' }],
+      },
+      {
+        header: 'Visible',
+        question: 'Choose safely?',
+        options: [{ label: 'Yes' }, { label: 'No' }],
+      },
+    ])).toBeNull();
   });
 
   it('maps custom and plugin tools to the explicit external tool contract', () => {

--- a/server-agents/opencode/src/agents/opencode/history-loader.ts
+++ b/server-agents/opencode/src/agents/opencode/history-loader.ts
@@ -308,7 +308,6 @@ export function convertOpenCodeStoredMessages(rawMessages: readonly OpenCodeMess
 
     if (info.role === 'assistant') {
       const providerError = openCodeStoredErrorMessage(info.error);
-      const aborted = isOpenCodeStoredAbort(info.error);
       const parts = Array.isArray(msg.parts) ? msg.parts : [];
       for (const rawPart of parts) {
         const part = asRecord(rawPart);
@@ -323,8 +322,9 @@ export function convertOpenCodeStoredMessages(rawMessages: readonly OpenCodeMess
           }
         } else if (part.type === 'text' && typeof part.text === 'string' && part.text.trim()) {
           push(new AssistantMessage(ts, part.text), part.id);
-        } else if (part.type === 'tool' && !aborted) {
+        } else if (part.type === 'tool') {
           const state = asRecord(part.state);
+          if (state.status !== 'completed' && state.status !== 'error') continue;
           const toolUse = convertOpenCodeToolUse(ts, part);
           push(toolUse, part.id);
 

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -66,6 +66,7 @@ import { convertOpenCodeEventToChatMessages } from './event-converter.js';
 import { OpenCodeSteeringController } from './steering.js';
 import {
   OpenCodeOperationRoutes,
+  type OpenCodeOperationEventSource,
   type OpenCodeOperationRoute,
 } from './operation-routes.js';
 import {
@@ -718,19 +719,36 @@ export class OpenCodeRuntime {
       return;
     }
 
+    const taskChildRoute = this.#operationRoutes.resolveTaskChild(sessionId);
+    if (
+      taskChildRoute
+      && event.type !== 'permission.asked'
+      && event.type !== 'question.asked'
+    ) {
+      this.#logger.debug('Ignoring an OpenCode task child transcript event', {
+        eventId: event.id ?? null,
+        eventType: event.type,
+        parentSessionId: taskChildRoute.sessionId,
+        childSessionId: sessionId,
+      });
+      return;
+    }
+
     // Marked parts always pass through current-turn adoption so a foreign named ID cannot
     // bypass collision refusal through ordinary named resolution.
     const isCompactionPart = isOpenCodeCompactionControlPart(event)
       || isOpenCodeCompactionContinuationPart(event);
-    const route = isCompactionPart
-      ? adoptOpenCodeCompactionPartRoute({
-          event,
-          logger: this.#logger,
-          operationRoutes: this.#operationRoutes,
-          session: this.#sessions.get(sessionId),
-          sessionId,
-        })
-      : this.#operationRoutes.resolve(sessionId, event);
+    const route = taskChildRoute ?? (
+      isCompactionPart
+        ? adoptOpenCodeCompactionPartRoute({
+            event,
+            logger: this.#logger,
+            operationRoutes: this.#operationRoutes,
+            session: this.#sessions.get(sessionId),
+            sessionId,
+          })
+        : this.#operationRoutes.resolve(sessionId, event)
+    );
     if (!route) {
       if (isCompactionPart) return;
       const part = event.properties?.part;
@@ -759,13 +777,19 @@ export class OpenCodeRuntime {
     }
     if (!acceptUniqueOpenCodeTurnEvent(route.turn, event, this.#logger)) return;
 
-    const session = this.#sessions.get(sessionId);
+    const source: OpenCodeOperationEventSource = taskChildRoute
+      ? { kind: 'task-child', sessionId }
+      : { kind: 'operation', sessionId };
+    const session = this.#sessions.get(route.sessionId);
     const isCurrentTurn = session?.turn === route.turn;
-    if (this.#decisions.handle(client, event, sessionId, route)) return;
+    if (this.#decisions.handle(client, event, source, route)) return;
     if (isCurrentTurn) this.steering.observeAcknowledgement(session, event);
     const belongs = openCodeEventBelongsToTurn(route.turn, event);
     this.#operationRoutes.observe(route, event);
-    if (belongs) this.#dispatchOpenCodeEvent(event, route);
+    if (belongs) {
+      this.#operationRoutes.bindTaskChildSession(route, event);
+      this.#dispatchOpenCodeEvent(event, route);
+    }
     const terminal = belongs ? openCodeAssistantTerminal(event) : null;
     if (terminal) route.turn.assistantTerminals.set(terminal.messageId, terminal);
   }

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -719,6 +719,7 @@ export class OpenCodeRuntime {
       return;
     }
 
+    this.#operationRoutes.bindTaskDescendantSession(event);
     const taskChildRoute = this.#operationRoutes.resolveTaskChild(sessionId);
     if (
       taskChildRoute

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -2,7 +2,6 @@
 
 import crypto from 'crypto';
 import { isRecord } from '@garcon/common/json';
-import type { PermissionDecisionPayload } from '@garcon/common/chat-command-contracts';
 import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import { buildPromptBody, parseOpenCodeModel } from './prompt.js';
 import {
@@ -25,7 +24,6 @@ import {
 } from './turn-events.js';
 import { ErrorMessage } from '@garcon/common/chat-types';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
-import { convertOpencodePermissionTool } from "./permission-tool-converter.js";
 import {
   runtimeRows,
   type AgentRuntimeEvent,
@@ -71,8 +69,7 @@ import {
   type OpenCodeOperationRoute,
 } from './operation-routes.js';
 import {
-  extractPermissionRequest,
-  mapPermissionDecision,
+  OpenCodeDecisionController,
   mapPermissionMode,
 } from './permissions.js';
 import { createOpenCodeInstance } from './server-instance.js';
@@ -106,14 +103,6 @@ const DEFAULT_OPENCODE_SHUTDOWN_STARTUP_GRACE_MS = 100;
 interface PendingTurnWaiter {
   promise: Promise<Error | null>;
   settle: (failure: Error | null) => void;
-}
-
-interface PendingPermission {
-  permissionOccurrenceId: string;
-  originalRequestId: string;
-  agentSessionId: string;
-  directory?: string;
-  operation: OpenCodeTurnContext['operation'];
 }
 
 interface OpenCodeRuntimeOptions {
@@ -183,7 +172,7 @@ export class OpenCodeRuntime {
   #sessions = new Map<string, OpenCodeSession>();
   #pendingSessionAborts = new WeakMap<OpenCodeSession, Promise<boolean>>();
   #pendingTurnWaiters = new Map<string, PendingTurnWaiter>();
-  #pendingPermissions = new Set<PendingPermission>();
+  readonly #decisions: OpenCodeDecisionController;
   readonly steering: OpenCodeSteeringController;
   readonly #endpointCoordinator: OpenCodeEndpointCoordinator;
   readonly #globalEventListener: OpenCodeGlobalEventListener;
@@ -212,6 +201,22 @@ export class OpenCodeRuntime {
     this.#logger = options.logger ?? SILENT_LOGGER;
     this.#operationRoutes = new OpenCodeOperationRoutes(this.#logger);
     this.#options = normalizeOptions(options);
+    this.#decisions = new OpenCodeDecisionController({
+      logger: this.#logger,
+      publish: (agentSessionId, operation, event) => this.#publish(
+        agentSessionId,
+        operation,
+        event,
+      ),
+      getClient: () => this.getClient(),
+      runScopedRequest: (label, scope, operation) => (
+        this.#runScopedSessionRequest(label, scope, operation)
+      ),
+      getSession: (agentSessionId) => this.#sessions.get(agentSessionId),
+      failTurn: (agentSessionId, session, message) => (
+        this.#failTurnForProviderError(agentSessionId, session, message)
+      ),
+    });
     this.#instanceCreations = new OpenCodeInstanceCreationTracker(() => this.#shuttingDown);
     this.#endpointCoordinator = new OpenCodeEndpointCoordinator({
       assertAvailable: () => this.#assertCanUseOpenCode(),
@@ -260,7 +265,7 @@ export class OpenCodeRuntime {
       this.#rejectTurnWaiter(agentSessionId, new Error('OpenCode runtime shutting down'));
     }
     this.#sessions.clear();
-    this.#pendingPermissions.clear();
+    this.#decisions.clear();
     const startup = this.#initPromise;
     this.#startupAbortController?.abort(new Error('OpenCode runtime shutting down'));
     this.#closeInstance();
@@ -440,7 +445,7 @@ export class OpenCodeRuntime {
       session.status = 'completed';
       session.lastActivityAt = Date.now();
       this.#operationRoutes.cancelRequest(session.turn, failure);
-      this.#cancelPendingPermissionsForSession(agentSessionId, 'cancelled');
+      this.#decisions.cancelForSession(agentSessionId, 'cancelled');
       this.#rejectTurnWaiter(agentSessionId, failure);
       this.#publishFailed(agentSessionId, session.turn.operation, failure.message);
     }
@@ -454,7 +459,7 @@ export class OpenCodeRuntime {
     session.providerWorkRequiresQuiescence = true;
     session.status = 'completed';
     session.lastActivityAt = Date.now();
-    this.#cancelPendingPermissionsForSession(agentSessionId, 'cancelled');
+    this.#decisions.cancelForSession(agentSessionId, 'cancelled');
     this.#rejectTurnWaiter(agentSessionId, new Error(message));
     // OpenCode stores a failed turn's provider error on its in-flight assistant
     // message, whose id the native loader uses as the error occurrence's
@@ -496,7 +501,7 @@ export class OpenCodeRuntime {
     session.providerWorkRequiresQuiescence = true;
     session.status = 'completed';
     session.lastActivityAt = Date.now();
-    this.#cancelPendingPermissionsForSession(route.sessionId, 'cancelled');
+    this.#decisions.cancelForSession(route.sessionId, 'cancelled');
     this.#rejectTurnWaiter(route.sessionId, error);
     this.#publishFailed(route.sessionId, route.turn.operation, message);
     if (this.isTemporarilyUnavailable()) this.#closeInstanceIfIdle();
@@ -532,7 +537,7 @@ export class OpenCodeRuntime {
       this.#failTurnForProviderError(agentSessionId, session, terminal.error);
       return;
     }
-    this.#cancelPendingPermissionsForSession(agentSessionId, 'session-complete');
+    this.#decisions.cancelForSession(agentSessionId, 'session-complete');
     session.status = 'completed';
     session.lastActivityAt = Date.now();
     this.#resolveTurnWaiter(agentSessionId);
@@ -697,52 +702,6 @@ export class OpenCodeRuntime {
     }
   }
 
-  #replyManualBypassPermission(
-    client: any,
-    route: OpenCodeOperationRoute,
-    requestId: string,
-  ): void {
-    void this.#runScopedSessionRequest(
-      'OpenCode manual bypass permission reply',
-      { directory: route.directory },
-      (signal, requestScope) => client.permission.reply(
-        withOpenCodeRequestScope({ requestID: requestId, reply: 'once' }, requestScope),
-        { signal },
-      ),
-    ).then((result) => {
-      throwOpenCodeResultError(result, 'OpenCode manual bypass permission reply failed');
-    }).catch((error) => {
-      const current = this.#sessions.get(route.sessionId);
-      if (
-        current?.status !== 'running'
-        || current.turn !== route.turn
-      ) {
-        this.#logger.debug('Ignoring a late OpenCode manual bypass reply failure', {
-          agentSessionId: route.sessionId,
-          error: errorMessage(error),
-        });
-        return;
-      }
-      this.#failTurnForProviderError(route.sessionId, current, errorMessage(error));
-    });
-  }
-
-  #cancelPendingPermissionsForSession(agentSessionId: string, reason: 'cancelled' | 'session-complete' | 'aborted'): void {
-    for (const pending of [...this.#pendingPermissions]) {
-      if (pending.agentSessionId !== agentSessionId) continue;
-      this.#pendingPermissions.delete(pending);
-      this.#publish(agentSessionId, pending.operation, {
-        type: 'permission',
-        runId: pending.operation.runId,
-        lifecycle: {
-          kind: 'cancelled',
-          permissionOccurrenceId: pending.permissionOccurrenceId,
-          reason,
-        },
-      });
-    }
-  }
-
   #handleGlobalSSEEvent(client: any, event: SSEEvent): void {
     const sessionId = extractSessionId(event);
     if (!sessionId) {
@@ -802,10 +761,7 @@ export class OpenCodeRuntime {
 
     const session = this.#sessions.get(sessionId);
     const isCurrentTurn = session?.turn === route.turn;
-    if (event.type === 'permission.asked') {
-      this.#handlePermissionEvent(client, event, sessionId, route);
-      return;
-    }
+    if (this.#decisions.handle(client, event, sessionId, route)) return;
     if (isCurrentTurn) this.steering.observeAcknowledgement(session, event);
     const belongs = openCodeEventBelongsToTurn(route.turn, event);
     this.#operationRoutes.observe(route, event);
@@ -827,63 +783,6 @@ export class OpenCodeRuntime {
       runId: session.turn.operation.runId,
       title: notice.title,
       content: notice.content,
-    });
-  }
-
-  #handlePermissionEvent(
-    client: any,
-    event: SSEEvent,
-    sessionId: string,
-    route: OpenCodeOperationRoute,
-  ): void {
-    const toolMessageId = event.properties?.tool?.messageID;
-    if (
-      typeof toolMessageId === 'string'
-      && !route.turn.assistantMessageIds.has(toolMessageId)
-    ) {
-      // The provider stays blocked on the unanswered request; the warning is
-      // the diagnostic and user interrupt is the remediation.
-      this.#logger.warn('Ignoring an OpenCode permission for a message outside its turn', {
-        agentSessionId: sessionId,
-        eventId: event.id ?? null,
-        toolMessageId,
-      });
-      return;
-    }
-    const permission = extractPermissionRequest(event);
-    if (!permission) return;
-    if (route.permissionMode === 'manualBypass') {
-      this.#replyManualBypassPermission(client, route, permission.requestId);
-      return;
-    }
-    const permissionOccurrenceId = crypto.randomUUID();
-    const pending: PendingPermission = {
-      permissionOccurrenceId,
-      originalRequestId: permission.requestId,
-      agentSessionId: sessionId,
-      directory: route.directory,
-      operation: route.turn.operation,
-    };
-    this.#pendingPermissions.add(pending);
-    const now = new Date().toISOString();
-    const requestedTool = convertOpencodePermissionTool(
-      now,
-      permissionOccurrenceId,
-      permission.toolInput,
-    );
-    this.#publish(sessionId, route.turn.operation, {
-      type: 'permission',
-      runId: route.turn.operation.runId,
-      lifecycle: {
-        kind: 'requested',
-        permissionOccurrenceId,
-        requestedTool,
-        options: [],
-      },
-      decision: Object.freeze({
-        permissionOccurrenceId,
-        respond: (decision: PermissionDecisionPayload) => this.#resolvePermission(pending, decision),
-      }),
     });
   }
 
@@ -1410,7 +1309,7 @@ export class OpenCodeRuntime {
     session.deferredTerminal = null;
     session.lastActivityAt = Date.now();
     this.#operationRoutes.retireTurn(turn);
-    this.#cancelPendingPermissionsForSession(agentSessionId, 'aborted');
+    this.#decisions.cancelForSession(agentSessionId, 'aborted');
     // The acknowledged stop is turn-terminal work: the terminal event settles
     // the core run and releases queued execution.
     this.#publishFinished(agentSessionId, turn.operation);
@@ -1433,32 +1332,6 @@ export class OpenCodeRuntime {
     return Array.from(this.#sessions.entries())
       .filter(([, session]) => session.status === 'running')
       .map(([id, session]) => ({ id, status: session.status, startedAt: session.startedAt }));
-  }
-
-  async #resolvePermission(
-    pending: PendingPermission,
-    decision: { allow: boolean; alwaysAllow?: boolean },
-  ): Promise<void> {
-    if (!this.#pendingPermissions.has(pending)) {
-      throw new Error('OpenCode permission occurrence is no longer pending');
-    }
-    const allow = Boolean(decision?.allow);
-    const reply = mapPermissionDecision(decision);
-    const client = await this.getClient();
-    const result = await this.#runScopedSessionRequest(
-      'OpenCode permission reply',
-      { directory: pending.directory },
-      (signal, requestScope) => client.permission.reply(
-        withOpenCodeRequestScope({
-          requestID: pending.originalRequestId,
-          reply,
-          message: allow ? undefined : 'User denied tool use',
-        }, requestScope),
-        { signal },
-      ),
-    );
-    throwOpenCodeResultError(result, 'OpenCode permission reply failed');
-    this.#pendingPermissions.delete(pending);
   }
 
   async runSingleQuery(prompt: string, options: Record<string, any> = {}): Promise<string> {
@@ -1545,5 +1418,6 @@ function shouldWarnForUnroutedOpenCodeEvent(eventType: string): boolean {
     || eventType === 'message.part.updated'
     || eventType === 'message.part.delta'
     || eventType === 'permission.asked'
+    || eventType === 'question.asked'
     || eventType === 'session.error';
 }

--- a/server-agents/opencode/src/agents/opencode/operation-routes.ts
+++ b/server-agents/opencode/src/agents/opencode/operation-routes.ts
@@ -143,6 +143,20 @@ export class OpenCodeOperationRoutes {
     if (!this.isRegistered(route)) return false;
     const childSessionId = taskChildSessionId(event);
     if (!childSessionId || childSessionId === route.sessionId) return false;
+    return this.#bindTaskChildSession(route, childSessionId);
+  }
+
+  // Affiliates nested tasks only through a parent already bound by task-part metadata.
+  // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/tool/task.ts#L158-L195
+  bindTaskDescendantSession(event: SSEEvent): OpenCodeOperationRoute | null {
+    const created = taskChildCreation(event);
+    if (!created) return null;
+    const route = this.resolveTaskChild(created.parentSessionId);
+    if (!route || !this.#bindTaskChildSession(route, created.childSessionId)) return null;
+    return route;
+  }
+
+  #bindTaskChildSession(route: OpenCodeOperationRoute, childSessionId: string): boolean {
     const existingChildRoute = this.#byTaskChildSession.get(childSessionId);
     const existingSessionRoute = [...this.#byTurn.values()]
       .find((candidate) => candidate.sessionId === childSessionId);
@@ -319,6 +333,27 @@ function taskChildSessionId(event: SSEEvent): string | null {
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return null;
   const sessionId = (metadata as Record<string, unknown>).sessionId;
   return typeof sessionId === 'string' && sessionId ? sessionId : null;
+}
+
+function taskChildCreation(event: SSEEvent): {
+  childSessionId: string;
+  parentSessionId: string;
+} | null {
+  if (event.type !== 'session.created') return null;
+  const sessionId = event.properties?.sessionID;
+  const info = event.properties?.info;
+  if (!info || typeof info !== 'object' || Array.isArray(info)) return null;
+  const childSessionId = (info as Record<string, unknown>).id;
+  const parentSessionId = (info as Record<string, unknown>).parentID;
+  if (
+    typeof sessionId !== 'string'
+    || !sessionId
+    || childSessionId !== sessionId
+    || typeof parentSessionId !== 'string'
+    || !parentSessionId
+    || parentSessionId === childSessionId
+  ) return null;
+  return { childSessionId, parentSessionId };
 }
 
 function partOperationIdentity(part: Record<string, unknown>): string | null {

--- a/server-agents/opencode/src/agents/opencode/operation-routes.ts
+++ b/server-agents/opencode/src/agents/opencode/operation-routes.ts
@@ -15,6 +15,10 @@ export interface OpenCodeOperationRoute {
   readonly requestAbortController: AbortController;
 }
 
+export type OpenCodeOperationEventSource =
+  | { readonly kind: 'operation'; readonly sessionId: string }
+  | { readonly kind: 'task-child'; readonly sessionId: string };
+
 export type OpenCodeCompactionPartAdoption =
   | { readonly kind: 'adopted'; readonly route: OpenCodeOperationRoute }
   | { readonly kind: 'route-retired' }
@@ -25,6 +29,7 @@ export class OpenCodeOperationRoutes {
   readonly #byPart = new Map<string, OpenCodeOperationRoute>();
   readonly #byMessage = new Map<string, OpenCodeOperationRoute>();
   readonly #byTurn = new Map<OpenCodeTurnContext, OpenCodeOperationRoute>();
+  readonly #byTaskChildSession = new Map<string, OpenCodeOperationRoute>();
   readonly #latestBoundOrdinalBySession = new Map<string, number>();
   #nextRegistrationOrdinal = 1;
 
@@ -38,6 +43,9 @@ export class OpenCodeOperationRoutes {
     permissionMode: PermissionMode,
     directory: string | undefined,
   ): OpenCodeOperationRoute {
+    if (this.#byTaskChildSession.has(sessionId)) {
+      throw new Error(`OpenCode session ${sessionId} is already routed as a task child`);
+    }
     const route = {
       sessionId,
       chatId,
@@ -131,6 +139,32 @@ export class OpenCodeOperationRoutes {
     return { kind: 'adopted', route };
   }
 
+  bindTaskChildSession(route: OpenCodeOperationRoute, event: SSEEvent): boolean {
+    if (!this.isRegistered(route)) return false;
+    const childSessionId = taskChildSessionId(event);
+    if (!childSessionId || childSessionId === route.sessionId) return false;
+    const existingChildRoute = this.#byTaskChildSession.get(childSessionId);
+    const existingSessionRoute = [...this.#byTurn.values()]
+      .find((candidate) => candidate.sessionId === childSessionId);
+    if (
+      (existingChildRoute && existingChildRoute !== route)
+      || (existingSessionRoute && existingSessionRoute !== route)
+    ) {
+      this.logger.warn('Ignoring an OpenCode task child session identity collision', {
+        parentSessionId: route.sessionId,
+        childSessionId,
+      });
+      return false;
+    }
+    this.#byTaskChildSession.set(childSessionId, route);
+    return true;
+  }
+
+  resolveTaskChild(sessionId: string): OpenCodeOperationRoute | null {
+    const route = this.#byTaskChildSession.get(sessionId);
+    return route && this.isRegistered(route) ? route : null;
+  }
+
   observe(route: OpenCodeOperationRoute, event: SSEEvent): void {
     const part = event.properties?.part;
     if (part?.id === route.turn.providerPromptPartId) {
@@ -178,6 +212,7 @@ export class OpenCodeOperationRoutes {
     this.#byPart.clear();
     this.#byMessage.clear();
     this.#byTurn.clear();
+    this.#byTaskChildSession.clear();
     this.#latestBoundOrdinalBySession.clear();
   }
 
@@ -264,11 +299,26 @@ export class OpenCodeOperationRoutes {
     for (const [key, candidate] of this.#byMessage) {
       if (candidate === route) this.#byMessage.delete(key);
     }
+    for (const [sessionId, candidate] of this.#byTaskChildSession) {
+      if (candidate === route) this.#byTaskChildSession.delete(sessionId);
+    }
     this.#byTurn.delete(route.turn);
     const sessionStillRouted = [...this.#byTurn.values()]
       .some((candidate) => candidate.sessionId === route.sessionId);
     if (!sessionStillRouted) this.#latestBoundOrdinalBySession.delete(route.sessionId);
   }
+}
+
+function taskChildSessionId(event: SSEEvent): string | null {
+  if (event.type !== 'message.part.updated') return null;
+  const part = event.properties?.part;
+  if (part?.type !== 'tool' || part.tool !== 'task') return null;
+  const state = part.state;
+  if (!state || typeof state !== 'object' || Array.isArray(state)) return null;
+  const metadata = (state as Record<string, unknown>).metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return null;
+  const sessionId = (metadata as Record<string, unknown>).sessionId;
+  return typeof sessionId === 'string' && sessionId ? sessionId : null;
 }
 
 function partOperationIdentity(part: Record<string, unknown>): string | null {

--- a/server-agents/opencode/src/agents/opencode/permissions.ts
+++ b/server-agents/opencode/src/agents/opencode/permissions.ts
@@ -1,3 +1,18 @@
+import crypto from 'node:crypto';
+import type { PermissionDecisionPayload } from '@garcon/common/chat-command-contracts';
+import { errorMessage } from '@garcon/server-agent-common/lib/errors';
+import type { AgentRuntimeOperation } from '@garcon/server-agent-common/execution/runtime-events';
+import type { OpenCodeSession } from './turn-events.js';
+import type { OpenCodeOperationRoute } from './operation-routes.js';
+import {
+  OpenCodeQuestionController,
+  type OpenCodeQuestionControllerOptions,
+} from './questions.js';
+import { convertOpencodePermissionTool } from './permission-tool-converter.js';
+import {
+  throwOpenCodeResultError,
+  withOpenCodeRequestScope,
+} from './sdk-result.js';
 import type { SSEEvent } from './sse-events.js';
 
 // Source of OpenCode permission keys:
@@ -69,4 +84,169 @@ export function extractPermissionRequest(event: SSEEvent): {
       tool: props.tool || null,
     },
   };
+}
+
+interface PendingOpenCodePermission {
+  readonly permissionOccurrenceId: string;
+  readonly originalRequestId: string;
+  readonly agentSessionId: string;
+  readonly directory?: string;
+  readonly operation: AgentRuntimeOperation;
+}
+
+interface OpenCodeDecisionControllerOptions extends OpenCodeQuestionControllerOptions {
+  readonly getSession: (agentSessionId: string) => OpenCodeSession | undefined;
+  readonly failTurn: (
+    agentSessionId: string,
+    session: OpenCodeSession,
+    message: string,
+  ) => void;
+}
+
+export class OpenCodeDecisionController {
+  readonly #pending = new Set<PendingOpenCodePermission>();
+  readonly #questions: OpenCodeQuestionController;
+
+  constructor(private readonly options: OpenCodeDecisionControllerOptions) {
+    this.#questions = new OpenCodeQuestionController(options);
+  }
+
+  handle(
+    client: any,
+    event: SSEEvent,
+    sessionId: string,
+    route: OpenCodeOperationRoute,
+  ): boolean {
+    if (event.type === 'question.asked') {
+      this.#questions.handle(event, sessionId, route);
+      return true;
+    }
+    if (event.type !== 'permission.asked') return false;
+
+    const toolMessageId = event.properties?.tool?.messageID;
+    if (
+      typeof toolMessageId === 'string'
+      && !route.turn.assistantMessageIds.has(toolMessageId)
+    ) {
+      this.options.logger.warn('Ignoring an OpenCode permission for a message outside its turn', {
+        agentSessionId: sessionId,
+        eventId: event.id ?? null,
+        toolMessageId,
+      });
+      return true;
+    }
+    const permission = extractPermissionRequest(event);
+    if (!permission) return true;
+    if (route.permissionMode === 'manualBypass') {
+      this.#replyManualBypass(client, route, permission.requestId);
+      return true;
+    }
+    const permissionOccurrenceId = crypto.randomUUID();
+    const pending: PendingOpenCodePermission = {
+      permissionOccurrenceId,
+      originalRequestId: permission.requestId,
+      agentSessionId: sessionId,
+      directory: route.directory,
+      operation: route.turn.operation,
+    };
+    this.#pending.add(pending);
+    const requestedTool = convertOpencodePermissionTool(
+      new Date().toISOString(),
+      permissionOccurrenceId,
+      permission.toolInput,
+    );
+    this.options.publish(sessionId, route.turn.operation, {
+      type: 'permission',
+      runId: route.turn.operation.runId,
+      lifecycle: {
+        kind: 'requested',
+        permissionOccurrenceId,
+        requestedTool,
+        options: [],
+      },
+      decision: Object.freeze({
+        permissionOccurrenceId,
+        respond: (decision: PermissionDecisionPayload) => this.#resolve(pending, decision),
+      }),
+    });
+    return true;
+  }
+
+  cancelForSession(
+    agentSessionId: string,
+    reason: 'cancelled' | 'session-complete' | 'aborted',
+  ): void {
+    for (const pending of [...this.#pending]) {
+      if (pending.agentSessionId !== agentSessionId) continue;
+      this.#pending.delete(pending);
+      this.options.publish(agentSessionId, pending.operation, {
+        type: 'permission',
+        runId: pending.operation.runId,
+        lifecycle: {
+          kind: 'cancelled',
+          permissionOccurrenceId: pending.permissionOccurrenceId,
+          reason,
+        },
+      });
+    }
+    this.#questions.cancelForSession(agentSessionId, reason);
+  }
+
+  clear(): void {
+    this.#pending.clear();
+    this.#questions.clear();
+  }
+
+  #replyManualBypass(
+    client: any,
+    route: OpenCodeOperationRoute,
+    requestId: string,
+  ): void {
+    void this.options.runScopedRequest(
+      'OpenCode manual bypass permission reply',
+      { directory: route.directory },
+      (signal, requestScope) => client.permission.reply(
+        withOpenCodeRequestScope({ requestID: requestId, reply: 'once' }, requestScope),
+        { signal },
+      ),
+    ).then((result) => {
+      throwOpenCodeResultError(result, 'OpenCode manual bypass permission reply failed');
+    }).catch((error) => {
+      const current = this.options.getSession(route.sessionId);
+      if (current?.status !== 'running' || current.turn !== route.turn) {
+        this.options.logger.debug('Ignoring a late OpenCode manual bypass reply failure', {
+          agentSessionId: route.sessionId,
+          error: errorMessage(error),
+        });
+        return;
+      }
+      this.options.failTurn(route.sessionId, current, errorMessage(error));
+    });
+  }
+
+  async #resolve(
+    pending: PendingOpenCodePermission,
+    decision: Pick<PermissionDecisionPayload, 'allow' | 'alwaysAllow'>,
+  ): Promise<void> {
+    if (!this.#pending.has(pending)) {
+      throw new Error('OpenCode permission occurrence is no longer pending');
+    }
+    const allow = Boolean(decision?.allow);
+    const reply = mapPermissionDecision(decision);
+    const client = await this.options.getClient();
+    const result = await this.options.runScopedRequest(
+      'OpenCode permission reply',
+      { directory: pending.directory },
+      (signal, requestScope) => client.permission.reply(
+        withOpenCodeRequestScope({
+          requestID: pending.originalRequestId,
+          reply,
+          message: allow ? undefined : 'User denied tool use',
+        }, requestScope),
+        { signal },
+      ),
+    );
+    throwOpenCodeResultError(result, 'OpenCode permission reply failed');
+    this.#pending.delete(pending);
+  }
 }

--- a/server-agents/opencode/src/agents/opencode/permissions.ts
+++ b/server-agents/opencode/src/agents/opencode/permissions.ts
@@ -43,10 +43,17 @@ export const OPENCODE_PERMISSION_KEYS = Object.freeze([
   'plan_exit',
 ] as const);
 
+const OPENCODE_NATIVE_PLAN_PERMISSIONS = new Set(['plan_enter', 'plan_exit']);
+
 export function mapPermissionMode(mode: string): Array<{ permission: string; pattern: string; action: string }> {
+  // Native plan transitions create unmarked synthetic continuations that cannot be safely
+  // affiliated with an operation, so bypass mode keeps them unavailable.
   const map: Record<string, Record<string, string>> = {
     acceptEdits: { edit: 'allow', bash: 'ask', webfetch: 'allow' },
-    bypassPermissions: Object.fromEntries(OPENCODE_PERMISSION_KEYS.map((permission) => [permission, 'allow'])),
+    bypassPermissions: Object.fromEntries(OPENCODE_PERMISSION_KEYS.map((permission) => [
+      permission,
+      OPENCODE_NATIVE_PLAN_PERMISSIONS.has(permission) ? 'deny' : 'allow',
+    ])),
     manualBypass: { edit: 'ask', bash: 'ask', webfetch: 'ask' },
     default: { edit: 'ask', bash: 'ask', webfetch: 'ask' },
   };

--- a/server-agents/opencode/src/agents/opencode/permissions.ts
+++ b/server-agents/opencode/src/agents/opencode/permissions.ts
@@ -2,7 +2,6 @@ import crypto from 'node:crypto';
 import type { PermissionDecisionPayload } from '@garcon/common/chat-command-contracts';
 import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import type { AgentRuntimeOperation } from '@garcon/server-agent-common/execution/runtime-events';
-import type { OpenCodeSession } from './turn-events.js';
 import type { OpenCodeOperationRoute } from './operation-routes.js';
 import {
   OpenCodeQuestionController,
@@ -94,14 +93,7 @@ interface PendingOpenCodePermission {
   readonly operation: AgentRuntimeOperation;
 }
 
-interface OpenCodeDecisionControllerOptions extends OpenCodeQuestionControllerOptions {
-  readonly getSession: (agentSessionId: string) => OpenCodeSession | undefined;
-  readonly failTurn: (
-    agentSessionId: string,
-    session: OpenCodeSession,
-    message: string,
-  ) => void;
-}
+type OpenCodeDecisionControllerOptions = OpenCodeQuestionControllerOptions;
 
 export class OpenCodeDecisionController {
   readonly #pending = new Set<PendingOpenCodePermission>();
@@ -118,7 +110,7 @@ export class OpenCodeDecisionController {
     route: OpenCodeOperationRoute,
   ): boolean {
     if (event.type === 'question.asked') {
-      this.#questions.handle(event, sessionId, route);
+      this.#questions.handle(client, event, sessionId, route);
       return true;
     }
     if (event.type !== 'permission.asked') return false;

--- a/server-agents/opencode/src/agents/opencode/permissions.ts
+++ b/server-agents/opencode/src/agents/opencode/permissions.ts
@@ -12,6 +12,7 @@ import {
 } from './questions.js';
 import { convertOpencodePermissionTool } from './permission-tool-converter.js';
 import {
+  isOpenCodeNotFoundResult,
   throwOpenCodeResultError,
   withOpenCodeRequestScope,
 } from './sdk-result.js';
@@ -206,6 +207,12 @@ export class OpenCodeDecisionController {
         { signal },
       ),
     ).then((result) => {
+      if (isOpenCodeNotFoundResult(result)) {
+        this.options.logger.debug('Ignoring an OpenCode reply for a missing permission request', {
+          agentSessionId: route.sessionId,
+        });
+        return;
+      }
       throwOpenCodeResultError(result, 'OpenCode manual bypass permission reply failed');
     }).catch((error) => {
       const current = this.options.getSession(route.sessionId);

--- a/server-agents/opencode/src/agents/opencode/permissions.ts
+++ b/server-agents/opencode/src/agents/opencode/permissions.ts
@@ -2,7 +2,10 @@ import crypto from 'node:crypto';
 import type { PermissionDecisionPayload } from '@garcon/common/chat-command-contracts';
 import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import type { AgentRuntimeOperation } from '@garcon/server-agent-common/execution/runtime-events';
-import type { OpenCodeOperationRoute } from './operation-routes.js';
+import type {
+  OpenCodeOperationEventSource,
+  OpenCodeOperationRoute,
+} from './operation-routes.js';
 import {
   OpenCodeQuestionController,
   type OpenCodeQuestionControllerOptions,
@@ -106,22 +109,23 @@ export class OpenCodeDecisionController {
   handle(
     client: any,
     event: SSEEvent,
-    sessionId: string,
+    source: OpenCodeOperationEventSource,
     route: OpenCodeOperationRoute,
   ): boolean {
     if (event.type === 'question.asked') {
-      this.#questions.handle(client, event, sessionId, route);
+      this.#questions.handle(client, event, source, route);
       return true;
     }
     if (event.type !== 'permission.asked') return false;
 
     const toolMessageId = event.properties?.tool?.messageID;
     if (
-      typeof toolMessageId === 'string'
+      source.kind === 'operation'
+      && typeof toolMessageId === 'string'
       && !route.turn.assistantMessageIds.has(toolMessageId)
     ) {
       this.options.logger.warn('Ignoring an OpenCode permission for a message outside its turn', {
-        agentSessionId: sessionId,
+        agentSessionId: route.sessionId,
         eventId: event.id ?? null,
         toolMessageId,
       });
@@ -137,7 +141,7 @@ export class OpenCodeDecisionController {
     const pending: PendingOpenCodePermission = {
       permissionOccurrenceId,
       originalRequestId: permission.requestId,
-      agentSessionId: sessionId,
+      agentSessionId: route.sessionId,
       directory: route.directory,
       operation: route.turn.operation,
     };
@@ -147,7 +151,7 @@ export class OpenCodeDecisionController {
       permissionOccurrenceId,
       permission.toolInput,
     );
-    this.options.publish(sessionId, route.turn.operation, {
+    this.options.publish(route.sessionId, route.turn.operation, {
       type: 'permission',
       runId: route.turn.operation.runId,
       lifecycle: {

--- a/server-agents/opencode/src/agents/opencode/questions.ts
+++ b/server-agents/opencode/src/agents/opencode/questions.ts
@@ -11,7 +11,10 @@ import type {
   AgentRuntimeOperation,
 } from '@garcon/server-agent-common/execution/runtime-events';
 import type { AgentLogger } from '@garcon/server-agent-interface';
-import type { OpenCodeOperationRoute } from './operation-routes.js';
+import type {
+  OpenCodeOperationEventSource,
+  OpenCodeOperationRoute,
+} from './operation-routes.js';
 import {
   throwOpenCodeResultError,
   withOpenCodeRequestScope,
@@ -138,16 +141,19 @@ export class OpenCodeQuestionController {
   handle(
     client: any,
     event: SSEEvent,
-    sessionId: string,
+    source: OpenCodeOperationEventSource,
     route: OpenCodeOperationRoute,
   ): void {
     const toolMessageId = event.properties?.tool?.messageID;
     if (
-      typeof toolMessageId !== 'string'
-      || !route.turn.assistantMessageIds.has(toolMessageId)
+      source.kind === 'operation'
+      && (
+        typeof toolMessageId !== 'string'
+        || !route.turn.assistantMessageIds.has(toolMessageId)
+      )
     ) {
       this.options.logger.warn('Ignoring an OpenCode question for a message outside its turn', {
-        agentSessionId: sessionId,
+        agentSessionId: route.sessionId,
         eventId: event.id ?? null,
       });
       return;
@@ -162,7 +168,8 @@ export class OpenCodeQuestionController {
       : null;
     if (!request || !requestedTool) {
       this.options.logger.warn('Ignoring a malformed OpenCode question request', {
-        agentSessionId: sessionId,
+        agentSessionId: route.sessionId,
+        sourceSessionId: source.sessionId,
         eventId: event.id ?? null,
       });
       const requestId = typeof event.properties?.id === 'string' && event.properties.id
@@ -175,13 +182,13 @@ export class OpenCodeQuestionController {
     const pending: PendingOpenCodeQuestion = {
       permissionOccurrenceId,
       originalRequestId: request.requestId,
-      agentSessionId: sessionId,
+      agentSessionId: route.sessionId,
       directory: route.directory,
       operation: route.turn.operation,
       questions: requestedTool.questions,
     };
     this.#pending.add(pending);
-    this.options.publish(sessionId, route.turn.operation, {
+    this.options.publish(route.sessionId, route.turn.operation, {
       type: 'permission',
       runId: route.turn.operation.runId,
       lifecycle: {

--- a/server-agents/opencode/src/agents/opencode/questions.ts
+++ b/server-agents/opencode/src/agents/opencode/questions.ts
@@ -16,6 +16,7 @@ import type {
   OpenCodeOperationRoute,
 } from './operation-routes.js';
 import {
+  isOpenCodeNotFoundResult,
   throwOpenCodeResultError,
   withOpenCodeRequestScope,
   type OpenCodeRequestScope,
@@ -240,6 +241,12 @@ export class OpenCodeQuestionController {
         { signal },
       ),
     ).then((result) => {
+      if (isOpenCodeNotFoundResult(result)) {
+        this.options.logger.debug('Ignoring an OpenCode rejection for a missing question request', {
+          agentSessionId: route.sessionId,
+        });
+        return;
+      }
       throwOpenCodeResultError(result, 'OpenCode unrenderable question reject failed');
     }).catch((error) => {
       const current = this.options.getSession(route.sessionId);

--- a/server-agents/opencode/src/agents/opencode/questions.ts
+++ b/server-agents/opencode/src/agents/opencode/questions.ts
@@ -5,6 +5,7 @@ import type {
 } from '@garcon/common/chat-command-contracts';
 import type { AskUserQuestionPrompt } from '@garcon/common/chat-types';
 import { isRecord } from '@garcon/common/json';
+import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import type {
   AgentRuntimeEvent,
   AgentRuntimeOperation,
@@ -18,6 +19,7 @@ import {
 } from './sdk-result.js';
 import type { SSEEvent } from './sse-events.js';
 import { convertOpenCodeQuestionToolUse } from './tool-use-converter.js';
+import type { OpenCodeSession } from './turn-events.js';
 
 export interface OpenCodeQuestionRequest {
   readonly requestId: string;
@@ -51,6 +53,12 @@ export interface OpenCodeQuestionControllerOptions {
     scope: OpenCodeRequestScope,
     operation: (signal: AbortSignal, scope: OpenCodeRequestScope) => Promise<T>,
   ) => Promise<T>;
+  readonly getSession: (agentSessionId: string) => OpenCodeSession | undefined;
+  readonly failTurn: (
+    agentSessionId: string,
+    session: OpenCodeSession,
+    message: string,
+  ) => void;
 }
 
 export function extractOpenCodeQuestionRequest(event: SSEEvent): OpenCodeQuestionRequest | null {
@@ -101,17 +109,24 @@ export function mapOpenCodeQuestionDecision(
     throw new Error('OpenCode question decision is missing an answered response');
   }
 
-  const answersByQuestion = new Map(
-    response.answers.map((answer) => [answer.questionId, answer.selectedOptionIds]),
-  );
+  const questionsById = new Map(questions.map((question) => [question.id, question]));
+  const answersByQuestion = new Map<string, string[]>();
+  for (const answer of response.answers) {
+    const question = questionsById.get(answer.questionId);
+    if (!question) throw new Error('OpenCode question decision contains an unknown question ID');
+    const optionLabels = new Map(question.options.map((option) => [option.id, option.label]));
+    const labels = answer.selectedOptionIds.map((optionId) => {
+      const label = optionLabels.get(optionId);
+      if (label === undefined) {
+        throw new Error('OpenCode question decision contains an unknown option ID');
+      }
+      return label;
+    });
+    answersByQuestion.set(answer.questionId, labels);
+  }
   return {
     kind: 'reply',
-    answers: questions.map((question) => {
-      const optionLabels = new Map(question.options.map((option) => [option.id, option.label]));
-      return (answersByQuestion.get(question.id) ?? [])
-        .map((optionId) => optionLabels.get(optionId) ?? optionId)
-        .filter(Boolean);
-    }),
+    answers: questions.map((question) => answersByQuestion.get(question.id) ?? []),
   };
 }
 
@@ -120,7 +135,12 @@ export class OpenCodeQuestionController {
 
   constructor(private readonly options: OpenCodeQuestionControllerOptions) {}
 
-  handle(event: SSEEvent, sessionId: string, route: OpenCodeOperationRoute): void {
+  handle(
+    client: any,
+    event: SSEEvent,
+    sessionId: string,
+    route: OpenCodeOperationRoute,
+  ): void {
     const toolMessageId = event.properties?.tool?.messageID;
     if (
       typeof toolMessageId !== 'string'
@@ -145,6 +165,10 @@ export class OpenCodeQuestionController {
         agentSessionId: sessionId,
         eventId: event.id ?? null,
       });
+      const requestId = typeof event.properties?.id === 'string' && event.properties.id
+        ? event.properties.id
+        : null;
+      if (requestId) this.#rejectUnrenderable(client, route, requestId);
       return;
     }
     const permissionOccurrenceId = crypto.randomUUID();
@@ -194,6 +218,33 @@ export class OpenCodeQuestionController {
 
   clear(): void {
     this.#pending.clear();
+  }
+
+  #rejectUnrenderable(
+    client: any,
+    route: OpenCodeOperationRoute,
+    requestId: string,
+  ): void {
+    void this.options.runScopedRequest(
+      'OpenCode unrenderable question reject',
+      { directory: route.directory },
+      (signal, requestScope) => client.question.reject(
+        withOpenCodeRequestScope({ requestID: requestId }, requestScope),
+        { signal },
+      ),
+    ).then((result) => {
+      throwOpenCodeResultError(result, 'OpenCode unrenderable question reject failed');
+    }).catch((error) => {
+      const current = this.options.getSession(route.sessionId);
+      if (current?.status !== 'running' || current.turn !== route.turn) {
+        this.options.logger.debug('Ignoring a late OpenCode question rejection failure', {
+          agentSessionId: route.sessionId,
+          error: errorMessage(error),
+        });
+        return;
+      }
+      this.options.failTurn(route.sessionId, current, errorMessage(error));
+    });
   }
 
   async #resolve(

--- a/server-agents/opencode/src/agents/opencode/questions.ts
+++ b/server-agents/opencode/src/agents/opencode/questions.ts
@@ -1,0 +1,229 @@
+import crypto from 'node:crypto';
+import type {
+  AskUserQuestionDecisionResponse,
+  PermissionDecisionPayload,
+} from '@garcon/common/chat-command-contracts';
+import type { AskUserQuestionPrompt } from '@garcon/common/chat-types';
+import { isRecord } from '@garcon/common/json';
+import type {
+  AgentRuntimeEvent,
+  AgentRuntimeOperation,
+} from '@garcon/server-agent-common/execution/runtime-events';
+import type { AgentLogger } from '@garcon/server-agent-interface';
+import type { OpenCodeOperationRoute } from './operation-routes.js';
+import {
+  throwOpenCodeResultError,
+  withOpenCodeRequestScope,
+  type OpenCodeRequestScope,
+} from './sdk-result.js';
+import type { SSEEvent } from './sse-events.js';
+import { convertOpenCodeQuestionToolUse } from './tool-use-converter.js';
+
+export interface OpenCodeQuestionRequest {
+  readonly requestId: string;
+  readonly toolCallId: string;
+  readonly questions: unknown;
+}
+
+export type OpenCodeQuestionDecision =
+  | { readonly kind: 'reply'; readonly answers: string[][] }
+  | { readonly kind: 'reject' };
+
+interface PendingOpenCodeQuestion {
+  readonly permissionOccurrenceId: string;
+  readonly originalRequestId: string;
+  readonly agentSessionId: string;
+  readonly directory?: string;
+  readonly operation: AgentRuntimeOperation;
+  readonly questions: AskUserQuestionPrompt[];
+}
+
+export interface OpenCodeQuestionControllerOptions {
+  readonly logger: AgentLogger;
+  readonly publish: (
+    agentSessionId: string,
+    operation: AgentRuntimeOperation,
+    event: AgentRuntimeEvent,
+  ) => void;
+  readonly getClient: () => Promise<any>;
+  readonly runScopedRequest: <T>(
+    label: string,
+    scope: OpenCodeRequestScope,
+    operation: (signal: AbortSignal, scope: OpenCodeRequestScope) => Promise<T>,
+  ) => Promise<T>;
+}
+
+export function extractOpenCodeQuestionRequest(event: SSEEvent): OpenCodeQuestionRequest | null {
+  if (event.type !== 'question.asked') return null;
+  const properties = event.properties ?? {};
+  const tool = isRecord(properties.tool) ? properties.tool : null;
+  if (
+    typeof properties.id !== 'string'
+    || !properties.id
+    || !Array.isArray(properties.questions)
+    || typeof tool?.callID !== 'string'
+    || !tool.callID
+  ) return null;
+  return {
+    requestId: properties.id,
+    toolCallId: tool.callID,
+    questions: properties.questions,
+  };
+}
+
+function parseQuestionResponse(
+  response: Record<string, unknown> | undefined,
+): AskUserQuestionDecisionResponse | null {
+  if (!response || response.type !== 'ask-user-question-response') return null;
+  if (response.outcome === 'skipped') {
+    if (response.reason !== undefined && typeof response.reason !== 'string') return null;
+    return response as unknown as AskUserQuestionDecisionResponse;
+  }
+  if (response.outcome !== 'answered' || !Array.isArray(response.answers)) return null;
+  for (const answer of response.answers) {
+    if (
+      !isRecord(answer)
+      || typeof answer.questionId !== 'string'
+      || !Array.isArray(answer.selectedOptionIds)
+      || !answer.selectedOptionIds.every((optionId) => typeof optionId === 'string')
+    ) return null;
+  }
+  return response as unknown as AskUserQuestionDecisionResponse;
+}
+
+export function mapOpenCodeQuestionDecision(
+  questions: readonly AskUserQuestionPrompt[],
+  decision: Pick<PermissionDecisionPayload, 'allow' | 'response'>,
+): OpenCodeQuestionDecision {
+  const response = parseQuestionResponse(decision.response);
+  if (!decision.allow || response?.outcome === 'skipped') return { kind: 'reject' };
+  if (!response || response.outcome !== 'answered') {
+    throw new Error('OpenCode question decision is missing an answered response');
+  }
+
+  const answersByQuestion = new Map(
+    response.answers.map((answer) => [answer.questionId, answer.selectedOptionIds]),
+  );
+  return {
+    kind: 'reply',
+    answers: questions.map((question) => {
+      const optionLabels = new Map(question.options.map((option) => [option.id, option.label]));
+      return (answersByQuestion.get(question.id) ?? [])
+        .map((optionId) => optionLabels.get(optionId) ?? optionId)
+        .filter(Boolean);
+    }),
+  };
+}
+
+export class OpenCodeQuestionController {
+  readonly #pending = new Set<PendingOpenCodeQuestion>();
+
+  constructor(private readonly options: OpenCodeQuestionControllerOptions) {}
+
+  handle(event: SSEEvent, sessionId: string, route: OpenCodeOperationRoute): void {
+    const toolMessageId = event.properties?.tool?.messageID;
+    if (
+      typeof toolMessageId !== 'string'
+      || !route.turn.assistantMessageIds.has(toolMessageId)
+    ) {
+      this.options.logger.warn('Ignoring an OpenCode question for a message outside its turn', {
+        agentSessionId: sessionId,
+        eventId: event.id ?? null,
+      });
+      return;
+    }
+    const request = extractOpenCodeQuestionRequest(event);
+    const requestedTool = request
+      ? convertOpenCodeQuestionToolUse(
+          new Date().toISOString(),
+          request.toolCallId,
+          request.questions,
+        )
+      : null;
+    if (!request || !requestedTool) {
+      this.options.logger.warn('Ignoring a malformed OpenCode question request', {
+        agentSessionId: sessionId,
+        eventId: event.id ?? null,
+      });
+      return;
+    }
+    const permissionOccurrenceId = crypto.randomUUID();
+    const pending: PendingOpenCodeQuestion = {
+      permissionOccurrenceId,
+      originalRequestId: request.requestId,
+      agentSessionId: sessionId,
+      directory: route.directory,
+      operation: route.turn.operation,
+      questions: requestedTool.questions,
+    };
+    this.#pending.add(pending);
+    this.options.publish(sessionId, route.turn.operation, {
+      type: 'permission',
+      runId: route.turn.operation.runId,
+      lifecycle: {
+        kind: 'requested',
+        permissionOccurrenceId,
+        requestedTool,
+        options: [],
+      },
+      decision: Object.freeze({
+        permissionOccurrenceId,
+        respond: (decision: PermissionDecisionPayload) => this.#resolve(pending, decision),
+      }),
+    });
+  }
+
+  cancelForSession(
+    agentSessionId: string,
+    reason: 'cancelled' | 'session-complete' | 'aborted',
+  ): void {
+    for (const pending of [...this.#pending]) {
+      if (pending.agentSessionId !== agentSessionId) continue;
+      this.#pending.delete(pending);
+      this.options.publish(agentSessionId, pending.operation, {
+        type: 'permission',
+        runId: pending.operation.runId,
+        lifecycle: {
+          kind: 'cancelled',
+          permissionOccurrenceId: pending.permissionOccurrenceId,
+          reason,
+        },
+      });
+    }
+  }
+
+  clear(): void {
+    this.#pending.clear();
+  }
+
+  async #resolve(
+    pending: PendingOpenCodeQuestion,
+    decision: PermissionDecisionPayload,
+  ): Promise<void> {
+    if (!this.#pending.has(pending)) {
+      throw new Error('OpenCode question occurrence is no longer pending');
+    }
+    const response = mapOpenCodeQuestionDecision(pending.questions, decision);
+    const client = await this.options.getClient();
+    const result = await this.options.runScopedRequest(
+      response.kind === 'reply' ? 'OpenCode question reply' : 'OpenCode question reject',
+      { directory: pending.directory },
+      (signal, requestScope) => response.kind === 'reply'
+        ? client.question.reply(
+            withOpenCodeRequestScope({
+              requestID: pending.originalRequestId,
+              answers: response.answers,
+            }, requestScope),
+            { signal },
+          )
+        : client.question.reject(
+            withOpenCodeRequestScope({ requestID: pending.originalRequestId }, requestScope),
+            { signal },
+          ),
+    );
+    throwOpenCodeResultError(result, response.kind === 'reply'
+      ? 'OpenCode question reply failed'
+      : 'OpenCode question reject failed');
+    this.#pending.delete(pending);
+  }
+}

--- a/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
@@ -112,7 +112,7 @@ export function convertOpenCodeQuestionToolUse(
   for (const [questionIndex, entry] of value.entries()) {
     const rawQuestion = asObject(entry);
     const prompt = asString(rawQuestion.question);
-    if (!prompt) continue;
+    if (!prompt) return null;
     const options: AskUserQuestionPrompt['options'] = [];
     if (Array.isArray(rawQuestion.options)) {
       for (const [optionIndex, entry] of rawQuestion.options.entries()) {

--- a/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
@@ -4,6 +4,7 @@
 import {
   AskUserQuestionToolUseMessage,
   BashToolUseMessage,
+  ExecToolUseMessage,
   ReadToolUseMessage,
   EditToolUseMessage,
   WriteToolUseMessage,
@@ -19,6 +20,7 @@ import {
   WriteStdinToolUseMessage,
   EnterPlanModeToolUseMessage,
   ExitPlanModeToolUseMessage,
+  ExternalToolUseMessage,
   UnknownToolUseMessage,
   type ToolUseChatMessage,
   type AskUserQuestionPrompt,
@@ -73,6 +75,33 @@ function canonicalize(raw: unknown): string {
   return raw.trim().toLowerCase().replace(/[\s_\-]+/g, '');
 }
 
+// Pins the built-in tool inventory shipped by OpenCode 1.18.19 so dependency
+// upgrades must reconcile every provider-owned tool with Garcon's contract.
+// https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/tool/registry.ts#L229-L249
+export const OPENCODE_BUILTIN_TOOL_IDS = Object.freeze([
+  'invalid',
+  'question',
+  'bash',
+  'read',
+  'glob',
+  'grep',
+  'edit',
+  'write',
+  'task',
+  'webfetch',
+  'todowrite',
+  'websearch',
+  'skill',
+  'apply_patch',
+  'execute',
+  'lsp',
+  'plan_exit',
+] as const);
+
+const OPENCODE_BUILTIN_TOOL_KEYS = new Set<string>(
+  OPENCODE_BUILTIN_TOOL_IDS.map(canonicalize),
+);
+
 export function convertOpenCodeQuestionToolUse(
   ts: string,
   toolId: string,
@@ -80,24 +109,27 @@ export function convertOpenCodeQuestionToolUse(
 ): AskUserQuestionToolUseMessage | null {
   if (!Array.isArray(value)) return null;
   const questions: AskUserQuestionPrompt[] = [];
-  for (const entry of value) {
+  for (const [questionIndex, entry] of value.entries()) {
     const rawQuestion = asObject(entry);
     const prompt = asString(rawQuestion.question);
     if (!prompt) continue;
     const options: AskUserQuestionPrompt['options'] = [];
     if (Array.isArray(rawQuestion.options)) {
-      for (const entry of rawQuestion.options) {
+      for (const [optionIndex, entry] of rawQuestion.options.entries()) {
         const rawOption = asObject(entry);
         const label = asString(rawOption.label);
         if (!label) continue;
-        const option: AskUserQuestionPrompt['options'][number] = { id: label, label };
+        const option: AskUserQuestionPrompt['options'][number] = {
+          id: `question-${questionIndex + 1}-option-${optionIndex + 1}`,
+          label,
+        };
         const description = asString(rawOption.description);
         if (description !== undefined) option.description = description;
         options.push(option);
       }
     }
     const question: AskUserQuestionPrompt = {
-      id: prompt,
+      id: `question-${questionIndex + 1}`,
       prompt,
       options,
       allowMultiple: asBoolean(rawQuestion.multiple) ?? false,
@@ -157,11 +189,11 @@ export function convertOpenCodeToolUse(ts: string, part: unknown): ToolUseChatMe
       return new WriteToolUseMessage(ts, toolId, filePath, asString(input.content));
     }
 
-    case 'applypatch':
-      return new ApplyPatchToolUseMessage(ts, toolId,
-        asString(input.file_path ?? input.filePath),
-        asString(input.old_string ?? input.oldString),
-        asString(input.new_string ?? input.newString));
+    case 'applypatch': {
+      const patch = asString(input.patchText ?? input.patch_text ?? input.patch);
+      if (patch === undefined) break;
+      return new ApplyPatchToolUseMessage(ts, toolId, undefined, undefined, undefined, patch);
+    }
 
     case 'grep':
       return new GrepToolUseMessage(ts, toolId,
@@ -195,7 +227,7 @@ export function convertOpenCodeToolUse(ts: string, part: unknown): ToolUseChatMe
         asString(input.description),
         asString(input.prompt),
         asString(input.model),
-        asString(input.resume));
+        asString(input.task_id ?? input.taskId ?? input.resume));
 
     case 'updateplan':
       return new UpdatePlanToolUseMessage(ts, toolId, normalizeTodoItems(input.items ?? input.todos));
@@ -210,9 +242,7 @@ export function convertOpenCodeToolUse(ts: string, part: unknown): ToolUseChatMe
     case 'exitplanmode':
     case 'exitplan':
     case 'planexit': {
-      const plan = asString(input.plan);
-      if (plan === undefined) break;
-      return new ExitPlanModeToolUseMessage(ts, toolId, plan,
+      return new ExitPlanModeToolUseMessage(ts, toolId, asString(input.plan) ?? '',
         Array.isArray(input.allowedPrompts) ? input.allowedPrompts : undefined);
     }
 
@@ -221,7 +251,22 @@ export function convertOpenCodeToolUse(ts: string, part: unknown): ToolUseChatMe
       if (question) return question;
       break;
     }
+
+    case 'execute': {
+      const code = asString(input.code);
+      if (code === undefined) break;
+      return new ExecToolUseMessage(ts, toolId, code, 'javascript');
+    }
+
+    case 'skill':
+    case 'lsp':
+    case 'invalid':
+      return new ExternalToolUseMessage(ts, toolId, rawName, asInput(state.input), 'opencode');
   }
 
-  return new UnknownToolUseMessage(ts, toolId, rawName, asInput(state.input));
+  const normalizedInput = asInput(state.input);
+  if (typeof rawPart.tool !== 'string' || OPENCODE_BUILTIN_TOOL_KEYS.has(key)) {
+    return new UnknownToolUseMessage(ts, toolId, rawName, normalizedInput);
+  }
+  return new ExternalToolUseMessage(ts, toolId, rawName, normalizedInput, 'opencode');
 }

--- a/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
@@ -2,6 +2,7 @@
 // ToolUseMessage subclasses. Owns all OpenCode-specific field extraction.
 
 import {
+  AskUserQuestionToolUseMessage,
   BashToolUseMessage,
   ReadToolUseMessage,
   EditToolUseMessage,
@@ -20,6 +21,7 @@ import {
   ExitPlanModeToolUseMessage,
   UnknownToolUseMessage,
   type ToolUseChatMessage,
+  type AskUserQuestionPrompt,
 } from '@garcon/common/chat-types';
 import { normalizeTodoItems } from '@garcon/server-agent-common/shared/normalize-util';
 
@@ -57,6 +59,10 @@ function asNumber(v: unknown): number | undefined {
   return undefined;
 }
 
+function asBoolean(v: unknown): boolean | undefined {
+  return typeof v === 'boolean' ? v : undefined;
+}
+
 function asChanges(v: unknown): Array<{ path?: string; kind?: string }> | undefined {
   return Array.isArray(v) ? v as Array<{ path?: string; kind?: string }> : undefined;
 }
@@ -65,6 +71,43 @@ function asChanges(v: unknown): Array<{ path?: string; kind?: string }> | undefi
 function canonicalize(raw: unknown): string {
   if (typeof raw !== 'string') return '';
   return raw.trim().toLowerCase().replace(/[\s_\-]+/g, '');
+}
+
+export function convertOpenCodeQuestionToolUse(
+  ts: string,
+  toolId: string,
+  value: unknown,
+): AskUserQuestionToolUseMessage | null {
+  if (!Array.isArray(value)) return null;
+  const questions: AskUserQuestionPrompt[] = [];
+  for (const entry of value) {
+    const rawQuestion = asObject(entry);
+    const prompt = asString(rawQuestion.question);
+    if (!prompt) continue;
+    const options: AskUserQuestionPrompt['options'] = [];
+    if (Array.isArray(rawQuestion.options)) {
+      for (const entry of rawQuestion.options) {
+        const rawOption = asObject(entry);
+        const label = asString(rawOption.label);
+        if (!label) continue;
+        const option: AskUserQuestionPrompt['options'][number] = { id: label, label };
+        const description = asString(rawOption.description);
+        if (description !== undefined) option.description = description;
+        options.push(option);
+      }
+    }
+    const question: AskUserQuestionPrompt = {
+      id: prompt,
+      prompt,
+      options,
+      allowMultiple: asBoolean(rawQuestion.multiple) ?? false,
+    };
+    const header = asString(rawQuestion.header);
+    if (header) question.header = header;
+    questions.push(question);
+  }
+  if (questions.length === 0) return null;
+  return new AskUserQuestionToolUseMessage(ts, toolId, undefined, questions);
 }
 
 /**
@@ -171,6 +214,12 @@ export function convertOpenCodeToolUse(ts: string, part: unknown): ToolUseChatMe
       if (plan === undefined) break;
       return new ExitPlanModeToolUseMessage(ts, toolId, plan,
         Array.isArray(input.allowedPrompts) ? input.allowedPrompts : undefined);
+    }
+
+    case 'question': {
+      const question = convertOpenCodeQuestionToolUse(ts, toolId, input.questions);
+      if (question) return question;
+      break;
     }
   }
 

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -106,6 +106,7 @@ export function acceptUniqueOpenCodeTurnEvent(
     && event.type !== 'message.part.updated'
     && event.type !== 'message.part.delta'
     && event.type !== 'permission.asked'
+    && event.type !== 'question.asked'
     && event.type !== 'session.status'
     && event.type !== 'session.error'
     && event.type !== 'session.compacted'


### PR DESCRIPTION
OpenCode could appear hung when provider questions or nested task blockers were not surfaced, while automatic V1 compaction and tool events could escape exact turn routing. This change maps built-in tools to shared contracts, routes questions, permissions, task descendants, and compaction continuations through their owning operations, preserves terminal and native-import behavior, suppresses unsafe native plan transitions, adds pinned real-binary coverage for compaction, steering, blockers, forks, and lifecycle failures, and gives the expanded server protocol suite sufficient bounded CI runtime.