### PR TITLE
Enable chat ID snippets before chat creation

### DIFF
--- a/common/snippets.ts
+++ b/common/snippets.ts
@@ -1,3 +1,5 @@
+import { parseChatId } from './chat-id.js';
+
 export const SNIPPET_MAX_COUNT = 100;
 export const SNIPPET_SHORT_NAME_MAX_LENGTH = 64;
 export const SNIPPET_TEMPLATE_MAX_LENGTH = 32_000;
@@ -83,7 +85,6 @@ export const SNIPPET_ERROR_CODES = {
   limitReached: 'SNIPPET_LIMIT_REACHED',
   expansionTooLong: 'SNIPPET_EXPANSION_TOO_LONG',
   chatNotFound: 'SNIPPET_CHAT_NOT_FOUND',
-  chatIdRequired: 'SNIPPET_CHAT_ID_REQUIRED',
   projectPathRequired: 'SNIPPET_PROJECT_PATH_REQUIRED',
   projectPathOutsideBase: 'SNIPPET_PROJECT_PATH_OUTSIDE_BASE',
   projectPathNotFound: 'SNIPPET_PROJECT_PATH_NOT_FOUND',
@@ -133,7 +134,8 @@ export interface SnippetsMutationResponse {
 }
 
 export type SnippetExpansionContext =
-  { type: 'chat'; chatId: string } | { type: 'project'; projectPath: string };
+  // Registered chats resolve their authoritative project path from the server registry.
+  { type: 'chat'; chatId: string } | { type: 'new-chat'; chatId: string; projectPath: string };
 
 export type SnippetArgumentsInput = { type: 'default' } | { type: 'value'; value: string };
 
@@ -298,24 +300,32 @@ export function normalizeExpandSnippetRequest(value: unknown): ExpandSnippetRequ
     return null;
   }
   if (context.type === 'chat') {
-    const chatId = requiredString(context.chatId);
-    return chatId
-      ? {
-          shortName: raw.shortName,
-          arguments: argumentsInput,
-          context: { type: 'chat', chatId },
-        }
-      : null;
+    try {
+      return {
+        shortName: raw.shortName,
+        arguments: argumentsInput,
+        context: { type: 'chat', chatId: parseChatId(context.chatId) },
+      };
+    } catch {
+      return null;
+    }
   }
-  if (context.type === 'project') {
+  if (context.type === 'new-chat') {
     const projectPath = requiredString(context.projectPath);
-    return projectPath
-      ? {
-          shortName: raw.shortName,
-          arguments: argumentsInput,
-          context: { type: 'project', projectPath },
-        }
-      : null;
+    if (!projectPath) return null;
+    try {
+      return {
+        shortName: raw.shortName,
+        arguments: argumentsInput,
+        context: {
+          type: 'new-chat',
+          chatId: parseChatId(context.chatId),
+          projectPath,
+        },
+      };
+    } catch {
+      return null;
+    }
   }
   return null;
 }

--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -76,6 +76,30 @@ export class SpaDriver {
     });
   }
 
+  async ensureDirectModelSelected(input: {
+    selectedAgentLabel: string;
+    optionAgentLabel: string;
+    modelLabel: string;
+  }): Promise<void> {
+    const directProviderSelected = await this.#page.evaluate(
+      ({ selectedAgentLabel, modelLabel }) => {
+        const dialog = document.querySelector('[role="dialog"]');
+        return [...(dialog?.querySelectorAll('button') ?? [])].some((element) => {
+          const name = element.getAttribute('aria-label') || element.textContent?.trim() || '';
+          return name.includes(selectedAgentLabel) && name.includes(modelLabel);
+        });
+      },
+      { selectedAgentLabel: input.selectedAgentLabel, modelLabel: input.modelLabel },
+    );
+    if (directProviderSelected) return;
+
+    await this.#clickNewChatModelSelector();
+    await this.waitForButton(input.optionAgentLabel, { timeout: 30_000 });
+    await this.clickButton(input.optionAgentLabel);
+    await this.waitForButton(input.modelLabel, { timeout: 30_000 });
+    await this.clickButton(input.modelLabel);
+  }
+
   async #startDirectChat<TRequest>(input: {
     content: string;
     projectPath?: string;
@@ -99,23 +123,7 @@ export class SpaDriver {
       ) === true,
       { timeout: 20_000 },
     );
-    const directProviderSelected = await this.#page.evaluate(
-      ({ selectedAgentLabel, modelLabel }) => {
-        const dialog = document.querySelector('[role="dialog"]');
-        return [...(dialog?.querySelectorAll('button') ?? [])].some((element) => {
-          const name = element.getAttribute('aria-label') || element.textContent?.trim() || '';
-          return name.includes(selectedAgentLabel) && name.includes(modelLabel);
-        });
-      },
-      { selectedAgentLabel: input.selectedAgentLabel, modelLabel: input.modelLabel },
-    );
-    if (!directProviderSelected) {
-      await this.#clickNewChatModelSelector();
-      await this.waitForButton(input.optionAgentLabel, { timeout: 30_000 });
-      await this.clickButton(input.optionAgentLabel);
-      await this.waitForButton(input.modelLabel, { timeout: 30_000 });
-      await this.clickButton(input.modelLabel);
-    }
+    await this.ensureDirectModelSelected(input);
 
     const requestedProjectPath = input.projectPath ?? this.#integration.dirs.project;
     const projectPath = await this.#page.$eval(

