### PR TITLE
Apply the chat permission mode to forked OpenCode sessions

### DIFF
--- a/integration-tests/support/scripted-opencode.ts
+++ b/integration-tests/support/scripted-opencode.ts
@@ -737,3 +737,22 @@ export function readOpenCodeSessionCount(databasePath: string): number {
     database.close();
   }
 }
+
+// Returns the session row's stored ruleset; undefined when the column is absent or empty.
+export function readOpenCodeSessionPermission(
+  native: OpenCodeNativeSession,
+): Array<{ permission: string; pattern: string; action: string }> | undefined {
+  const database = new Database(native.databasePath, { readonly: true, strict: true });
+  try {
+    const row = database.query('SELECT permission FROM session WHERE id = ?')
+      .get(native.agentSessionId) as { permission: string | null } | null;
+    if (!row?.permission) return undefined;
+    return JSON.parse(row.permission) as Array<{
+      permission: string;
+      pattern: string;
+      action: string;
+    }>;
+  } finally {
+    database.close();
+  }
+}

--- a/integration-tests/tests/server/opencode-scripted-persistence.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-persistence.test.ts
@@ -1,10 +1,15 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   assistantContents,
   userContents,
 } from '../../support/chat-assertions.js';
-import { chatCompletionsText } from '../../support/fake-chat-completions-model.js';
+import {
+  chatCompletionsText,
+  chatCompletionsToolUse,
+} from '../../support/fake-chat-completions-model.js';
 import {
   withIntegrationFixture,
   type IntegrationFixtureOptions,
@@ -18,6 +23,7 @@ import {
   openCodeNativeSession,
   openCodePaths,
   readOpenCodeSessionCount,
+  readOpenCodeSessionPermission,
   readOpenCodeSessionRows,
   readSupervisorStates,
   scriptedOpenCodeRunRequest,
@@ -350,6 +356,66 @@ describeOnLinux('scripted OpenCode persistence', () => {
         .toBeGreaterThan(sourceRows.messages.length);
       expect(assistantContents((await fixture.client.getMessages(forkChatId)).messages)
         .some((content) => content.includes(sourceContinuation))).toBe(false);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
+  // The forked native session inherits nothing from the source session upstream, so
+  // Garcon applies the chat's ruleset at fork time. Without it the forked turn's bash
+  // tool call would stall behind a native permission request despite bypass mode.
+  test('carries the chat permission mode into the forked native session', async () => {
+    const testEnvironment = requireEnvironment();
+    const sourceReply = marker('FORKPERM_SOURCE_REPLY');
+    const forkReply = marker('FORKPERM_FORK_REPLY');
+    const toolMarker = 'fork-permission.marker';
+    testEnvironment.model.scriptTurn([chatCompletionsText(sourceReply)]);
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse('call_fork_perm_tool', 'bash', {
+      command: `touch ${toolMarker}`,
+    })]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(forkReply)]);
+
+    await withIntegrationFixture('opencode-scripted-fork-permission', async (fixture) => {
+      const sourceChatId = fixture.newChatId();
+      const sourceCursor = fixture.client.markEvents();
+      const source = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId: sourceChatId,
+        projectPath: fixture.dirs.project,
+        command: marker('FORKPERM_SOURCE_PROMPT'),
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: sourceChatId,
+        turnId: source.turnId,
+        marker: sourceReply,
+        afterIndex: sourceCursor,
+      });
+
+      const forkChatId = fixture.newChatId();
+      const forkCursor = fixture.client.markEvents();
+      const forkTurn = await fixture.client.forkRunChat({
+        clientRequestId: crypto.randomUUID(),
+        clientMessageId: crypto.randomUUID(),
+        sourceChatId,
+        chatId: forkChatId,
+        command: marker('FORKPERM_FORK_PROMPT'),
+        permissionMode: 'bypassPermissions',
+        thinkingMode: 'none',
+        agentSettings: { ownerId: 'opencode', schemaVersion: 1, values: {} },
+        model: undefined,
+      });
+      await waitForVisibleResponse({
+        fixture,
+        chatId: forkChatId,
+        turnId: forkTurn.turnId,
+        marker: forkReply,
+        afterIndex: forkCursor,
+      });
+
+      expect(existsSync(join(fixture.dirs.project, toolMarker))).toBe(true);
+      const forkNative = await openCodeNativeSession(fixture, forkChatId);
+      const permission = readOpenCodeSessionPermission(forkNative);
+      expect(permission).toContainEqual({ permission: 'bash', pattern: '*', action: 'allow' });
+      expect(permission).toContainEqual({ permission: 'edit', pattern: '*', action: 'allow' });
       testEnvironment.model.assertSettled();
     }, withScriptedOpenCode());
   }, 120_000);

