### PR TITLE
Make long handoff compaction visible and resilient

### DIFF
--- a/common/__tests__/ws-events.test.js
+++ b/common/__tests__/ws-events.test.js
@@ -24,6 +24,19 @@ describe('parseServerWsMessage chat-operational-notice', () => {
     });
   });
 
+  it('parses an informational notice', () => {
+    expect(parseServerWsMessage({
+      type: 'chat-operational-notice',
+      chatId: 'chat-1',
+      noticeType: 'info',
+      content: 'Compacting earlier chat history.',
+    })).toMatchObject({
+      chatId: 'chat-1',
+      noticeType: 'info',
+      content: 'Compacting earlier chat history.',
+    });
+  });
+
   it('rejects an unknown notice type', () => {
     expect(parseServerWsMessage({
       type: 'chat-operational-notice',

--- a/common/chat-types.ts
+++ b/common/chat-types.ts
@@ -736,8 +736,9 @@ export class CompactionMessage {
 
 // Marks a cross-agent continuation boundary in the conversation. Messages
 // before this point were produced by `fromAgentId`; the chat continues under
-// `toAgentId` with a fresh seeded session, so prior tool state is not carried
-// over. Generic across agents: identifies both sides by agent id and model.
+// `toAgentId` with a fresh seeded session. Earlier context is carried as
+// history rather than a live native session. Generic across agents: identifies
+// both sides by agent id and model.
 export class AgentSwitchMessage {
   readonly type = 'agent-switch' as const;
   constructor(

--- a/common/handoff-timeouts.ts
+++ b/common/handoff-timeouts.ts
@@ -1,0 +1,5 @@
+export const AGENT_HANDOFF_HTTP_TIMEOUT_MS = 13 * 60 * 1_000;
+
+// Bun clamps positive per-request idle timeouts to 255 seconds. Zero disables
+// the idle timer while the client timeout bounds the handoff request.
+export const AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS = 0;

--- a/common/ws-events.ts
+++ b/common/ws-events.ts
@@ -178,7 +178,7 @@ export class ChatExecutionControlUpdatedMessage {
   ) {}
 }
 
-export type ChatOperationalNoticeType = 'warning' | 'error';
+export type ChatOperationalNoticeType = 'info' | 'warning' | 'error';
 
 // Process-only advisory overlay for the chat feed. Notices never enter the
 // transcript sequence space, pages, replay, search, or shares.
@@ -687,7 +687,9 @@ export function parseServerWsMessage(
     case 'chat-operational-notice': {
       const chatId = requiredStr(data.chatId);
       const content = requiredStr(data.content);
-      const noticeType = data.noticeType === 'warning' || data.noticeType === 'error'
+      const noticeType = data.noticeType === 'info'
+        || data.noticeType === 'warning'
+        || data.noticeType === 'error'
         ? data.noticeType
         : null;
       return chatId && content && noticeType

--- a/server-agents/common/src/direct/__tests__/openai-compatible-chat-runtime.test.js
+++ b/server-agents/common/src/direct/__tests__/openai-compatible-chat-runtime.test.js
@@ -219,6 +219,25 @@ describe('OpenAiCompatibleChatRuntime', () => {
     expect(requestBodies[1].stream).toBe(true);
   });
 
+  it('honors a five-minute explicit one-shot timeout', async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.fetch = mock(async () => streamResponse('OK'));
+    globalThis.setTimeout = mock((callback, delay, ...args) => (
+      originalSetTimeout(callback, delay, ...args)
+    ));
+
+    try {
+      await runOpenAiCompatibleSingleQuery(runtimeConfig('/tmp/unused'), 'test', {
+        model: 'glm-5.2',
+        timeoutMs: 5 * 60_000,
+      });
+
+      expect(globalThis.setTimeout).toHaveBeenCalledWith(expect.any(Function), 5 * 60_000);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   it('aggregates streamed one-shot response chunks before returning', async () => {
     globalThis.fetch = mock(async () => streamResponse(
       '<thi',

--- a/server-agents/common/src/direct/__tests__/single-query-options.test.js
+++ b/server-agents/common/src/direct/__tests__/single-query-options.test.js
@@ -8,8 +8,9 @@ describe('Direct single-query options', () => {
   it('keeps the 30-second default and bounds explicit timeouts', () => {
     expect(directSingleQueryTimeoutMs({})).toBe(30_000);
     expect(directSingleQueryTimeoutMs({ timeoutMs: 110_000 })).toBe(110_000);
+    expect(directSingleQueryTimeoutMs({ timeoutMs: 5 * 60_000 })).toBe(5 * 60_000);
     expect(directSingleQueryTimeoutMs({ timeoutMs: 10 })).toBe(1_000);
-    expect(directSingleQueryTimeoutMs({ timeoutMs: 999_000 })).toBe(120_000);
+    expect(directSingleQueryTimeoutMs({ timeoutMs: 999_000 })).toBe(5 * 60_000);
   });
 
   it('combines a caller deadline with the adapter timeout signal', () => {

--- a/server-agents/common/src/direct/single-query-options.ts
+++ b/server-agents/common/src/direct/single-query-options.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_DIRECT_SINGLE_QUERY_TIMEOUT_MS = 30_000;
-export const MAX_DIRECT_SINGLE_QUERY_TIMEOUT_MS = 120_000;
+export const MAX_DIRECT_SINGLE_QUERY_TIMEOUT_MS = 5 * 60_000;
 
 export function directSingleQueryTimeoutMs(options: Record<string, unknown>): number {
   const value = options.timeoutMs;

--- a/server/__tests__/server-event-wiring.test.js
+++ b/server/__tests__/server-event-wiring.test.js
@@ -473,13 +473,13 @@ describe('server event wiring', () => {
   it('broadcasts operational notices without entering transcript sequence space', () => {
     const fixture = createFixture();
 
-    fixture.wiring.notifyOperationalNotice('chat-1', 'warning', 'Carryover was compacted.');
+    fixture.wiring.notifyOperationalNotice('chat-1', 'info', 'Carryover is being compacted.');
 
     expect(fixture.published).toEqual([expect.objectContaining({
       type: 'chat-operational-notice',
       chatId: 'chat-1',
-      noticeType: 'warning',
-      content: 'Carryover was compacted.',
+      noticeType: 'info',
+      content: 'Carryover is being compacted.',
     })]);
     expect(fixture.metadata.updateFromAppendedMessages).not.toHaveBeenCalled();
   });

--- a/server/chats/__tests__/carryover-compaction.test.js
+++ b/server/chats/__tests__/carryover-compaction.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, mock } from 'bun:test';
 import {
+  MAX_DIRECT_SINGLE_QUERY_TIMEOUT_MS,
+} from '@garcon/server-agent-common/direct/single-query-options';
+import {
   AssistantMessage,
   BashToolUseMessage,
   TranscriptNoticeMessage,
@@ -116,6 +119,12 @@ function run(instance, {
 }
 
 describe('carryover compaction', () => {
+  it('keeps the Direct timeout cap at least as large as a compaction attempt', () => {
+    expect(MAX_DIRECT_SINGLE_QUERY_TIMEOUT_MS).toBeGreaterThanOrEqual(
+      CARRYOVER_COMPACTION_TIMEOUT_MS,
+    );
+  });
+
   it('returns empty or small complete projections before reading Settings', async () => {
     const getUiSettings = mock(() => {
       throw new Error('Settings must not be read');

--- a/server/chats/__tests__/carryover-compaction.test.js
+++ b/server/chats/__tests__/carryover-compaction.test.js
@@ -10,7 +10,10 @@ import {
   createCarryoverTranscript,
 } from '../../../common/transcript-seed.js';
 import { usableHandoffTokenBudget } from '../../../common/handoff-sizing.js';
-import { CarryOverCompactionService } from '../carryover-compaction.ts';
+import {
+  CARRYOVER_COMPACTION_TIMEOUT_MS,
+  CarryOverCompactionService,
+} from '../carryover-compaction.ts';
 import { estimateHandoffTokens } from '../handoff-token-budget.ts';
 
 const TIME = '2026-01-01T00:00:00.000Z';
@@ -53,6 +56,7 @@ function service({
   unsafeSingleQuery = false,
   contextWindowTokens = 200_000,
   getUiSettings,
+  onCompactionStarted = mock(() => {}),
 } = {}) {
   const empty = discovery === 'empty';
   const fail = () => {
@@ -83,9 +87,14 @@ function service({
     singleQueryRunsToolsWithoutPermission: mock(() => unsafeSingleQuery),
   };
   return {
-    instance: new CarryOverCompactionService({ agents, getUiSettings: settings }),
+    instance: new CarryOverCompactionService({
+      agents,
+      getUiSettings: settings,
+      onCompactionStarted,
+    }),
     agents,
     getUiSettings: settings,
+    onCompactionStarted,
     runSingleQuery,
   };
 }
@@ -140,11 +149,17 @@ describe('carryover compaction', () => {
     const above = longHistory(20);
     expect(estimateHandoffTokens(createCarryoverTranscript(below, 0).prefix)).toBeLessThan(100_000);
     expect(estimateHandoffTokens(createCarryoverTranscript(above, 0).prefix)).toBeGreaterThan(100_000);
-    const { instance, runSingleQuery } = service();
+    const { instance, onCompactionStarted, runSingleQuery } = service();
 
     expect((await run(instance, { messages: below })).summary).toBeNull();
     expect((await run(instance, { messages: above })).summary).toBe('objective: ship it');
+    expect(onCompactionStarted).toHaveBeenCalledOnce();
+    expect(onCompactionStarted).toHaveBeenCalledWith('chat-1');
     expect(runSingleQuery).toHaveBeenCalledTimes(1);
+    expect(runSingleQuery.mock.calls[0][1]).toMatchObject({
+      timeoutMs: CARRYOVER_COMPACTION_TIMEOUT_MS,
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it('requires enabled compaction for long histories with operation-aware copy', async () => {
@@ -167,13 +182,14 @@ describe('carryover compaction', () => {
     ['discovery failure', { discovery: 'throws', selection: {} }, 'could be resolved'],
     ['unsafe integration', { unsafeSingleQuery: true }, 'without a permission gate'],
   ])('rejects %s before querying', async (_label, options, reason) => {
-    const { instance, runSingleQuery } = service(options);
+    const { instance, onCompactionStarted, runSingleQuery } = service(options);
 
     await expect(run(instance)).rejects.toMatchObject({
       code: 'CARRYOVER_COMPACTION_UNAVAILABLE',
       status: 422,
       message: expect.stringContaining(reason),
     });
+    expect(onCompactionStarted).not.toHaveBeenCalled();
     expect(runSingleQuery).not.toHaveBeenCalled();
   });
 
@@ -225,13 +241,14 @@ describe('carryover compaction', () => {
   });
 
   it('rejects a wrapper that leaves no room for a transcript', async () => {
-    const { instance, runSingleQuery } = service();
+    const { instance, onCompactionStarted, runSingleQuery } = service();
     const destination = { ...DESTINATION, prompt: 'instruction '.repeat(200_000) };
 
     await expect(run(instance, { destination })).rejects.toMatchObject({
       code: 'CARRYOVER_COMPACTION_UNAVAILABLE',
       message: expect.stringContaining('does not fit the configured window'),
     });
+    expect(onCompactionStarted).not.toHaveBeenCalled();
     expect(runSingleQuery).not.toHaveBeenCalled();
   });
 
@@ -283,7 +300,7 @@ describe('carryover compaction', () => {
 
   it('retries once from the original history at 70% of the first entry budget', async () => {
     let attempt = 0;
-    const { instance, runSingleQuery } = service({
+    const { instance, onCompactionStarted, runSingleQuery } = service({
       respond: async () => {
         attempt += 1;
         if (attempt === 1) throw new Error('first attempt failed');
@@ -294,6 +311,7 @@ describe('carryover compaction', () => {
     const result = await run(instance, { messages: longHistory(40) });
 
     expect(result.summary).toBe('second attempt succeeded');
+    expect(onCompactionStarted).toHaveBeenCalledOnce();
     expect(runSingleQuery).toHaveBeenCalledTimes(2);
     const firstPrompt = runSingleQuery.mock.calls[0][0];
     const secondPrompt = runSingleQuery.mock.calls[1][0];
@@ -302,6 +320,10 @@ describe('carryover compaction', () => {
     expect(secondPrompt).toContain('token_0_0');
     expect(runSingleQuery.mock.calls[0][1].signal)
       .not.toBe(runSingleQuery.mock.calls[1][1].signal);
+    expect(runSingleQuery.mock.calls.map(([, options]) => options.timeoutMs)).toEqual([
+      CARRYOVER_COMPACTION_TIMEOUT_MS,
+      CARRYOVER_COMPACTION_TIMEOUT_MS,
+    ]);
   });
 
   it.each([

--- a/server/chats/carryover-compaction.ts
+++ b/server/chats/carryover-compaction.ts
@@ -22,7 +22,6 @@ import { resolveGenerationContextForSelection } from '../settings/generation-con
 import { resolveEffectiveGenerationConfig } from '../settings/generation-effective.js';
 import {
   createGenerationRequestSignal,
-  GENERATION_PROVIDER_TIMEOUT_MS,
 } from '../settings/generation-limits.js';
 import { DomainError } from '../lib/domain-error.js';
 import { errorMessage } from '../lib/errors.js';
@@ -38,6 +37,9 @@ const logger = createLogger('chats:carryover-compaction');
 const SUMMARY_OPEN = '<summary>';
 const SUMMARY_CLOSE = '</summary>';
 const utf8Encoder = new TextEncoder();
+// The Direct runtime cap in server-agents/common/src/direct/single-query-options.ts
+// must remain at least this large.
+export const CARRYOVER_COMPACTION_TIMEOUT_MS = 5 * 60_000;
 
 export interface CarryOverCompactionAgents {
   singleQueryRunsToolsWithoutPermission(agentId: string): boolean;
@@ -67,6 +69,7 @@ export interface CarryOverCompactionDestination {
 export interface CarryOverCompactionDeps {
   readonly agents: CarryOverCompactionAgents;
   getUiSettings(): { agentSwitchCompaction?: unknown } | null | undefined;
+  onCompactionStarted?(chatId: string): void;
 }
 
 export interface CarryOverCompactionInput {
@@ -173,6 +176,7 @@ export class CarryOverCompactionService {
         lastFailure = new Error('the reduced compaction prompt does not fit');
         break;
       }
+      if (attempt === 0) this.deps.onCompactionStarted?.(input.chatId);
       try {
         const raw = await this.deps.agents.runSingleQuery(fitted.value.prompt, {
           agentId: selection.agentId,
@@ -183,8 +187,8 @@ export class CarryOverCompactionService {
           apiProviderId: selection.apiProviderId,
           modelEndpointId: selection.modelEndpointId,
           modelProtocol: selection.modelProtocol,
-          timeoutMs: GENERATION_PROVIDER_TIMEOUT_MS,
-          signal: createGenerationRequestSignal(input.signal),
+          timeoutMs: CARRYOVER_COMPACTION_TIMEOUT_MS,
+          signal: createGenerationRequestSignal(input.signal, CARRYOVER_COMPACTION_TIMEOUT_MS),
         });
         const summary = validateCompactionSummary(raw);
         const context = projectSummaryWithSpine(summary, spine);

--- a/server/routes/__tests__/chats-command-routes.test.js
+++ b/server/routes/__tests__/chats-command-routes.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { QUEUE_ENTRY_ID_MAX_BYTES } from '../../../common/chat-command-contracts.ts';
+import { AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS } from '../../../common/handoff-timeouts.ts';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -515,7 +516,7 @@ function createRouteAgent(sessionOverrides = {}) {
   };
 }
 
-async function callJson(handler, body, method = 'POST') {
+async function callJson(handler, body, method = 'POST', server) {
   const inputBody = body && typeof body === 'object' && 'chatId' in body
     ? {
         ...body,
@@ -530,8 +531,9 @@ async function callJson(handler, body, method = 'POST') {
     : body;
   const requestBody = inputBody;
   parseJsonBody.mockResolvedValueOnce(requestBody);
-  const response = await handler(new Request('http://localhost/test', { method }));
-  return { response, body: await response.json() };
+  const request = new Request('http://localhost/test', { method });
+  const response = await handler(request, new URL(request.url), server);
+  return { request, response, body: await response.json() };
 }
 
 function agentRunBody(overrides = {}) {
@@ -569,6 +571,7 @@ describe('REST chat command routes', () => {
 
   it('POST /run returns before agent completion and persists before running', async () => {
     const agent = createRouteAgent();
+    const server = { timeout: mock(() => undefined) };
     const order = [];
     let resolveRun;
     const runPromise = new Promise((resolve) => {
@@ -583,7 +586,12 @@ describe('REST chat command routes', () => {
       return runPromise;
     });
 
-    const { response, body } = await callJson(agent.routes['/api/v1/chats/run'].POST, agentRunBody());
+    const { response, body } = await callJson(
+      agent.routes['/api/v1/chats/run'].POST,
+      agentRunBody(),
+      'POST',
+      server,
+    );
 
     expect(response.status).toBe(202);
     expect(body).toMatchObject({
@@ -598,6 +606,7 @@ describe('REST chat command routes', () => {
       `/api/v1/chats/turn-receipt?chatId=${CHAT_ID}&turnId=${body.turnId}`,
     );
     expect(order).toEqual(['pending', 'run']);
+    expect(server.timeout).not.toHaveBeenCalled();
     expect(agent.queue.registerPendingUserInput).toHaveBeenCalledWith(
       CHAT_ID,
       'hello',
@@ -737,11 +746,12 @@ describe('REST chat command routes', () => {
 
   it('POST /run rejects a handoff before preparation when the chat is not idle', async () => {
     const agent = createRouteAgent();
+    const server = { timeout: mock(() => undefined) };
     const control = storedQueue([queueEntry('entry-1')], { version: 5 });
     agent.queue.ownsExecution.mockReturnValue(true);
     agent.queue.readChatExecutionControl.mockResolvedValue(control);
 
-    const { response, body } = await callJson(
+    const { request, response, body } = await callJson(
       agent.routes['/api/v1/chats/run'].POST,
       {
         clientRequestId: 'req-handoff-busy',
@@ -759,6 +769,8 @@ describe('REST chat command routes', () => {
           },
         },
       },
+      'POST',
+      server,
     );
 
     expect(response.status).toBe(409);
@@ -769,6 +781,50 @@ describe('REST chat command routes', () => {
       control: { version: 5, queue: { entries: [{ id: 'entry-1' }] } },
     });
     expect(agent.queue.reserveDirectTurn).not.toHaveBeenCalled();
+    expect(server.timeout).toHaveBeenCalledWith(
+      request,
+      AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS,
+    );
+  });
+
+  it('POST /run disables the Bun idle timeout for an accepted handoff', async () => {
+    const agent = createRouteAgent();
+    const server = { timeout: mock(() => undefined) };
+
+    const { request, response, body } = await callJson(
+      agent.routes['/api/v1/chats/run'].POST,
+      {
+        clientRequestId: 'req-handoff-accepted',
+        clientMessageId: 'msg-handoff-accepted',
+        chatId: CHAT_ID,
+        command: 'delegate this work',
+        handoff: {
+          expectedAgentOwnershipEpoch: 'epoch-1',
+          target: {
+            agentId: 'codex',
+            model: 'gpt-5.5',
+            permissionMode: 'default',
+            thinkingMode: 'high',
+            agentSettings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+          },
+        },
+      },
+      'POST',
+      server,
+    );
+
+    expect(response.status).toBe(202);
+    expect(body).toMatchObject({
+      success: true,
+      commandType: 'agent-run',
+      clientRequestId: 'req-handoff-accepted',
+      status: 'accepted',
+    });
+    expect(AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS).toBe(0);
+    expect(server.timeout).toHaveBeenCalledWith(
+      request,
+      AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS,
+    );
   });
 
   it('POST /fork-run forks once and schedules the target turn', async () => {

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -8,6 +8,7 @@ import {
   normalizeThinkingMode,
 } from '../../common/chat-modes.js';
 import type { JsonObject } from '../../common/json.js';
+import { AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS } from '../../common/handoff-timeouts.js';
 import {
   parseReorderChatRequest,
   type ReorderChatRequest,
@@ -69,7 +70,6 @@ import {
   carryOverRevision,
 } from '../chats/carryover-segments.js';
 
-const logger = createLogger('routes:chats');
 import type {
   ExecutionSettingsPatchRequest,
   ModelPatchRequest,
@@ -114,6 +114,18 @@ import {
   generateChatTitleFromMessage,
   TitleGenerationError,
 } from '../chats/title-generator.js';
+
+const logger = createLogger('routes:chats');
+
+interface RequestTimeoutServer {
+  timeout(request: Request, seconds: number): void;
+}
+
+function isRequestTimeoutServer(value: unknown): value is RequestTimeoutServer {
+  return value !== null
+    && typeof value === 'object'
+    && typeof (value as { timeout?: unknown }).timeout === 'function';
+}
 
 function acceptedTurnResponse(result: CommandAcceptedResponse): Response {
   if (!result.chatId || !result.turnId) {
@@ -742,10 +754,18 @@ export default function createChatRoutes({
     }
   }
 
-  async function postRunChat(body: unknown): Promise<Response> {
+  async function postRunChat(
+    body: unknown,
+    request: Request,
+    _url: URL,
+    server?: unknown,
+  ): Promise<Response> {
     try {
       const input = parseCommandRequest(parseAgentRunCommandRequest, body);
       const images = validatedCommandAttachments(input.images);
+      if (input.handoff && isRequestTimeoutServer(server)) {
+        server.timeout(request, AGENT_HANDOFF_REQUEST_TIMEOUT_SECONDS);
+      }
       const result = await commands.submitRun({ ...input, images });
 
       return acceptedTurnResponse(result);

--- a/server/server.ts
+++ b/server/server.ts
@@ -50,7 +50,10 @@ import { HandoffArtifactService } from './chats/handoff-artifact/service.js';
 import { TranscriptSearchController } from './chats/search/controller.js';
 import { TranscriptSearchSettingsCoordinator } from './chats/search/settings-coordinator.js';
 import { AgentRegistry } from './agents/index.js';
-import { CarryOverCompactionService } from './chats/carryover-compaction.js';
+import {
+  CARRYOVER_COMPACTION_TIMEOUT_MS,
+  CarryOverCompactionService,
+} from './chats/carryover-compaction.js';
 import { PreparedCarryoverStore } from './chats/prepared-carryover.js';
 import { defaultAgentIntegrations } from './agents/default-agent-integrations.js';
 import { IntegrationHostFactory } from './agents/integration-host.js';
@@ -423,6 +426,13 @@ export async function startServer(): Promise<void> {
     carryOverCompaction = new CarryOverCompactionService({
       agents: agentRegistry,
       getUiSettings: () => settings.getUiSettings(),
+      onCompactionStarted(chatId) {
+        eventWiring?.notifyOperationalNotice(
+          chatId,
+          'info',
+          `Compacting earlier chat history. This may take up to ${CARRYOVER_COMPACTION_TIMEOUT_MS / 60_000} minutes per attempt.`,
+        );
+      },
     });
     const transcriptSearchService = new TranscriptSearchService({
       workspaceDirectory: workspaceDir,

--- a/server/settings/generation-limits.ts
+++ b/server/settings/generation-limits.ts
@@ -6,8 +6,11 @@ const GENERATION_TIMEOUT_CODES = new Set([
   'UND_ERR_BODY_TIMEOUT',
 ]);
 
-export function createGenerationRequestSignal(externalSignal?: AbortSignal): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(GENERATION_PROVIDER_TIMEOUT_MS);
+export function createGenerationRequestSignal(
+  externalSignal?: AbortSignal,
+  timeoutMs = GENERATION_PROVIDER_TIMEOUT_MS,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   return externalSignal
     ? AbortSignal.any([externalSignal, timeoutSignal])
     : timeoutSignal;

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -134,7 +134,7 @@
 	"chat_mermaid_viewer_title": "Mermaid diagram",
 	"chat_mermaid_viewer_viewport": "Mermaid diagram viewport; drag to pan, pinch or Control- or Command-wheel to zoom",
 	"chat_message_agent_switch": "Continued from {from} under {to}",
-	"chat_message_agent_switch_note": "prior tool state not carried over",
+	"chat_message_agent_switch_note": "new agent session; earlier context is carried as history",
 	"chat_message_compacted": "Context compacted",
 	"chat_message_compaction_auto": "auto",
 	"chat_message_compaction_hide_summary": "Hide summary",

--- a/web/src/lib/api/__tests__/chats-contract.test.ts
+++ b/web/src/lib/api/__tests__/chats-contract.test.ts
@@ -450,7 +450,7 @@ describe('chats API contract', () => {
 		});
 
 		expect(timeout).toHaveBeenNthCalledWith(1, 30_000);
-		expect(timeout).toHaveBeenNthCalledWith(2, 10 * 60_000);
+		expect(timeout).toHaveBeenNthCalledWith(2, 13 * 60_000);
 	});
 
 	it('rejects a successful handoff response without a durable chat projection', async () => {

--- a/web/src/lib/api/chats.ts
+++ b/web/src/lib/api/chats.ts
@@ -89,6 +89,7 @@ import {
 } from '$shared/chat-execution-control';
 import { CHAT_STOP_OUTCOMES, type ChatStopOutcome } from '$shared/chat-types';
 import type { AgentCommandImage } from '$shared/ws-requests';
+import { AGENT_HANDOFF_HTTP_TIMEOUT_MS } from '$shared/handoff-timeouts';
 import {
 	parseReorderChatResponse,
 	type ReorderChatRequest,
@@ -96,7 +97,6 @@ import {
 } from '$shared/chat-order-contracts';
 
 const CHAT_TITLE_GENERATION_TIMEOUT_MS = 120_000;
-const AGENT_HANDOFF_TIMEOUT_MS = 10 * 60_000;
 
 function withParsedControl<T extends { control: ChatExecutionControlState }>(response: T): T {
 	const control = parseChatExecutionControlState(response.control);
@@ -195,7 +195,7 @@ export async function runChat(params: AgentRunCommandRequest): Promise<AgentTurn
 	const response = await apiPost<AgentTurnCommandResponse>(
 		'/api/v1/chats/run',
 		params,
-		params.handoff ? { timeoutMs: AGENT_HANDOFF_TIMEOUT_MS } : undefined,
+		params.handoff ? { timeoutMs: AGENT_HANDOFF_HTTP_TIMEOUT_MS } : undefined,
 	);
 	if (params.handoff && !response.chat) {
 		throw new Error('Invalid handoff response: durable chat projection is missing');

--- a/web/src/lib/components/chat/AgentSwitchRow.svelte
+++ b/web/src/lib/components/chat/AgentSwitchRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	// Renders a cross-agent continuation boundary: a divider marking where the
-	// chat was continued under a different agent with a fresh seeded session,
-	// so prior tool state was not carried over.
+	// chat was continued under a different agent with a fresh seeded session and
+	// earlier context carried as history.
 
 	import ArrowRightLeft from '@lucide/svelte/icons/arrow-right-left';
 	import type { AgentSwitchMessage } from '$shared/chat-types';

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -5,6 +5,7 @@
 		AssistantMessage,
 		ThinkingMessage,
 		isToolUseMessage,
+		isHandoffSummaryNoticeDetail,
 		ErrorMessage,
 		TranscriptNoticeMessage,
 		CliRowMessage,
@@ -747,14 +748,26 @@
 								{#if asNotice.title}
 									<div class="min-w-0 truncate text-xs font-medium">{asNotice.title}</div>
 								{/if}
-								<div
-									class={[
-										'text-sm whitespace-pre-wrap break-words',
-										asNotice.title && 'mt-1',
-									]}
-								>
-									{asNotice.content}
-								</div>
+								{#if isHandoffSummaryNoticeDetail(asNotice.detail)}
+									<div class={['text-sm', asNotice.title && 'mt-1']}>
+										<Markdown
+											source={asNotice.content}
+											variant="presented"
+											fileLinkBasePath={projectBasePath}
+											onLinkNavigate={handleLinkNavigate}
+											{acquireTransientActivity}
+										/>
+									</div>
+								{:else}
+									<div
+										class={[
+											'text-sm whitespace-pre-wrap break-words',
+											asNotice.title && 'mt-1',
+										]}
+									>
+										{asNotice.content}
+									</div>
+								{/if}
 							{/snippet}
 						</ChatEventCard>
 					{:else if asError}

--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -11,6 +11,7 @@
 		TranscriptNoticeMessage,
 		CliRowMessage,
 		isToolUseMessage,
+		isHandoffSummaryNoticeDetail,
 	} from '$shared/chat-types';
 	import Markdown from '$lib/components/chat/Markdown.svelte';
 	import MessageRenderFallback from '$lib/components/chat/MessageRenderFallback.svelte';
@@ -335,14 +336,20 @@
 										{#if message.title}
 											<div class="min-w-0 truncate text-xs font-medium">{message.title}</div>
 										{/if}
-										<div
-											class={[
-												'text-sm whitespace-pre-wrap break-words',
-												message.title && 'mt-1',
-											]}
-										>
-											{message.content}
-										</div>
+										{#if isHandoffSummaryNoticeDetail(message.detail)}
+											<div class={['text-sm', message.title && 'mt-1']}>
+												<Markdown source={message.content} variant="presented" />
+											</div>
+										{:else}
+											<div
+												class={[
+													'text-sm whitespace-pre-wrap break-words',
+													message.title && 'mt-1',
+												]}
+											>
+												{message.content}
+											</div>
+										{/if}
 									{/snippet}
 								</ChatEventCard>
 							{:else if message instanceof ErrorMessage}

--- a/web/src/lib/components/chat/__tests__/AgentSwitchRow.test.ts
+++ b/web/src/lib/components/chat/__tests__/AgentSwitchRow.test.ts
@@ -13,7 +13,7 @@ describe('AgentSwitchRow', () => {
 
 		expect(screen.getByText('Continued from Codex under Claude')).toBeTruthy();
 		expect(screen.getByText('(claude-sonnet-4-6)')).toBeTruthy();
-		expect(screen.getByText('prior tool state not carried over')).toBeTruthy();
+		expect(screen.getByText('new agent session; earlier context is carried as history')).toBeTruthy();
 	});
 
 	it('falls back to the raw agent id for unknown agents and omits an absent model', () => {

--- a/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
@@ -27,6 +27,22 @@ describe('ConversationMessage chat rows', () => {
 		expect(card?.querySelector('button')).toBeNull();
 	});
 
+	it('renders handoff summaries as Markdown', () => {
+		const { container } = render(ConversationMessageHost, {
+			message: new TranscriptNoticeMessage(
+				AT,
+				'## Current objective\n\nPreserve **typed provenance**.',
+				{ type: 'handoff-summary' },
+				'Handoff summary',
+			),
+		});
+
+		const card = screen.getByText('Handoff summary').closest('article');
+		expect(card?.querySelector('h2')?.textContent).toBe('Current objective');
+		expect(card?.querySelector('strong')?.textContent).toBe('typed provenance');
+		expect(container.querySelector('.markdown-body')).toBeTruthy();
+	});
+
 	it('keeps provider errors on the generic error path', () => {
 		render(ConversationMessageHost, {
 			message: new ErrorMessage(AT, 'Synthetic error.'),

--- a/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
+++ b/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
@@ -230,6 +230,25 @@ describe('SharedChatPage', () => {
 		expect(screen.getByText('6 of 6 messages')).toBeTruthy();
 	});
 
+	it('renders shared handoff summaries as Markdown', async () => {
+		const shared = response([], 0, 1, { nextBefore: null });
+		shared.snapshot.messages = [{
+			type: 'transcript-notice',
+			timestamp: '2025-01-02T03:05:00.000Z',
+			content: '## Current objective\n\nPreserve **typed provenance**.',
+			title: 'Handoff summary',
+			detail: { type: 'handoff-summary' },
+		}];
+		shared.page.end = 1;
+		vi.mocked(sharesApi.getSharedChat).mockResolvedValueOnce(shared);
+
+		const { container } = render(SharedChatPageTestHost);
+
+		await screen.findByText('Handoff summary');
+		expect(container.querySelector('h2')?.textContent).toBe('Current objective');
+		expect(container.querySelector('strong')?.textContent).toBe('typed provenance');
+	});
+
 	it('styles the complete shared CLI user message surface', async () => {
 		const shared = response([], 0, 1, { nextBefore: null });
 		shared.snapshot.messages = [{


### PR DESCRIPTION
Long agent handoffs can outlive the default provider and HTTP timeouts while giving users no indication that compaction is running. This change gives each compaction attempt five minutes across all integrations, keeps handoff HTTP requests alive within a 13-minute client bound, adds the new typed `info` operational-notice contract for a transient compaction-start message, and renders durable handoff summaries as Markdown in live and shared chats.