--- a/integration-tests/tests/e2e/snippet-new-chat-id.test.ts
+++ b/integration-tests/tests/e2e/snippet-new-chat-id.test.ts
@@ -45,39 +45,11 @@ describe("Lightpanda new-chat snippet expansion", () => {
         { timeout: 20_000 },
       );
 
-      const directProviderSelected = await fixture.page.evaluate(() => {
-        const dialog = document.querySelector('[role="dialog"]');
-        return [...(dialog?.querySelectorAll("button") ?? [])].some(
-          (element) => {
-            const name =
-              element.getAttribute("aria-label") ||
-              element.textContent?.trim() ||
-              "";
-            return (
-              name.includes("Direct (Chat Completions)") &&
-              name.includes("Integration Echo")
-            );
-          },
-        );
+      await app.ensureDirectModelSelected({
+        selectedAgentLabel: "Direct (Chat Completions)",
+        optionAgentLabel: "Chat Completions",
+        modelLabel: "Integration Echo",
       });
-      if (!directProviderSelected) {
-        await fixture.page.evaluate(() => {
-          const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
-          const button = dialog
-            ? [...dialog.querySelectorAll<HTMLButtonElement>("button")].find(
-                (element) =>
-                  (element.getAttribute("aria-label") ?? "").includes(" / "),
-              )
-            : null;
-          if (!button || button.disabled)
-            throw new Error("Missing new chat model selector.");
-          button.click();
-        });
-        await app.waitForButton("Chat Completions", { timeout: 30_000 });
-        await app.clickButton("Chat Completions");
-        await app.waitForButton("Integration Echo", { timeout: 30_000 });
-        await app.clickButton("Integration Echo");
-      }
 
       await app.fill(
         '[role="dialog"] input[aria-label="Project Path"]',

--- a/integration-tests/tests/e2e/snippet-new-chat-id.test.ts
+++ b/integration-tests/tests/e2e/snippet-new-chat-id.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  SnippetsMutationResponse,
+  SnippetsSnapshot,
+} from "../../../common/snippets.js";
+import { withE2eFixture } from "../../support/e2e-fixture.js";
+import { SpaDriver } from "../../support/spa-driver.js";
+
+const NEW_CHAT_COMPOSER =
+  '[role="dialog"] textarea[placeholder="How can I help you today?"]';
+
+describe("Lightpanda new-chat snippet expansion", () => {
+  test("uses one chat ID through expansion, navigation, and server creation", async () => {
+    await withE2eFixture("snippet-new-chat-id", async (fixture) => {
+      const snapshot =
+        await fixture.integration.client.get<SnippetsSnapshot>(
+          "/api/v1/snippets",
+        );
+      await fixture.integration.client.post<SnippetsMutationResponse>(
+        "/api/v1/snippets",
+        {
+          expectedRevision: snapshot.revision,
+          snippet: {
+            shortName: "handoff",
+            template: "Continue chat {{chat_id}}",
+            defaultArguments: "",
+          },
+        },
+      );
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.clickButton("New Chat");
+      await fixture.page.waitForFunction(
+        () => {
+          const dialog = document.querySelector('[role="dialog"]');
+          return (
+            dialog !== null &&
+            dialog.querySelector(
+              '[role="status"][aria-label="Loading chat defaults..."]',
+            ) === null
+          );
+        },
+        { timeout: 20_000 },
+      );
+
+      const directProviderSelected = await fixture.page.evaluate(() => {
+        const dialog = document.querySelector('[role="dialog"]');
+        return [...(dialog?.querySelectorAll("button") ?? [])].some(
+          (element) => {
+            const name =
+              element.getAttribute("aria-label") ||
+              element.textContent?.trim() ||
+              "";
+            return (
+              name.includes("Direct (Chat Completions)") &&
+              name.includes("Integration Echo")
+            );
+          },
+        );
+      });
+      if (!directProviderSelected) {
+        await fixture.page.evaluate(() => {
+          const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+          const button = dialog
+            ? [...dialog.querySelectorAll<HTMLButtonElement>("button")].find(
+                (element) =>
+                  (element.getAttribute("aria-label") ?? "").includes(" / "),
+              )
+            : null;
+          if (!button || button.disabled)
+            throw new Error("Missing new chat model selector.");
+          button.click();
+        });
+        await app.waitForButton("Chat Completions", { timeout: 30_000 });
+        await app.clickButton("Chat Completions");
+        await app.waitForButton("Integration Echo", { timeout: 30_000 });
+        await app.clickButton("Integration Echo");
+      }
+
+      await app.fill(
+        '[role="dialog"] input[aria-label="Project Path"]',
+        fixture.integration.dirs.project,
+      );
+      await app.fill(NEW_CHAT_COMPOSER, "/s handoff");
+      await app.waitForDialogButtonEnabled("Start session");
+      await app.clickButton("Start session");
+      await fixture.page.waitForFunction(
+        (selector) =>
+          /^Continue chat \d{16}$/.test(
+            document.querySelector<HTMLTextAreaElement>(selector)?.value ?? "",
+          ),
+        { timeout: 20_000 },
+        NEW_CHAT_COMPOSER,
+      );
+
+      const expandedPrompt = await fixture.page.$eval(
+        NEW_CHAT_COMPOSER,
+        (element) => (element as HTMLTextAreaElement).value,
+      );
+      const chatId = expandedPrompt.replace("Continue chat ", "");
+      expect(
+        (await fixture.integration.client.listChats()).sessions,
+      ).not.toContainEqual(expect.objectContaining({ id: chatId }));
+
+      const requestPromise =
+        fixture.integration.fakeProviders.openAi.waitForRequest(
+          { lastUserText: expandedPrompt },
+          { timeoutMs: 20_000 },
+        );
+      await app.waitForDialogButtonEnabled("Start session");
+      await app.clickButton("Start session");
+      await requestPromise;
+      await fixture.page.waitForFunction(
+        (expectedChatId) =>
+          window.location.pathname ===
+          `/chat/${encodeURIComponent(expectedChatId)}`,
+        { timeout: 20_000 },
+        chatId,
+      );
+
+      const navigatedChatId = decodeURIComponent(
+        new URL(fixture.page.url()).pathname.slice(6),
+      );
+      expect(navigatedChatId).toBe(chatId);
+      expect(
+        (await fixture.integration.client.listChats()).sessions,
+      ).toContainEqual(expect.objectContaining({ id: chatId }));
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});

--- a/integration-tests/tests/server/snippet-default-arguments.test.ts
+++ b/integration-tests/tests/server/snippet-default-arguments.test.ts
@@ -65,13 +65,18 @@ describe('snippet default arguments', () => {
         });
         expect(updated.snapshot.revision).toBe(8);
         expect(updated.snapshot.snippets[0]?.defaultArguments).toBe('staged\nchanges');
+        const prospectiveChatId = fixture.newChatId();
 
         const omitted = await fixture.client.post<ExpandSnippetResponse>(
           '/api/v1/snippets/expand',
           {
             shortName: 'review',
             arguments: { type: 'default' },
-            context: { type: 'project', projectPath: fixture.dirs.project },
+            context: {
+              type: 'new-chat',
+              chatId: prospectiveChatId,
+              projectPath: fixture.dirs.project,
+            },
           },
         );
         expect(omitted.expandedText).toBe(`Review staged\nchanges in ${fixture.dirs.project}`);
@@ -81,7 +86,11 @@ describe('snippet default arguments', () => {
           {
             shortName: 'review',
             arguments: { type: 'value', value: '' },
-            context: { type: 'project', projectPath: fixture.dirs.project },
+            context: {
+              type: 'new-chat',
+              chatId: prospectiveChatId,
+              projectPath: fixture.dirs.project,
+            },
           },
         );
         expect(explicitEmpty.expandedText).toBe(`Review  in ${fixture.dirs.project}`);
@@ -91,13 +100,31 @@ describe('snippet default arguments', () => {
             fixture.client.post('/api/v1/snippets/expand', {
               shortName: 'review',
               arguments: argumentsInput,
-              context: { type: 'project', projectPath: fixture.dirs.project },
+              context: {
+                type: 'new-chat',
+                chatId: prospectiveChatId,
+                projectPath: fixture.dirs.project,
+              },
             }),
           ).rejects.toMatchObject({
             status: 400,
             body: { errorCode: 'SNIPPET_VALIDATION_FAILED' },
           });
         }
+
+        expect((await fixture.client.listChats()).sessions).not.toContainEqual(
+          expect.objectContaining({ id: prospectiveChatId }),
+        );
+        await expect(
+          fixture.client.post('/api/v1/snippets/expand', {
+            shortName: 'review',
+            arguments: { type: 'default' },
+            context: { type: 'project', projectPath: fixture.dirs.project },
+          }),
+        ).rejects.toMatchObject({
+          status: 400,
+          body: { errorCode: 'SNIPPET_VALIDATION_FAILED' },
+        });
 
         await fixture.restartGarcon();
         const restarted = await fixture.client.get<SnippetsSnapshot>('/api/v1/snippets');
@@ -107,7 +134,11 @@ describe('snippet default arguments', () => {
           fixture.client.post<ExpandSnippetResponse>('/api/v1/snippets/expand', {
             shortName: 'review',
             arguments: { type: 'default' },
-            context: { type: 'project', projectPath: fixture.dirs.project },
+            context: {
+              type: 'new-chat',
+              chatId: prospectiveChatId,
+              projectPath: fixture.dirs.project,
+            },
           }),
         ).resolves.toMatchObject({
           expandedText: `Review staged\nchanges in ${fixture.dirs.project}`,

--- a/server/routes/__tests__/snippets.test.js
+++ b/server/routes/__tests__/snippets.test.js
@@ -76,7 +76,7 @@ describe('snippet routes', () => {
     const omittedRequest = {
       shortName: 'review',
       arguments: { type: 'default' },
-      context: { type: 'chat', chatId: 'chat-a' },
+      context: { type: 'chat', chatId: '1787471053739199' },
     };
     const result = await call(routes['/api/v1/snippets/expand'].POST, omittedRequest, 'POST');
     expect(result.response.status).toBe(200);
@@ -93,7 +93,11 @@ describe('snippet routes', () => {
     const explicitEmptyRequest = {
       shortName: 'review',
       arguments: { type: 'value', value: '' },
-      context: { type: 'chat', chatId: 'chat-a' },
+      context: {
+        type: 'new-chat',
+        chatId: '1787471053739200',
+        projectPath: '/repo',
+      },
     };
     await call(routes['/api/v1/snippets/expand'].POST, explicitEmptyRequest, 'POST');
     expect(snippets.expand).toHaveBeenLastCalledWith(explicitEmptyRequest);
@@ -112,7 +116,7 @@ describe('snippet routes', () => {
         {
           shortName: 'review',
           arguments: argumentsInput,
-          context: { type: 'chat', chatId: 'chat-a' },
+          context: { type: 'chat', chatId: '1787471053739199' },
         },
         'POST',
       );

--- a/server/snippets/__tests__/contracts.test.js
+++ b/server/snippets/__tests__/contracts.test.js
@@ -134,7 +134,10 @@ describe('snippet contracts', () => {
     ).toBeNull();
     const { defaultArguments: _defaultArguments, ...preDefaultArgumentsSnippet } = snippet();
     expect(
-      normalizeSnippetsSnapshot({ revision: 1, snippets: [preDefaultArgumentsSnippet] }),
+      normalizeSnippetsSnapshot({
+        revision: 1,
+        snippets: [preDefaultArgumentsSnippet],
+      }),
     ).toBeNull();
     expect(
       normalizeSnippetsSnapshot({
@@ -202,35 +205,59 @@ describe('snippet contracts', () => {
   });
 
   it('preserves raw explicit arguments and accepts only explicit expansion contexts', () => {
+    const registeredChatId = '1787471053739199';
+    const prospectiveChatId = '1787471053739200';
     expect(
       normalizeExpandSnippetRequest({
         shortName: 'review_api',
         arguments: { type: 'value', value: 'first  line\nsecond' },
-        context: { type: 'chat', chatId: ' 123 ' },
+        context: {
+          type: 'chat',
+          chatId: registeredChatId,
+          projectPath: '/ignored',
+        },
       }),
     ).toEqual({
       shortName: 'review_api',
       arguments: { type: 'value', value: 'first  line\nsecond' },
-      context: { type: 'chat', chatId: '123' },
+      context: { type: 'chat', chatId: registeredChatId },
     });
     expect(
       normalizeExpandSnippetRequest({
         shortName: 'review_api',
         arguments: { type: 'default' },
-        context: { type: 'project', projectPath: ' /repo ' },
+        context: {
+          type: 'new-chat',
+          chatId: prospectiveChatId,
+          projectPath: ' /repo ',
+        },
       }),
     ).toEqual({
       shortName: 'review_api',
       arguments: { type: 'default' },
-      context: { type: 'project', projectPath: '/repo' },
+      context: {
+        type: 'new-chat',
+        chatId: prospectiveChatId,
+        projectPath: '/repo',
+      },
     });
-    expect(
-      normalizeExpandSnippetRequest({
-        shortName: 'review_api',
-        arguments: { type: 'value', value: '' },
-        context: { type: 'unknown', projectPath: '/repo' },
-      }),
-    ).toBeNull();
+    for (const context of [
+      { type: 'project', projectPath: '/repo' },
+      { type: 'unknown', chatId: prospectiveChatId, projectPath: '/repo' },
+      { type: 'chat', chatId: '123' },
+      { type: 'chat' },
+      { type: 'new-chat', chatId: '123', projectPath: '/repo' },
+      { type: 'new-chat', chatId: prospectiveChatId, projectPath: ' ' },
+      { type: 'new-chat', chatId: prospectiveChatId },
+    ]) {
+      expect(
+        normalizeExpandSnippetRequest({
+          shortName: 'review_api',
+          arguments: { type: 'value', value: '' },
+          context,
+        }),
+      ).toBeNull();
+    }
     expect(
       normalizeExpandSnippetRequest({
         shortName: 'review_api',
@@ -238,14 +265,22 @@ describe('snippet contracts', () => {
           type: 'value',
           value: 'x'.repeat(SNIPPET_ARGUMENTS_MAX_LENGTH + 1),
         },
-        context: { type: 'project', projectPath: '/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: prospectiveChatId,
+          projectPath: '/repo',
+        },
       }),
     ).toBeNull();
     expect(
       normalizeExpandSnippetRequest({
         shortName: 'review_api',
         arguments: '',
-        context: { type: 'project', projectPath: '/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: prospectiveChatId,
+          projectPath: '/repo',
+        },
       }),
     ).toBeNull();
   });

--- a/server/snippets/__tests__/service.test.js
+++ b/server/snippets/__tests__/service.test.js
@@ -9,6 +9,9 @@ import { SnippetStore } from '../store.ts';
 
 const createdDirs = [];
 const originalProjectBaseDir = process.env.GARCON_PROJECT_BASE_DIR;
+const REGISTERED_CHAT_ID = '1787471053739199';
+const PROSPECTIVE_CHAT_ID = '1787471053739200';
+const MISSING_CHAT_ID = '1787471053739201';
 
 async function serviceFixture() {
   const dir = path.join(os.tmpdir(), `garcon-snippet-service-${randomUUID()}`);
@@ -17,11 +20,13 @@ async function serviceFixture() {
   const store = new SnippetStore(dir);
   await store.init();
   const events = [];
+  const chatLookups = [];
   const service = new SnippetService({
     store,
     chats: {
       getChat(id) {
-        return id === 'chat-a' ? { projectPath: '/registered/repo' } : null;
+        chatLookups.push(id);
+        return id === REGISTERED_CHAT_ID ? { projectPath: '/registered/repo' } : null;
       },
     },
     projectPaths: {
@@ -33,7 +38,7 @@ async function serviceFixture() {
     now: () => new Date('2026-01-01T00:00:00.000Z'),
   });
   service.onInvalidated((reason) => events.push(reason));
-  return { service, events };
+  return { service, events, chatLookups };
 }
 
 describe('snippet service', () => {
@@ -72,8 +77,8 @@ describe('snippet service', () => {
     expect(events).toEqual(['created', 'updated', 'removed']);
   });
 
-  it('expands chat and project contexts without emitting invalidations', async () => {
-    const { service, events } = await serviceFixture();
+  it('expands registered and prospective chat contexts without emitting invalidations', async () => {
+    const { service, events, chatLookups } = await serviceFixture();
     await service.create({
       expectedRevision: 0,
       snippet: {
@@ -87,7 +92,11 @@ describe('snippet service', () => {
       await service.expand({
         shortName: 'review',
         arguments: { type: 'value', value: 'contracts' },
-        context: { type: 'chat', chatId: 'chat-a' },
+        context: {
+          type: 'chat',
+          chatId: REGISTERED_CHAT_ID,
+          projectPath: '/ignored',
+        },
       }),
     ).toMatchObject({
       snippetUpdatedAt: '2026-01-01T00:00:00.000Z',
@@ -98,12 +107,17 @@ describe('snippet service', () => {
       await service.expand({
         shortName: 'review',
         arguments: { type: 'value', value: 'routes' },
-        context: { type: 'project', projectPath: '/draft/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: PROSPECTIVE_CHAT_ID,
+          projectPath: '/draft/repo',
+        },
       }),
     ).toMatchObject({
       contextProjectPath: '/draft/repo',
       expandedText: 'Review routes in /canonical/draft/repo',
     });
+    expect(chatLookups).toEqual([REGISTERED_CHAT_ID]);
     expect(events).toEqual([]);
   });
 
@@ -122,7 +136,11 @@ describe('snippet service', () => {
       service.expand({
         shortName: 'review',
         arguments: { type: 'default' },
-        context: { type: 'project', projectPath: '/draft/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: PROSPECTIVE_CHAT_ID,
+          projectPath: '/draft/repo',
+        },
       }),
     ).resolves.toMatchObject({
       expandedText: '{{project_path}} changes / {{project_path}} changes / /canonical/draft/repo',
@@ -131,14 +149,22 @@ describe('snippet service', () => {
       service.expand({
         shortName: 'review',
         arguments: { type: 'value', value: '' },
-        context: { type: 'project', projectPath: '/draft/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: PROSPECTIVE_CHAT_ID,
+          projectPath: '/draft/repo',
+        },
       }),
     ).resolves.toMatchObject({ expandedText: ' /  / /canonical/draft/repo' });
     await expect(
       service.expand({
         shortName: 'review',
         arguments: { type: 'value', value: '  ' },
-        context: { type: 'project', projectPath: '/draft/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: PROSPECTIVE_CHAT_ID,
+          projectPath: '/draft/repo',
+        },
       }),
     ).resolves.toMatchObject({
       expandedText: '   /    / /canonical/draft/repo',
@@ -170,7 +196,11 @@ describe('snippet service', () => {
       service.expand({
         shortName: 'large',
         arguments: { type: 'default' },
-        context: { type: 'project', projectPath: '/draft/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: PROSPECTIVE_CHAT_ID,
+          projectPath: '/draft/repo',
+        },
       }),
     ).rejects.toMatchObject({
       code: 'SNIPPET_EXPANSION_TOO_LONG',
@@ -178,8 +208,8 @@ describe('snippet service', () => {
     });
   });
 
-  it('expands chat IDs only when an existing chat supplies the context', async () => {
-    const { service } = await serviceFixture();
+  it('expands the supplied ID for both registered and prospective chats', async () => {
+    const { service, chatLookups } = await serviceFixture();
     await service.create({
       expectedRevision: 0,
       snippet: {
@@ -193,18 +223,25 @@ describe('snippet service', () => {
       service.expand({
         shortName: 'handoff',
         arguments: { type: 'value', value: 'the review' },
-        context: { type: 'chat', chatId: 'chat-a' },
+        context: { type: 'chat', chatId: REGISTERED_CHAT_ID },
       }),
     ).resolves.toMatchObject({
-      expandedText: 'Reply to chat-a about the review',
+      expandedText: `Reply to ${REGISTERED_CHAT_ID} about the review`,
     });
     await expect(
       service.expand({
         shortName: 'handoff',
         arguments: { type: 'value', value: 'the review' },
-        context: { type: 'project', projectPath: '/draft/repo' },
+        context: {
+          type: 'new-chat',
+          chatId: PROSPECTIVE_CHAT_ID,
+          projectPath: '/draft/repo',
+        },
       }),
-    ).rejects.toMatchObject({ code: 'SNIPPET_CHAT_ID_REQUIRED', status: 422 });
+    ).resolves.toMatchObject({
+      expandedText: `Reply to ${PROSPECTIVE_CHAT_ID} about the review`,
+    });
+    expect(chatLookups).toEqual([REGISTERED_CHAT_ID]);
   });
 
   it('rejects missing chats and unknown snippets', async () => {
@@ -213,7 +250,7 @@ describe('snippet service', () => {
       service.expand({
         shortName: 'missing',
         arguments: { type: 'value', value: '' },
-        context: { type: 'chat', chatId: 'chat-a' },
+        context: { type: 'chat', chatId: REGISTERED_CHAT_ID },
       }),
     ).rejects.toMatchObject({ code: 'SNIPPET_NOT_FOUND', status: 404 });
     await service.create({
@@ -228,7 +265,7 @@ describe('snippet service', () => {
       service.expand({
         shortName: 'review',
         arguments: { type: 'value', value: '' },
-        context: { type: 'chat', chatId: 'missing' },
+        context: { type: 'chat', chatId: MISSING_CHAT_ID },
       }),
     ).rejects.toMatchObject({ code: 'SNIPPET_CHAT_NOT_FOUND', status: 404 });
   });

--- a/server/snippets/service.ts
+++ b/server/snippets/service.ts
@@ -4,7 +4,6 @@ import { promises as fs } from 'fs';
 import {
   normalizeExpandSnippetRequest,
   normalizeSnippetDefinitionInput,
-  snippetTemplateUsesChatId,
   type CreateSnippetRequest,
   type ExpandSnippetRequest,
   type ExpandSnippetResponse,
@@ -163,14 +162,6 @@ export class SnippetService extends EventEmitter<SnippetServiceEvents> {
     }
     const argumentsText =
       input.arguments.type === 'default' ? snippet.defaultArguments : input.arguments.value;
-    const chatId = input.context.type === 'chat' ? input.context.chatId : null;
-    if (chatId === null && snippetTemplateUsesChatId(snippet.template)) {
-      throw new SnippetDomainError(
-        'SNIPPET_CHAT_ID_REQUIRED',
-        'The {{chat_id}} placeholder requires an existing chat',
-        422,
-      );
-    }
     const { contextProjectPath, resolvedProjectPath } = await this.#resolveProjectPath(
       input.context,
     );
@@ -179,7 +170,7 @@ export class SnippetService extends EventEmitter<SnippetServiceEvents> {
       expandedText = expandSnippetTemplate(snippet.template, {
         arguments: argumentsText,
         projectPath: resolvedProjectPath,
-        chatId: chatId ?? '',
+        chatId: input.context.chatId,
       });
     } catch (error) {
       if (error instanceof SnippetExpansionError) {
@@ -207,7 +198,7 @@ export class SnippetService extends EventEmitter<SnippetServiceEvents> {
     contextProjectPath: string;
     resolvedProjectPath: string;
   }> {
-    if (context.type === 'project') {
+    if (context.type === 'new-chat') {
       return {
         contextProjectPath: context.projectPath,
         resolvedProjectPath: await this.deps.projectPaths.resolve(context.projectPath),

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1748,7 +1748,7 @@
 	"snippets_template_expand": "Expand snippet text",
 	"snippets_template_editor_label": "Expanded snippet text",
 	"snippets_template_editor_title": "Snippet text",
-	"snippets_template_help": "Supports {argumentsToken}, {projectPathToken}, and {chatIdToken} replacements. {chatIdToken} requires an existing chat.",
+	"snippets_template_help": "Supports {argumentsToken}, {projectPathToken}, and {chatIdToken} replacements. {chatIdToken} works in both existing and new chats.",
 	"snippets_template_placeholder": "From {chatIdToken}, review {argumentsToken} in {projectPathToken}.",
 	"snippets_template_required": "Enter snippet text.",
 	"snippets_template_too_long": "Snippet text cannot exceed 32,000 characters.",

--- a/web/src/lib/api/__tests__/snippets-contract.test.ts
+++ b/web/src/lib/api/__tests__/snippets-contract.test.ts
@@ -68,12 +68,12 @@ describe('snippets API contract', () => {
 		await expandSnippet({
 			shortName: snippet.shortName,
 			arguments: { type: 'default' },
-			context: { type: 'project', projectPath: '/repo' },
+			context: { type: 'new-chat', chatId: '1787471053739199', projectPath: '/repo' },
 		});
 		await expandSnippet({
 			shortName: snippet.shortName,
 			arguments: { type: 'value', value: '' },
-			context: { type: 'project', projectPath: '/repo' },
+			context: { type: 'new-chat', chatId: '1787471053739199', projectPath: '/repo' },
 		});
 
 		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
@@ -137,7 +137,7 @@ describe('snippets API contract', () => {
 			expandSnippet({
 				shortName: 'review',
 				arguments: { type: 'value', value: 'the API' },
-				context: { type: 'project', projectPath: '/repo' },
+				context: { type: 'new-chat', chatId: '1787471053739199', projectPath: '/repo' },
 			}),
 		).rejects.toThrow('Invalid snippet expansion response');
 	});
@@ -150,7 +150,7 @@ describe('snippets API contract', () => {
 			{
 				shortName: 'review',
 				arguments: { type: 'value', value: 'the API' },
-				context: { type: 'project', projectPath: '/repo' },
+				context: { type: 'new-chat', chatId: '1787471053739199', projectPath: '/repo' },
 			},
 			{ signal: controller.signal },
 		);

--- a/web/src/lib/components/chat/NewChatDialog.svelte
+++ b/web/src/lib/components/chat/NewChatDialog.svelte
@@ -5,7 +5,7 @@
 
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { getAppShell, getChatSessions, getWorkspaceCoordinator } from '$lib/context';
-	import { createClientChatId } from '$shared/client-chat-id';
+	import type { ChatId } from '$shared/chat-id';
 	import { gotoChat } from '$lib/chat/actions/chat-navigation.js';
 	import type { NewChatConfig } from '$lib/types/app';
 	import NewChatForm from './NewChatForm.svelte';
@@ -21,9 +21,7 @@
 		if (!next) appShell.closeNewChatDialog();
 	}
 
-	function handleStartChat(config: NewChatConfig) {
-		const chatId = createClientChatId();
-
+	function handleStartChat(config: NewChatConfig, chatId: ChatId) {
 		sessions.createDraft({
 			id: chatId,
 			projectPath: config.projectPath,

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -171,7 +171,7 @@
 	function reseed(): void {
 		snippetExpansion.cancel();
 		promptRefinement.abort();
-		prospectiveChatId = createClientChatId();
+		prospectiveChatId = null;
 		composerEditor.reset();
 		snippetInteractionGeneration += 1;
 		snippetPalette.reset();
@@ -354,10 +354,15 @@
 		if (snippetExpansion.pending) textareaRef?.focus();
 	}
 
+	function ensureProspectiveChatId(): ChatId {
+		if (!prospectiveChatId) prospectiveChatId = createClientChatId();
+		return prospectiveChatId;
+	}
+
 	function expansionContext() {
 		const projectPath = form.trimmedPath;
-		if (projectPath && prospectiveChatId) {
-			return { type: 'new-chat' as const, chatId: prospectiveChatId, projectPath };
+		if (projectPath) {
+			return { type: 'new-chat' as const, chatId: ensureProspectiveChatId(), projectPath };
 		}
 		notifications.error(m.chat_new_chat_errors_project_path_required());
 		return null;
@@ -375,7 +380,6 @@
 			return 'cancelled';
 		}
 		const sourceText = form.firstMessage;
-		const chatId = context.chatId;
 		const projectPath = context.projectPath;
 		const start = range?.start ?? textareaRef.selectionStart;
 		const end = range?.end ?? textareaRef.selectionEnd;
@@ -399,7 +403,6 @@
 				return 'cancelled';
 			}
 			if (
-				prospectiveChatId !== chatId ||
 				form.trimmedPath !== projectPath ||
 				result.response.contextProjectPath !== projectPath ||
 				form.firstMessage !== sourceText
@@ -429,7 +432,6 @@
 		const context = expansionContext();
 		if (!context) return;
 		const sourceText = form.firstMessage;
-		const chatId = context.chatId;
 		const projectPath = context.projectPath;
 		try {
 			const [result] = await Promise.all([
@@ -442,7 +444,6 @@
 			]);
 			if (result.kind !== 'expanded') return;
 			if (
-				prospectiveChatId !== chatId ||
 				form.trimmedPath !== projectPath ||
 				result.response.contextProjectPath !== projectPath ||
 				form.firstMessage !== sourceText
@@ -479,8 +480,7 @@
 			return;
 		}
 		const config = form.buildConfig();
-		const chatId = prospectiveChatId;
-		if (config && chatId) onStartChat(config, chatId);
+		if (config) onStartChat(config, ensureProspectiveChatId());
 	}
 
 	function handleKeyDown(e: KeyboardEvent): void {

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -68,6 +68,8 @@
 	import { SnippetExpansionController } from '$lib/snippets/snippet-expansion-controller.svelte.js';
 	import { ApiError } from '$lib/api/client.js';
 	import { snippetTemplateUsesArguments, type Snippet } from '$shared/snippets';
+	import { createClientChatId } from '$shared/client-chat-id';
+	import type { ChatId } from '$shared/chat-id';
 	import { transientLayerAttachment } from '$lib/workspace/transient-layer-action.js';
 	import { allocateTransientLayerId } from '$lib/workspace/transient-layer-id.js';
 	import { nonDirectAgentIds } from '$lib/agents/direct-agents.js';
@@ -76,7 +78,7 @@
 
 	interface Props {
 		prefill?: string;
-		onStartChat: (config: NewChatConfig) => void;
+		onStartChat: (config: NewChatConfig, chatId: ChatId) => void;
 		onCancel?: () => void;
 	}
 
@@ -126,6 +128,7 @@
 
 	let isMobile = $state(false);
 	let pendingTextareaFocus = $state(true);
+	let prospectiveChatId = $state<ChatId | null>(null);
 	const allKnownTags = $derived(
 		Array.from(new Set(sessions.orderedChats.flatMap((c) => c.tags))).sort(),
 	);
@@ -168,6 +171,7 @@
 	function reseed(): void {
 		snippetExpansion.cancel();
 		promptRefinement.abort();
+		prospectiveChatId = createClientChatId();
 		composerEditor.reset();
 		snippetInteractionGeneration += 1;
 		snippetPalette.reset();
@@ -352,7 +356,9 @@
 
 	function expansionContext() {
 		const projectPath = form.trimmedPath;
-		if (projectPath) return { type: 'project' as const, projectPath };
+		if (projectPath && prospectiveChatId) {
+			return { type: 'new-chat' as const, chatId: prospectiveChatId, projectPath };
+		}
 		notifications.error(m.chat_new_chat_errors_project_path_required());
 		return null;
 	}
@@ -369,6 +375,7 @@
 			return 'cancelled';
 		}
 		const sourceText = form.firstMessage;
+		const chatId = context.chatId;
 		const projectPath = context.projectPath;
 		const start = range?.start ?? textareaRef.selectionStart;
 		const end = range?.end ?? textareaRef.selectionEnd;
@@ -392,6 +399,7 @@
 				return 'cancelled';
 			}
 			if (
+				prospectiveChatId !== chatId ||
 				form.trimmedPath !== projectPath ||
 				result.response.contextProjectPath !== projectPath ||
 				form.firstMessage !== sourceText
@@ -421,6 +429,7 @@
 		const context = expansionContext();
 		if (!context) return;
 		const sourceText = form.firstMessage;
+		const chatId = context.chatId;
 		const projectPath = context.projectPath;
 		try {
 			const [result] = await Promise.all([
@@ -433,6 +442,7 @@
 			]);
 			if (result.kind !== 'expanded') return;
 			if (
+				prospectiveChatId !== chatId ||
 				form.trimmedPath !== projectPath ||
 				result.response.contextProjectPath !== projectPath ||
 				form.firstMessage !== sourceText
@@ -469,7 +479,8 @@
 			return;
 		}
 		const config = form.buildConfig();
-		if (config) onStartChat(config);
+		const chatId = prospectiveChatId;
+		if (config && chatId) onStartChat(config, chatId);
 	}
 
 	function handleKeyDown(e: KeyboardEvent): void {
@@ -497,6 +508,7 @@
 	}
 
 	function cancelForm(): void {
+		snippetExpansion.cancel();
 		promptRefinement.abort();
 		composerEditor.close();
 		onCancel?.();

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -420,7 +420,7 @@
 		const projectPath = chat?.projectPath.trim();
 		if (!chat || !projectPath) return null;
 		return chat.status === 'draft'
-			? { type: 'project', projectPath }
+			? { type: 'new-chat', chatId: chat.id, projectPath }
 			: { type: 'chat', chatId: chat.id };
 	}
 

--- a/web/src/lib/components/chat/__tests__/NewChatDialog.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatDialog.test.ts
@@ -4,6 +4,9 @@ import type { RefinePromptResponse } from '$shared/prompt-refinement';
 import type { RemoteSettingsSnapshot } from '$shared/settings';
 import * as refinementApi from '$lib/api/prompt-refinement';
 import * as settingsApi from '$lib/api/settings';
+import * as snippetsApi from '$lib/api/snippets';
+import * as navigation from '$lib/chat/actions/chat-navigation.js';
+import * as clientChatId from '$shared/client-chat-id';
 import NewChatDialogTestHost from './NewChatDialogTestHost.svelte';
 import { resetPromptEditorStub } from '$lib/components/prompt-editor/__tests__/PromptEditorStub.svelte';
 
@@ -26,10 +29,21 @@ vi.mock('$lib/api/prompt-refinement', async (importOriginal) => {
 	return { ...actual, refinePrompt: vi.fn() };
 });
 
-vi.mock('$lib/components/prompt-editor/PromptEditor.svelte', async () => ({
-	default: (await import('$lib/components/prompt-editor/__tests__/PromptEditorStub.svelte'))
-		.default,
-}));
+	vi.mock('$lib/api/snippets', async (importOriginal) => {
+		const actual = await importOriginal<typeof import('$lib/api/snippets')>();
+		return { ...actual, expandSnippet: vi.fn() };
+});
+
+vi.mock('$lib/chat/actions/chat-navigation.js', () => ({ gotoChat: vi.fn() }));
+
+	vi.mock('$shared/client-chat-id', () => ({
+		createClientChatId: vi.fn(() => '1787471053739199'),
+	}));
+
+	vi.mock('$lib/components/prompt-editor/PromptEditor.svelte', async () => ({
+		default: (await import('$lib/components/prompt-editor/__tests__/PromptEditorStub.svelte'))
+			.default,
+	}));
 
 interface DeferredRefinement {
 	promise: Promise<RefinePromptResponse>;
@@ -98,14 +112,71 @@ describe('NewChatDialog', () => {
 			})),
 		);
 		vi.mocked(settingsApi.getRemoteSettings).mockResolvedValue(makeSnapshot());
+		vi.mocked(navigation.gotoChat).mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
 		cleanup();
 		resetPromptEditorStub();
 		vi.mocked(refinementApi.refinePrompt).mockReset();
+		vi.mocked(snippetsApi.expandSnippet).mockReset();
 		vi.unstubAllGlobals();
 		vi.clearAllMocks();
+	});
+
+	it('uses one prospective ID for expansion, draft creation, and navigation', async () => {
+		const onCreateDraft = vi.fn();
+		vi.mocked(snippetsApi.expandSnippet).mockImplementationOnce(async (request) => {
+			if (request.context.type !== 'new-chat') throw new Error('Expected new-chat context');
+			return {
+				success: true,
+				snippetId: 'snippet-handoff',
+				snippetUpdatedAt: '2026-01-01T00:00:00.000Z',
+				shortName: 'handoff',
+				contextProjectPath: request.context.projectPath,
+				expandedText: `Continue chat ${request.context.chatId}`,
+			};
+		});
+		render(NewChatDialogTestHost, {
+			snippetTemplate: 'Continue chat {{chat_id}}',
+			onCreateDraft,
+		});
+		await waitFor(() => {
+			expect(screen.queryByRole('status', { name: 'Loading chat defaults...' })).toBeNull();
+		});
+		const messageInput = screen.getByPlaceholderText(
+			'How can I help you today?',
+		) as HTMLTextAreaElement;
+		await fireEvent.input(messageInput, { target: { value: '/s handoff' } });
+		await waitFor(() => {
+			expect((screen.getByRole('button', { name: 'Start session' }) as HTMLButtonElement).disabled).toBe(
+				false,
+			);
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Start session' }));
+		await waitFor(() => expect(messageInput.value).toBe('Continue chat 1787471053739199'));
+		await fireEvent.click(screen.getByRole('button', { name: 'Start session' }));
+
+		await waitFor(() => expect(onCreateDraft).toHaveBeenCalledTimes(1));
+		expect(snippetsApi.expandSnippet).toHaveBeenCalledWith(
+			expect.objectContaining({
+				context: {
+					type: 'new-chat',
+					chatId: '1787471053739199',
+					projectPath: '/workspace',
+				},
+			}),
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+		expect(onCreateDraft).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: '1787471053739199',
+				startup: expect.objectContaining({ firstMessage: 'Continue chat 1787471053739199' }),
+			}),
+		);
+		expect(navigation.gotoChat).toHaveBeenCalledWith('1787471053739199');
+		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(1);
 	});
 
 	it('keeps the small-screen dialog within the safe viewport', async () => {

--- a/web/src/lib/components/chat/__tests__/NewChatDialogTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/NewChatDialogTestHost.svelte
@@ -18,6 +18,13 @@
 	import { createNotificationsStore } from '$lib/stores/notifications.svelte.js';
 	import { createSnippetsStore } from '$lib/snippets/snippets-store.svelte.js';
 
+	interface Props {
+		snippetTemplate?: string | null;
+		onCreateDraft?: (draft: unknown) => void;
+	}
+
+	let { snippetTemplate = null, onCreateDraft = () => {} }: Props = $props();
+
 	const appShell = createAppShellStore();
 	appShell.projectBasePath = '/workspace';
 	appShell.openNewChatDialog();
@@ -33,12 +40,28 @@
 	setTransientLayers(transientLayers);
 	setSnippets(
 		createSnippetsStore({
-			get: async () => ({ revision: 0, snippets: [] }),
+			get: async () => ({
+				revision: 0,
+				snippets: snippetTemplate
+					? [
+							{
+								id: 'snippet-handoff',
+								shortName: 'handoff',
+								template: snippetTemplate,
+								defaultArguments: '',
+								createdAt: '2026-01-01T00:00:00.000Z',
+								updatedAt: '2026-01-01T00:00:00.000Z',
+							},
+						]
+					: [],
+			}),
 		}),
 	);
 	setChatSessions({
 		orderedChats: [],
-		createDraft() {},
+		createDraft(draft: unknown) {
+			onCreateDraft(draft);
+		},
 	} as never);
 	setWorkspaceCoordinator({
 		focusChat: () => Promise.resolve(),

--- a/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
@@ -5,6 +5,11 @@ import * as settingsApi from '$lib/api/settings';
 import * as gitApi from '$lib/api/git';
 import type { RemoteSettingsSnapshot } from '$shared/settings';
 import * as snippetsApi from '$lib/api/snippets';
+import * as clientChatId from '$shared/client-chat-id';
+import { parseChatId } from '$shared/chat-id';
+
+const PROSPECTIVE_CHAT_ID = parseChatId('1787471053739199');
+const RESEEDED_CHAT_ID = parseChatId('1787471053739200');
 
 vi.mock('$lib/api/chats', () => ({
 	validateStart: vi.fn(),
@@ -23,6 +28,10 @@ vi.mock('$lib/api/snippets', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api/snippets')>();
 	return { ...actual, expandSnippet: vi.fn() };
 });
+
+vi.mock('$shared/client-chat-id', () => ({
+	createClientChatId: vi.fn(() => '1787471053739199'),
+}));
 
 function deferred<T>() {
 	let resolve!: (value: T) => void;
@@ -159,6 +168,8 @@ describe('NewChatForm', () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 		vi.mocked(snippetsApi.expandSnippet).mockReset();
+		vi.mocked(clientChatId.createClientChatId).mockReset();
+		vi.mocked(clientChatId.createClientChatId).mockReturnValue(PROSPECTIVE_CHAT_ID);
 	});
 
 	it('does not submit on Enter on mobile (Enter inserts a newline)', async () => {
@@ -182,6 +193,7 @@ describe('NewChatForm', () => {
 		await fireEvent.keyDown(messageInput, { key: 'Enter' });
 
 		expect(onStartChat).toHaveBeenCalledTimes(1);
+		expect(onStartChat.mock.calls[0]?.[1]).toBe(PROSPECTIVE_CHAT_ID);
 	});
 
 	it('shows a centered spinner and hides the composer until settings load', async () => {
@@ -538,13 +550,52 @@ describe('NewChatForm', () => {
 			{
 				shortName: 'review',
 				arguments: { type: 'value', value: 'the API' },
-				context: { type: 'project', projectPath: '/workspace/project' },
+				context: {
+					type: 'new-chat',
+					chatId: PROSPECTIVE_CHAT_ID,
+					projectPath: '/workspace/project',
+				},
 			},
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
 
 		await fireEvent.keyDown(messageInput, { key: 'Enter' });
 		expect(onStartChat).toHaveBeenCalledTimes(1);
+		expect(onStartChat).toHaveBeenCalledWith(
+			expect.objectContaining({ firstMessage: 'Review the API in /workspace/project' }),
+			PROSPECTIVE_CHAT_ID,
+		);
+	});
+
+	it('keeps the prospective ID stable across edits and rotates it on reseed', async () => {
+		stubMatchMedia(false);
+		vi.mocked(clientChatId.createClientChatId)
+			.mockReset()
+			.mockReturnValueOnce(PROSPECTIVE_CHAT_ID)
+			.mockReturnValueOnce(RESEEDED_CHAT_ID);
+		const onStartChat = vi.fn();
+		const messageInput = await renderSubmittableForm(onStartChat);
+
+		await fireEvent.input(screen.getByRole('textbox', { name: 'Project Path' }), {
+			target: { value: '/workspace/other' },
+		});
+		await fireEvent.input(messageInput, { target: { value: 'edited prompt' } });
+		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(1);
+
+		await fireEvent.click(screen.getByTestId('reseed-new-chat'));
+		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(2);
+		await fireEvent.input(messageInput, { target: { value: 'after reseed' } });
+		await waitFor(() => {
+			expect(
+				(screen.getByRole('button', { name: 'Start session' }) as HTMLButtonElement).disabled,
+			).toBe(false);
+		});
+		await fireEvent.keyDown(messageInput, { key: 'Enter' });
+
+		expect(onStartChat).toHaveBeenCalledWith(
+			expect.objectContaining({ firstMessage: 'after reseed' }),
+			RESEEDED_CHAT_ID,
+		);
 	});
 
 	it('distinguishes omitted slash arguments from an explicit empty value', async () => {
@@ -571,7 +622,11 @@ describe('NewChatForm', () => {
 			{
 				shortName: 'review',
 				arguments: { type: 'default' },
-				context: { type: 'project', projectPath: '/workspace/project' },
+				context: {
+					type: 'new-chat',
+					chatId: PROSPECTIVE_CHAT_ID,
+					projectPath: '/workspace/project',
+				},
 			},
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
@@ -580,7 +635,11 @@ describe('NewChatForm', () => {
 			{
 				shortName: 'review',
 				arguments: { type: 'value', value: '' },
-				context: { type: 'project', projectPath: '/workspace/project' },
+				context: {
+					type: 'new-chat',
+					chatId: PROSPECTIVE_CHAT_ID,
+					projectPath: '/workspace/project',
+				},
 			},
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
@@ -616,7 +675,11 @@ describe('NewChatForm', () => {
 			{
 				shortName: 'review',
 				arguments: { type: 'value', value: '' },
-				context: { type: 'project', projectPath: '/workspace/project' },
+				context: {
+					type: 'new-chat',
+					chatId: PROSPECTIVE_CHAT_ID,
+					projectPath: '/workspace/project',
+				},
 			},
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
@@ -651,7 +714,11 @@ describe('NewChatForm', () => {
 			{
 				shortName: 'review',
 				arguments: { type: 'value', value: 'saved default' },
-				context: { type: 'project', projectPath: '/workspace/project' },
+				context: {
+					type: 'new-chat',
+					chatId: PROSPECTIVE_CHAT_ID,
+					projectPath: '/workspace/project',
+				},
 			},
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);

--- a/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
@@ -598,6 +598,53 @@ describe('NewChatForm', () => {
 		);
 	});
 
+	it('does not apply an old-ID expansion after reseeding', async () => {
+		stubMatchMedia(false);
+		vi.mocked(clientChatId.createClientChatId)
+			.mockReset()
+			.mockReturnValueOnce(PROSPECTIVE_CHAT_ID)
+			.mockReturnValueOnce(RESEEDED_CHAT_ID);
+		const pending = deferred<Awaited<ReturnType<typeof snippetsApi.expandSnippet>>>();
+		vi.mocked(snippetsApi.expandSnippet).mockReturnValueOnce(pending.promise);
+		const onStartChat = vi.fn();
+		const messageInput = await renderSubmittableForm(onStartChat);
+		await fireEvent.input(messageInput, { target: { value: '/snippet review stale ID' } });
+		await fireEvent.keyDown(messageInput, { key: 'Enter' });
+		await screen.findByRole('button', { name: 'Expanding snippet' });
+
+		await fireEvent.click(screen.getByTestId('reseed-new-chat'));
+		await fireEvent.input(messageInput, { target: { value: 'after reseed' } });
+		pending.resolve({
+			success: true,
+			snippetId: 'snippet-review',
+			snippetUpdatedAt: '2026-01-01T00:00:00.000Z',
+			shortName: 'review',
+			contextProjectPath: '/workspace/project',
+			expandedText: 'must not apply',
+		});
+
+		await pending.promise;
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(messageInput.value).toBe('after reseed');
+		await waitFor(() => {
+			expect(
+				(screen.getByRole('button', { name: 'Start session' }) as HTMLButtonElement).disabled,
+			).toBe(false);
+		});
+		await fireEvent.keyDown(messageInput, { key: 'Enter' });
+
+		expect(snippetsApi.expandSnippet).toHaveBeenCalledWith(
+			expect.objectContaining({
+				context: expect.objectContaining({ chatId: PROSPECTIVE_CHAT_ID }),
+			}),
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+		expect(onStartChat).toHaveBeenCalledWith(
+			expect.objectContaining({ firstMessage: 'after reseed' }),
+			RESEEDED_CHAT_ID,
+		);
+	});
+
 	it('distinguishes omitted slash arguments from an explicit empty value', async () => {
 		stubMatchMedia(false);
 		vi.mocked(snippetsApi.expandSnippet).mockResolvedValue({

--- a/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
@@ -567,23 +567,33 @@ describe('NewChatForm', () => {
 		);
 	});
 
-	it('keeps the prospective ID stable across edits and rotates it on reseed', async () => {
+	it('mints the prospective ID lazily and clears it on reseed', async () => {
 		stubMatchMedia(false);
 		vi.mocked(clientChatId.createClientChatId)
 			.mockReset()
 			.mockReturnValueOnce(PROSPECTIVE_CHAT_ID)
 			.mockReturnValueOnce(RESEEDED_CHAT_ID);
+		vi.mocked(snippetsApi.expandSnippet).mockResolvedValueOnce({
+			success: true,
+			snippetId: 'snippet-review',
+			snippetUpdatedAt: '2026-01-01T00:00:00.000Z',
+			shortName: 'review',
+			contextProjectPath: '/workspace/project',
+			expandedText: 'expanded prompt',
+		});
 		const onStartChat = vi.fn();
 		const messageInput = await renderSubmittableForm(onStartChat);
 
-		await fireEvent.input(screen.getByRole('textbox', { name: 'Project Path' }), {
-			target: { value: '/workspace/other' },
-		});
+		await fireEvent.input(messageInput, { target: { value: '/snippet review first' } });
+		expect(clientChatId.createClientChatId).not.toHaveBeenCalled();
+		await fireEvent.keyDown(messageInput, { key: 'Enter' });
+		await waitFor(() => expect(messageInput.value).toBe('expanded prompt'));
+		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(1);
 		await fireEvent.input(messageInput, { target: { value: 'edited prompt' } });
 		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(1);
 
 		await fireEvent.click(screen.getByTestId('reseed-new-chat'));
-		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(2);
+		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(1);
 		await fireEvent.input(messageInput, { target: { value: 'after reseed' } });
 		await waitFor(() => {
 			expect(
@@ -592,13 +602,14 @@ describe('NewChatForm', () => {
 		});
 		await fireEvent.keyDown(messageInput, { key: 'Enter' });
 
+		expect(clientChatId.createClientChatId).toHaveBeenCalledTimes(2);
 		expect(onStartChat).toHaveBeenCalledWith(
 			expect.objectContaining({ firstMessage: 'after reseed' }),
 			RESEEDED_CHAT_ID,
 		);
 	});
 
-	it('does not apply an old-ID expansion after reseeding', async () => {
+	it('cancels an in-flight expansion on reseed', async () => {
 		stubMatchMedia(false);
 		vi.mocked(clientChatId.createClientChatId)
 			.mockReset()

--- a/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/context';
 	import { createRemoteSettingsStore } from '$lib/stores/remote-settings.svelte';
 	import type { NewChatConfig } from '$lib/types/app.js';
+	import type { ChatId } from '$shared/chat-id';
 	import { createSnippetsStore } from '$lib/snippets/snippets-store.svelte.js';
 	import { createNotificationsStore } from '$lib/stores/notifications.svelte.js';
 	import KeyboardShortcuts from '$lib/components/shared/KeyboardShortcuts.svelte';
@@ -29,7 +30,7 @@
 		snippetTrigger?: string;
 		snippetTemplate?: string;
 		snippetDefaultArguments?: string;
-		onStartChat?: (config: NewChatConfig) => void;
+		onStartChat?: (config: NewChatConfig, chatId: ChatId) => void;
 	}
 
 	let {
@@ -61,11 +62,13 @@
 
 	setNotifications(notifications);
 
+	let seedListener = () => {};
 	const appShell = {
 		projectBasePath: '/workspace',
 		isMobile: false,
 		openSnippets() {},
-		onNewChatDialogSeed() {
+		onNewChatDialogSeed(callback: () => void) {
+			seedListener = callback;
 			return () => {};
 		},
 	} as never;
@@ -221,6 +224,8 @@
 
 <svelte:window onkeydowncapture={(event) => transientLayers.handleEscape(event)} />
 <NewChatForm {onStartChat} />
+
+<button type="button" data-testid="reseed-new-chat" onclick={() => seedListener()}>Reseed</button>
 
 <div data-testid="snippet-load-count">{snippetLoadCount}</div>
 {#each notifications.items as notification (notification.id)}

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -976,6 +976,39 @@ describe('PromptComposer focus', () => {
 		expect(onsubmit).toHaveBeenCalledTimes(1);
 	});
 
+	it('uses a new-chat expansion context for a local draft', async () => {
+		vi.mocked(snippetsApi.expandSnippet).mockResolvedValueOnce({
+			success: true,
+			snippetId: 'snippet-review',
+			snippetUpdatedAt: '2026-01-01T00:00:00.000Z',
+			shortName: 'review',
+			contextProjectPath: '/workspace/project',
+			expandedText: 'draft expansion',
+		});
+		render(PromptComposerTestHost, {
+			selectedChatId: '1787471053739199',
+			selectedStatus: 'draft',
+		});
+		const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+		await fireEvent.input(textarea, { target: { value: '/s review' } });
+
+		await fireEvent.keyDown(textarea, { key: 'Enter' });
+
+		await waitFor(() => expect(textarea.value).toBe('draft expansion'));
+		expect(snippetsApi.expandSnippet).toHaveBeenCalledWith(
+			{
+				shortName: 'review',
+				arguments: { type: 'default' },
+				context: {
+					type: 'new-chat',
+					chatId: '1787471053739199',
+					projectPath: '/workspace/project',
+				},
+			},
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+	});
+
 	it('distinguishes omitted slash arguments from an explicit empty value', async () => {
 		vi.mocked(snippetsApi.expandSnippet).mockResolvedValue({
 			success: true,

--- a/web/src/lib/snippets/__tests__/snippet-expansion-controller.test.ts
+++ b/web/src/lib/snippets/__tests__/snippet-expansion-controller.test.ts
@@ -5,7 +5,7 @@ import type { ExpandSnippetRequest, ExpandSnippetResponse } from '$shared/snippe
 const request: ExpandSnippetRequest = {
 	shortName: 'review',
 	arguments: { type: 'value', value: 'the API' },
-	context: { type: 'project', projectPath: '/repo' },
+	context: { type: 'new-chat', chatId: '1787471053739199', projectPath: '/repo' },
 };
 
 const response: ExpandSnippetResponse = {


### PR DESCRIPTION
Allows snippets containing `{{chat_id}}` to expand in the New Chat flow by assigning a stable prospective chat ID before creation and carrying it through draft creation, navigation, and submission. Expansion remains server-side, registered chats retain server-authoritative project paths, and prospective chats use their selected path without reserving a chat. Migration: the project-only expansion context is replaced by the explicit `new-chat` context in the coupled client/server API.