### PR TITLE
Make comparison range the edit control

### DIFF
--- a/integration-tests/support/spa-driver.ts
+++ b/integration-tests/support/spa-driver.ts
@@ -608,6 +608,27 @@ export class SpaDriver {
     }, name);
   }
 
+  async clickEditComparison(options: { within?: string } = {}): Promise<void> {
+    await this.#page.waitForFunction(
+      (rootSelector) => {
+        const root = rootSelector ? document.querySelector(rootSelector) : document;
+        return root !== null && [...root.querySelectorAll<HTMLButtonElement>(
+          'button[data-git-comparison-range]',
+        )].some((element) => !element.closest('[aria-hidden="true"]'));
+      },
+      { timeout: 20_000 },
+      options.within ?? null,
+    );
+    await this.#page.evaluate((rootSelector) => {
+      const root = rootSelector ? document.querySelector(rootSelector) : document;
+      const button = [...(root?.querySelectorAll<HTMLButtonElement>(
+        'button[data-git-comparison-range]',
+      ) ?? [])].find((element) => !element.closest('[aria-hidden="true"]'));
+      if (!button) throw new Error('Missing comparison range edit button.');
+      button.click();
+    }, options.within ?? null);
+  }
+
   async userMessageNavigatorRows(): Promise<string[]> {
     return this.#page.$$eval(
       '[data-user-message-navigator-row]',

--- a/integration-tests/tests/chromium/git-comparison-header.test.ts
+++ b/integration-tests/tests/chromium/git-comparison-header.test.ts
@@ -159,8 +159,11 @@ async function comparisonHeaderGeometry(page: Page) {
         },
       );
       return {
-        sameLine: Math.abs(rangeRect.top - statsRect.top) <= 1,
-        statsBelowRange: statsRect.top > rangeRect.top + 1,
+        rangeIsButton: range instanceof HTMLButtonElement,
+        rangeHeight: rangeRect.height,
+        rangeLeftInset: rangeRect.left - summaryRect.left,
+        sameLine: Math.abs(rangeLabelRect.top - primaryStatRect.top) <= 1,
+        statsBelowRange: primaryStatRect.top > rangeLabelRect.top + 1,
         labelTopDelta: Math.abs(rangeLabelRect.top - primaryStatRect.top),
         labelBottomDelta: Math.abs(
           rangeLabelRect.bottom - primaryStatRect.bottom,
@@ -205,6 +208,9 @@ describe("Chromium Git comparison header", () => {
         markPhase("checking the fitting one-line summary");
         await setHeaderWidth(fixture.page, 760);
         const wide = await comparisonHeaderGeometry(fixture.page);
+        expect(wide.rangeIsButton).toBe(true);
+        expect(wide.rangeHeight).toBeGreaterThanOrEqual(24);
+        expect(wide.rangeLeftInset).toBeGreaterThanOrEqual(0);
         expect(wide.sameLine).toBe(true);
         expect(wide.labelTopDelta).toBeLessThanOrEqual(1);
         expect(wide.labelBottomDelta).toBeLessThanOrEqual(1);

--- a/integration-tests/tests/chromium/git-history-breakpoints.test.ts
+++ b/integration-tests/tests/chromium/git-history-breakpoints.test.ts
@@ -423,29 +423,22 @@ async function verifyCompareResponsiveActions(
       (candidate) => candidate.textContent?.trim() === 'Diff settings',
     );
     const separator = element.querySelector('[data-slot="dropdown-menu-separator"]');
-    const edit = Array.from(element.querySelectorAll('[role="menuitem"]')).find(
-      (candidate) => candidate.textContent?.trim() === 'Edit',
-    );
     const refresh = Array.from(element.querySelectorAll('[role="menuitem"]')).find(
       (candidate) => candidate.textContent?.trim() === 'Refresh',
     );
-    if (!settings || !separator || !edit || !refresh) return null;
+    if (!settings || !separator || !refresh) return null;
     return {
       settingsBeforeSeparator: Boolean(
         settings.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING,
       ),
-      separatorBeforeEdit: Boolean(
-        separator.compareDocumentPosition(edit) & Node.DOCUMENT_POSITION_FOLLOWING,
-      ),
-      editBeforeRefresh: Boolean(
-        edit.compareDocumentPosition(refresh) & Node.DOCUMENT_POSITION_FOLLOWING,
+      separatorBeforeRefresh: Boolean(
+        separator.compareDocumentPosition(refresh) & Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     };
   });
   expect(order).toEqual({
     settingsBeforeSeparator: true,
-    separatorBeforeEdit: true,
-    editBeforeRefresh: true,
+    separatorBeforeRefresh: true,
   });
   expect(fixture.browserErrors).toEqual([]);
 }

--- a/integration-tests/tests/e2e/git-comparison.test.ts
+++ b/integration-tests/tests/e2e/git-comparison.test.ts
@@ -78,7 +78,7 @@ describe('Lightpanda Git comparison', () => {
       await waitForComparisonMarkers(fixture.page, ['working tree marker'], [
         'head comparison marker',
       ]);
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
       await app.fill('#git-comparison-from', 'origin/main');
       await app.clickDialogButton('Revision');
@@ -101,7 +101,7 @@ describe('Lightpanda Git comparison', () => {
       await waitForComparisonMarkers(fixture.page, ['head comparison marker'], [
         'working tree marker',
       ]);
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
       expect(await fixture.page.$eval(
         '#git-comparison-from',
@@ -148,7 +148,7 @@ describe('Lightpanda Git comparison', () => {
       await waitForComparisonMarkers(fixture.page, ['head comparison marker'], [
         'working tree marker',
       ]);
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
       expect(await fixture.page.$eval(
         '#git-comparison-from',
@@ -219,7 +219,7 @@ describe('Lightpanda Git comparison', () => {
         '[data-git-diff-document]',
         (element) => element.textContent,
       )).toContain('Working Tree');
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
 
       expect(await fixture.page.$eval(
@@ -394,7 +394,7 @@ describe('Lightpanda Git comparison', () => {
         },
         { timeout: 20_000 },
       );
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
       await app.fill('#git-comparison-from', 'origin/main');
       await app.clickDialogButton('Revision');

--- a/integration-tests/tests/e2e/git-view-surfaces.test.ts
+++ b/integration-tests/tests/e2e/git-view-surfaces.test.ts
@@ -5,6 +5,9 @@ import type { Page } from 'puppeteer-core';
 import { withE2eFixture } from '../../support/e2e-fixture.js';
 import { SpaDriver } from '../../support/spa-driver.js';
 
+const COMPARE_PANEL = '[role="tabpanel"][data-workspace-surface-id="singleton:git-compare"]'
+  + '[aria-hidden="false"]';
+
 async function runGit(projectPath: string, args: string[]): Promise<string> {
   const process = Bun.spawn(['git', ...args], {
     cwd: projectPath,
@@ -725,7 +728,7 @@ describe('Lightpanda standalone Git views', () => {
         },
         { timeout: 20_000 },
       );
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
       await app.fill('#git-comparison-from', 'HEAD~1');
       await app.clickDialogButton('Revision');
@@ -772,7 +775,7 @@ describe('Lightpanda standalone Git views', () => {
         },
         { timeout: 20_000 },
       );
-      await app.clickResponsiveAction('Edit');
+      await app.clickEditComparison({ within: COMPARE_PANEL });
       await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
       expect(await fixture.page.$eval(
         '#git-comparison-from',

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -667,7 +667,7 @@
 	"git_compare_swap_revisions": "Swap revisions",
 	"git_compare_use_direct": "Use Direct",
 	"git_compare_action": "Compare",
-	"git_compare_edit": "Edit",
+	"git_compare_edit_comparison": "Edit comparison",
 	"git_compare_refresh": "Refresh comparison",
 	"git_compare_context_refresh_required": "Refresh the comparison to apply the new context setting.",
 	"git_more_actions": "More Git actions",

--- a/web/src/lib/components/git/GitComparePanel.svelte
+++ b/web/src/lib/components/git/GitComparePanel.svelte
@@ -91,7 +91,6 @@
 	<GitCompareToolbar
 		{controller}
 		{presentation}
-		onEdit={editComparison}
 		onRefresh={refreshComparison}
 		onClose={() => void workspace.closeSurface(singletonSurfaceId('git-compare'))}
 		{closeDisabled}

--- a/web/src/lib/components/git/GitCompareToolbar.svelte
+++ b/web/src/lib/components/git/GitCompareToolbar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Pencil from '@lucide/svelte/icons/pencil';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import type { GitCompareSurfaceController } from '$lib/git/review/git-compare-surface.svelte.js';
 	import type { ResponsiveSurfaceAction } from '$lib/components/shared/ResponsiveSurfaceActions.svelte';
@@ -11,14 +10,12 @@
 	let {
 		controller,
 		presentation,
-		onEdit,
 		onRefresh,
 		onClose,
 		closeDisabled,
 	}: {
 		controller: GitCompareSurfaceController;
 		presentation: 'main' | 'sidebar' | 'mobile';
-		onEdit: () => void;
 		onRefresh: () => void;
 		onClose: () => void;
 		closeDisabled: boolean;
@@ -27,13 +24,6 @@
 	const reviewDisplay = getGitReviewDisplay();
 	const localSettings = getLocalSettings();
 	const actions = $derived<ResponsiveSurfaceAction[]>([
-		{
-			id: 'edit',
-			label: m.git_compare_edit(),
-			icon: Pencil,
-			onclick: onEdit,
-			priority: 0,
-		},
 		{
 			id: 'refresh',
 			label: m.git_header_refresh(),

--- a/web/src/lib/components/git/GitComparisonHeader.svelte
+++ b/web/src/lib/components/git/GitComparisonHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
+	import Pencil from '@lucide/svelte/icons/pencil';
 	import type { GitComparisonSnapshotReady } from '$lib/api/git-comparison.js';
 	import type { HostId } from '$lib/workspace/surface-types.js';
 	import WorkspaceFullscreenButton from '$lib/components/workspace/WorkspaceFullscreenButton.svelte';
@@ -13,6 +14,7 @@
 		fileTreeVisible: boolean;
 		onToggleFileTree: () => void;
 		onBack?: () => void;
+		onEdit?: () => void;
 		fullscreenHost: HostId | null;
 	}
 
@@ -22,6 +24,7 @@
 		fileTreeVisible,
 		onToggleFileTree,
 		onBack,
+		onEdit,
 		fullscreenHost,
 	}: GitComparisonHeaderProps = $props();
 	let additions = $derived(snapshot.files.reduce((sum, file) => sum + file.additions, 0));
@@ -34,6 +37,16 @@
 		snapshot.to.kind === 'working-tree' ? snapshot.to.shortFingerprint : snapshot.to.shortHash,
 	);
 </script>
+
+{#snippet rangeEndpoints()}
+	<span class="truncate" title={snapshot.from.label} data-git-comparison-range-label
+		>{snapshot.from.label}</span
+	>
+	<span class="shrink-0">{snapshot.from.shortHash}</span>
+	<ArrowRight class="h-3.5 w-3.5 self-center" aria-hidden="true" />
+	<span class="truncate" title={toLabel}>{toLabel}</span>
+	<span class="shrink-0">{toIdentity}</span>
+{/snippet}
 
 <header class="border-b border-border bg-background px-3 py-1.5">
 	<div class="flex min-w-0 items-center gap-2" data-git-comparison-header-row>
@@ -52,15 +65,22 @@
 			class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-8 gap-y-0.5 overflow-hidden font-mono text-xs text-muted-foreground"
 			data-git-comparison-summary
 		>
-			<div class="flex min-w-0 max-w-full shrink items-baseline gap-1.5" data-git-comparison-range>
-				<span class="truncate" title={snapshot.from.label} data-git-comparison-range-label
-					>{snapshot.from.label}</span
+			{#if onEdit}
+				<button
+					type="button"
+					class="flex min-w-0 max-w-full shrink cursor-pointer items-baseline gap-1.5 rounded py-1 text-left hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-interactive-accent"
+					data-git-comparison-range
+					onclick={onEdit}
 				>
-				<span class="shrink-0">{snapshot.from.shortHash}</span>
-				<ArrowRight class="h-3.5 w-3.5 self-center" aria-hidden="true" />
-				<span class="truncate" title={toLabel}>{toLabel}</span>
-				<span class="shrink-0">{toIdentity}</span>
-			</div>
+					{@render rangeEndpoints()}
+					<Pencil class="h-3 w-3 shrink-0 self-center opacity-60" aria-hidden="true" />
+					<span class="sr-only">{m.git_compare_edit_comparison()}</span>
+				</button>
+			{:else}
+				<div class="flex min-w-0 max-w-full shrink items-baseline gap-1.5" data-git-comparison-range>
+					{@render rangeEndpoints()}
+				</div>
+			{/if}
 			<div
 				class="relative flex max-w-full shrink flex-wrap items-baseline gap-x-2 gap-y-0.5"
 				data-git-comparison-stats

--- a/web/src/lib/components/git/GitComparisonScreen.svelte
+++ b/web/src/lib/components/git/GitComparisonScreen.svelte
@@ -51,6 +51,7 @@
 			{fileTreeVisible}
 			{onToggleFileTree}
 			{onBack}
+			{onEdit}
 			{fullscreenHost}
 		/>
 		{#if comparison.staleMessage}
@@ -78,7 +79,7 @@
 			class="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
 			onclick={onEdit}
 		>
-			{m.git_compare_edit()}
+			{m.git_compare_edit_comparison()}
 		</button>
 	{/if}
 {/snippet}

--- a/web/src/lib/components/git/GitDiffDocumentScreen.svelte
+++ b/web/src/lib/components/git/GitDiffDocumentScreen.svelte
@@ -274,9 +274,12 @@
 			</div>
 		</div>
 	{:else if isLoading}
-		<div class="flex h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
-			<LoaderCircle class="h-5 w-5 animate-spin" />
-			{loadingLabel}
+		<div class="flex h-32 flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+			<div class="flex items-center gap-2">
+				<LoaderCircle class="h-5 w-5 animate-spin" />
+				{loadingLabel}
+			</div>
+			{@render fallbackActions?.()}
 		</div>
 	{:else}
 		<div class="flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center">

--- a/web/src/lib/components/git/__tests__/GitComparePanelContentStub.svelte
+++ b/web/src/lib/components/git/__tests__/GitComparePanelContentStub.svelte
@@ -1,1 +1,8 @@
+<script lang="ts">
+	let { onEdit }: { onEdit?: () => void } = $props();
+</script>
+
 <div data-testid="git-compare-panel-content"></div>
+{#if onEdit}
+	<button type="button" onclick={onEdit}>Edit comparison</button>
+{/if}

--- a/web/src/lib/components/git/__tests__/GitComparePanelToolbarStub.svelte
+++ b/web/src/lib/components/git/__tests__/GitComparePanelToolbarStub.svelte
@@ -1,5 +1,1 @@
-<script lang="ts">
-	let { onEdit }: { onEdit: () => void } = $props();
-</script>
-
-<button type="button" onclick={onEdit}>Edit comparison</button>
+<div data-testid="git-compare-panel-toolbar"></div>

--- a/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
+++ b/web/src/lib/components/git/__tests__/GitComparisonScreen.test.ts
@@ -48,6 +48,22 @@ describe('GitComparisonScreen', () => {
 		expect(screen.queryByText('Comparison could not be loaded.')).toBeNull();
 	});
 
+	it('keeps comparison editing available during initialization', async () => {
+		const onEdit = vi.fn();
+		render(GitComparisonScreen, {
+			comparison: new GitComparisonController(),
+			isLoading: true,
+			presentation: 'main',
+			fontSize: 12,
+			onEdit,
+			onRefresh: vi.fn(),
+			onOpenChat: vi.fn(),
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Edit comparison' }));
+		expect(onEdit).toHaveBeenCalledOnce();
+	});
+
 	it('preserves a real comparison failure after initialization', () => {
 		const comparison = new GitComparisonController();
 		comparison.error = 'Revision HEAD was not found.';
@@ -68,6 +84,46 @@ describe('GitComparisonScreen', () => {
 		expect(screen.getByText('Working Tree')).toBeTruthy();
 		expect(screen.queryByText('Compare revisions')).toBeNull();
 		expect(screen.queryByText('Direct')).toBeNull();
+	});
+
+	it('offers the comparison range itself as the edit entry point', async () => {
+		const comparison = new GitComparisonController();
+		comparison.snapshot = readySnapshot();
+		const onEdit = vi.fn();
+
+		render(GitComparisonScreen, {
+			comparison,
+			isLoading: false,
+			presentation: 'main',
+			fontSize: 12,
+			onEdit,
+			onRefresh: vi.fn(),
+			onOpenChat: vi.fn(),
+		});
+
+		const range = screen.getByRole('button', { name: /Edit comparison/ });
+		expect(range.getAttribute('data-git-comparison-range')).not.toBeNull();
+		expect(range.textContent).toContain('HEAD~1');
+		expect(range.textContent).toContain('Working Tree');
+		await fireEvent.click(range);
+		expect(onEdit).toHaveBeenCalledOnce();
+	});
+
+	it('keeps the comparison range inert when editing is unavailable', () => {
+		const comparison = new GitComparisonController();
+		comparison.snapshot = readySnapshot();
+
+		render(GitComparisonScreen, {
+			comparison,
+			isLoading: false,
+			presentation: 'main',
+			fontSize: 12,
+			onRefresh: vi.fn(),
+			onOpenChat: vi.fn(),
+		});
+
+		expect(screen.queryByRole('button', { name: /Edit comparison/ })).toBeNull();
+		expect(screen.getByText('HEAD~1')).toBeTruthy();
 	});
 
 	it('identifies a comparison made since the common ancestor', () => {
@@ -107,7 +163,7 @@ describe('GitComparisonScreen', () => {
 			onOpenChat: vi.fn(),
 		});
 
-		expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+		expect(screen.queryByRole('button', { name: /Edit comparison/ })).toBeNull();
 		await fireEvent.click(screen.getByRole('button', { name: 'Back to commit selection' }));
 		expect(onBack).toHaveBeenCalledOnce();
 	});
@@ -122,6 +178,7 @@ describe('GitComparisonScreen', () => {
 				isLoading: false,
 				presentation,
 				fontSize: 12,
+				onEdit: vi.fn(),
 				onRefresh: vi.fn(),
 				onOpenChat: vi.fn(),
 			});

--- a/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
+++ b/web/src/lib/components/git/__tests__/GitHistoryView.test.ts
@@ -892,7 +892,7 @@ describe('GitHistoryView', () => {
 			'direct',
 			expect.objectContaining({ context: 5 }),
 		);
-		expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+		expect(screen.queryByRole('button', { name: /Edit comparison/ })).toBeNull();
 		const comparison = container.querySelector<HTMLElement>('[data-git-diff-document]');
 		expect(comparison).toBeTruthy();
 		if (!comparison) return;


### PR DESCRIPTION
Moves the Git Compare edit affordance from the detached toolbar action into the displayed revision range, making the range and pencil icon a single accessible button that opens Compare revisions. The change preserves edit access during loading and error states, keeps responsive layout and touch and focus behavior intact, and updates unit and browser coverage for the new interaction.