### PR TITLE
Fix duplicate attachment keys in chat messages

### DIFF
--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -508,7 +508,7 @@
 							</div>
 							{#if asUser.images && asUser.images.length > 0}
 								<div class="mt-2 grid grid-cols-2 gap-2">
-									{#each asUser.images as img, idx (img.name || idx)}
+									{#each asUser.images as img, idx (idx)}
 										{#if isImageAttachment(img)}
 											<img
 												src={img.data}

--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -283,7 +283,7 @@
 										</div>
 										{#if message.images && message.images.length > 0}
 											<div class="mt-2 grid grid-cols-2 gap-2">
-												{#each message.images as image, imageIndex (image.name || imageIndex)}
+												{#each message.images as image, imageIndex (imageIndex)}
 													<img
 														src={image.data}
 														alt={image.name}

--- a/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
+++ b/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
@@ -193,4 +193,27 @@ describe('SharedChatPage', () => {
 		expect(container.querySelectorAll('article.cli-row-message')).toHaveLength(2);
 		expect(screen.getByText('4 of 4 messages')).toBeTruthy();
 	});
+
+	it('renders attachments with duplicate filenames', async () => {
+		const chatRows = response([], 0, 1, { nextBefore: null });
+		chatRows.snapshot.messages = [
+			{
+				type: 'user-message',
+				timestamp: '2025-01-02T03:05:00.000Z',
+				content: 'Two screenshots',
+				images: [
+					{ name: 'image.png', data: 'data:image/png;base64,one' },
+					{ name: 'image.png', data: 'data:image/png;base64,two' },
+				],
+			},
+		];
+		chatRows.page.end = 1;
+		vi.mocked(sharesApi.getSharedChat).mockResolvedValueOnce(chatRows);
+
+		const { container } = render(SharedChatPageTestHost);
+
+		await screen.findByText('Two screenshots');
+		expect(container.querySelectorAll('img')).toHaveLength(2);
+		expect(screen.queryByText(/Failed to render message/)).toBeNull();
+	});
 });


### PR DESCRIPTION
Fixes #558

## Root cause

Shared and regular chat message attachment loops keyed items by filename (`image.name || index`). Two attachments with the same filename, as in the reported shared chat, generated duplicate Svelte each-block keys and the message boundary displayed `Failed to render message`.

## Change

- Key attachment loops by their per-message array index in `SharedChatPage` and `ConversationMessage`.
- Add a regression test with two `image.png` attachments.

## Validation

- `bun run --cwd web i18n:compile`
- `bun run --cwd web test -- SharedChatPage.test.ts` (5 passed)
- `bun run --cwd web check` (0 errors, 0 warnings)
- `bun run --cwd web lint`
- `git diff --check`