### PR TITLE
Collapse handoff summaries by default

### DIFF
--- a/integration-tests/tests/chromium/chat-row-visibility.test.ts
+++ b/integration-tests/tests/chromium/chat-row-visibility.test.ts
@@ -583,7 +583,7 @@ describe('Chromium transcript chat rows', () => {
           collapsed: true,
         });
         const collapsedBodyBox = await rowLocator(fixture.page, custom)
-          .locator('.cli-collapsible-body-collapsed')
+          .locator('.collapsible-body-collapsed')
           .boundingBox();
         expect(collapsedBodyBox).not.toBeNull();
         expect(collapsedBodyBox!.height).toBeLessThanOrEqual(160);

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1041,7 +1041,7 @@
 .composer-thinking-active [data-slot='chat-processing-status'] {
 	border-color: var(--composer-thinking-status-border);
 }
-.cli-collapsible-body-collapsed {
+.collapsible-body-collapsed {
 	max-height: 10rem;
 	overflow: hidden;
 	-webkit-mask-image: linear-gradient(to bottom, black 7rem, transparent 10rem);

--- a/web/src/lib/components/chat/ConversationFeedItemState.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedItemState.svelte.ts
@@ -1,5 +1,5 @@
 export type ConversationDisclosureKind =
-	'thinking' | 'tool-input' | 'tool-result' | 'compaction' | 'cli-body';
+	'thinking' | 'tool-input' | 'tool-result' | 'compaction' | 'cli-body' | 'notice-body';
 
 export interface ConversationDisclosureStatePort {
 	open(kind: ConversationDisclosureKind, localId: string, defaultOpen: boolean): boolean;

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -5,7 +5,6 @@
 		AssistantMessage,
 		ThinkingMessage,
 		isToolUseMessage,
-		isHandoffSummaryNoticeDetail,
 		ErrorMessage,
 		TranscriptNoticeMessage,
 		CliRowMessage,
@@ -38,7 +37,8 @@
 	import ChatEventCard from './rows/ChatEventCard.svelte';
 	import CliRow from './rows/CliRow.svelte';
 	import CliPresentationHeader from './rows/CliPresentationHeader.svelte';
-	import CliCollapsibleBody from './rows/CliCollapsibleBody.svelte';
+	import CollapsibleBody from './rows/CollapsibleBody.svelte';
+	import TranscriptNoticeRow from './rows/TranscriptNoticeRow.svelte';
 	import { cliPresentationSurfaceClass } from '$lib/chat/transcript/cli-presentation-style';
 	import ChatToolEventRenderer from './tools/ChatToolEventRenderer.svelte';
 	import {
@@ -513,7 +513,7 @@
 									title={userMessagePresentation.title}
 								/>
 							{/if}
-							<CliCollapsibleBody
+							<CollapsibleBody
 								disclosure={userMessagePresentation?.disclosure}
 								alwaysExpanded={localSettings.alwaysExpandCliMessages}
 								expanded={disclosureState?.open('cli-body', 'body', false)}
@@ -532,7 +532,7 @@
 										/>
 									</div>
 								{/snippet}
-							</CliCollapsibleBody>
+							</CollapsibleBody>
 							{#if asUser.images && asUser.images.length > 0}
 								<div class="mt-2 grid grid-cols-2 gap-2">
 									{#each asUser.images as img, idx (idx)}
@@ -743,33 +743,13 @@
 							{disclosureState}
 						/>
 					{:else if asNotice}
-						<ChatEventCard variant="info">
-							{#snippet body()}
-								{#if asNotice.title}
-									<div class="min-w-0 truncate text-xs font-medium">{asNotice.title}</div>
-								{/if}
-								{#if isHandoffSummaryNoticeDetail(asNotice.detail)}
-									<div class={['text-sm', asNotice.title && 'mt-1']}>
-										<Markdown
-											source={asNotice.content}
-											variant="presented"
-											fileLinkBasePath={projectBasePath}
-											onLinkNavigate={handleLinkNavigate}
-											{acquireTransientActivity}
-										/>
-									</div>
-								{:else}
-									<div
-										class={[
-											'text-sm whitespace-pre-wrap break-words',
-											asNotice.title && 'mt-1',
-										]}
-									>
-										{asNotice.content}
-									</div>
-								{/if}
-							{/snippet}
-						</ChatEventCard>
+						<TranscriptNoticeRow
+							message={asNotice}
+							fileLinkBasePath={projectBasePath}
+							onLinkNavigate={handleLinkNavigate}
+							{acquireTransientActivity}
+							{disclosureState}
+						/>
 					{:else if asError}
 						<ChatEventCard variant="error">
 							{#snippet body()}

--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -11,7 +11,6 @@
 		TranscriptNoticeMessage,
 		CliRowMessage,
 		isToolUseMessage,
-		isHandoffSummaryNoticeDetail,
 	} from '$shared/chat-types';
 	import Markdown from '$lib/components/chat/Markdown.svelte';
 	import MessageRenderFallback from '$lib/components/chat/MessageRenderFallback.svelte';
@@ -19,7 +18,8 @@
 	import ChatEventCard from '$lib/components/chat/rows/ChatEventCard.svelte';
 	import CliRow from '$lib/components/chat/rows/CliRow.svelte';
 	import CliPresentationHeader from '$lib/components/chat/rows/CliPresentationHeader.svelte';
-	import CliCollapsibleBody from '$lib/components/chat/rows/CliCollapsibleBody.svelte';
+	import CollapsibleBody from '$lib/components/chat/rows/CollapsibleBody.svelte';
+	import TranscriptNoticeRow from '$lib/components/chat/rows/TranscriptNoticeRow.svelte';
 	import { cliPresentationSurfaceClass } from '$lib/chat/transcript/cli-presentation-style';
 	import { cn } from '$lib/utils/cn';
 	import { getAppTitle } from '$lib/context';
@@ -273,7 +273,7 @@
 												title={userPresentation.title}
 											/>
 										{/if}
-										<CliCollapsibleBody disclosure={userPresentation?.disclosure}>
+										<CollapsibleBody disclosure={userPresentation?.disclosure}>
 											{#snippet children()}
 												<div class={userPresentation?.style ? 'mt-1 text-sm' : 'text-sm'}>
 													<Markdown
@@ -282,7 +282,7 @@
 													/>
 												</div>
 											{/snippet}
-										</CliCollapsibleBody>
+										</CollapsibleBody>
 										{#if message.images && message.images.length > 0}
 											<div class="mt-2 grid grid-cols-2 gap-2">
 												{#each message.images as image, imageIndex (imageIndex)}
@@ -331,27 +331,7 @@
 							{:else if message instanceof CliRowMessage}
 								<CliRow {message} />
 							{:else if message instanceof TranscriptNoticeMessage}
-								<ChatEventCard variant="info">
-									{#snippet body()}
-										{#if message.title}
-											<div class="min-w-0 truncate text-xs font-medium">{message.title}</div>
-										{/if}
-										{#if isHandoffSummaryNoticeDetail(message.detail)}
-											<div class={['text-sm', message.title && 'mt-1']}>
-												<Markdown source={message.content} variant="presented" />
-											</div>
-										{:else}
-											<div
-												class={[
-													'text-sm whitespace-pre-wrap break-words',
-													message.title && 'mt-1',
-												]}
-											>
-												{message.content}
-											</div>
-										{/if}
-									{/snippet}
-								</ChatEventCard>
+								<TranscriptNoticeRow {message} />
 							{:else if message instanceof ErrorMessage}
 								<ChatEventCard variant="error">
 									{#snippet body()}

--- a/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
@@ -11,6 +11,15 @@ import { ConversationFeedItemState } from '../ConversationFeedItemState.svelte';
 
 const AT = '2026-08-18T12:00:00.000Z';
 
+function handoffNotice(): TranscriptNoticeMessage {
+	return new TranscriptNoticeMessage(
+		AT,
+		'## Current objective\n\nPreserve **typed provenance**.',
+		{ type: 'handoff-summary' },
+		'Handoff summary',
+	);
+}
+
 describe('ConversationMessage chat rows', () => {
 	afterEach(() => cleanup());
 
@@ -27,20 +36,72 @@ describe('ConversationMessage chat rows', () => {
 		expect(card?.querySelector('button')).toBeNull();
 	});
 
-	it('renders handoff summaries as Markdown', () => {
-		const { container } = render(ConversationMessageHost, {
+	it('renders handoff summaries as Markdown behind a body collapsed by default', () => {
+		const { container } = render(ConversationMessageHost, { message: handoffNotice() });
+
+		const button = screen.getByRole('button', { name: 'Show more' });
+		expect(button.getAttribute('aria-expanded')).toBe('false');
+		expect(document.getElementById(button.getAttribute('aria-controls')!)?.classList).toContain(
+			'collapsible-body-collapsed',
+		);
+		const card = screen.getByText('Handoff summary').closest('article');
+		expect(card?.querySelector('h2')?.textContent).toBe('Current objective');
+		expect(card?.querySelector('strong')?.textContent).toBe('typed provenance');
+		expect(container.querySelector('.markdown-body')).toBeTruthy();
+	});
+
+	it('keeps handoff summaries collapsed when CLI messages are always expanded', () => {
+		render(ConversationMessageHost, {
+			message: handoffNotice(),
+			alwaysExpandCliMessages: true,
+		});
+
+		expect(screen.getByRole('button', { name: 'Show more' }).getAttribute('aria-expanded')).toBe(
+			'false',
+		);
+	});
+
+	it('expands a collapsed handoff summary through Show more', async () => {
+		render(ConversationMessageHost, { message: handoffNotice() });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
+			'true',
+		);
+	});
+
+	it('preserves handoff summary expansion across remounts through the feed disclosure state', async () => {
+		const itemState = new ConversationFeedItemState();
+		const disclosureState = itemState.disclosurePort('notice-row-1');
+		const message = handoffNotice();
+		const first = render(ConversationMessageHost, { message, disclosureState });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
+			'true',
+		);
+		first.unmount();
+
+		render(ConversationMessageHost, { message, disclosureState });
+		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
+			'true',
+		);
+	});
+
+	it('expands a collapsed handoff summary before focus can remain clipped', async () => {
+		render(ConversationMessageHost, {
 			message: new TranscriptNoticeMessage(
 				AT,
-				'## Current objective\n\nPreserve **typed provenance**.',
+				'[Focused link](https://example.com)',
 				{ type: 'handoff-summary' },
 				'Handoff summary',
 			),
 		});
 
-		const card = screen.getByText('Handoff summary').closest('article');
-		expect(card?.querySelector('h2')?.textContent).toBe('Current objective');
-		expect(card?.querySelector('strong')?.textContent).toBe('typed provenance');
-		expect(container.querySelector('.markdown-body')).toBeTruthy();
+		await fireEvent.focusIn(screen.getByRole('link', { name: 'Focused link' }));
+		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
+			'true',
+		);
 	});
 
 	it('keeps provider errors on the generic error path', () => {
@@ -206,7 +267,7 @@ describe('ConversationMessage chat rows', () => {
 		expect(button.getAttribute('aria-expanded')).toBe('false');
 		expect(button.classList).toContain('min-h-6');
 		expect(document.getElementById(button.getAttribute('aria-controls')!)?.classList).toContain(
-			'cli-collapsible-body-collapsed',
+			'collapsible-body-collapsed',
 		);
 		await fireEvent.click(button);
 		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
@@ -272,7 +333,7 @@ describe('ConversationMessage chat rows', () => {
 
 		expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull();
 		expect(
-			screen.getByText('Long CLI content').closest('.cli-collapsible-body-collapsed'),
+			screen.getByText('Long CLI content').closest('.collapsible-body-collapsed'),
 		).toBeNull();
 	});
 

--- a/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
+++ b/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
@@ -245,6 +245,12 @@ describe('SharedChatPage', () => {
 		const { container } = render(SharedChatPageTestHost);
 
 		await screen.findByText('Handoff summary');
+
+		const disclosure = screen.getByRole('button', { name: 'Show more' });
+		expect(disclosure.getAttribute('aria-expanded')).toBe('false');
+		await fireEvent.click(disclosure);
+		expect(screen.getByRole('button', { name: 'Show less' })).toBeTruthy();
+
 		expect(container.querySelector('h2')?.textContent).toBe('Current objective');
 		expect(container.querySelector('strong')?.textContent).toBe('typed provenance');
 	});

--- a/web/src/lib/components/chat/__tests__/conversation-feed-virtual-items.test.ts
+++ b/web/src/lib/components/chat/__tests__/conversation-feed-virtual-items.test.ts
@@ -3,6 +3,7 @@ import {
 	BashToolUseMessage,
 	GlobToolUseMessage,
 	ToolResultMessage,
+	TranscriptNoticeMessage,
 	UserMessage,
 } from '$shared/chat-types';
 import type { PendingPermissionRequest } from '$lib/types/chat';
@@ -173,6 +174,23 @@ describe('conversation virtual feed model', () => {
 		expect(estimateConversationFeedItemSize(ordinary, 1)).toBe(124);
 		expect(estimateConversationFeedItemSize(collapsible, 1)).toBe(124);
 		expect(estimateConversationFeedItemSize(presented, 1)).toBe(156);
+	});
+
+	it('bounds collapsed handoff notices while plain notices stay compact', () => {
+		const plain = new TranscriptNoticeMessage('2026-08-03T00:00:00.000Z', 'Plain notice.');
+		const handoff = new TranscriptNoticeMessage(
+			'2026-08-03T00:00:00.000Z',
+			'# Summary\n\nCarried context.',
+			{ type: 'handoff-summary' },
+			'Handoff summary',
+		);
+		const model = build([
+			{ kind: 'message', id: 'generation-1:1', index: 1, ordinal: 1, message: plain },
+			{ kind: 'message', id: 'generation-1:2', index: 2, ordinal: 2, message: handoff },
+		]);
+
+		expect(estimateConversationFeedItemSize(model.items[1], 1)).toBe(64);
+		expect(estimateConversationFeedItemSize(model.items[2], 1)).toBe(242);
 	});
 
 	it('includes viewport geometry and established floating permission spacing', () => {

--- a/web/src/lib/components/chat/conversation-feed-virtual-items.ts
+++ b/web/src/lib/components/chat/conversation-feed-virtual-items.ts
@@ -1,5 +1,6 @@
 import {
 	isToolUseMessage,
+	isHandoffSummaryNoticeDetail,
 	ToolResultMessage,
 } from '$shared/chat-types';
 import type { PendingPermissionRequest } from '$lib/types/chat';
@@ -291,6 +292,11 @@ export function estimateConversationFeedItemSize(
 	if (layout === 'hidden') return 0;
 	if (layout === 'permission') return 240 * scale + spacing;
 	if (renderItem.kind === 'local-notice') return 52 * scale + spacing;
+	if (renderItem.message.type === 'transcript-notice') {
+		// The collapsed handoff body is clamp-bounded, so its default height is stable
+		// enough to estimate even though expansion is measured after render.
+		return (isHandoffSummaryNoticeDetail(renderItem.message.detail) ? 230 : 52) * scale + spacing;
+	}
 	if (renderItem.message.type === 'user-message') {
 		return (renderItem.message.presentation?.style ? 144 : 112) * scale + spacing;
 	}

--- a/web/src/lib/components/chat/rows/CliRow.svelte
+++ b/web/src/lib/components/chat/rows/CliRow.svelte
@@ -6,7 +6,7 @@
 	import type { MarkdownLinkNavigateEvent } from '../Markdown.svelte';
 	import ChatEventCard from './ChatEventCard.svelte';
 	import CliPresentationHeader from './CliPresentationHeader.svelte';
-	import CliCollapsibleBody from './CliCollapsibleBody.svelte';
+	import CollapsibleBody from './CollapsibleBody.svelte';
 	import type { ConversationDisclosureStatePort } from '../ConversationFeedItemState.svelte.js';
 
 	interface Props {
@@ -46,7 +46,7 @@
 	>
 		{#snippet body()}
 			<CliPresentationHeader style={message.presentation.style} title={message.title} />
-			<CliCollapsibleBody
+			<CollapsibleBody
 				disclosure={message.disclosure}
 				{alwaysExpanded}
 				expanded={disclosureState?.open('cli-body', 'body', false)}
@@ -69,7 +69,7 @@
 						<div class="mt-1 whitespace-pre-wrap break-words text-sm">{message.content}</div>
 					{/if}
 				{/snippet}
-			</CliCollapsibleBody>
+			</CollapsibleBody>
 		{/snippet}
 	</ChatEventCard>
 </div>

--- a/web/src/lib/components/chat/rows/CollapsibleBody.svelte
+++ b/web/src/lib/components/chat/rows/CollapsibleBody.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-	import type { CliBodyDisclosure } from '$shared/cli-presentation';
 	import type { Snippet } from 'svelte';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface Props {
-		disclosure?: CliBodyDisclosure;
+		disclosure?: 'expanded' | 'collapsed';
 		alwaysExpanded?: boolean;
 		expanded?: boolean;
 		onExpandedChange?: (expanded: boolean) => void;
@@ -44,7 +43,7 @@
 {#if collapsible}
 	<div
 		id={bodyId}
-		class:cli-collapsible-body-collapsed={!bodyExpanded}
+		class:collapsible-body-collapsed={!bodyExpanded}
 		onfocusin={expandOnFocus}
 	>
 		{@render children()}

--- a/web/src/lib/components/chat/rows/TranscriptNoticeRow.svelte
+++ b/web/src/lib/components/chat/rows/TranscriptNoticeRow.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	// Renders a durable transcript notice. Handoff summaries collapse by default
+	// behind the shared clamp so very long summaries stay bounded, while the
+	// server-supplied title remains visible for orientation.
+	import { isHandoffSummaryNoticeDetail, TranscriptNoticeMessage } from '$shared/chat-types';
+	import ChatEventCard from './ChatEventCard.svelte';
+	import CollapsibleBody from './CollapsibleBody.svelte';
+	import Markdown from '../Markdown.svelte';
+	import type { MarkdownLinkNavigateEvent } from '../Markdown.svelte';
+	import type { ConversationDisclosureStatePort } from '../ConversationFeedItemState.svelte.js';
+
+	interface Props {
+		message: TranscriptNoticeMessage;
+		fileLinkBasePath?: string | null;
+		onLinkNavigate?: (link: MarkdownLinkNavigateEvent) => boolean | void;
+		acquireTransientActivity?: (close: () => void) => () => void;
+		disclosureState?: ConversationDisclosureStatePort;
+	}
+
+	let {
+		message,
+		fileLinkBasePath,
+		onLinkNavigate,
+		acquireTransientActivity,
+		disclosureState,
+	}: Props = $props();
+
+	const isHandoffSummary = $derived(isHandoffSummaryNoticeDetail(message.detail));
+</script>
+
+<ChatEventCard variant="info">
+	{#snippet body()}
+		{#if message.title}
+			<div class="min-w-0 truncate text-xs font-medium">{message.title}</div>
+		{/if}
+		{#if isHandoffSummary}
+			<CollapsibleBody
+				disclosure="collapsed"
+				expanded={disclosureState?.open('notice-body', 'body', false)}
+				onExpandedChange={disclosureState
+					? (expanded) => disclosureState.setOpen('notice-body', 'body', expanded, false)
+					: undefined}
+			>
+				{#snippet children()}
+					<div class={['text-sm', message.title && 'mt-1']}>
+						<Markdown
+							source={message.content}
+							variant="presented"
+							fileLinkBasePath={fileLinkBasePath ?? undefined}
+							{onLinkNavigate}
+							{acquireTransientActivity}
+						/>
+					</div>
+				{/snippet}
+			</CollapsibleBody>
+		{:else}
+			<div class={['text-sm whitespace-pre-wrap break-words', message.title && 'mt-1']}>
+				{message.content}
+			</div>
+		{/if}
+	{/snippet}
+</ChatEventCard>


### PR DESCRIPTION
Long handoff summaries can overwhelm the transcript, so this change renders typed handoff-summary notices as collapsed-by-default Markdown while keeping their title visible, preserving accessible expansion controls and live-feed expansion state, sharing the notice renderer with public transcripts, generalizing the existing CLI collapse primitive, and updating virtual-size estimates and coverage.