--- a/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
@@ -24,11 +24,25 @@ function createRuntimeWithClient(client) {
 }
 
 async function waitForMockCall(fn) {
+  await waitForCondition(() => fn.mock.calls.length > 0);
+}
+
+async function waitForCondition(predicate) {
   for (let attempt = 0; attempt < 50; attempt += 1) {
-    if (fn.mock.calls.length > 0) return;
+    if (predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
-  throw new Error('Timed out waiting for mock call');
+  throw new Error('Timed out waiting for condition');
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 function operation(runId) {
@@ -127,6 +141,109 @@ describe('OpenCodeRuntime fork', () => {
     expect(failure?.code).toBe('TRANSCRIPT_UNAVAILABLE');
     expect(failure?.retryable).toBe(true);
     expect(failure?.details).toEqual({ nativeForkReason: 'source-missing' });
+  });
+
+  it('applies the chat permission mode to the forked session', async () => {
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const { runtime } = createRuntimeWithClient({
+      session: { fork, update },
+    });
+
+    await expect(runtime.forkSession('source-session', {
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+    })).resolves.toBe('forked-session');
+
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][0];
+    expect(payload.sessionID).toBe('forked-session');
+    expect(payload.directory).toBe('/repo');
+    expect(payload.permission).toContainEqual({ permission: 'bash', pattern: '*', action: 'allow' });
+    expect(payload.permission).toContainEqual({ permission: 'edit', pattern: '*', action: 'allow' });
+    // Native plan transitions stay denied even under bypass, matching session creation.
+    expect(payload.permission).toContainEqual({ permission: 'plan_enter', pattern: '*', action: 'deny' });
+  });
+
+  it('deletes the forked session when the permission update fails', async () => {
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => Promise.resolve({ error: { message: 'update rejected' } }));
+    const remove = mock(() => Promise.resolve({ data: true }));
+    const { runtime } = createRuntimeWithClient({
+      session: { fork, update, delete: remove },
+    });
+
+    const failure = await runtime.forkSession('source-session', {
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+    }).then(() => null, (error) => error);
+
+    expect(failure?.message).toBe('update rejected');
+    expect(failure?.code).toBe('TRANSCRIPT_UNAVAILABLE');
+    expect(failure?.retryable).toBe(true);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+  });
+
+  it('does not touch session update when no permission mode is given', async () => {
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const { runtime } = createRuntimeWithClient({
+      session: { fork, update },
+    });
+
+    await expect(runtime.forkSession('source-session')).resolves.toBe('forked-session');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('retains the forked session deletion when the endpoint dies and replays it on the replacement', async () => {
+    const termination = deferred();
+    let firstClosed = false;
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => Promise.reject(new Error('server gone')));
+    const deadDelete = mock(() => Promise.reject(new Error('dead endpoint')));
+    const replacementDelete = mock(() => Promise.resolve({ data: true }));
+    let factoryCalls = 0;
+    const createInstance = mock(() => {
+      factoryCalls += 1;
+      return Promise.resolve(factoryCalls === 1
+        ? {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { fork, update, delete: deadDelete },
+          },
+          server: {
+            close: () => { firstClosed = true; },
+            termination: termination.promise,
+          },
+        }
+        : {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { delete: replacementDelete },
+          },
+          server: { close: mock(() => {}) },
+        });
+    });
+    const runtime = new OpenCodeRuntime({ createInstance });
+
+    const failure = await runtime.forkSession('source-session', {
+      projectPath: '/repo',
+      permissionMode: 'bypassPermissions',
+    }).then(() => null, (error) => error);
+    expect(failure?.code).toBe('TRANSCRIPT_UNAVAILABLE');
+    expect(failure?.retryable).toBe(true);
+    // The delete through the dying endpoint fails, so the deletion is retained.
+    expect(deadDelete).toHaveBeenCalledTimes(1);
+
+    termination.resolve({ kind: 'exit', code: 1, signal: null });
+    await waitForCondition(() => firstClosed);
+    await runtime.getClient();
+    await waitForCondition(() => replacementDelete.mock.calls.length > 0);
+    expect(replacementDelete.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+    await runtime.shutdown();
   });
 
   it('creates new sessions and submits the first prompt in the project directory', async () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
@@ -10,12 +10,13 @@ async function* neverEndingStream() {
 }
 
 function createForking(session) {
+  const update = mock(() => Promise.resolve({ data: {} }));
   const runtime = new OpenCodeRuntime({
     createInstance: mock(() => Promise.resolve({
       client: {
         permission: { reply: mock(() => Promise.resolve({})) },
         global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
-        session,
+        session: { update, ...session },
       },
       server: { close: mock(() => {}) },
     })),
@@ -24,6 +25,7 @@ function createForking(session) {
   return {
     runtime,
     nativeSessions,
+    update,
     forking: createOpenCodeNativeForking({
       runtime,
       nativeSessions,
@@ -91,6 +93,21 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
       sessionID: 'source-session',
       directory: '/repo',
     });
+  });
+
+  it('applies the request permission mode to the forked native session', async () => {
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const { forking, update } = createForking({ fork });
+
+    const outcome = await forking.fork(forkRequest({ permissionMode: 'bypassPermissions' }));
+
+    expect(outcome.kind).toBe('materialized');
+    expect(update).toHaveBeenCalledTimes(1);
+    const payload = update.mock.calls[0][0];
+    expect(payload.sessionID).toBe('forked-session');
+    expect(payload.directory).toBe('/repo');
+    expect(payload.permission).toContainEqual({ permission: 'bash', pattern: '*', action: 'allow' });
+    expect(payload.permission).toContainEqual({ permission: 'plan_enter', pattern: '*', action: 'deny' });
   });
 
   it('bounds a part anchor just past its owning message', async () => {

--- a/server-agents/opencode/src/agents/opencode/forking.ts
+++ b/server-agents/opencode/src/agents/opencode/forking.ts
@@ -44,6 +44,9 @@ export function createOpenCodeNativeForking(
         : null;
       const forkedSessionId = await options.runtime.forkSession(sourceSessionId, {
         projectPath: request.projectPath,
+        // The forked native session must carry the chat's ruleset; OpenCode's fork
+        // does not inherit it from the source session.
+        permissionMode: request.permissionMode,
         // OpenCode resolves the boundary by exact identity and clones its
         // chronological prefix.
         // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/session/session.ts#L704-L706

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -1601,7 +1601,7 @@ export class OpenCodeRuntime {
 
   async forkSession(
     sourceSessionId: string,
-    options: { projectPath?: string | null; messageId?: string } = {},
+    options: { projectPath?: string | null; messageId?: string; permissionMode?: string } = {},
   ): Promise<string> {
     // OpenCode persists a manual compaction control before its summary runs, so
     // a whole-tip fork mid-compaction would clone a pending control into the
@@ -1615,11 +1615,48 @@ export class OpenCodeRuntime {
         { nativeForkReason: 'not-settled' },
       );
     }
-    return this.#endpointCoordinator.forkSession(
+    const forkedSessionId = await this.#endpointCoordinator.forkSession(
       sourceSessionId,
       options,
       (label, scope, operation) => this.#runScopedSessionRequest(label, scope, operation),
     );
+    // Native fork clones only messages: the forked session carries no permission
+    // ruleset, so without this the forked chat prompts for everything the source
+    // had allowed. https://github.com/anomalyco/opencode/blob/v1.18.22/packages/opencode/src/session/session.ts#L691-L701
+    const permissionMode = options.permissionMode;
+    if (permissionMode) {
+      try {
+        await this.withClientLease(async (client) => {
+          const result = await this.#runScopedSessionRequest(
+            'OpenCode fork permission update',
+            createOpenCodeRequestScope(options.projectPath),
+            (requestSignal, requestScope) => client.session.update(
+              withOpenCodeRequestScope({
+                sessionID: forkedSessionId,
+                permission: mapPermissionMode(permissionMode),
+              }, requestScope),
+              { signal: requestSignal },
+            ),
+          );
+          throwOpenCodeResultError(result, 'Failed to apply OpenCode fork permission mode');
+        });
+      } catch (error) {
+        // Never leave a forked session behind with a ruleset that does not match the
+        // chat record; the fork caller retries the whole operation. Cleanup goes
+        // through the retained-deletion path: an update that failed because the
+        // endpoint died would otherwise orphan a full transcript clone.
+        await this.#deleteSessionBestEffort(
+          forkedSessionId,
+          createOpenCodeRequestScope(options.projectPath),
+        );
+        throw new AgentIntegrationError(
+          'TRANSCRIPT_UNAVAILABLE',
+          errorMessage(error),
+          true,
+        );
+      }
+    }
+    return forkedSessionId;
   }
 
   async deleteSession(agentSessionId: string, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Problem

OpenCode's native `session.fork` clones only messages — the forked session carries no permission ruleset (upstream v1.18.22 `session.ts`, still unfixed on latest `origin/dev`), and Garcon applies `mapPermissionMode` natively only at `session.create`. Forked opencode chats therefore emitted permission prompts even though the forked chat record correctly kept bypass mode.

## Fix

- The forking facet forwards `request.permissionMode` (present on `AgentNativeForkRequest`, previously ignored).
- `OpenCodeRuntime.forkSession` applies the mapped ruleset to the forked session via `session.update` before the chat binds to it.
- Update failure cleans up through the retained best-effort deletion path (a dead endpoint cannot orphan the transcript clone; deletion replays on the replacement instance) and rethrows a retryable `TRANSCRIPT_UNAVAILABLE`.

Behavior change: forked OpenCode sessions natively carry the chat's permission ruleset; fork fails retryably instead of binding a session with default permissions.

## Tests

- Unit: ruleset application, update-failure cleanup, no-update-without-mode, facet forwarding, delete retention/replay.
- Scripted real-binary: a forked-turn bash tool call runs with no permission prompt and the forked session row stores the bypass ruleset; with the fix reverted the test deterministically stalls (original bug).
- Root `bun run test`, `bun run typecheck`, and the integration server suite (343 tests) all pass.