### PR TITLE
Prevent OpenCode resume hangs after Stop

### DIFF
--- a/integration-tests/support/fake-chat-completions-model.ts
+++ b/integration-tests/support/fake-chat-completions-model.ts
@@ -54,6 +54,7 @@ export interface RecordedChatCompletionsRequest {
   readonly lastUserText: string;
   readonly toolResults: ReadonlyArray<{ toolCallId: string; content: string }>;
   readonly receivedAt: number;
+  abortedAt: number | null;
 }
 
 export function chatCompletionsText(
@@ -398,7 +399,13 @@ export class FakeChatCompletionsModel {
       lastUserText: recordedUserTexts.at(-1) ?? '',
       toolResults: toolResults(record),
       receivedAt: Date.now(),
+      abortedAt: null,
     };
+    const observeAbort = () => {
+      if (recorded.abortedAt === null) recorded.abortedAt = Date.now();
+    };
+    if (request.signal.aborted) observeAbort();
+    else request.signal.addEventListener('abort', observeAbort, { once: true });
     this.#requests.push(recorded);
     const turn = this.#turns.shift();
     if (!turn) {

--- a/integration-tests/support/opencode-process-supervisor.ts
+++ b/integration-tests/support/opencode-process-supervisor.ts
@@ -30,6 +30,7 @@ export interface OpenCodeProcessState {
   parentStartTimeTicks: string;
   mode: 'direct' | 'proxy';
   status: 'running' | 'stopping' | 'stopped';
+  backendUrl?: string;
   reason?: 'signal' | 'parent-exited' | 'provider-exited' | 'startup-failed';
   version?: string;
 }
@@ -473,6 +474,7 @@ export async function runOpenCodeProcessSupervisor(argv: string[]): Promise<numb
     if (parentWatcher) clearInterval(parentWatcher);
     if (providerProcessWatcher) clearInterval(providerProcessWatcher);
     refreshProviderProcesses();
+    state.backendUrl = undefined;
     state.status = 'stopping';
     state.reason = reason;
     shutdownPromise = (async () => {
@@ -611,6 +613,12 @@ export async function runOpenCodeProcessSupervisor(argv: string[]): Promise<numb
         return exitCode;
       }
       const backendUrl = await waitForBackendReady(backend, backendPort);
+      if (stopping) {
+        await shutdownPromise;
+        return exitCode;
+      }
+      state.backendUrl = backendUrl;
+      await writeState();
       if (stopping) {
         await shutdownPromise;
         return exitCode;

--- a/integration-tests/support/opencode-process-supervisor.ts
+++ b/integration-tests/support/opencode-process-supervisor.ts
@@ -30,6 +30,7 @@ export interface OpenCodeProcessState {
   parentStartTimeTicks: string;
   mode: 'direct' | 'proxy';
   status: 'running' | 'stopping' | 'stopped';
+  // Proxy-only test access to the backend; shutdown clears it before persisting stopped state.
   backendUrl?: string;
   reason?: 'signal' | 'parent-exited' | 'provider-exited' | 'startup-failed';
   version?: string;

--- a/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
@@ -395,7 +395,7 @@ describeOnLinux('scripted OpenCode unrequested native abort', () => {
       });
       expect(terminal).toMatchObject({
         type: 'agent-run-failed',
-        error: 'OpenCode interrupted the current turn unexpectedly',
+        error: 'OpenCode interrupted the turn',
       });
       await fixture.client.waitForProcessing(chatId, false, {
         afterIndex: interruptedCursor,

--- a/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   chatCompletionsText,
   chatCompletionsToolUse,
+  type RecordedChatCompletionsRequest,
 } from '../../support/fake-chat-completions-model.js';
 import {
   withIntegrationFixture,
@@ -75,7 +76,7 @@ describeOnLinux('scripted OpenCode interrupt lifecycle', () => {
         command: marker('HELD_PROMPT'),
       }));
       if (!active.turnId) throw new Error('OpenCode start response omitted its turn id.');
-      await held.requested;
+      const heldRequest = await held.requested;
 
       const stopCursor = fixture.client.markEvents();
       const stopped = await fixture.client.stopChat({
@@ -103,9 +104,10 @@ describeOnLinux('scripted OpenCode interrupt lifecycle', () => {
         active.turnId,
       );
 
-      // Stop confirms the request, not provider quiescence. Releasing the model only after
-      // OpenCode persists its abort prevents a normal completion from winning that race.
+      // Stop confirms the request, not provider quiescence. The held response must stay
+      // unavailable until OpenCode has both persisted the abort and closed the model request.
       await waitForAbortedAssistant(fixture, chatId);
+      await waitForModelRequestAbort(heldRequest);
       held.release();
 
       testEnvironment.model.reset();
@@ -380,7 +382,7 @@ describeOnLinux('scripted OpenCode unrequested native abort', () => {
       const native = await openCodeNativeSession(fixture, chatId);
       const interruptedCursor = fixture.client.markEvents();
       // An out-of-band native abort reproduces the provider result, not the unknown upstream
-      // trigger: Garcon receives the same owned MessageAbortedError without entering Stop.
+      // trigger. Unlike Garcon Stop, this endpoint returns after OpenCode finalizes cancellation.
       try {
         await abortOpenCodeSessionOutOfBand(fixture, native.agentSessionId);
       } finally {
@@ -549,6 +551,15 @@ async function waitForAbortedAssistant(
     await Bun.sleep(25);
   }
   throw new Error('OpenCode never settled the aborted assistant message.');
+}
+
+async function waitForModelRequestAbort(request: RecordedChatCompletionsRequest): Promise<void> {
+  const deadline = Date.now() + LIVE_TURN_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (request.abortedAt !== null) return;
+    await Bun.sleep(25);
+  }
+  throw new Error('OpenCode never closed the aborted turn model request.');
 }
 
 async function waitForFile(path: string): Promise<void> {

--- a/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-interrupt.test.ts
@@ -103,8 +103,9 @@ describeOnLinux('scripted OpenCode interrupt lifecycle', () => {
         active.turnId,
       );
 
-      // The recovery begins immediately after Garcon confirms the stop. The abort endpoint
-      // does not return until OpenCode has interrupted its session runner.
+      // Stop confirms the request, not provider quiescence. Releasing the model only after
+      // OpenCode persists its abort prevents a normal completion from winning that race.
+      await waitForAbortedAssistant(fixture, chatId);
       held.release();
 
       testEnvironment.model.reset();
@@ -126,7 +127,6 @@ describeOnLinux('scripted OpenCode interrupt lifecycle', () => {
       expect(fixture.client.eventsSince(stopCursor).some((event) =>
         event.type === 'chat-messages'
         && event.chatId === chatId
-        && event.turnId === active.turnId
         && event.messages.some((entry) =>
           entry.message.type === 'assistant-message'
           && entry.message.content.includes(stoppedReply))
@@ -336,6 +336,105 @@ describeOnLinux('scripted OpenCode interrupt lifecycle', () => {
   }, 120_000);
 });
 
+describeOnLinux('scripted OpenCode unrequested native abort', () => {
+  beforeEach(() => {
+    environment = startScriptedOpenCodeTestEnvironment({ proxy: true });
+  });
+
+  afterEach(() => {
+    environment?.dispose();
+    environment = undefined;
+  });
+
+  test('surfaces the failure and recovers on the next turn', async () => {
+    const testEnvironment = requireEnvironment();
+    const initialReply = marker('INTERRUPT_INITIAL_REPLY');
+    const interruptedPrompt = marker('INTERRUPTED_PROMPT');
+    const interruptedReply = marker('INTERRUPTED_REPLY');
+    const recoveryReply = marker('INTERRUPT_RECOVERY_REPLY');
+    testEnvironment.model.scriptTurn([chatCompletionsText(initialReply)]);
+
+    await withIntegrationFixture('opencode-unrequested-native-abort', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const initialCursor = fixture.client.markEvents();
+      const initial = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: marker('INTERRUPT_INITIAL_PROMPT'),
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: initial.turnId,
+        marker: initialReply,
+        afterIndex: initialCursor,
+      });
+
+      const held = testEnvironment.model.scriptHeldTurn([chatCompletionsText(interruptedReply)]);
+      const active = await fixture.client.runChat(scriptedOpenCodeRunRequest({
+        chatId,
+        command: interruptedPrompt,
+      }));
+      await held.requested;
+
+      const native = await openCodeNativeSession(fixture, chatId);
+      const interruptedCursor = fixture.client.markEvents();
+      // An out-of-band native abort reproduces the provider result, not the unknown upstream
+      // trigger: Garcon receives the same owned MessageAbortedError without entering Stop.
+      try {
+        await abortOpenCodeSessionOutOfBand(fixture, native.agentSessionId);
+      } finally {
+        held.release();
+      }
+
+      const terminal = await fixture.client.waitForTurnTerminal(chatId, active.turnId, {
+        afterIndex: interruptedCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      expect(terminal).toMatchObject({
+        type: 'agent-run-failed',
+        error: 'OpenCode interrupted the current turn unexpectedly',
+      });
+      await fixture.client.waitForProcessing(chatId, false, {
+        afterIndex: interruptedCursor,
+        timeoutMs: LIVE_TURN_TIMEOUT_MS,
+      });
+      expect(fixture.client.eventsSince(interruptedCursor).filter((event) =>
+        (event.type === 'agent-run-failed' || event.type === 'agent-run-finished')
+        && event.chatId === chatId
+        && event.turnId === active.turnId
+      )).toHaveLength(1);
+      expect(messagesOfType((await fixture.client.getMessages(chatId)).messages, 'error'))
+        .toHaveLength(1);
+
+      // Native history cannot distinguish this failure from an acknowledged Stop, so a native
+      // reload intentionally omits the live error while retaining the interrupted user message.
+      await reloadFromNativeHistory(fixture, chatId);
+      const reloaded = (await fixture.client.getMessages(chatId)).messages;
+      expect(userContents(reloaded)).toContain(interruptedPrompt);
+      expect(messagesOfType(reloaded, 'error')).toEqual([]);
+
+      testEnvironment.model.reset();
+      testEnvironment.model.scriptTurn([chatCompletionsText(recoveryReply)]);
+      const recoveryCursor = fixture.client.markEvents();
+      const recovery = await fixture.client.runChat(scriptedOpenCodeRunRequest({
+        chatId,
+        command: marker('INTERRUPT_RECOVERY_PROMPT'),
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: recovery.turnId,
+        marker: recoveryReply,
+        afterIndex: recoveryCursor,
+      });
+      expect(assistantContents((await fixture.client.getMessages(chatId)).messages).join('\n'))
+        .not.toContain(interruptedReply);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+});
+
 function expectAbortedToolRows(
   messages: readonly TranscriptMessage[],
   command: string,
@@ -369,6 +468,32 @@ function withScriptedOpenCode(): IntegrationFixtureOptions {
 
 function marker(label: string): string {
   return `SCRIPTED_OPENCODE_INTERRUPT_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+}
+
+async function abortOpenCodeSessionOutOfBand(
+  fixture: IntegrationFixture,
+  agentSessionId: string,
+): Promise<void> {
+  const supervisors = (await readSupervisorStates(fixture.dirs))
+    .filter((state) => state.status === 'running');
+  if (supervisors.length !== 1 || !supervisors[0].backendUrl) {
+    throw new Error('Expected one running proxied OpenCode supervisor with a backend URL.');
+  }
+  const endpoint = new URL(
+    `/session/${encodeURIComponent(agentSessionId)}/abort`,
+    supervisors[0].backendUrl,
+  );
+  endpoint.searchParams.set('directory', fixture.dirs.project);
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    signal: AbortSignal.timeout(LIVE_TURN_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`OpenCode native abort failed with HTTP ${response.status}.`);
+  }
+  if (await response.json() !== true) {
+    throw new Error('OpenCode native abort was not acknowledged.');
+  }
 }
 
 function expectOpenCodeStoppedTurnEventOrder(
@@ -416,13 +541,9 @@ async function waitForAbortedAssistant(
   while (Date.now() < deadline) {
     const rows = readOpenCodeSessionRows(native);
     const assistant = rows.messages.find((row) => row.data.role === 'assistant');
-    const time = assistant?.data.time;
-    if (
-      assistant
-      && (assistant.data.error !== undefined
-        || (time !== null && typeof time === 'object'
-          && (time as Record<string, unknown>).completed !== undefined))
-    ) {
+    const error = assistant?.data.error;
+    if (error !== null && typeof error === 'object'
+      && (error as Record<string, unknown>).name === 'MessageAbortedError') {
       return;
     }
     await Bun.sleep(25);

--- a/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
@@ -1519,12 +1519,12 @@ describe('OpenCodeRuntime abort', () => {
       await waitFor(() => terminalEvents(published.events).length === 1);
       expect(runtime.isRunning('session-1')).toBe(false);
       expect(failureMessages(published.events)).toEqual([
-        'OpenCode interrupted the current turn unexpectedly',
+        'OpenCode interrupted the turn',
       ]);
       const [errorRow] = publishedMessages(published.events);
       expect(errorRow).toMatchObject({
         type: 'error',
-        content: 'OpenCode interrupted the current turn unexpectedly',
+        content: 'OpenCode interrupted the turn',
       });
       expect(getNativeMessageRevisionSource(errorRow)).toMatchObject({
         entryId: 'assistant-aborted',
@@ -1598,11 +1598,11 @@ describe('OpenCodeRuntime abort', () => {
     }));
 
     await expect(interruptedTurn).rejects.toThrow(
-      'OpenCode interrupted the current turn unexpectedly',
+      'OpenCode interrupted the turn',
     );
     expect(runtime.isRunning('session-1')).toBe(false);
     expect(failureMessages(interrupted.events)).toEqual([
-      'OpenCode interrupted the current turn unexpectedly',
+      'OpenCode interrupted the turn',
     ]);
 
     const recovered = collectOperation('run-c');
@@ -1718,10 +1718,10 @@ describe('OpenCodeRuntime abort', () => {
     }));
 
     await expect(compaction).rejects.toThrow(
-      'OpenCode interrupted the current turn unexpectedly',
+      'OpenCode interrupted the turn',
     );
     expect(failureMessages(compacted.events)).toEqual([
-      'OpenCode interrupted the current turn unexpectedly',
+      'OpenCode interrupted the turn',
     ]);
     const [errorRow] = publishedMessages(compacted.events);
     expect(getNativeMessageRevisionSource(errorRow)).toMatchObject({
@@ -2468,7 +2468,7 @@ describe('OpenCodeRuntime abort', () => {
       if (!terminalBeforeRejection) publishAbortedTerminal();
       await waitFor(() => failureMessages(published.events).length === 1);
       expect(failureMessages(published.events)).toEqual([
-        'OpenCode interrupted the current turn without confirming the requested stop',
+        'OpenCode interrupted the turn',
       ]);
       expect(runtime.isRunning('session-1')).toBe(false);
 
@@ -2508,7 +2508,7 @@ describe('OpenCodeRuntime abort', () => {
     });
   }
 
-  it('describes internal successor quiescence separately from a user Stop', async () => {
+  it('fails a deferred abort when successor quiescence is rejected', async () => {
     const eventStream = createEventStream();
     const promptAsync = mock(() => Promise.resolve({}));
     const abortResponse = deferred();
@@ -2557,7 +2557,7 @@ describe('OpenCodeRuntime abort', () => {
     abortResponse.resolve({ error: { message: 'abort rejected' } });
     await waitFor(() => promptAsync.mock.calls.length === 2);
     expect(failureMessages(published.events)).toEqual([
-      'OpenCode interrupted the previous turn while preparing the next message',
+      'OpenCode interrupted the turn',
     ]);
 
     eventStream.push(envelope({
@@ -2583,7 +2583,7 @@ describe('OpenCodeRuntime abort', () => {
     runtime.shutdown();
   });
 
-  it('attributes a user Stop coalesced onto successor quiescence', async () => {
+  it('coalesces a user Stop onto successor quiescence', async () => {
     const eventStream = createEventStream();
     const promptAsync = mock(() => Promise.resolve({}));
     const abortResponse = deferred();
@@ -2634,7 +2634,7 @@ describe('OpenCodeRuntime abort', () => {
     await expect(stopping).resolves.toBe(false);
     await waitFor(() => promptAsync.mock.calls.length === 2);
     expect(failureMessages(published.events)).toEqual([
-      'OpenCode interrupted the current turn without confirming the requested stop',
+      'OpenCode interrupted the turn',
     ]);
 
     eventStream.push(envelope({

--- a/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { getNativeMessageRevisionSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { OpenCodeRuntime } from '../opencode.js';
 
 function deferred() {
@@ -163,6 +164,7 @@ function createRuntime(
   const {
     turnPrompt,
     permissionReply = mock(() => Promise.resolve({})),
+    sessionOverrides = {},
     ...options
   } = runtimeOptions;
   const prompt = turnPrompt ?? mock((...args) => {
@@ -182,6 +184,7 @@ function createRuntime(
           prompt,
           promptAsync,
           abort,
+          ...sessionOverrides,
         },
       },
       server: { close: mock(() => undefined) },
@@ -1518,10 +1521,14 @@ describe('OpenCodeRuntime abort', () => {
       expect(failureMessages(published.events)).toEqual([
         'OpenCode interrupted the current turn unexpectedly',
       ]);
-      expect(publishedMessages(published.events)).toMatchObject([{
+      const [errorRow] = publishedMessages(published.events);
+      expect(errorRow).toMatchObject({
         type: 'error',
         content: 'OpenCode interrupted the current turn unexpectedly',
-      }]);
+      });
+      expect(getNativeMessageRevisionSource(errorRow)).toMatchObject({
+        entryId: 'assistant-aborted',
+      });
     } finally {
       eventStream.close();
       runtime.shutdown();
@@ -1634,6 +1641,92 @@ describe('OpenCodeRuntime abort', () => {
       outcome: 'finished',
     }]);
     expect(abort).not.toHaveBeenCalled();
+    eventStream.close();
+    runtime.shutdown();
+  });
+
+  it('fails an unexpectedly aborted manual compaction', async () => {
+    const eventStream = createEventStream();
+    const promptAsync = mock(() => Promise.resolve({}));
+    const summarizeResponse = deferred();
+    const summarize = mock(() => summarizeResponse.promise);
+    const runtime = createRuntime(
+      mock(() => Promise.resolve({ data: true })),
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      {
+        turnPrompt: promptThrough(eventStream, promptAsync),
+        sessionOverrides: { summarize },
+      },
+    );
+    const initial = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'initial',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+    }));
+    await waitFor(() => terminalEvents(initial.events).length === 1);
+
+    const compacted = collectOperation('run-compact');
+    const compaction = runtime.compact({
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      model: 'provider/model',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: compacted.operation,
+    });
+    await waitFor(() => summarize.mock.calls.length === 1);
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: { id: 'part-compaction', messageID: 'user-compaction', type: 'compaction' },
+      },
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    summarizeResponse.resolve({ data: true });
+    eventStream.push(envelope({
+      id: 'evt_0004',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: {
+          id: 'assistant-summary',
+          role: 'assistant',
+          parentID: 'user-compaction',
+          summary: true,
+          finish: 'error',
+          time: { completed: Date.now() },
+          error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+        },
+      },
+    }));
+
+    await expect(compaction).rejects.toThrow(
+      'OpenCode interrupted the current turn unexpectedly',
+    );
+    expect(failureMessages(compacted.events)).toEqual([
+      'OpenCode interrupted the current turn unexpectedly',
+    ]);
+    const [errorRow] = publishedMessages(compacted.events);
+    expect(getNativeMessageRevisionSource(errorRow)).toMatchObject({
+      entryId: 'assistant-summary',
+    });
     eventStream.close();
     runtime.shutdown();
   });
@@ -2119,6 +2212,68 @@ describe('OpenCodeRuntime abort', () => {
     runtime.shutdown();
   });
 
+  it('keeps a recorded abort silent when prompt transport fails during Stop', async () => {
+    const eventStream = createEventStream();
+    const promptAsync = mock(() => Promise.resolve({}));
+    const promptRequest = deferred();
+    const acknowledged = deferred();
+    const debug = mock(() => undefined);
+    const turnPrompt = mock((...args) => {
+      void promptAsync(...args);
+      return promptRequest.promise;
+    });
+    const runtime = createRuntime(
+      mock(() => acknowledged.promise),
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      { turnPrompt, logger: { debug, info() {}, warn() {}, error() {} } },
+    );
+    const published = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'hello',
+        },
+      },
+    }));
+
+    const aborting = runtime.abort('session-1');
+    await Promise.resolve();
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(terminalEvents(published.events)).toEqual([]);
+    promptRequest.reject(new Error('prompt transport closed'));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(terminalEvents(published.events)).toEqual([]);
+    expect(debug).toHaveBeenCalledWith(
+      'OpenCode prompt failed after an aborted terminal',
+      { error: 'prompt transport closed' },
+    );
+
+    acknowledged.resolve({ data: true });
+    await expect(aborting).resolves.toBe(true);
+    expect(failureMessages(published.events)).toEqual([]);
+    expect(terminalEvents(published.events)).toEqual([{
+      type: 'run-ended',
+      runId: 'run-a',
+      outcome: 'finished',
+    }]);
+    eventStream.close();
+    runtime.shutdown();
+  });
+
   it('does not finish the turn when its named completion arrives before abort resolves', async () => {
     const eventStream = createEventStream();
     const promptAsync = mock(() => Promise.resolve({}));
@@ -2263,13 +2418,101 @@ describe('OpenCodeRuntime abort', () => {
     runtime.shutdown();
   });
 
-  it('fails a deferred named abort when Stop is rejected and quiesces before recovery', async () => {
+  for (const { ordering, terminalBeforeRejection } of [
+    { ordering: 'before', terminalBeforeRejection: true },
+    { ordering: 'after', terminalBeforeRejection: false },
+  ]) {
+    it(`fails a named abort consistently when its terminal arrives ${ordering} Stop rejection`, async () => {
+      const eventStream = createEventStream();
+      const promptAsync = mock(() => Promise.resolve({}));
+      const acknowledged = deferred();
+      const abort = mock(() => acknowledged.promise);
+      const runtime = createRuntime(
+        abort,
+        promptAsync,
+        mock(() => Promise.resolve({ stream: eventStream.stream() })),
+        { turnPrompt: promptThrough(eventStream, promptAsync) },
+      );
+      const published = await start(runtime, { runId: 'run-a' });
+      eventStream.push(envelope({
+        id: 'evt_0001',
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-1',
+          part: {
+            id: promptAsync.mock.calls[0][0].parts[0].id,
+            messageID: 'user-a',
+            type: 'text',
+            text: 'hello',
+          },
+        },
+      }));
+
+      const aborting = runtime.abort('session-1');
+      await Promise.resolve();
+      const publishAbortedTerminal = () => eventStream.push(completedAssistantEnvelope({
+        eventId: 'evt_0002',
+        messageId: 'assistant-a',
+        parentId: 'user-a',
+        error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+        finish: 'error',
+      }));
+      if (terminalBeforeRejection) {
+        publishAbortedTerminal();
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(failureMessages(published.events)).toEqual([]);
+      }
+
+      acknowledged.resolve({ error: { message: 'abort rejected' } });
+      await expect(aborting).resolves.toBe(false);
+      if (!terminalBeforeRejection) publishAbortedTerminal();
+      await waitFor(() => failureMessages(published.events).length === 1);
+      expect(failureMessages(published.events)).toEqual([
+        'OpenCode interrupted the current turn without confirming the requested stop',
+      ]);
+      expect(runtime.isRunning('session-1')).toBe(false);
+
+      const recovered = collectOperation('run-b');
+      const recoveredTurn = runtime.runTurn({
+        command: 'recover',
+        agentSessionId: 'session-1',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        permissionMode: 'default',
+        operation: recovered.operation,
+      });
+      await waitFor(() => promptAsync.mock.calls.length === 2);
+      expect(abort).toHaveBeenCalledTimes(1);
+      eventStream.push(envelope({
+        id: 'evt_0003',
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-1',
+          part: {
+            id: promptAsync.mock.calls[1][0].parts[0].id,
+            messageID: 'user-b',
+            type: 'text',
+            text: 'recover',
+          },
+        },
+      }));
+      eventStream.push(completedAssistantEnvelope({
+        eventId: 'evt_0004',
+        messageId: 'assistant-b',
+        parentId: 'user-b',
+      }));
+      await expect(recoveredTurn).resolves.toBeUndefined();
+      expect(failureMessages(recovered.events)).toEqual([]);
+      eventStream.close();
+      runtime.shutdown();
+    });
+  }
+
+  it('describes internal successor quiescence separately from a user Stop', async () => {
     const eventStream = createEventStream();
     const promptAsync = mock(() => Promise.resolve({}));
-    const acknowledged = deferred();
-    const abort = mock()
-      .mockImplementationOnce(() => acknowledged.promise)
-      .mockImplementationOnce(() => Promise.resolve({ data: true }));
+    const abortResponse = deferred();
+    const abort = mock(() => abortResponse.promise);
     const runtime = createRuntime(
       abort,
       promptAsync,
@@ -2291,24 +2534,6 @@ describe('OpenCodeRuntime abort', () => {
       },
     }));
 
-    const aborting = runtime.abort('session-1');
-    await Promise.resolve();
-    eventStream.push(completedAssistantEnvelope({
-      eventId: 'evt_0002',
-      messageId: 'assistant-a',
-      parentId: 'user-a',
-      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
-      finish: 'error',
-    }));
-    await new Promise((resolve) => setImmediate(resolve));
-
-    acknowledged.resolve({ error: { message: 'abort rejected' } });
-    await expect(aborting).resolves.toBe(false);
-    expect(failureMessages(published.events)).toEqual([
-      'OpenCode interrupted the current turn unexpectedly',
-    ]);
-    expect(runtime.isRunning('session-1')).toBe(false);
-
     const recovered = collectOperation('run-b');
     const recoveredTurn = runtime.runTurn({
       command: 'recover',
@@ -2318,8 +2543,23 @@ describe('OpenCodeRuntime abort', () => {
       permissionMode: 'default',
       operation: recovered.operation,
     });
+    await waitFor(() => abort.mock.calls.length === 1);
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(failureMessages(published.events)).toEqual([]);
+
+    abortResponse.resolve({ error: { message: 'abort rejected' } });
     await waitFor(() => promptAsync.mock.calls.length === 2);
-    expect(abort).toHaveBeenCalledTimes(2);
+    expect(failureMessages(published.events)).toEqual([
+      'OpenCode interrupted the previous turn while preparing the next message',
+    ]);
+
     eventStream.push(envelope({
       id: 'evt_0003',
       type: 'message.part.updated',
@@ -2339,7 +2579,83 @@ describe('OpenCodeRuntime abort', () => {
       parentId: 'user-b',
     }));
     await expect(recoveredTurn).resolves.toBeUndefined();
-    expect(failureMessages(recovered.events)).toEqual([]);
+    eventStream.close();
+    runtime.shutdown();
+  });
+
+  it('attributes a user Stop coalesced onto successor quiescence', async () => {
+    const eventStream = createEventStream();
+    const promptAsync = mock(() => Promise.resolve({}));
+    const abortResponse = deferred();
+    const abort = mock(() => abortResponse.promise);
+    const runtime = createRuntime(
+      abort,
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      { turnPrompt: promptThrough(eventStream, promptAsync) },
+    );
+    const published = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'hello',
+        },
+      },
+    }));
+
+    const recovered = collectOperation('run-b');
+    const recoveredTurn = runtime.runTurn({
+      command: 'recover',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: recovered.operation,
+    });
+    await waitFor(() => abort.mock.calls.length === 1);
+    const stopping = runtime.abort('session-1');
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(failureMessages(published.events)).toEqual([]);
+
+    abortResponse.resolve({ error: { message: 'abort rejected' } });
+    await expect(stopping).resolves.toBe(false);
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+    expect(failureMessages(published.events)).toEqual([
+      'OpenCode interrupted the current turn without confirming the requested stop',
+    ]);
+
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[1][0].parts[0].id,
+          messageID: 'user-b',
+          type: 'text',
+          text: 'recover',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0004',
+      messageId: 'assistant-b',
+      parentId: 'user-b',
+    }));
+    await expect(recoveredTurn).resolves.toBeUndefined();
     eventStream.close();
     runtime.shutdown();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/abort.test.js
@@ -1481,6 +1481,163 @@ describe('OpenCodeRuntime abort', () => {
     runtime.shutdown();
   });
 
+  it('fails a starting turn when its named assistant is unexpectedly aborted', async () => {
+    const eventStream = createEventStream();
+    const promptAsync = mock(() => Promise.resolve({}));
+    const runtime = createRuntime(
+      mock(() => Promise.resolve({ data: true })),
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      { turnPrompt: promptThrough(eventStream, promptAsync) },
+    );
+    const published = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'hello',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-aborted',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+
+    try {
+      await waitFor(() => terminalEvents(published.events).length === 1);
+      expect(runtime.isRunning('session-1')).toBe(false);
+      expect(failureMessages(published.events)).toEqual([
+        'OpenCode interrupted the current turn unexpectedly',
+      ]);
+      expect(publishedMessages(published.events)).toMatchObject([{
+        type: 'error',
+        content: 'OpenCode interrupted the current turn unexpectedly',
+      }]);
+    } finally {
+      eventStream.close();
+      runtime.shutdown();
+    }
+  });
+
+  it('fails an unexpectedly aborted continuation and recovers without quiescing it', async () => {
+    const eventStream = createEventStream();
+    const abort = mock(() => Promise.resolve({ data: true }));
+    const promptAsync = mock(() => Promise.resolve({}));
+    const runtime = createRuntime(
+      abort,
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      { turnPrompt: promptThrough(eventStream, promptAsync) },
+    );
+    const initial = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'initial',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+    }));
+    await waitFor(() => terminalEvents(initial.events).length === 1);
+
+    const interrupted = collectOperation('run-b');
+    const interruptedTurn = runtime.runTurn({
+      command: 'continue',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: interrupted.operation,
+    });
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[1][0].parts[0].id,
+          messageID: 'user-b',
+          type: 'text',
+          text: 'continue',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0004',
+      messageId: 'assistant-b',
+      parentId: 'user-b',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+
+    await expect(interruptedTurn).rejects.toThrow(
+      'OpenCode interrupted the current turn unexpectedly',
+    );
+    expect(runtime.isRunning('session-1')).toBe(false);
+    expect(failureMessages(interrupted.events)).toEqual([
+      'OpenCode interrupted the current turn unexpectedly',
+    ]);
+
+    const recovered = collectOperation('run-c');
+    const recoveredTurn = runtime.runTurn({
+      command: 'recover',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: recovered.operation,
+    });
+    await waitFor(() => promptAsync.mock.calls.length === 3);
+    eventStream.push(envelope({
+      id: 'evt_0005',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[2][0].parts[0].id,
+          messageID: 'user-c',
+          type: 'text',
+          text: 'recover',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0006',
+      messageId: 'assistant-c',
+      parentId: 'user-c',
+    }));
+
+    await expect(recoveredTurn).resolves.toBeUndefined();
+    expect(terminalEvents(recovered.events)).toEqual([{
+      type: 'run-ended',
+      runId: 'run-c',
+      outcome: 'finished',
+    }]);
+    expect(abort).not.toHaveBeenCalled();
+    eventStream.close();
+    runtime.shutdown();
+  });
+
   it('fails a context overflow that reaches idle without successful compaction', async () => {
     const eventStream = createEventStream();
     const promptAsync = mock(() => Promise.resolve({}));
@@ -1801,7 +1958,7 @@ describe('OpenCodeRuntime abort', () => {
     runtime.shutdown();
   });
 
-  it('ignores a late MessageAbortedError unwind while a successor turn is running', async () => {
+  it('ignores a retired turn\'s named aborted assistant while a successor is running', async () => {
     const eventStream = createEventStream();
     const promptAsync = mock(() => Promise.resolve({}));
     const runtime = createRuntime(
@@ -1811,6 +1968,27 @@ describe('OpenCodeRuntime abort', () => {
       { turnPrompt: promptThrough(eventStream, promptAsync) },
     );
     const firstPublished = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'first',
+        },
+      },
+    }));
+    eventStream.push(envelope({
+      id: 'evt_0002',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: { id: 'assistant-a', role: 'assistant', parentID: 'user-a' },
+      },
+    }));
     await expect(runtime.abort('session-1')).resolves.toBe(true);
 
     const successorPublished = collectOperation('run-b');
@@ -1824,14 +2002,12 @@ describe('OpenCodeRuntime abort', () => {
     });
     await waitFor(() => promptAsync.mock.calls.length === 2);
 
-    // The first turn's abort unwind lands in the successor's running window and is ignored.
-    eventStream.push(envelope({
-      id: 'evt_0001',
-      type: 'session.error',
-      properties: {
-        sessionID: 'session-1',
-        error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
-      },
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0003',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
     }));
     await Promise.resolve();
     await Promise.resolve();
@@ -1840,7 +2016,7 @@ describe('OpenCodeRuntime abort', () => {
     expect(runtime.isRunning('session-1')).toBe(true);
 
     eventStream.push(envelope({
-      id: 'evt_0002',
+      id: 'evt_0004',
       type: 'message.updated',
       properties: {
         sessionID: 'session-1',
@@ -1848,7 +2024,7 @@ describe('OpenCodeRuntime abort', () => {
       },
     }));
     eventStream.push(envelope({
-      id: 'evt_0003',
+      id: 'evt_0005',
       type: 'message.part.updated',
       properties: {
         sessionID: 'session-1',
@@ -1861,7 +2037,7 @@ describe('OpenCodeRuntime abort', () => {
       },
     }));
     eventStream.push(envelope({
-      id: 'evt_0004',
+      id: 'evt_0006',
       type: 'message.updated',
       properties: {
         sessionID: 'session-1',
@@ -1869,7 +2045,7 @@ describe('OpenCodeRuntime abort', () => {
       },
     }));
     eventStream.push(envelope({
-      id: 'evt_0005',
+      id: 'evt_0007',
       type: 'message.part.updated',
       properties: {
         sessionID: 'session-1',
@@ -1877,7 +2053,7 @@ describe('OpenCodeRuntime abort', () => {
       },
     }));
     eventStream.push(completedAssistantEnvelope({
-      eventId: 'evt_0006',
+      eventId: 'evt_0008',
       messageId: 'assistant-b',
       parentId: 'user-b',
     }));
@@ -1889,6 +2065,56 @@ describe('OpenCodeRuntime abort', () => {
     expect(terminalEvents(firstPublished.events)).toHaveLength(1);
     expect(terminalEvents(successorPublished.events)).toHaveLength(1);
 
+    eventStream.close();
+    runtime.shutdown();
+  });
+
+  it('keeps an acknowledged Stop silent when its named aborted assistant arrives', async () => {
+    const eventStream = createEventStream();
+    const promptAsync = mock(() => Promise.resolve({}));
+    const acknowledged = deferred();
+    const runtime = createRuntime(
+      mock(() => acknowledged.promise),
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      { turnPrompt: promptThrough(eventStream, promptAsync) },
+    );
+    const published = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'hello',
+        },
+      },
+    }));
+
+    const aborting = runtime.abort('session-1');
+    await Promise.resolve();
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(terminalEvents(published.events)).toEqual([]);
+
+    acknowledged.resolve({ data: true });
+    await expect(aborting).resolves.toBe(true);
+    expect(failureMessages(published.events)).toEqual([]);
+    expect(terminalEvents(published.events)).toEqual([{
+      type: 'run-ended',
+      runId: 'run-a',
+      outcome: 'finished',
+    }]);
+    expect(runtime.isRunning('session-1')).toBe(false);
     eventStream.close();
     runtime.shutdown();
   });
@@ -2033,6 +2259,87 @@ describe('OpenCodeRuntime abort', () => {
     await expect(aborting).resolves.toBe(false);
     expect(failureMessages(published.events)).toEqual(['cannot compact']);
     expect(runtime.isRunning('session-1')).toBe(false);
+    eventStream.close();
+    runtime.shutdown();
+  });
+
+  it('fails a deferred named abort when Stop is rejected and quiesces before recovery', async () => {
+    const eventStream = createEventStream();
+    const promptAsync = mock(() => Promise.resolve({}));
+    const acknowledged = deferred();
+    const abort = mock()
+      .mockImplementationOnce(() => acknowledged.promise)
+      .mockImplementationOnce(() => Promise.resolve({ data: true }));
+    const runtime = createRuntime(
+      abort,
+      promptAsync,
+      mock(() => Promise.resolve({ stream: eventStream.stream() })),
+      { turnPrompt: promptThrough(eventStream, promptAsync) },
+    );
+    const published = await start(runtime, { runId: 'run-a' });
+    eventStream.push(envelope({
+      id: 'evt_0001',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-a',
+          type: 'text',
+          text: 'hello',
+        },
+      },
+    }));
+
+    const aborting = runtime.abort('session-1');
+    await Promise.resolve();
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0002',
+      messageId: 'assistant-a',
+      parentId: 'user-a',
+      error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      finish: 'error',
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    acknowledged.resolve({ error: { message: 'abort rejected' } });
+    await expect(aborting).resolves.toBe(false);
+    expect(failureMessages(published.events)).toEqual([
+      'OpenCode interrupted the current turn unexpectedly',
+    ]);
+    expect(runtime.isRunning('session-1')).toBe(false);
+
+    const recovered = collectOperation('run-b');
+    const recoveredTurn = runtime.runTurn({
+      command: 'recover',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: recovered.operation,
+    });
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+    expect(abort).toHaveBeenCalledTimes(2);
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: promptAsync.mock.calls[1][0].parts[0].id,
+          messageID: 'user-b',
+          type: 'text',
+          text: 'recover',
+        },
+      },
+    }));
+    eventStream.push(completedAssistantEnvelope({
+      eventId: 'evt_0004',
+      messageId: 'assistant-b',
+      parentId: 'user-b',
+    }));
+    await expect(recoveredTurn).resolves.toBeUndefined();
+    expect(failureMessages(recovered.events)).toEqual([]);
     eventStream.close();
     runtime.shutdown();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/idle-retirement.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/idle-retirement.test.js
@@ -4,10 +4,12 @@ import { OpenCodeRuntime } from '../opencode.js';
 
 function deferred() {
   let resolve;
-  const promise = new Promise((resolvePromise) => {
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function pendingUntilAborted(signal) {
@@ -21,6 +23,31 @@ function pendingUntilAborted(signal) {
 async function* connectedStream(signal) {
   yield { payload: { type: 'server.connected', properties: {} } };
   await pendingUntilAborted(signal);
+}
+
+function createEventStream() {
+  const events = [{ payload: { type: 'server.connected', properties: {} } }];
+  const waiters = [];
+  let closed = false;
+  return {
+    push(payload) {
+      events.push({ directory: '/repo', payload });
+      for (const resolve of waiters.splice(0)) resolve();
+    },
+    close() {
+      closed = true;
+      for (const resolve of waiters.splice(0)) resolve();
+    },
+    async *stream() {
+      while (!closed || events.length > 0) {
+        if (events.length > 0) {
+          yield events.shift();
+          continue;
+        }
+        await new Promise((resolve) => waiters.push(resolve));
+      }
+    },
+  };
 }
 
 function configuredProvidersResult(model) {
@@ -483,6 +510,93 @@ describe('OpenCodeRuntime idle retirement', () => {
       await timers.callback(10)();
       expect(close).toHaveBeenCalledTimes(1);
     } finally {
+      await runtime.shutdown();
+      timers.restore();
+    }
+  });
+
+  it('retires after a rejected Stop releases a deferred terminal from a failed prompt', async () => {
+    const timers = captureIntervals();
+    const eventStream = createEventStream();
+    const close = mock(() => eventStream.close());
+    const promptResponse = deferred();
+    const abortResponse = deferred();
+    const prompt = mock(() => promptResponse.promise);
+    let now = 0;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(() => Promise.resolve({
+        client: {
+          global: {
+            event: mock(() => Promise.resolve({ stream: eventStream.stream() })),
+          },
+          permission: { reply: mock(() => Promise.resolve({})) },
+          session: {
+            create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
+            prompt,
+            abort: mock(() => abortResponse.promise),
+          },
+        },
+        server: { close },
+      })),
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      runtime.startPurgeTimer();
+      await runtime.startSession({
+        command: 'hello',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        permissionMode: 'default',
+        operation: { runId: 'run-1', publish() {} },
+      });
+      eventStream.push({
+        id: 'evt-user',
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-1',
+          part: {
+            id: prompt.mock.calls[0][0].parts[0].id,
+            messageID: 'user-a',
+            type: 'text',
+            text: 'hello',
+          },
+        },
+      });
+
+      const stopping = runtime.abort('session-1');
+      eventStream.push({
+        id: 'evt-assistant',
+        type: 'message.updated',
+        properties: {
+          sessionID: 'session-1',
+          info: {
+            id: 'assistant-aborted',
+            role: 'assistant',
+            parentID: 'user-a',
+            error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+            finish: 'error',
+            time: { completed: Date.now() },
+          },
+        },
+      });
+      await Bun.sleep(0);
+      promptResponse.reject(new Error('prompt transport closed'));
+      await Bun.sleep(0);
+      abortResponse.resolve({ error: { message: 'abort rejected' } });
+      await expect(stopping).resolves.toBe(false);
+      for (let attempt = 0; attempt < 100 && runtime.isRunning('session-1'); attempt += 1) {
+        await Bun.sleep(0);
+      }
+      expect(runtime.isRunning('session-1')).toBe(false);
+
+      now = 100;
+      await timers.callback(10)();
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      eventStream.close();
       await runtime.shutdown();
       timers.restore();
     }

--- a/server-agents/opencode/src/agents/opencode/__tests__/idle-retirement.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/idle-retirement.test.js
@@ -264,4 +264,70 @@ describe('OpenCodeRuntime idle retirement', () => {
       timers.restore();
     }
   });
+
+  it('retires after an unexpectedly aborted turn settles', async () => {
+    const timers = captureIntervals();
+    const close = mock(() => {});
+    const events = [];
+    let now = 0;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(() => Promise.resolve({
+        client: {
+          global: {
+            event: mock(({ signal }) => Promise.resolve({ stream: connectedStream(signal) })),
+          },
+          permission: { reply: mock(() => Promise.resolve({})) },
+          session: {
+            create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
+            prompt: mock(() => Promise.resolve({
+              data: {
+                info: {
+                  id: 'assistant-aborted',
+                  role: 'assistant',
+                  error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+                  finish: 'error',
+                  time: { completed: Date.now() },
+                },
+                parts: [],
+              },
+            })),
+          },
+        },
+        server: { close },
+      })),
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      runtime.startPurgeTimer();
+      await runtime.startSession({
+        command: 'hello',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        permissionMode: 'default',
+        operation: { runId: 'run-1', publish: (event) => events.push(event) },
+      });
+      for (let attempt = 0; attempt < 100 && runtime.isRunning('session-1'); attempt += 1) {
+        await Bun.sleep(0);
+      }
+      expect(runtime.isRunning('session-1')).toBe(false);
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'run-ended',
+        outcome: 'failed',
+      }));
+
+      now = 99;
+      await timers.callback(10)();
+      expect(close).not.toHaveBeenCalled();
+
+      now = 100;
+      await timers.callback(10)();
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.shutdown();
+      timers.restore();
+    }
+  });
 });

--- a/server-agents/opencode/src/agents/opencode/__tests__/idle-retirement.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/idle-retirement.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { OpenCodeIdleLifecycle } from '../idle-lifecycle.js';
 import { OpenCodeRuntime } from '../opencode.js';
 
 function deferred() {
@@ -327,6 +328,207 @@ describe('OpenCodeRuntime idle retirement', () => {
       expect(close).toHaveBeenCalledTimes(1);
     } finally {
       await runtime.shutdown();
+      timers.restore();
+    }
+  });
+
+  it('retires after a rejected prompt request settles the turn', async () => {
+    const timers = captureIntervals();
+    const close = mock(() => {});
+    let now = 0;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(() => Promise.resolve({
+        client: {
+          global: {
+            event: mock(({ signal }) => Promise.resolve({ stream: connectedStream(signal) })),
+          },
+          permission: { reply: mock(() => Promise.resolve({})) },
+          session: {
+            create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
+            prompt: mock(() => Promise.reject(new Error('prompt transport closed'))),
+          },
+        },
+        server: { close },
+      })),
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      runtime.startPurgeTimer();
+      await runtime.startSession({
+        command: 'hello',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        permissionMode: 'default',
+        operation: { runId: 'run-1', publish() {} },
+      });
+      for (let attempt = 0; attempt < 100 && runtime.isRunning('session-1'); attempt += 1) {
+        await Bun.sleep(0);
+      }
+      expect(runtime.isRunning('session-1')).toBe(false);
+
+      now = 100;
+      await timers.callback(10)();
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.shutdown();
+      timers.restore();
+    }
+  });
+
+  it('retires after an acknowledged Stop', async () => {
+    const timers = captureIntervals();
+    const close = mock(() => {});
+    let now = 0;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(() => Promise.resolve({
+        client: {
+          global: {
+            event: mock(({ signal }) => Promise.resolve({ stream: connectedStream(signal) })),
+          },
+          permission: { reply: mock(() => Promise.resolve({})) },
+          session: {
+            create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
+            prompt: mock((_, { signal }) => pendingUntilAborted(signal)),
+            abort: mock(() => Promise.resolve({ data: true })),
+          },
+        },
+        server: { close },
+      })),
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      runtime.startPurgeTimer();
+      await runtime.startSession({
+        command: 'hello',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        permissionMode: 'default',
+        operation: { runId: 'run-1', publish() {} },
+      });
+      await expect(runtime.abort('session-1')).resolves.toBe(true);
+      expect(runtime.isRunning('session-1')).toBe(false);
+
+      now = 100;
+      await timers.callback(10)();
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.shutdown();
+      timers.restore();
+    }
+  });
+
+  it('retires after a rejected Stop settles a completed aborted prompt', async () => {
+    const timers = captureIntervals();
+    const close = mock(() => {});
+    const promptResponse = deferred();
+    const abortResponse = deferred();
+    let now = 0;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(() => Promise.resolve({
+        client: {
+          global: {
+            event: mock(({ signal }) => Promise.resolve({ stream: connectedStream(signal) })),
+          },
+          permission: { reply: mock(() => Promise.resolve({})) },
+          session: {
+            create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
+            prompt: mock(() => promptResponse.promise),
+            abort: mock(() => abortResponse.promise),
+          },
+        },
+        server: { close },
+      })),
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      runtime.startPurgeTimer();
+      await runtime.startSession({
+        command: 'hello',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        permissionMode: 'default',
+        operation: { runId: 'run-1', publish() {} },
+      });
+      const stopping = runtime.abort('session-1');
+      promptResponse.resolve({
+        data: {
+          info: {
+            id: 'assistant-aborted',
+            role: 'assistant',
+            error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+            finish: 'error',
+            time: { completed: Date.now() },
+          },
+          parts: [],
+        },
+      });
+      await Bun.sleep(0);
+      abortResponse.resolve({ error: { message: 'abort rejected' } });
+      await expect(stopping).resolves.toBe(false);
+      for (let attempt = 0; attempt < 100 && runtime.isRunning('session-1'); attempt += 1) {
+        await Bun.sleep(0);
+      }
+      expect(runtime.isRunning('session-1')).toBe(false);
+
+      now = 100;
+      await timers.callback(10)();
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.shutdown();
+      timers.restore();
+    }
+  });
+});
+
+describe('OpenCodeIdleLifecycle', () => {
+  it('retains a settled session until its pending steering revert is applied', () => {
+    const timers = captureIntervals();
+    const originalDateNow = Date.now;
+    const purgeSession = mock(() => undefined);
+    const session = {
+      status: 'completed',
+      providerWorkRequiresQuiescence: false,
+      pendingSteeringRevertMessageId: 'user-steer',
+      lastActivityAt: 0,
+    };
+    const lifecycle = new OpenCodeIdleLifecycle({
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+      sessions: () => [['session-1', session]],
+      purgeSession,
+      hasInstance: () => false,
+      hasStartup: () => false,
+      endpointIdle: () => true,
+      routesIdle: () => true,
+      decisionsIdle: () => true,
+      hasPendingTurnWaiters: () => false,
+      isShuttingDown: () => false,
+      runTransition: (operation) => operation(),
+      invalidateModels() {},
+      closeInstance() {},
+      now: () => Date.now(),
+    });
+
+    try {
+      lifecycle.start();
+      Date.now = () => 31 * 60 * 1000;
+      timers.callback(5 * 60 * 1000)();
+      expect(purgeSession).not.toHaveBeenCalled();
+
+      session.pendingSteeringRevertMessageId = null;
+      timers.callback(5 * 60 * 1000)();
+      expect(purgeSession).toHaveBeenCalledWith('session-1', session);
+    } finally {
+      lifecycle.stop();
+      Date.now = originalDateNow;
       timers.restore();
     }
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/permissions.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/permissions.test.js
@@ -654,6 +654,11 @@ describe('OpenCodeRuntime permissions', () => {
       outcome: 'failed',
       error: { code: 'PROVIDER_FAILURE', message: 'permission endpoint failed' },
     });
+    expect(manual.events.flatMap((event) => event.type === 'rows' ? event.rows : []))
+      .toContainEqual(expect.objectContaining({
+        message: expect.objectContaining({ type: 'error', content: 'permission endpoint failed' }),
+        providerMeta: { entryId: 'assistant-manual' },
+      }));
     expect(client.global.event).toHaveBeenCalledTimes(1);
 
     eventStream.close();

--- a/server-agents/opencode/src/agents/opencode/__tests__/steering.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/steering.test.js
@@ -372,6 +372,156 @@ describe('OpenCodeRuntime steering', () => {
     await runtime.shutdown();
   });
 
+  it('keeps accepted-steering specificity for a deferred abort without retaining quiescence', async () => {
+    const steeringSubmission = deferred();
+    let submissionCount = 0;
+    const promptAsync = mock(() => {
+      submissionCount += 1;
+      return submissionCount === 2 ? steeringSubmission.promise : Promise.resolve({});
+    });
+    const abort = mock(() => Promise.resolve({ data: true }));
+    const { runtime, eventStream, revert } = createRuntime({ promptAsync, abort });
+    const published = await start(runtime);
+    await bindPrompt(eventStream, promptAsync, 0, 'hello');
+    const target = await waitForTarget(runtime);
+    const steering = runtime.steering.steer(steerRequest(target));
+    await waitFor(() => promptAsync.mock.calls.length === 2);
+
+    const steerPartId = promptAsync.mock.calls[1][0].parts[0].id;
+    eventStream.push(envelope({
+      id: 'evt_0003',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: steerPartId,
+          messageID: 'user-steer',
+          type: 'text',
+          text: '/review the current approach',
+        },
+      },
+    }));
+    eventStream.push(envelope({
+      id: 'evt_0004',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: {
+          id: 'assistant-aborted',
+          role: 'assistant',
+          parentID: 'user-1',
+          finish: 'error',
+          time: { completed: Date.now() },
+          error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+        },
+      },
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(terminalEvents(published.events)).toEqual([]);
+
+    steeringSubmission.resolve({});
+    await expect(steering).resolves.toEqual({ kind: 'accepted' });
+    await waitFor(() => terminalEvents(published.events).length === 1);
+    const failureMessage = 'OpenCode stopped before processing accepted steering input';
+    expect(terminalEvents(published.events)).toEqual([{
+      type: 'run-ended',
+      runId: 'run-default',
+      outcome: 'failed',
+      error: { code: 'PROVIDER_FAILURE', message: failureMessage },
+    }]);
+    expect(publishedMessages(published.events)).toContainEqual(expect.objectContaining({
+      type: 'error',
+      content: failureMessage,
+    }));
+
+    const recoveryOperation = collectOperation('run-recovery');
+    const recovery = runtime.runTurn({
+      command: 'recover',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      model: 'provider/model',
+      permissionMode: 'default',
+      operation: recoveryOperation.operation,
+    });
+    await waitFor(() => promptAsync.mock.calls.length === 3);
+    expect(abort).not.toHaveBeenCalled();
+    expect(revert).toHaveBeenCalledWith(expect.objectContaining({
+      sessionID: 'session-1',
+      messageID: 'user-steer',
+      directory: '/repo',
+    }), expect.any(Object));
+
+    const recoveryMessageId = await bindPrompt(eventStream, promptAsync, 2, 'recover');
+    pushAssistant(eventStream, {
+      messageId: 'assistant-recovery',
+      parentId: recoveryMessageId,
+      text: 'recovered',
+      eventNumber: 7,
+      finish: 'stop',
+    });
+    await expect(recovery).resolves.toBeUndefined();
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('quiesces an unconfirmed steering delivery before the next turn', async () => {
+    let submissionCount = 0;
+    const promptAsync = mock(() => {
+      submissionCount += 1;
+      return submissionCount === 2
+        ? Promise.reject(new Error('steering transport failed'))
+        : Promise.resolve({});
+    });
+    const abort = mock(() => Promise.resolve({ data: true }));
+    const { runtime, eventStream } = createRuntime({ promptAsync, abort });
+    const published = await start(runtime);
+    await bindPrompt(eventStream, promptAsync, 0, 'hello');
+    const target = await waitForTarget(runtime);
+
+    await expect(runtime.steering.steer(steerRequest(target))).resolves.toEqual({
+      kind: 'failed',
+      outcome: 'unknown',
+      message: 'OpenCode steering delivery could not be confirmed',
+    });
+    pushAssistant(eventStream, {
+      messageId: 'assistant-initial',
+      parentId: 'user-1',
+      text: 'initial reply',
+      eventNumber: 3,
+      finish: 'stop',
+    });
+    await waitFor(() => terminalEvents(published.events).length === 1);
+
+    const recoveryOperation = collectOperation('run-recovery');
+    const recovery = runtime.runTurn({
+      command: 'recover',
+      agentSessionId: 'session-1',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      model: 'provider/model',
+      permissionMode: 'default',
+      operation: recoveryOperation.operation,
+    });
+    await waitFor(() => promptAsync.mock.calls.length === 3);
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(abort.mock.invocationCallOrder[0]).toBeLessThan(
+      promptAsync.mock.invocationCallOrder[2],
+    );
+
+    const recoveryMessageId = await bindPrompt(eventStream, promptAsync, 2, 'recover');
+    pushAssistant(eventStream, {
+      messageId: 'assistant-recovery',
+      parentId: recoveryMessageId,
+      text: 'recovered',
+      eventNumber: 7,
+      finish: 'stop',
+    });
+    await expect(recovery).resolves.toBeUndefined();
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
   it('reports a provider rejection after delivery preparation without accepting it', async () => {
     let promptCount = 0;
     const promptAsync = mock(() => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/steering.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/steering.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { OpenCodeRuntime } from '../opencode.js';
+import { OpenCodeSteeringController } from '../steering.js';
+import { createOpenCodeTurnContext } from '../turn-events.js';
 
 function deferred() {
   let resolve;
@@ -99,13 +101,21 @@ function createEventStream() {
       closed = true;
       for (const resolve of waiters.splice(0)) resolve();
     },
-    async *stream() {
-      while (!closed || events.length > 0) {
-        if (events.length > 0) {
-          yield events.shift();
-          continue;
+    async *stream(signal) {
+      const abort = () => {
+        for (const resolve of waiters.splice(0)) resolve();
+      };
+      signal?.addEventListener('abort', abort, { once: true });
+      try {
+        while (!signal?.aborted && (!closed || events.length > 0)) {
+          if (events.length > 0) {
+            yield events.shift();
+            continue;
+          }
+          await new Promise((resolve) => waiters.push(resolve));
         }
-        await new Promise((resolve) => waiters.push(resolve));
+      } finally {
+        signal?.removeEventListener('abort', abort);
       }
     },
   };
@@ -117,6 +127,29 @@ async function waitFor(predicate) {
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
   throw new Error('Timed out waiting for condition');
+}
+
+function captureIntervals() {
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const intervals = new Map();
+  globalThis.setInterval = mock((callback, intervalMs) => {
+    const timer = { unref: mock(() => {}) };
+    intervals.set(intervalMs, { callback, timer });
+    return timer;
+  });
+  globalThis.clearInterval = mock(() => {});
+  return {
+    callback(intervalMs) {
+      const entry = intervals.get(intervalMs);
+      if (!entry) throw new Error(`Missing ${intervalMs}ms interval`);
+      return entry.callback;
+    },
+    restore() {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    },
+  };
 }
 
 function createRuntime(overrides = {}) {
@@ -133,12 +166,16 @@ function createRuntime(overrides = {}) {
   };
   const abort = overrides.abort ?? mock(() => Promise.resolve({ data: true }));
   const revert = overrides.revert ?? mock(() => Promise.resolve({ data: {} }));
+  const close = mock(() => undefined);
   const runtime = new OpenCodeRuntime({
     requestTimeoutMs: overrides.requestTimeoutMs,
+    idleRetirementDelayMs: overrides.idleRetirementDelayMs,
+    idleRetirementCheckIntervalMs: overrides.idleRetirementCheckIntervalMs,
+    now: overrides.now,
     createInstance: mock(() => Promise.resolve({
       client: {
         permission: { reply: mock(() => Promise.resolve({})) },
-        global: { event: mock(() => Promise.resolve({ stream: eventStream.stream() })) },
+        global: { event: mock(({ signal }) => Promise.resolve({ stream: eventStream.stream(signal) })) },
         session: {
           create: mock(() => Promise.resolve({ data: { id: 'session-1' } })),
           prompt,
@@ -147,10 +184,10 @@ function createRuntime(overrides = {}) {
           revert,
         },
       },
-      server: { close: mock(() => undefined) },
+      server: { close },
     })),
   });
-  return { runtime, eventStream, promptAsync, abort, revert };
+  return { runtime, eventStream, promptAsync, abort, revert, close };
 }
 
 async function start(runtime, overrides = {}) {
@@ -247,6 +284,24 @@ function pushAssistant(eventStream, {
       },
     }));
   }
+}
+
+function pushAbortedAssistant(eventStream, { messageId, parentId, eventNumber }) {
+  eventStream.push(envelope({
+    id: `evt_${String(eventNumber).padStart(4, '0')}`,
+    type: 'message.updated',
+    properties: {
+      sessionID: 'session-1',
+      info: {
+        id: messageId,
+        role: 'assistant',
+        parentID: parentId,
+        finish: 'error',
+        time: { completed: Date.now() },
+        error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+      },
+    },
+  }));
 }
 
 describe('OpenCodeRuntime steering', () => {
@@ -372,7 +427,7 @@ describe('OpenCodeRuntime steering', () => {
     await runtime.shutdown();
   });
 
-  it('keeps accepted-steering specificity for a deferred abort without retaining quiescence', async () => {
+  it('keeps accepted-steering specificity and quiesces before recovery', async () => {
     const steeringSubmission = deferred();
     let submissionCount = 0;
     const promptAsync = mock(() => {
@@ -401,21 +456,11 @@ describe('OpenCodeRuntime steering', () => {
         },
       },
     }));
-    eventStream.push(envelope({
-      id: 'evt_0004',
-      type: 'message.updated',
-      properties: {
-        sessionID: 'session-1',
-        info: {
-          id: 'assistant-aborted',
-          role: 'assistant',
-          parentID: 'user-1',
-          finish: 'error',
-          time: { completed: Date.now() },
-          error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
-        },
-      },
-    }));
+    pushAbortedAssistant(eventStream, {
+      messageId: 'assistant-aborted',
+      parentId: 'user-1',
+      eventNumber: 4,
+    });
     await new Promise((resolve) => setImmediate(resolve));
     expect(terminalEvents(published.events)).toEqual([]);
 
@@ -445,12 +490,15 @@ describe('OpenCodeRuntime steering', () => {
       operation: recoveryOperation.operation,
     });
     await waitFor(() => promptAsync.mock.calls.length === 3);
-    expect(abort).not.toHaveBeenCalled();
+    expect(abort).toHaveBeenCalledTimes(1);
     expect(revert).toHaveBeenCalledWith(expect.objectContaining({
       sessionID: 'session-1',
       messageID: 'user-steer',
       directory: '/repo',
     }), expect.any(Object));
+    expect(abort.mock.invocationCallOrder[0]).toBeLessThan(
+      revert.mock.invocationCallOrder[0],
+    );
 
     const recoveryMessageId = await bindPrompt(eventStream, promptAsync, 2, 'recover');
     pushAssistant(eventStream, {
@@ -520,6 +568,158 @@ describe('OpenCodeRuntime steering', () => {
     await expect(recovery).resolves.toBeUndefined();
     eventStream.close();
     await runtime.shutdown();
+  });
+
+  it('retires the provider process after an unconfirmed steer on a finished turn', async () => {
+    const timers = captureIntervals();
+    let now = 0;
+    let submissionCount = 0;
+    const promptAsync = mock(() => {
+      submissionCount += 1;
+      return submissionCount === 2
+        ? Promise.reject(new Error('steering transport failed'))
+        : Promise.resolve({});
+    });
+    const fixture = createRuntime({
+      promptAsync,
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      fixture.runtime.startPurgeTimer();
+      const published = await start(fixture.runtime);
+      await bindPrompt(fixture.eventStream, promptAsync, 0, 'hello');
+      const target = await waitForTarget(fixture.runtime);
+      await expect(fixture.runtime.steering.steer(steerRequest(target))).resolves.toMatchObject({
+        kind: 'failed',
+        outcome: 'unknown',
+      });
+      pushAssistant(fixture.eventStream, {
+        messageId: 'assistant-initial',
+        parentId: 'user-1',
+        text: 'initial reply',
+        eventNumber: 3,
+        finish: 'stop',
+      });
+      await waitFor(() => terminalEvents(published.events).length === 1);
+
+      now = 100;
+      await timers.callback(10)();
+      expect(fixture.close).toHaveBeenCalledTimes(1);
+
+      const recoveryOperation = collectOperation('run-recovery');
+      const recovery = fixture.runtime.runTurn({
+        command: 'recover',
+        agentSessionId: 'session-1',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        model: 'provider/model',
+        permissionMode: 'default',
+        operation: recoveryOperation.operation,
+      });
+      fixture.eventStream.push(connectedEnvelope());
+      await waitFor(() => promptAsync.mock.calls.length === 3);
+      expect(fixture.abort).not.toHaveBeenCalled();
+      const recoveryMessageId = await bindPrompt(fixture.eventStream, promptAsync, 2, 'recover');
+      pushAssistant(fixture.eventStream, {
+        messageId: 'assistant-recovery',
+        parentId: recoveryMessageId,
+        text: 'recovered',
+        eventNumber: 7,
+        finish: 'stop',
+      });
+      await expect(recovery).resolves.toBeUndefined();
+    } finally {
+      fixture.eventStream.close();
+      await fixture.runtime.shutdown();
+      timers.restore();
+    }
+  });
+
+  it('preserves an accepted steering revert across provider process retirement', async () => {
+    const timers = captureIntervals();
+    let now = 0;
+    const fixture = createRuntime({
+      idleRetirementDelayMs: 100,
+      idleRetirementCheckIntervalMs: 10,
+      now: () => now,
+    });
+
+    try {
+      fixture.runtime.startPurgeTimer();
+      const published = await start(fixture.runtime);
+      await bindPrompt(fixture.eventStream, fixture.promptAsync, 0, 'hello');
+      const target = await waitForTarget(fixture.runtime);
+      const steering = fixture.runtime.steering.steer(steerRequest(target));
+      await waitFor(() => fixture.promptAsync.mock.calls.length === 2);
+      fixture.eventStream.push(envelope({
+        id: 'evt_0003',
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-1',
+          part: {
+            id: fixture.promptAsync.mock.calls[1][0].parts[0].id,
+            messageID: 'user-steer',
+            type: 'text',
+            text: '/review the current approach',
+          },
+        },
+      }));
+      await expect(steering).resolves.toEqual({ kind: 'accepted' });
+      pushAbortedAssistant(fixture.eventStream, {
+        messageId: 'assistant-aborted',
+        parentId: 'user-1',
+        eventNumber: 4,
+      });
+      await waitFor(() => terminalEvents(published.events).length === 1);
+
+      now = 100;
+      await timers.callback(10)();
+      expect(fixture.close).toHaveBeenCalledTimes(1);
+
+      const recoveryOperation = collectOperation('run-recovery');
+      const recovery = fixture.runtime.runTurn({
+        command: 'recover',
+        agentSessionId: 'session-1',
+        chatId: 'chat-1',
+        projectPath: '/repo',
+        model: 'provider/model',
+        permissionMode: 'default',
+        operation: recoveryOperation.operation,
+      });
+      fixture.eventStream.push(connectedEnvelope());
+      await waitFor(() => fixture.promptAsync.mock.calls.length === 3);
+      expect(fixture.abort).not.toHaveBeenCalled();
+      expect(fixture.revert).toHaveBeenCalledWith(expect.objectContaining({
+        sessionID: 'session-1',
+        messageID: 'user-steer',
+        directory: '/repo',
+      }), expect.any(Object));
+      expect(fixture.revert.mock.invocationCallOrder[0]).toBeLessThan(
+        fixture.promptAsync.mock.invocationCallOrder[2],
+      );
+
+      const recoveryMessageId = await bindPrompt(
+        fixture.eventStream,
+        fixture.promptAsync,
+        2,
+        'recover',
+      );
+      pushAssistant(fixture.eventStream, {
+        messageId: 'assistant-recovery',
+        parentId: recoveryMessageId,
+        text: 'recovered',
+        eventNumber: 7,
+        finish: 'stop',
+      });
+      await expect(recovery).resolves.toBeUndefined();
+    } finally {
+      fixture.eventStream.close();
+      await fixture.runtime.shutdown();
+      timers.restore();
+    }
   });
 
   it('reports a provider rejection after delivery preparation without accepting it', async () => {
@@ -737,3 +937,85 @@ async function waitForTarget(runtime) {
   });
   return target;
 }
+
+function createControllerFixture(options = {}) {
+  const turn = createOpenCodeTurnContext(collectOperation('run-a').operation);
+  turn.providerMessageId = 'user-a';
+  turn.providerPromptRequestCompleted = options.providerPromptRequestCompleted ?? false;
+  const session = {
+    status: 'running',
+    chatId: 'chat-1',
+    model: 'provider/model',
+    permissionMode: 'default',
+    directory: '/repo',
+    startedAt: new Date(0).toISOString(),
+    lastActivityAt: 0,
+    providerWorkRequiresQuiescence: false,
+    activeSteeringDeliveries: 0,
+    deferredTerminal: null,
+    pendingSteeringRevertMessageId: null,
+    turn,
+  };
+  const promptAsync = options.promptAsync ?? mock(() => Promise.resolve({}));
+  const controller = new OpenCodeSteeringController({
+    requestTimeoutMs: 100,
+    getSession: () => session,
+    getClient: () => Promise.resolve({ session: { promptAsync } }),
+    runScopedRequest: (_label, scope, operation) => (
+      operation(new AbortController().signal, scope)
+    ),
+    releaseDeferredTerminal() {},
+    bindOperationPart: () => true,
+    unbindOperationPart() {},
+  });
+  return { controller, promptAsync, session, turn };
+}
+
+describe('OpenCodeSteeringController', () => {
+  it('re-arms quiescence when a late steering acknowledgement remains unconsumed', async () => {
+    const fixture = createControllerFixture({ providerPromptRequestCompleted: true });
+    const target = fixture.controller.captureTarget('session-1');
+    const steering = fixture.controller.steer(steerRequest(target));
+    await waitFor(() => fixture.promptAsync.mock.calls.length === 1);
+
+    fixture.controller.observeAcknowledgement(fixture.session, envelope({
+      id: 'evt_steer',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: {
+          id: fixture.promptAsync.mock.calls[0][0].parts[0].id,
+          messageID: 'user-steer',
+          type: 'text',
+          text: '/review the current approach',
+        },
+      },
+    }).payload);
+
+    await expect(steering).resolves.toEqual({ kind: 'accepted' });
+    expect(fixture.turn.pendingSteeringMessageIds).toEqual(new Set(['user-steer']));
+    expect(fixture.session.providerWorkRequiresQuiescence).toBe(true);
+  });
+
+  it('does not re-arm quiescence after an acknowledged Stop', async () => {
+    const preparation = deferred();
+    const preparationStarted = deferred();
+    const fixture = createControllerFixture();
+    const target = fixture.controller.captureTarget('session-1');
+    const steering = fixture.controller.steer(steerRequest(target, {
+      prepareDelivery: () => {
+        preparationStarted.resolve();
+        return preparation.promise;
+      },
+    }));
+    await preparationStarted.promise;
+
+    fixture.session.status = 'aborted';
+    fixture.session.providerWorkRequiresQuiescence = false;
+    preparation.reject(new Error('delivery preparation stopped'));
+
+    await expect(steering).rejects.toThrow('delivery preparation stopped');
+    expect(fixture.promptAsync).not.toHaveBeenCalled();
+    expect(fixture.session.providerWorkRequiresQuiescence).toBe(false);
+  });
+});

--- a/server-agents/opencode/src/agents/opencode/__tests__/turn-events.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/turn-events.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  activateOpenCodeSessionTurn,
+  createOpenCodeTurnContext,
+  openCodeTurnRequiresProviderQuiescence,
+} from '../turn-events.js';
+
+function operation(runId) {
+  return { runId, publish() {} };
+}
+
+describe('OpenCode turn events', () => {
+  it('clears retired-turn control state when a successor activates', () => {
+    const previousTurn = createOpenCodeTurnContext(operation('run-previous'));
+    const successorTurn = createOpenCodeTurnContext(operation('run-successor'));
+    const session = {
+      status: 'completed',
+      aborting: true,
+      chatId: 'chat-previous',
+      model: 'provider/previous',
+      thinkingVariant: 'high',
+      permissionMode: 'default',
+      directory: '/previous',
+      startedAt: new Date(0).toISOString(),
+      lastActivityAt: 0,
+      providerWorkRequiresQuiescence: true,
+      activeSteeringDeliveries: 1,
+      deferredTerminal: { outcome: 'aborted', messageId: 'assistant-previous' },
+      pendingSteeringRevertMessageId: null,
+      turn: previousTurn,
+    };
+
+    activateOpenCodeSessionTurn(session, {
+      chatId: 'chat-successor',
+      model: 'provider/successor',
+      thinkingVariant: 'low',
+      permissionMode: 'plan',
+      directory: '/successor',
+      turn: successorTurn,
+    });
+
+    expect(session).toMatchObject({
+      status: 'running',
+      aborting: false,
+      providerWorkRequiresQuiescence: false,
+      activeSteeringDeliveries: 0,
+      deferredTerminal: null,
+      chatId: 'chat-successor',
+      model: 'provider/successor',
+      thinkingVariant: 'low',
+      permissionMode: 'plan',
+      directory: '/successor',
+      turn: successorTurn,
+    });
+    expect(session.lastActivityAt).toBeGreaterThan(0);
+  });
+
+  it('derives quiescence from incomplete prompts and uncertain steering', () => {
+    const turn = createOpenCodeTurnContext(operation('run-a'));
+    expect(openCodeTurnRequiresProviderQuiescence(turn)).toBe(true);
+
+    turn.providerPromptRequestCompleted = true;
+    expect(openCodeTurnRequiresProviderQuiescence(turn)).toBe(false);
+
+    turn.providerSteeringDeliveryUnconfirmed = true;
+    expect(openCodeTurnRequiresProviderQuiescence(turn)).toBe(true);
+
+    turn.providerSteeringDeliveryUnconfirmed = false;
+    turn.pendingSteeringMessageIds.add('user-steer');
+    expect(openCodeTurnRequiresProviderQuiescence(turn)).toBe(true);
+  });
+});

--- a/server-agents/opencode/src/agents/opencode/idle-lifecycle.ts
+++ b/server-agents/opencode/src/agents/opencode/idle-lifecycle.ts
@@ -44,7 +44,9 @@ export class OpenCodeIdleLifecycle {
     this.#sessionPurger = new IdleSessionPurger({
       sessions: options.sessions,
       isRunning: (session) => (
-        session.status === 'running' || session.providerWorkRequiresQuiescence
+        session.status === 'running'
+        || session.providerWorkRequiresQuiescence
+        || session.pendingSteeringRevertMessageId !== null
       ),
       lastActivityAt: (session) => session.lastActivityAt,
       purge: options.purgeSession,
@@ -114,9 +116,9 @@ export class OpenCodeIdleLifecycle {
       || !this.#options.decisionsIdle()
       || this.#options.hasPendingTurnWaiters()
     ) return false;
+    // Process retirement quiesces settled sessions; closeInstance clears their purge fence.
     return Array.from(this.#options.sessions()).every(([, session]) => (
       session.status !== 'running'
-      && !session.providerWorkRequiresQuiescence
       && !session.aborting
       && session.activeSteeringDeliveries === 0
       && session.deferredTerminal === null

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -18,13 +18,16 @@ import {
 } from './sse-events.js';
 import {
   acceptUniqueOpenCodeTurnEvent,
+  activateOpenCodeSessionTurn,
   createOpenCodeTurnContext,
   openCodeEventBelongsToTurn,
+  openCodeTurnRequiresProviderQuiescence,
   relocateOpenCodeSession,
+  shouldWarnForUnroutedOpenCodeEvent,
   type OpenCodeSession,
   type OpenCodeTurnContext,
 } from './turn-events.js';
-import { CompactionMessage, ErrorMessage } from '@garcon/common/chat-types';
+import { CompactionMessage } from '@garcon/common/chat-types';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import {
   runtimeRows,
@@ -87,6 +90,10 @@ import {
 } from './model-catalog.js';
 import { adoptOpenCodeCompactionPartRoute, manualCompactionBoundaryRow } from './compaction-routing.js';
 import { OpenCodeIdleLifecycle } from './idle-lifecycle.js';
+import {
+  openCodeAbortedTurnFailureMessage,
+  openCodeProviderFailureRow,
+} from './turn-failure.js';
 
 const SILENT_LOGGER: AgentLogger = Object.freeze({
   debug() {},
@@ -397,6 +404,10 @@ export class OpenCodeRuntime {
     this.#instanceGeneration += 1;
     this.#globalEventListener.close();
     this.#operationRoutes.clear();
+    // Closing the provider process definitively quiesces every settled session.
+    for (const session of this.#sessions.values()) {
+      if (session.status !== 'running') session.providerWorkRequiresQuiescence = false;
+    }
     if (instance) {
       // Killing a still-live process must preserve the availability cooldown
       // that prompted the close; an already-exited process keeps death
@@ -657,20 +668,17 @@ export class OpenCodeRuntime {
     }
   }
 
-  #failTurnForProviderError(agentSessionId: string, session: OpenCodeSession, message: string): void {
+  #failTurnForProviderError(
+    agentSessionId: string, session: OpenCodeSession, message: string, entryId?: string,
+  ): void {
     this.steering.stagePendingCleanup(session);
-    session.providerWorkRequiresQuiescence = true;
+    session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(session.turn);
     session.status = 'completed';
     session.lastActivityAt = Date.now();
     this.#decisions.cancelForSession(agentSessionId, 'cancelled');
     this.#rejectTurnWaiter(agentSessionId, new Error(message));
-    const failedMessageId = lastValue(session.turn.assistantMessageIds);
-    const errorRow = new ErrorMessage(new Date().toISOString(), message);
-    this.#publishRows(
-      agentSessionId,
-      session.turn.operation,
-      [failedMessageId ? attachNativeMessageSource(errorRow, { entryId: failedMessageId }) : errorRow],
-    );
+    const row = openCodeProviderFailureRow(message, entryId, session.turn.assistantMessageIds);
+    this.#publishRows(agentSessionId, session.turn.operation, [row]);
     this.#publishFailed(agentSessionId, session.turn.operation, message);
   }
 
@@ -685,24 +693,32 @@ export class OpenCodeRuntime {
       if (this.isTemporarilyUnavailable()) this.#idleLifecycle.closeInstanceIfIdle();
       return;
     }
-    const providerTerminal = lastValue(route.turn.assistantTerminals.values());
+    const providerTerminal = Array.from(route.turn.assistantTerminals.values()).at(-1);
     if (providerTerminal?.outcome === 'failed') {
-      this.#failTurnForProviderError(route.sessionId, session, providerTerminal.error);
-      if (this.isTemporarilyUnavailable()) this.#idleLifecycle.closeInstanceIfIdle();
-      return;
+      this.#failTurnForProviderError(
+        route.sessionId, session, providerTerminal.error, providerTerminal.messageId,
+      );
+    } else if (providerTerminal?.outcome === 'aborted') {
+      this.#logger.debug('OpenCode prompt failed after an aborted terminal', { error: errorMessage(error) });
+      this.#settleTurnTerminal(route.sessionId, session, providerTerminal);
+    } else {
+      const message = errorMessage(error);
+      this.#logger.error('OpenCode prompt failed', {
+        agentSessionId: route.sessionId,
+        error: message,
+      });
+      this.steering.stagePendingCleanup(session);
+      session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(route.turn);
+      session.status = 'completed';
+      session.lastActivityAt = Date.now();
+      this.#decisions.cancelForSession(route.sessionId, 'cancelled');
+      this.#rejectTurnWaiter(route.sessionId, error);
+      this.#publishFailed(route.sessionId, route.turn.operation, message);
     }
-    const message = errorMessage(error);
-    this.#logger.error('OpenCode prompt failed', {
-      agentSessionId: route.sessionId,
-      error: message,
-    });
-    this.steering.stagePendingCleanup(session);
-    session.providerWorkRequiresQuiescence = true;
-    session.status = 'completed';
-    session.lastActivityAt = Date.now();
-    this.#decisions.cancelForSession(route.sessionId, 'cancelled');
-    this.#rejectTurnWaiter(route.sessionId, error);
-    this.#publishFailed(route.sessionId, route.turn.operation, message);
+    const active = this.#sessions.get(route.sessionId);
+    if (active?.turn !== route.turn || active.status !== 'running') {
+      this.#operationRoutes.unregister(route);
+    }
     if (this.isTemporarilyUnavailable()) this.#idleLifecycle.closeInstanceIfIdle();
   }
 
@@ -722,19 +738,22 @@ export class OpenCodeRuntime {
         agentSessionId,
         session,
         'OpenCode stopped before processing accepted steering input',
+        terminal.messageId,
       );
       return;
     }
     if (terminal.outcome === 'aborted') {
-      // OpenCode can abort later prompts after an early cancellation.
-      // https://github.com/anomalyco/opencode/issues/30144
-      const message = 'OpenCode interrupted the current turn unexpectedly';
-      this.#logger.warn(message, { agentSessionId, messageId: terminal.messageId });
-      this.#failTurnForProviderError(agentSessionId, session, message);
+      const message = openCodeAbortedTurnFailureMessage(session.turn);
+      this.#logger.warn('OpenCode interrupted the current turn', {
+        agentSessionId, messageId: terminal.messageId, detail: message,
+      });
+      this.#failTurnForProviderError(agentSessionId, session, message, terminal.messageId);
       return;
     }
     if (terminal.outcome === 'failed') {
-      this.#failTurnForProviderError(agentSessionId, session, terminal.error);
+      this.#failTurnForProviderError(
+        agentSessionId, session, terminal.error, terminal.messageId,
+      );
       return;
     }
     this.#decisions.cancelForSession(agentSessionId, 'session-complete');
@@ -835,7 +854,7 @@ export class OpenCodeRuntime {
     const sess = this.#sessions.get(agentSessionId);
     if (request.executionAdmission?.signal.aborted) {
       if (sess?.turn === turn) {
-        sess.providerWorkRequiresQuiescence = true;
+        sess.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(turn);
         sess.status = 'completed';
         sess.lastActivityAt = Date.now();
       }
@@ -845,7 +864,7 @@ export class OpenCodeRuntime {
     this.#logger.error(options.logLabel, { agentSessionId, error: error.message });
     if (!sess || sess.status !== 'running' || sess.turn !== turn) return error;
     if (options.stageSteeringCleanup) this.steering.stagePendingCleanup(sess);
-    sess.providerWorkRequiresQuiescence = true;
+    sess.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(turn);
     sess.status = 'completed';
     sess.lastActivityAt = Date.now();
     this.#clearTurnWaiter(agentSessionId);
@@ -868,17 +887,7 @@ export class OpenCodeRuntime {
     },
   ): void {
     if (session) {
-      session.status = 'running';
-      session.aborting = false;
-      session.activeSteeringDeliveries = 0;
-      session.deferredTerminal = null;
-      session.chatId = input.chatId;
-      session.model = input.model;
-      session.thinkingVariant = input.thinkingVariant;
-      session.permissionMode = input.permissionMode;
-      session.directory = input.directory;
-      session.lastActivityAt = Date.now();
-      session.turn = input.turn;
+      activateOpenCodeSessionTurn(session, input);
       return;
     }
     this.#sessions.set(agentSessionId, {
@@ -995,7 +1004,7 @@ export class OpenCodeRuntime {
         const session = this.#sessions.get(route.sessionId);
         if (session?.turn === route.turn) {
           route.turn.providerPromptRequestCompleted = true;
-          if (!route.turn.providerSteeringDeliveryUnconfirmed) session.providerWorkRequiresQuiescence = false;
+          session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(route.turn);
         }
         this.#operationRoutes.unregister(route);
       }
@@ -1291,7 +1300,7 @@ export class OpenCodeRuntime {
       await pending;
       return;
     }
-    if (session.status === 'running') await this.abort(agentSessionId);
+    if (session.status === 'running') await this.#abortSession(agentSessionId, 'quiescence');
   }
 
   async startSession(request: OpenCodeStartRequest): Promise<string> {
@@ -1683,8 +1692,15 @@ export class OpenCodeRuntime {
   }
 
   abort(agentSessionId: string): Promise<boolean> {
+    return this.#abortSession(agentSessionId, 'user-stop');
+  }
+
+  #abortSession(agentSessionId: string, intent: 'user-stop' | 'quiescence'): Promise<boolean> {
     const session = this.#sessions.get(agentSessionId);
     if (!session || session.status !== 'running') return Promise.resolve(false);
+    if (intent === 'user-stop' || session.turn.providerAbortIntent === null) {
+      session.turn.providerAbortIntent = intent;
+    }
     const existing = this.#pendingSessionAborts.get(session);
     if (existing) return existing;
 
@@ -1729,6 +1745,7 @@ export class OpenCodeRuntime {
     }
 
     session.providerWorkRequiresQuiescence = false;
+    session.aborting = false;
     if (
       this.#sessions.get(agentSessionId) !== session
       || session.status !== 'running'
@@ -1830,21 +1847,4 @@ export class OpenCodeRuntime {
   startPurgeTimer(): void {
     this.#idleLifecycle.start();
   }
-}
-
-// The failing assistant message is the last one the turn observed; the native
-// error occurrence is stored on it, so its id is the canonical error identity.
-function lastValue<T>(values: Iterable<T>): T | null {
-  let last: T | null = null;
-  for (const value of values) last = value;
-  return last;
-}
-
-function shouldWarnForUnroutedOpenCodeEvent(eventType: string): boolean {
-  return eventType === 'message.updated'
-    || eventType === 'message.part.updated'
-    || eventType === 'message.part.delta'
-    || eventType === 'permission.asked'
-    || eventType === 'question.asked'
-    || eventType === 'session.error';
 }

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -91,7 +91,7 @@ import {
 import { adoptOpenCodeCompactionPartRoute, manualCompactionBoundaryRow } from './compaction-routing.js';
 import { OpenCodeIdleLifecycle } from './idle-lifecycle.js';
 import {
-  openCodeAbortedTurnFailureMessage,
+  OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE,
   openCodeProviderFailureRow,
 } from './turn-failure.js';
 
@@ -717,6 +717,8 @@ export class OpenCodeRuntime {
     }
     const active = this.#sessions.get(route.sessionId);
     if (active?.turn !== route.turn || active.status !== 'running') {
+      // Settled routes either observed a terminal or require quiescence before provider reuse;
+      // retaining either route blocks idle retirement indefinitely.
       this.#operationRoutes.unregister(route);
     }
     if (this.isTemporarilyUnavailable()) this.#idleLifecycle.closeInstanceIfIdle();
@@ -743,11 +745,15 @@ export class OpenCodeRuntime {
       return;
     }
     if (terminal.outcome === 'aborted') {
-      const message = openCodeAbortedTurnFailureMessage(session.turn);
       this.#logger.warn('OpenCode interrupted the current turn', {
-        agentSessionId, messageId: terminal.messageId, detail: message,
+        agentSessionId, messageId: terminal.messageId,
       });
-      this.#failTurnForProviderError(agentSessionId, session, message, terminal.messageId);
+      this.#failTurnForProviderError(
+        agentSessionId,
+        session,
+        OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE,
+        terminal.messageId,
+      );
       return;
     }
     if (terminal.outcome === 'failed') {
@@ -769,6 +775,7 @@ export class OpenCodeRuntime {
     if (!terminal) return;
     session.deferredTerminal = null;
     this.#settleTurnTerminal(agentSessionId, session, terminal);
+    if (session.status !== 'running') this.#operationRoutes.retireTurn(session.turn);
   }
 
   #clearTurnWaiter(agentSessionId: string): void {
@@ -1300,7 +1307,7 @@ export class OpenCodeRuntime {
       await pending;
       return;
     }
-    if (session.status === 'running') await this.#abortSession(agentSessionId, 'quiescence');
+    if (session.status === 'running') await this.abort(agentSessionId);
   }
 
   async startSession(request: OpenCodeStartRequest): Promise<string> {
@@ -1692,15 +1699,8 @@ export class OpenCodeRuntime {
   }
 
   abort(agentSessionId: string): Promise<boolean> {
-    return this.#abortSession(agentSessionId, 'user-stop');
-  }
-
-  #abortSession(agentSessionId: string, intent: 'user-stop' | 'quiescence'): Promise<boolean> {
     const session = this.#sessions.get(agentSessionId);
     if (!session || session.status !== 'running') return Promise.resolve(false);
-    if (intent === 'user-stop' || session.turn.providerAbortIntent === null) {
-      session.turn.providerAbortIntent = intent;
-    }
     const existing = this.#pendingSessionAborts.get(session);
     if (existing) return existing;
 

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -664,10 +664,6 @@ export class OpenCodeRuntime {
     session.lastActivityAt = Date.now();
     this.#decisions.cancelForSession(agentSessionId, 'cancelled');
     this.#rejectTurnWaiter(agentSessionId, new Error(message));
-    // OpenCode stores a failed turn's provider error on its in-flight assistant
-    // message, whose id the native loader uses as the error occurrence's
-    // identity. Carrying that same id on the live error keeps one canonical
-    // occurrence across live and restart rather than a duplicate.
     const failedMessageId = lastValue(session.turn.assistantMessageIds);
     const errorRow = new ErrorMessage(new Date().toISOString(), message);
     this.#publishRows(
@@ -721,19 +717,20 @@ export class OpenCodeRuntime {
       return;
     }
     session.deferredTerminal = null;
-    if (terminal.outcome === 'aborted') {
-      this.#logger.debug('Ignoring OpenCode abort unwind for a Garcon-retired turn', {
-        agentSessionId,
-        messageId: terminal.messageId,
-      });
-      return;
-    }
     if (session.turn.pendingSteeringMessageIds.size > 0) {
       this.#failTurnForProviderError(
         agentSessionId,
         session,
         'OpenCode stopped before processing accepted steering input',
       );
+      return;
+    }
+    if (terminal.outcome === 'aborted') {
+      // OpenCode can abort later prompts after an early cancellation.
+      // https://github.com/anomalyco/opencode/issues/30144
+      const message = 'OpenCode interrupted the current turn unexpectedly';
+      this.#logger.warn(message, { agentSessionId, messageId: terminal.messageId });
+      this.#failTurnForProviderError(agentSessionId, session, message);
       return;
     }
     if (terminal.outcome === 'failed') {
@@ -996,7 +993,10 @@ export class OpenCodeRuntime {
     } finally {
       if (sourceRetired) {
         const session = this.#sessions.get(route.sessionId);
-        if (session?.turn === route.turn) session.providerWorkRequiresQuiescence = false;
+        if (session?.turn === route.turn) {
+          route.turn.providerPromptRequestCompleted = true;
+          if (!route.turn.providerSteeringDeliveryUnconfirmed) session.providerWorkRequiresQuiescence = false;
+        }
         this.#operationRoutes.unregister(route);
       }
     }

--- a/server-agents/opencode/src/agents/opencode/steering.ts
+++ b/server-agents/opencode/src/agents/opencode/steering.ts
@@ -130,6 +130,7 @@ export class OpenCodeSteeringController {
         );
       } catch {
         preserveCorrelation = true;
+        turn.providerSteeringDeliveryUnconfirmed = true;
         session.providerWorkRequiresQuiescence = true;
         return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
       }
@@ -143,6 +144,7 @@ export class OpenCodeSteeringController {
           'OpenCode steering acknowledgement',
         );
       } catch {
+        turn.providerSteeringDeliveryUnconfirmed = true;
         session.providerWorkRequiresQuiescence = true;
         return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
       }
@@ -150,6 +152,7 @@ export class OpenCodeSteeringController {
     } catch (error) {
       if (!attempted) throw error;
       preserveCorrelation = true;
+      turn.providerSteeringDeliveryUnconfirmed = true;
       session.providerWorkRequiresQuiescence = true;
       return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
     } finally {
@@ -210,6 +213,9 @@ export class OpenCodeSteeringController {
     session.activeSteeringDeliveries = Math.max(0, session.activeSteeringDeliveries - 1);
     if (session.activeSteeringDeliveries > 0 || session.turn !== turn) return;
     this.options.releaseDeferredTerminal(agentSessionId, session);
+    if (turn.providerPromptRequestCompleted && !turn.providerSteeringDeliveryUnconfirmed) {
+      session.providerWorkRequiresQuiescence = false;
+    }
   }
 }
 

--- a/server-agents/opencode/src/agents/opencode/steering.ts
+++ b/server-agents/opencode/src/agents/opencode/steering.ts
@@ -16,6 +16,7 @@ import {
 import {
   createOpenCodePromptPartId,
   observeOpenCodeSteeringPart,
+  openCodeTurnRequiresProviderQuiescence,
   type OpenCodeSession,
   type OpenCodeTurnContext,
 } from './turn-events.js';
@@ -131,7 +132,7 @@ export class OpenCodeSteeringController {
       } catch {
         preserveCorrelation = true;
         turn.providerSteeringDeliveryUnconfirmed = true;
-        session.providerWorkRequiresQuiescence = true;
+        session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(turn);
         return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
       }
 
@@ -145,7 +146,7 @@ export class OpenCodeSteeringController {
         );
       } catch {
         turn.providerSteeringDeliveryUnconfirmed = true;
-        session.providerWorkRequiresQuiescence = true;
+        session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(turn);
         return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
       }
       return { kind: 'accepted' };
@@ -153,7 +154,7 @@ export class OpenCodeSteeringController {
       if (!attempted) throw error;
       preserveCorrelation = true;
       turn.providerSteeringDeliveryUnconfirmed = true;
-      session.providerWorkRequiresQuiescence = true;
+      session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(turn);
       return failedSteer('unknown', 'OpenCode steering delivery could not be confirmed');
     } finally {
       if (this.#acknowledgements.get(partId) === pending) {
@@ -213,9 +214,8 @@ export class OpenCodeSteeringController {
     session.activeSteeringDeliveries = Math.max(0, session.activeSteeringDeliveries - 1);
     if (session.activeSteeringDeliveries > 0 || session.turn !== turn) return;
     this.options.releaseDeferredTerminal(agentSessionId, session);
-    if (turn.providerPromptRequestCompleted && !turn.providerSteeringDeliveryUnconfirmed) {
-      session.providerWorkRequiresQuiescence = false;
-    }
+    if (session.status !== 'running') return;
+    session.providerWorkRequiresQuiescence = openCodeTurnRequiresProviderQuiescence(turn);
   }
 }
 

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -19,6 +19,8 @@ export interface OpenCodeTurnContext {
   // OpenCode assigns this ID and Garcon resolves it from the submitted prompt part event.
   providerMessageId: string | null;
   providerPromptPartId: string;
+  providerPromptRequestCompleted: boolean;
+  providerSteeringDeliveryUnconfirmed: boolean;
   // Identity of the last surfaced retry notice so stream replays and repeated
   // status frames for the same scheduled attempt append one row, not many.
   lastRetryNoticeKey: string | null;
@@ -78,6 +80,8 @@ export function createOpenCodeTurnContext(
     compaction: options.compaction === true,
     providerMessageId: null,
     providerPromptPartId: createOpenCodePromptPartId(),
+    providerPromptRequestCompleted: false,
+    providerSteeringDeliveryUnconfirmed: false,
     lastRetryNoticeKey: null,
     providerContinuationMessageIds: new Set(),
     recentEventIds: new Set(),

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -21,6 +21,7 @@ export interface OpenCodeTurnContext {
   providerPromptPartId: string;
   providerPromptRequestCompleted: boolean;
   providerSteeringDeliveryUnconfirmed: boolean;
+  providerAbortIntent: 'user-stop' | 'quiescence' | null;
   // Identity of the last surfaced retry notice so stream replays and repeated
   // status frames for the same scheduled attempt append one row, not many.
   lastRetryNoticeKey: string | null;
@@ -49,8 +50,8 @@ export interface OpenCodeSession {
   directory?: string;
   startedAt: string;
   lastActivityAt: number;
-  // A transport or control-plane failure can retire Garcon's turn while OpenCode still owns
-  // provider work. The next turn aborts that work before submitting another prompt.
+  // Turn-derived uncertainty requires an abort before reuse; stream loss and an in-flight
+  // abort pin it true. Process closure clears it, while pending reverts remain purge-fenced.
   providerWorkRequiresQuiescence: boolean;
   activeSteeringDeliveries: number;
   deferredTerminal: OpenCodeAssistantTerminal | null;
@@ -63,6 +64,31 @@ export interface OpenCodeSession {
 export function relocateOpenCodeSession(session: OpenCodeSession, directory: string): void {
   session.directory = directory;
   session.lastActivityAt = Date.now();
+}
+
+export function activateOpenCodeSessionTurn(
+  session: OpenCodeSession,
+  input: {
+    chatId: string;
+    model: string | undefined;
+    thinkingVariant?: string;
+    permissionMode: PermissionMode;
+    directory: string | undefined;
+    turn: OpenCodeTurnContext;
+  },
+): void {
+  session.status = 'running';
+  session.aborting = false;
+  session.providerWorkRequiresQuiescence = false;
+  session.activeSteeringDeliveries = 0;
+  session.deferredTerminal = null;
+  session.chatId = input.chatId;
+  session.model = input.model;
+  session.thinkingVariant = input.thinkingVariant;
+  session.permissionMode = input.permissionMode;
+  session.directory = input.directory;
+  session.lastActivityAt = Date.now();
+  session.turn = input.turn;
 }
 
 // OpenCode assigns IDs before durable commits, so concurrent publishers can deliver unseen
@@ -82,6 +108,7 @@ export function createOpenCodeTurnContext(
     providerPromptPartId: createOpenCodePromptPartId(),
     providerPromptRequestCompleted: false,
     providerSteeringDeliveryUnconfirmed: false,
+    providerAbortIntent: null,
     lastRetryNoticeKey: null,
     providerContinuationMessageIds: new Set(),
     recentEventIds: new Set(),
@@ -94,6 +121,12 @@ export function createOpenCodeTurnContext(
     messageRoles: new Map(),
     assistantPartTypes: new Map(),
   };
+}
+
+export function openCodeTurnRequiresProviderQuiescence(turn: OpenCodeTurnContext): boolean {
+  return !turn.providerPromptRequestCompleted
+    || turn.providerSteeringDeliveryUnconfirmed
+    || turn.pendingSteeringMessageIds.size > 0;
 }
 
 export function createOpenCodePromptPartId(): string {
@@ -211,4 +244,13 @@ export function openCodeEventBelongsToTurn(
     return typeof messageId === 'string' && turn.assistantMessageIds.has(messageId);
   }
   return true;
+}
+
+export function shouldWarnForUnroutedOpenCodeEvent(eventType: string): boolean {
+  return eventType === 'message.updated'
+    || eventType === 'message.part.updated'
+    || eventType === 'message.part.delta'
+    || eventType === 'permission.asked'
+    || eventType === 'question.asked'
+    || eventType === 'session.error';
 }

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -21,7 +21,6 @@ export interface OpenCodeTurnContext {
   providerPromptPartId: string;
   providerPromptRequestCompleted: boolean;
   providerSteeringDeliveryUnconfirmed: boolean;
-  providerAbortIntent: 'user-stop' | 'quiescence' | null;
   // Identity of the last surfaced retry notice so stream replays and repeated
   // status frames for the same scheduled attempt append one row, not many.
   lastRetryNoticeKey: string | null;
@@ -50,8 +49,9 @@ export interface OpenCodeSession {
   directory?: string;
   startedAt: string;
   lastActivityAt: number;
-  // Turn-derived uncertainty requires an abort before reuse; stream loss and an in-flight
-  // abort pin it true. Process closure clears it, while pending reverts remain purge-fenced.
+  // Turn-derived uncertainty requires an abort before reuse. Stream loss pins it until process
+  // closure; abort start sets it eagerly, while steering release and settlement may recompute it.
+  // Pending reverts remain purge-fenced.
   providerWorkRequiresQuiescence: boolean;
   activeSteeringDeliveries: number;
   deferredTerminal: OpenCodeAssistantTerminal | null;
@@ -108,7 +108,6 @@ export function createOpenCodeTurnContext(
     providerPromptPartId: createOpenCodePromptPartId(),
     providerPromptRequestCompleted: false,
     providerSteeringDeliveryUnconfirmed: false,
-    providerAbortIntent: null,
     lastRetryNoticeKey: null,
     providerContinuationMessageIds: new Set(),
     recentEventIds: new Set(),

--- a/server-agents/opencode/src/agents/opencode/turn-failure.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-failure.ts
@@ -1,0 +1,27 @@
+import { ErrorMessage } from '@garcon/common/chat-types';
+import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
+import type { OpenCodeTurnContext } from './turn-events.js';
+
+export function openCodeProviderFailureRow(
+  message: string,
+  entryId: string | undefined,
+  fallbackEntryIds: Iterable<string>,
+): ErrorMessage {
+  const row = new ErrorMessage(new Date().toISOString(), message);
+  const sourceEntryId = entryId ?? Array.from(fallbackEntryIds).at(-1);
+  // Terminal failures use their exact assistant; control failures retain the last observed
+  // assistant as the stable native occurrence used before this helper was extracted.
+  return sourceEntryId ? attachNativeMessageSource(row, { entryId: sourceEntryId }) : row;
+}
+
+export function openCodeAbortedTurnFailureMessage(turn: OpenCodeTurnContext): string {
+  // Early cancellation can poison later prompts without a new user Stop.
+  // https://github.com/anomalyco/opencode/issues/30144
+  if (turn.providerAbortIntent === 'user-stop') {
+    return 'OpenCode interrupted the current turn without confirming the requested stop';
+  }
+  if (turn.providerAbortIntent === 'quiescence') {
+    return 'OpenCode interrupted the previous turn while preparing the next message';
+  }
+  return 'OpenCode interrupted the current turn unexpectedly';
+}

--- a/server-agents/opencode/src/agents/opencode/turn-failure.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-failure.ts
@@ -1,6 +1,9 @@
 import { ErrorMessage } from '@garcon/common/chat-types';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
-import type { OpenCodeTurnContext } from './turn-events.js';
+
+// Early cancellation can poison later prompts without a new user Stop.
+// https://github.com/anomalyco/opencode/issues/30144
+export const OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE = 'OpenCode interrupted the turn';
 
 export function openCodeProviderFailureRow(
   message: string,
@@ -12,16 +15,4 @@ export function openCodeProviderFailureRow(
   // Terminal failures use their exact assistant; control failures retain the last observed
   // assistant as the stable native occurrence used before this helper was extracted.
   return sourceEntryId ? attachNativeMessageSource(row, { entryId: sourceEntryId }) : row;
-}
-
-export function openCodeAbortedTurnFailureMessage(turn: OpenCodeTurnContext): string {
-  // Early cancellation can poison later prompts without a new user Stop.
-  // https://github.com/anomalyco/opencode/issues/30144
-  if (turn.providerAbortIntent === 'user-stop') {
-    return 'OpenCode interrupted the current turn without confirming the requested stop';
-  }
-  if (turn.providerAbortIntent === 'quiescence') {
-    return 'OpenCode interrupted the previous turn while preparing the next message';
-  }
-  return 'OpenCode interrupted the current turn unexpectedly';
 }


### PR DESCRIPTION
Prevents OpenCode chats from remaining stuck after an unsolicited aborted terminal by surfacing the provider failure while preserving silent user-initiated Stop behavior, tightening turn quiescence and idle-retirement cleanup, and adding unit and pinned-real-binary regression coverage for successful recovery on the next message.