### PR TITLE
perf(chat): return before provider delete cleanup

### DIFF
--- a/server/chats/__tests__/agent-ownership-journal.test.js
+++ b/server/chats/__tests__/agent-ownership-journal.test.js
@@ -52,6 +52,7 @@ function createRegistry(initialEntries) {
   const entries = new Map(Object.entries(initialEntries));
   return {
     getChat: (chatId) => entries.get(chatId) ?? null,
+    setChat: (chatId, value) => entries.set(chatId, value),
     listAllChats: () => Object.fromEntries(entries),
     updateChat: mock(async (chatId, patch) => {
       const current = entries.get(chatId);
@@ -258,6 +259,92 @@ describe('AgentOwnershipJournal', () => {
     await expect(journal.initialize()).rejects.toThrow('Invalid agent ownership journal');
   });
 
+  it('removes registry ownership without waiting for provider release', async () => {
+    const registry = createRegistry({ chat: chat() });
+    let releaseStarted;
+    let releaseProvider;
+    const release = mock(() => new Promise((resolve) => {
+      releaseProvider = resolve;
+      releaseStarted?.();
+    }));
+    const ledger = { deleteChat: mock(() => {}) };
+    const journal = new AgentOwnershipJournal({
+      workspaceDir,
+      registry,
+      integrations: createIntegrations(release),
+      ledger,
+    });
+    await journal.initialize();
+
+    const started = new Promise((resolve) => { releaseStarted = resolve; });
+    await journal.delete('chat');
+
+    expect(registry.getChat('chat')).toBeNull();
+    expect(ledger.deleteChat).toHaveBeenCalledWith('chat');
+    expect((await readJournal(workspaceDir)).ownershipIntents[0]).toMatchObject({
+      chatId: 'chat',
+      phase: 'registry-removed',
+    });
+    await started;
+    expect(release).toHaveBeenCalledTimes(1);
+    releaseProvider();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if ((await readJournal(workspaceDir)).ownershipIntents.length === 0) return;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error('delete cleanup did not settle');
+  });
+
+  it('does not let blocked cleanup A delay delete B', async () => {
+    const registry = createRegistry({ chatA: chat(), chatB: chat('target-agent') });
+    let releaseA;
+    const release = mock((request) => {
+      if (request.chat.chatId === 'chatA') return new Promise((resolve) => { releaseA = resolve; });
+      return Promise.resolve();
+    });
+    const journal = new AgentOwnershipJournal({
+      workspaceDir,
+      registry,
+      integrations: createIntegrations(release),
+      ledger: { deleteChat: mock(() => {}) },
+    });
+    await journal.initialize();
+
+    await journal.delete('chatA');
+    const deleteB = journal.delete('chatB');
+    await Promise.race([
+      deleteB,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('delete B blocked')), 100)),
+    ]);
+    expect(registry.getChat('chatB')).toBeNull();
+    releaseA();
+    await waitForEmptyJournal(workspaceDir);
+  });
+
+  it('does not delete a recreated same-id ledger during old provider cleanup', async () => {
+    const original = chat();
+    const replacement = chat('target-agent');
+    const registry = createRegistry({ chat: original });
+    let releaseProvider;
+    const release = mock(() => new Promise((resolve) => { releaseProvider = resolve; }));
+    const ledger = { deleteChat: mock(() => {}) };
+    const journal = new AgentOwnershipJournal({
+      workspaceDir,
+      registry,
+      integrations: createIntegrations(release),
+      ledger,
+    });
+    await journal.initialize();
+
+    await journal.delete('chat');
+    registry.setChat('chat', replacement);
+    releaseProvider();
+    await waitForEmptyJournal(workspaceDir);
+
+    expect(ledger.deleteChat).toHaveBeenCalledTimes(1);
+    expect(registry.getChat('chat')).toBe(replacement);
+  });
+
   it('retains delete cleanup when provider release fails', async () => {
     const reference = referenceFor('source-agent');
     await writeJournal(workspaceDir, {
@@ -320,6 +407,14 @@ function referenceFor(agentId) {
     settings: envelope(agentId),
     agentOwnershipEpoch: `${agentId}-epoch`,
   };
+}
+
+async function waitForEmptyJournal(workspaceDir) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if ((await readJournal(workspaceDir)).ownershipIntents.length === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('delete cleanup did not settle');
 }
 
 async function readJournal(workspaceDir) {

--- a/server/chats/agent-ownership-journal.ts
+++ b/server/chats/agent-ownership-journal.ts
@@ -69,7 +69,8 @@ export class AgentOwnershipJournal {
   readonly #ledger: Pick<TranscriptLedgerService, 'deleteChat'>;
   readonly #releaseTimeoutMs: number;
   #journal: AgentOwnershipJournalFileV5 = emptyOwnershipJournalV5();
-  #cleanupPromise: Promise<void> = Promise.resolve();
+  #deletePromise: Promise<void> = Promise.resolve();
+  #providerCleanupPromise: Promise<void> = Promise.resolve();
   #mutationPromise: Promise<void> = Promise.resolve();
 
   constructor(options: {
@@ -233,7 +234,7 @@ export class AgentOwnershipJournal {
   }
 
   delete(chatId: string): Promise<void> {
-    return this.#scheduleCleanupWork(() => this.#deleteNow(chatId));
+    return this.#scheduleDeleteWork(() => this.#deleteNow(chatId));
   }
 
   async #deleteNow(chatId: string): Promise<void> {
@@ -270,7 +271,15 @@ export class AgentOwnershipJournal {
     await this.#registry.flush();
     const removed = { ...intent, phase: 'registry-removed' as const };
     await this.#replaceIntent(removed);
-    await this.#finishDelete(removed);
+    // The provider-neutral ledger must be removed before delete resolves. Only
+    // provider/native release is detached, so same-id recreation is safe.
+    this.#ledger.deleteChat(chatId);
+    void this.#scheduleProviderCleanup(() => this.#finishDelete(removed)).catch((error) => {
+      logger.warn('Delete cleanup scheduling failed', {
+        chatId,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   async #recoverDelete(intent: DeleteIntentV2): Promise<void> {
@@ -284,7 +293,8 @@ export class AgentOwnershipJournal {
     }
     const removed = { ...intent, phase: 'registry-removed' as const };
     await this.#replaceIntent(removed);
-    void this.#scheduleCleanupWork(() => this.#finishDelete(removed)).catch((error) => {
+    this.#ledger.deleteChat(intent.chatId);
+    void this.#scheduleProviderCleanup(() => this.#finishDelete(removed)).catch((error) => {
       logger.warn('Recovered delete cleanup failed', {
         chatId: intent.chatId,
         reason: error instanceof Error ? error.message : String(error),
@@ -293,7 +303,6 @@ export class AgentOwnershipJournal {
   }
 
   async #finishDelete(intent: DeleteIntentV2): Promise<void> {
-    this.#ledger.deleteChat(intent.chatId);
     let remaining = [...intent.releaseReferences];
     for (const reference of [...remaining]) {
       const integration = this.#integrations.get(reference.agentId);
@@ -345,9 +354,15 @@ export class AgentOwnershipJournal {
     }));
   }
 
-  #scheduleCleanupWork<T>(work: () => Promise<T>): Promise<T> {
-    const operation = this.#cleanupPromise.catch(() => undefined).then(work);
-    this.#cleanupPromise = operation.then(() => undefined, () => undefined);
+  #scheduleDeleteWork<T>(work: () => Promise<T>): Promise<T> {
+    const operation = this.#deletePromise.catch(() => undefined).then(work);
+    this.#deletePromise = operation.then(() => undefined, () => undefined);
+    return operation;
+  }
+
+  #scheduleProviderCleanup<T>(work: () => Promise<T>): Promise<T> {
+    const operation = this.#providerCleanupPromise.catch(() => undefined).then(work);
+    this.#providerCleanupPromise = operation.then(() => undefined, () => undefined);
     return operation;
   }
 


### PR DESCRIPTION
## What was broken

Deleting a chat through the desktop API waited for provider/native transcript release to finish before returning success. That release can hit the configured provider-cleanup timeout, so a chat that was already durably removed from the registry appeared to delete very slowly.

## Profiling evidence

- The 9.28-second desktop recording shows delayed sidebar row/action-button interaction and a slow confirm-to-chat-removed path.
- Source tracing of the real delete path (`DELETE /api/v1/chats` → abort active turn → ownership journal → registry removal → provider/native transcript release) confirmed the backend bottleneck: durable registry removal happened before the response, but `AgentOwnershipJournal.delete()` still awaited the slow provider/native release before resolving.
- The provider/native release is external and timeout-bounded; its latency is therefore not a reliable user-visible delete latency.
- The sidebar is already virtualized. No Chrome Performance trace, heap snapshot, or long-task measurement has yet proven a frontend memory/rendering bottleneck, so sidebar optimization remains separate and is not included here.

## What this changes

- Return after durable registry removal and provider-neutral ledger deletion.
- Schedule provider/native transcript release asynchronously on its own serialized background chain.
- Keep delete-intent cleanup restart-safe: failures remain in the ownership journal and are retried by the existing recovery path.
- Keep delete mutations serialized without allowing blocked provider cleanup A to delay delete B.
- Add regression coverage for blocked cleanup, same-id recreation, ledger ordering, and cleanup failure retention.

This PR intentionally does not change the sidebar rendering architecture. The reported slow row/button selection needs a separate browser Performance/heap profile before an optimization is selected.

Refs #575

## Tests

- `bun test ./server/chats/__tests__/agent-ownership-journal.test.js` — 11 passed, 0 failed
- `bun run --cwd server typecheck` — passed
- `bun run --cwd web i18n:compile` — passed
- `bun run --cwd web check` — 0 errors, 0 warnings
- `bun run lint` — passed
- `git diff --check` — passed

Prompted by: yk (@chiayong)
