### PR TITLE
Align sidebar chat row status and actions

### DIFF
--- a/web/src/lib/components/sidebar/SidebarChatItem.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatItem.svelte
@@ -262,7 +262,7 @@
 {/snippet}
 
 {#snippet chatSummary()}
-	<div class={cn('relative flex-1 min-w-0', isSingleLineLayout && 'flex items-center gap-1')}>
+	<div class="relative flex-1 min-w-0">
 		<SidebarChatSummary
 			{session}
 			{isSelected}
@@ -270,10 +270,14 @@
 			showTimestamp={true}
 			showProjectPath={!displayOptions.groupByProject || showProjectPathInGroup}
 			chatItemLayout={displayOptions.chatItemLayout}
+			titleBadge={isSingleLineLayout ? stateBadge : undefined}
+			hasDesktopOverlayMenu={!isMobile && !isMultiSelectMode}
 			onTagClick={isMultiSelectMode ? undefined : onTagClick}
 			onManageTags={isMultiSelectMode || !onManageTags ? undefined : () => onManageTags(session)}
 		/>
-		{@render stateBadge()}
+		{#if !isSingleLineLayout}
+			{@render stateBadge()}
+		{/if}
 	</div>
 {/snippet}
 

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -78,7 +78,7 @@
 			{#if isProcessing}
 				<span class="sr-only">{m.chat_pane_processing()}</span>
 				<span
-					class={cn('flex items-center justify-end', singleLineStatusClass)}
+					class={cn('flex items-center justify-end pr-0.5', singleLineStatusClass)}
 					aria-hidden="true"
 				>
 					<span

--- a/web/src/lib/components/sidebar/SidebarChatSummary.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatSummary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import ChatAgentTags from '../shared/ChatAgentTags.svelte';
 	import type { ChatSessionRecord } from '$lib/types/chat-session';
@@ -15,6 +16,8 @@
 		showTimestamp?: boolean;
 		showProjectPath?: boolean;
 		chatItemLayout?: SidebarChatItemLayout;
+		titleBadge?: Snippet;
+		hasDesktopOverlayMenu?: boolean;
 		onTagClick?: (tag: string) => void;
 		onManageTags?: () => void;
 	}
@@ -27,6 +30,8 @@
 		showTimestamp = false,
 		showProjectPath = true,
 		chatItemLayout = 'default',
+		titleBadge,
+		hasDesktopOverlayMenu = false,
 		onTagClick,
 		onManageTags,
 	}: SidebarChatSummaryProps = $props();
@@ -42,11 +47,18 @@
 	let formattedTimestamp = $derived(
 		showTimestamp ? formatSidebarChatTimestamp(activityTimestamp, currentTime) : null,
 	);
+	let singleLineStatusClass = $derived(
+		cn(
+			'ml-auto shrink-0',
+			hasDesktopOverlayMenu &&
+				'mr-6 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:mr-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover:pointer-events-none [@media(hover:hover)_and_(pointer:fine)]:group-hover:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within:opacity-0',
+		),
+	);
 
 	let displayProjectPath = $derived(formatSidebarProjectPath(projectPath));
 </script>
 
-<div class={cn('relative min-w-0', !isSingleLine && 'w-full')} data-slot="sidebar-chat-summary">
+<div class="relative w-full min-w-0" data-slot="sidebar-chat-summary">
 	{#if isSingleLine}
 		<div
 			class={cn(
@@ -62,17 +74,23 @@
 					{m.sidebar_chat_unread()}
 				</span>
 			{/if}
+			{@render titleBadge?.()}
 			{#if isProcessing}
 				<span class="sr-only">{m.chat_pane_processing()}</span>
 				<span
-					class="sidebar-processing-indicator size-2 shrink-0 rounded-full bg-status-processing"
+					class={cn('flex items-center justify-end', singleLineStatusClass)}
 					aria-hidden="true"
-					data-slot="sidebar-chat-processing-indicator"
-				></span>
+				>
+					<span
+						class="sidebar-processing-indicator size-2 shrink-0 rounded-full bg-status-processing"
+						data-slot="sidebar-chat-processing-indicator"
+					></span>
+				</span>
 			{:else if formattedTimestamp}
 				<span
 					class={cn(
-						'shrink-0 whitespace-nowrap rounded-full border px-1.5 text-[11px] leading-4 tabular-nums',
+						'whitespace-nowrap rounded-full border px-1.5 text-[11px] leading-4 tabular-nums',
+						singleLineStatusClass,
 						isSelected
 							? 'border-sidebar-chat-item-selected-foreground/25 bg-sidebar-chat-item-selected-foreground/10 text-sidebar-chat-item-selected-foreground/80'
 							: 'border-border/70 bg-muted/40 text-muted-foreground',

--- a/web/src/lib/components/sidebar/__tests__/SidebarChatItemHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarChatItemHost.svelte
@@ -11,6 +11,7 @@
 		isPinned?: boolean;
 		isArchived?: boolean;
 		isMobile?: boolean;
+		isMultiSelectMode?: boolean;
 		enableNativeDrag?: boolean;
 		displayOptions?: SidebarDisplayOptions;
 		onTagClick?: (tag: string) => void;
@@ -30,6 +31,7 @@
 		isPinned = false,
 		isArchived = false,
 		isMobile = false,
+		isMultiSelectMode = false,
 		enableNativeDrag = true,
 		displayOptions = {
 			groupByProject: false,
@@ -79,6 +81,7 @@
 	{isPinned}
 	{isArchived}
 	{isMobile}
+	{isMultiSelectMode}
 	{enableNativeDrag}
 	{displayOptions}
 	onChatSelect={() => {}}

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -86,7 +86,8 @@ describe('shared sidebar chat row', () => {
 		expect(screen.getByText('3h ago')).toBeTruthy();
 		expect(title.parentElement?.className).toContain('leading-[1.3]');
 		expect(screen.getByText('3h ago').className).toContain('font-normal');
-		expect(screen.getByText('3h ago').className).not.toContain('md:group-hover:opacity-0');
+		expect(screen.getByText('3h ago').className).not.toContain('ml-auto');
+		expect(screen.getByText('3h ago').className).not.toContain('group-hover:opacity-0');
 		expect(screen.queryByText('Jan 1')).toBeNull();
 		expect(screen.queryByText('12:00 AM')).toBeNull();
 		expect(screen.getByTitle('/very/long/workspace/projects/feature-branch/app')).toBeTruthy();
@@ -238,6 +239,13 @@ describe('shared sidebar chat row', () => {
 		);
 		expect(timestampBadge?.textContent).toBe('3h ago');
 		expect(timestampBadge?.className).toContain('tabular-nums');
+		expect(timestampBadge?.className).toContain('ml-auto');
+		expect(timestampBadge?.className).toContain('group-hover:opacity-0');
+		expect(timestampBadge?.className).toContain('group-focus-within:opacity-0');
+		expect(timestampBadge?.className).toContain('mr-6');
+		expect(timestampBadge?.className).toContain(
+			'[@media(hover:hover)_and_(pointer:fine)]:mr-0',
+		);
 		expect(timestampBadge?.getAttribute('title')).toBeTruthy();
 
 		const stateBadge = document.querySelector<HTMLElement>(
@@ -248,10 +256,17 @@ describe('shared sidebar chat row', () => {
 		expect(stateBadge?.getAttribute('aria-hidden')).toBeNull();
 		expect(screen.getByText('Pinned').className).toContain('sr-only');
 		if (!stateBadge || !timestampBadge) throw new Error('expected badges');
-		expect(timestampBadge.compareDocumentPosition(stateBadge)).toBe(
+		expect(title.compareDocumentPosition(stateBadge)).toBe(
 			Node.DOCUMENT_POSITION_FOLLOWING,
 		);
-		expect(title.compareDocumentPosition(timestampBadge)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+		expect(stateBadge.compareDocumentPosition(timestampBadge)).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING,
+		);
+		expect(stateBadge.parentElement).toBe(title.parentElement);
+		expect(timestampBadge.parentElement).toBe(title.parentElement);
+		expect(
+			document.querySelector<HTMLElement>('[data-slot="sidebar-chat-summary"]')?.className,
+		).toContain('w-full');
 
 		// The row button keeps the default-mode overlay anchor placement without
 		// reserving a right gutter, with reduced vertical padding.
@@ -261,6 +276,28 @@ describe('shared sidebar chat row', () => {
 		const menuAnchor = document.querySelector<HTMLElement>('.sidebar-item-menu-anchor');
 		expect(menuAnchor?.className).toContain('top-1/2');
 		expect(menuAnchor?.className).toContain('-translate-y-1/2');
+	});
+
+	it('does not reserve title space for an absent single-line state badge', () => {
+		render(SidebarChatItemHost, {
+			session: createChat({ isUnread: false }),
+			displayOptions: {
+				groupByProject: false,
+				groupNestedProjectPaths: false,
+				chatItemLayout: 'single-line',
+				sortMode: 'manual',
+			},
+		});
+
+		const title = screen.getByText('Shared row chat');
+		const timestampBadge = document.querySelector<HTMLElement>(
+			'[data-slot="sidebar-chat-timestamp-badge"]',
+		);
+		expect(document.querySelector('[data-slot="sidebar-chat-state-badge"]')).toBeNull();
+		const titleRowChildren = Array.from(title.parentElement?.children ?? []);
+		expect(titleRowChildren).toHaveLength(2);
+		expect(titleRowChildren[0]).toBe(title);
+		expect(titleRowChildren[1]).toBe(timestampBadge);
 	});
 
 	it('shows the processing indicator instead of the timestamp badge in single-line mode', () => {
@@ -274,9 +311,19 @@ describe('shared sidebar chat row', () => {
 			},
 		});
 
-		expect(document.querySelector('[data-slot="sidebar-chat-processing-indicator"]')).toBeTruthy();
+		const processingIndicator = document.querySelector<HTMLElement>(
+			'[data-slot="sidebar-chat-processing-indicator"]',
+		);
+		expect(processingIndicator).toBeTruthy();
 		expect(document.querySelector('[data-slot="sidebar-chat-timestamp-badge"]')).toBeNull();
-		expect(screen.getByText('Chat is processing').className).toContain('sr-only');
+		expect(processingIndicator?.parentElement?.className).toContain('ml-auto');
+		expect(processingIndicator?.parentElement?.className).toContain('group-hover:opacity-0');
+		expect(processingIndicator?.parentElement?.className).toContain(
+			'group-focus-within:opacity-0',
+		);
+		const processingLabel = screen.getByText('Chat is processing');
+		expect(processingLabel.className).toContain('sr-only');
+		expect(processingIndicator?.contains(processingLabel)).toBe(false);
 	});
 
 	it('prefers the pinned badge over the archived badge in single-line mode', () => {
@@ -311,9 +358,39 @@ describe('shared sidebar chat row', () => {
 		});
 
 		expect(document.querySelectorAll('[data-slot="sidebar-chat-summary"]')).toHaveLength(1);
-		expect(document.querySelector('[data-slot="sidebar-chat-timestamp-badge"]')).toBeTruthy();
-		expect(document.querySelector('[data-slot="sidebar-chat-state-badge"]')).toBeTruthy();
+		const timestampBadge = document.querySelector<HTMLElement>(
+			'[data-slot="sidebar-chat-timestamp-badge"]',
+		);
+		const stateBadge = document.querySelector<HTMLElement>(
+			'[data-slot="sidebar-chat-state-badge"]',
+		);
+		expect(timestampBadge?.className).toContain('ml-auto');
+		expect(timestampBadge?.className).not.toContain('group-hover:opacity-0');
+		expect(timestampBadge?.className).not.toContain('mr-6');
+		expect(stateBadge).toBeTruthy();
+		expect(stateBadge?.parentElement).toBe(screen.getByText('Shared row chat').parentElement);
 		expect(screen.getByRole('button', { name: 'Chat actions' })).toBeTruthy();
+	});
+
+	it('keeps the single-line status visible without a menu in desktop multi-select mode', () => {
+		render(SidebarChatItemHost, {
+			session: createChat({ isUnread: false }),
+			isMultiSelectMode: true,
+			displayOptions: {
+				groupByProject: false,
+				groupNestedProjectPaths: false,
+				chatItemLayout: 'single-line',
+				sortMode: 'manual',
+			},
+		});
+
+		const timestampBadge = document.querySelector<HTMLElement>(
+			'[data-slot="sidebar-chat-timestamp-badge"]',
+		);
+		expect(timestampBadge?.className).toContain('ml-auto');
+		expect(timestampBadge?.className).not.toContain('mr-6');
+		expect(timestampBadge?.className).not.toContain('group-hover:opacity-0');
+		expect(screen.queryByRole('button', { name: 'Chat actions' })).toBeNull();
 	});
 
 	it('hides the project path in grouped chat rows while keeping timestamps', () => {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-row.test.ts
@@ -317,6 +317,7 @@ describe('shared sidebar chat row', () => {
 		expect(processingIndicator).toBeTruthy();
 		expect(document.querySelector('[data-slot="sidebar-chat-timestamp-badge"]')).toBeNull();
 		expect(processingIndicator?.parentElement?.className).toContain('ml-auto');
+		expect(processingIndicator?.parentElement?.className).toContain('pr-0.5');
 		expect(processingIndicator?.parentElement?.className).toContain('group-hover:opacity-0');
 		expect(processingIndicator?.parentElement?.className).toContain(
 			'group-focus-within:opacity-0',


### PR DESCRIPTION
Keeps single-line sidebar chat rows compact by placing pinned and archived state immediately after the title while right-aligning the timestamp or processing state. On desktop the trailing status yields to the overflow menu on hover or focus, while mobile and multi-select retain their persistent controls; component coverage verifies ordering, absence, processing, and input-mode behavior.