### PR TITLE
Improve chat drag-and-drop: panel drags in recent sort, pane swaps, toolbar overlap

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1017,6 +1017,7 @@
 	"workspace_drop_zone_left": "Left",
 	"workspace_drop_zone_right": "Right",
 	"workspace_drop_zone_replace": "Replace",
+	"workspace_drop_zone_swap": "Swap panes",
 	"workspace_drop_zone_max_panes": "4 panes max",
 	"workspace_drop_zone_already_open": "Already open",
 	"workspace_scroll_to_bottom": "Scroll to bottom",

--- a/web/src/lib/components/chat/__tests__/split-drop-controller.test.ts
+++ b/web/src/lib/components/chat/__tests__/split-drop-controller.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
 	dragLeftContainer,
 	resolveDropZone,
+	resolvePaneDropTarget,
+	splitDropBlockedReason,
+	splitDropResultPresentation,
 	SPLIT_DROP_ZONES,
+	type ActiveSplitDropTarget,
 } from '../split-drop-controller.svelte';
+import * as m from '$lib/paraglide/messages.js';
 
 const rect = {
 	left: 100,
@@ -44,6 +49,140 @@ describe('dragLeftContainer', () => {
 
 		expect(dragLeftContainer(makeDragLeave(container, outside))).toBe(true);
 		expect(dragLeftContainer(makeDragLeave(container, null))).toBe(true);
+	});
+});
+
+describe('resolvePaneDropTarget', () => {
+	const panes = [
+		{ paneId: 'pane-1', rect: { left: 0, top: 0, width: 400, height: 300 } },
+		{ paneId: 'pane-2', rect: { left: 400, top: 0, width: 400, height: 300 } },
+	];
+
+	it('targets the pane under the pointer with its edge zone for sidebar drags', () => {
+		const resolved = resolvePaneDropTarget(panes, 410, 150, null);
+		expect(resolved?.paneId).toBe('pane-2');
+		expect(resolved?.zone).toBe('left');
+		expect(resolved?.rect).toBe(panes[1].rect);
+	});
+
+	it('falls back to the nearest pane for sidebar drags outside every pane', () => {
+		const resolved = resolvePaneDropTarget(panes, 100, 400, null);
+		expect(resolved?.paneId).toBe('pane-1');
+		expect(resolved?.zone).toBe('bottom');
+	});
+
+	it('targets the whole pane for pane-origin drags regardless of the pointer band', () => {
+		const resolved = resolvePaneDropTarget(panes, 410, 10, 'pane-1');
+		expect(resolved?.paneId).toBe('pane-2');
+		expect(resolved?.zone).toBe('center');
+	});
+
+	it('offers no target over the dragged pane itself', () => {
+		expect(resolvePaneDropTarget(panes, 200, 150, 'pane-1')).toBeNull();
+	});
+
+	it('excludes the dragged pane from the nearest-pane fallback', () => {
+		const resolved = resolvePaneDropTarget(panes, 100, 400, 'pane-1');
+		expect(resolved?.paneId).toBe('pane-2');
+		expect(resolved?.zone).toBe('center');
+	});
+});
+
+describe('splitDropBlockedReason', () => {
+	it('blocks sidebar drags onto edge zones once the pane limit is reached', () => {
+		expect(
+			splitDropBlockedReason({
+				isPaneSwap: false,
+				isExistingSidebarChat: false,
+				zone: 'left',
+				paneCount: 4,
+			}),
+		).toBe('max-panes');
+	});
+
+	it('never blocks pane swaps, which do not add a pane', () => {
+		expect(
+			splitDropBlockedReason({
+				isPaneSwap: true,
+				isExistingSidebarChat: false,
+				zone: 'left',
+				paneCount: 4,
+			}),
+		).toBeUndefined();
+	});
+
+	it('allows center drops and already-open chats at the pane limit', () => {
+		expect(
+			splitDropBlockedReason({
+				isPaneSwap: false,
+				isExistingSidebarChat: false,
+				zone: 'center',
+				paneCount: 4,
+			}),
+		).toBeUndefined();
+		expect(
+			splitDropBlockedReason({
+				isPaneSwap: false,
+				isExistingSidebarChat: true,
+				zone: 'left',
+				paneCount: 4,
+			}),
+		).toBeUndefined();
+	});
+
+	it('allows edge zones below the pane limit', () => {
+		expect(
+			splitDropBlockedReason({
+				isPaneSwap: false,
+				isExistingSidebarChat: false,
+				zone: 'left',
+				paneCount: 3,
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe('splitDropResultPresentation', () => {
+	function makeTarget(overrides: Partial<ActiveSplitDropTarget>): ActiveSplitDropTarget {
+		return {
+			paneId: 'pane-1',
+			zone: 'center',
+			rect: { left: 0, top: 0, width: 400, height: 300 },
+			...overrides,
+		};
+	}
+
+	it('presents blocked targets before any other reason', () => {
+		const presentation = splitDropResultPresentation(
+			makeTarget({ blockedReason: 'max-panes', swapReason: 'pane-swap' }),
+		);
+		expect(presentation.label).toBe(m.workspace_drop_zone_max_panes());
+		expect(presentation.toneClass).toContain('border-destructive/50');
+		expect(presentation.labelClass).toContain('text-destructive');
+	});
+
+	it('presents pane swaps before the already-open focus reason', () => {
+		const presentation = splitDropResultPresentation(makeTarget({ swapReason: 'pane-swap' }));
+		expect(presentation.label).toBe(m.workspace_drop_zone_swap());
+		expect(presentation.toneClass).toContain('border-accent/50');
+		expect(presentation.labelClass).toContain('text-accent-foreground');
+	});
+
+	it('presents already-open sidebar chats with the accent tone', () => {
+		const presentation = splitDropResultPresentation(makeTarget({ focusReason: 'already-open' }));
+		expect(presentation.label).toBe(m.workspace_drop_zone_already_open());
+		expect(presentation.toneClass).toContain('border-accent/50');
+	});
+
+	it('presents the hovered zone label for plain sidebar drags', () => {
+		const left = splitDropResultPresentation(makeTarget({ zone: 'left' }));
+		expect(left.label).toBe(m.workspace_drop_zone_left());
+		expect(left.toneClass).toContain('border-primary/50');
+		expect(left.labelClass).toContain('text-primary');
+
+		const center = splitDropResultPresentation(makeTarget({ zone: 'center' }));
+		expect(center.label).toBe(m.workspace_drop_zone_replace());
+		expect(center.toneClass).toContain('border-accent/50');
 	});
 });
 

--- a/web/src/lib/components/chat/split-drop-controller.svelte.ts
+++ b/web/src/lib/components/chat/split-drop-controller.svelte.ts
@@ -6,9 +6,11 @@ export type SplitDropZone = 'left' | 'right' | 'top' | 'bottom' | 'center';
 export type ActiveSplitDropTarget = {
 	paneId: string;
 	zone: SplitDropZone;
-	rect: DOMRect;
+	rect: Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>;
 	blockedReason?: 'max-panes';
 	focusReason?: 'already-open';
+	// Present for pane-origin drags: the whole target pane is a swap target.
+	swapReason?: 'pane-swap';
 };
 
 export type FocusedOverlayRect = {
@@ -87,6 +89,119 @@ export function resolveDropZone(
 
 function isSplitEdgeZone(zone: SplitDropZone): boolean {
 	return zone !== 'center';
+}
+
+export interface PaneDropGeometry {
+	paneId: string;
+	rect: Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>;
+}
+
+export interface PaneDropResolution {
+	paneId: string;
+	zone: SplitDropZone;
+	rect: PaneDropGeometry['rect'];
+}
+
+// Resolves which pane a drop lands on. Pane-origin drags always target the
+// whole pane for a swap, and the dragged pane itself is never a valid target.
+export function resolvePaneDropTarget(
+	panes: PaneDropGeometry[],
+	clientX: number,
+	clientY: number,
+	draggedPaneId: string | null,
+): PaneDropResolution | null {
+	let fallback: PaneDropGeometry | null = null;
+	let fallbackDistance = Infinity;
+	for (const pane of panes) {
+		const { rect } = pane;
+		const containsPointer =
+			clientX >= rect.left &&
+			clientX <= rect.left + rect.width &&
+			clientY >= rect.top &&
+			clientY <= rect.top + rect.height;
+		if (containsPointer) {
+			if (pane.paneId === draggedPaneId) return null;
+			return {
+				paneId: pane.paneId,
+				zone: draggedPaneId ? 'center' : resolveDropZone(rect, clientX, clientY),
+				rect,
+			};
+		}
+		if (pane.paneId === draggedPaneId) continue;
+		const centerX = rect.left + rect.width / 2;
+		const centerY = rect.top + rect.height / 2;
+		const distance = Math.hypot(clientX - centerX, clientY - centerY);
+		if (distance < fallbackDistance) {
+			fallback = pane;
+			fallbackDistance = distance;
+		}
+	}
+
+	if (!fallback) return null;
+	return {
+		paneId: fallback.paneId,
+		zone: draggedPaneId ? 'center' : resolveDropZone(fallback.rect, clientX, clientY),
+		rect: fallback.rect,
+	};
+}
+
+// Pane swaps never add a pane, so the max-panes guard only applies to
+// sidebar-origin drags landing on an edge zone.
+export function splitDropBlockedReason(input: {
+	isPaneSwap: boolean;
+	isExistingSidebarChat: boolean;
+	zone: SplitDropZone;
+	paneCount: number;
+}): 'max-panes' | undefined {
+	if (input.isPaneSwap || input.isExistingSidebarChat) return undefined;
+	if (input.paneCount < 4) return undefined;
+	return isSplitEdgeZone(input.zone) ? 'max-panes' : undefined;
+}
+
+export interface SplitDropResultPresentation {
+	toneClass: string;
+	label: string;
+	labelClass: string;
+}
+
+// Presentation precedence for the drop outcome preview: blocked, then pane
+// swap, then already-open focus, then the hovered split zone.
+export function splitDropResultPresentation(
+	target: ActiveSplitDropTarget,
+): SplitDropResultPresentation {
+	if (target.blockedReason === 'max-panes') {
+		return {
+			toneClass: 'bg-destructive/15 border-2 border-destructive/50',
+			label: m.workspace_drop_zone_max_panes(),
+			labelClass: 'bg-destructive/15 text-destructive',
+		};
+	}
+	if (target.swapReason) {
+		return {
+			toneClass: 'bg-accent/20 border-2 border-accent/50',
+			label: m.workspace_drop_zone_swap(),
+			labelClass: 'bg-accent/20 text-accent-foreground',
+		};
+	}
+	if (target.focusReason === 'already-open') {
+		return {
+			toneClass: 'bg-accent/20 border-2 border-accent/50',
+			label: m.workspace_drop_zone_already_open(),
+			labelClass: 'bg-accent/20 text-accent-foreground',
+		};
+	}
+	const zonePresentation = SPLIT_DROP_ZONES.find((entry) => entry.zone === target.zone);
+	return {
+		toneClass:
+			target.zone === 'center'
+				? 'bg-accent/20 border-2 border-accent/50'
+				: 'bg-primary/20 border-2 border-primary/50',
+		label: zonePresentation?.label() ?? '',
+		labelClass:
+			target.zone === 'center'
+				? 'bg-accent/20 text-accent-foreground'
+				: 'bg-primary/15 text-primary',
+	};
 }
 
 // True when a dragleave event actually exits the container instead of
@@ -202,12 +317,12 @@ export class SplitDropController {
 	handleActiveSplitDragOver(event: DragEvent): void {
 		if (!this.#canHandleDrag() || !this.#showActiveSplitDropLayer) return;
 		const target = this.resolveActiveSplitDropTarget(event);
+		this.activeSplitDropTarget = target;
 		if (!target) return;
 
 		event.preventDefault();
 		event.stopPropagation();
 		if (event.dataTransfer) event.dataTransfer.dropEffect = target.blockedReason ? 'none' : 'move';
-		this.activeSplitDropTarget = target;
 	}
 
 	handleActiveSplitDrop(
@@ -240,39 +355,21 @@ export class SplitDropController {
 		const splitRootEl = this.#options.splitRootEl;
 		if (!splitRootEl) return null;
 
-		let fallback: { paneId: string; rect: DOMRect; distance: number } | null = null;
+		const geometries: PaneDropGeometry[] = [];
 		for (const pane of this.#options.splitLayout.panes) {
 			const paneEl = splitRootEl.querySelector<HTMLElement>(`[data-pane-id="${pane.id}"]`);
 			if (!paneEl) continue;
-
-			const rect = paneEl.getBoundingClientRect();
-			const containsPointer =
-				event.clientX >= rect.left &&
-				event.clientX <= rect.right &&
-				event.clientY >= rect.top &&
-				event.clientY <= rect.bottom;
-			if (containsPointer) {
-				return this.toActiveSplitDropTarget(
-					pane.id,
-					resolveDropZone(rect, event.clientX, event.clientY),
-					rect,
-				);
-			}
-
-			const centerX = rect.left + rect.width / 2;
-			const centerY = rect.top + rect.height / 2;
-			const distance = Math.hypot(event.clientX - centerX, event.clientY - centerY);
-			if (!fallback || distance < fallback.distance) {
-				fallback = { paneId: pane.id, rect, distance };
-			}
+			geometries.push({ paneId: pane.id, rect: paneEl.getBoundingClientRect() });
 		}
 
-		if (!fallback) return null;
-		return this.toActiveSplitDropTarget(
-			fallback.paneId,
-			resolveDropZone(fallback.rect, event.clientX, event.clientY),
-			fallback.rect,
+		const resolved = resolvePaneDropTarget(
+			geometries,
+			event.clientX,
+			event.clientY,
+			this.#options.splitLayout.draggedPaneId,
 		);
+		if (!resolved) return null;
+		return this.toActiveSplitDropTarget(resolved.paneId, resolved.zone, resolved.rect);
 	}
 
 	isActiveZone(zone: SplitDropZone): boolean {
@@ -297,30 +394,17 @@ export class SplitDropController {
 
 	resultToneClass(): string {
 		const target = this.activeSplitDropTarget;
-		if (!target) return '';
-		if (target.blockedReason === 'max-panes')
-			return 'bg-destructive/15 border-2 border-destructive/50';
-		if (target.focusReason === 'already-open') return 'bg-accent/20 border-2 border-accent/50';
-		return target.zone === 'center'
-			? 'bg-accent/20 border-2 border-accent/50'
-			: 'bg-primary/20 border-2 border-primary/50';
+		return target ? splitDropResultPresentation(target).toneClass : '';
 	}
 
 	resultLabel(): string {
 		const target = this.activeSplitDropTarget;
-		if (!target) return '';
-		if (target.blockedReason === 'max-panes') return m.workspace_drop_zone_max_panes();
-		if (target.focusReason === 'already-open') return m.workspace_drop_zone_already_open();
-		return SPLIT_DROP_ZONES.find((entry) => entry.zone === target.zone)?.label() ?? '';
+		return target ? splitDropResultPresentation(target).label : '';
 	}
 
 	resultLabelClass(): string {
 		const target = this.activeSplitDropTarget;
-		if (target?.blockedReason === 'max-panes') return 'bg-destructive/15 text-destructive';
-		if (target?.focusReason === 'already-open') return 'bg-accent/20 text-accent-foreground';
-		return target?.zone === 'center'
-			? 'bg-accent/20 text-accent-foreground'
-			: 'bg-primary/15 text-primary';
+		return target ? splitDropResultPresentation(target).labelClass : '';
 	}
 
 	activeTargetStyle(): string {
@@ -377,26 +461,27 @@ export class SplitDropController {
 		);
 	}
 
-	#toBlockedReason(isExistingSidebarChat: boolean, zone: SplitDropZone): 'max-panes' | undefined {
-		if (isExistingSidebarChat) return undefined;
-		const paneCount = this.#options.splitLayout.paneCount;
-		if (typeof paneCount !== 'number' || paneCount < 4) return undefined;
-		return isSplitEdgeZone(zone) ? 'max-panes' : undefined;
-	}
-
 	private toActiveSplitDropTarget(
 		paneId: string,
 		zone: SplitDropZone,
-		rect: DOMRect,
+		rect: PaneDropGeometry['rect'],
 	): ActiveSplitDropTarget {
-		const draggedChat = this.#options.splitLayout.draggedChatId;
+		const splitLayout = this.#options.splitLayout;
+		const draggedChat = splitLayout.draggedChatId;
+		const isPaneSwap = splitLayout.draggedPaneId !== null;
 		const isExistingSidebarChat = this.#isExistingSidebarChat(draggedChat);
 		return {
 			paneId,
 			zone,
 			rect,
 			focusReason: isExistingSidebarChat ? 'already-open' : undefined,
-			blockedReason: this.#toBlockedReason(isExistingSidebarChat, zone),
+			swapReason: isPaneSwap ? 'pane-swap' : undefined,
+			blockedReason: splitDropBlockedReason({
+				isPaneSwap,
+				isExistingSidebarChat,
+				zone,
+				paneCount: splitLayout.paneCount,
+			}),
 		};
 	}
 }

--- a/web/src/lib/components/sidebar/SidebarVirtualSortableChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarVirtualSortableChatList.svelte
@@ -130,9 +130,11 @@
 	} | null = null;
 	let separatorPixelRatio = $state(1);
 	let bottomPadding = $derived(isMobile ? mobileBottomPadding : desktopBottomPadding);
-	// Manual drag/quick-move only applies to the manual sort order; the
+	// Reorder and quick-move only apply to the manual sort order; the
 	// recent-activity sort is derived, so reordering is disabled there.
-	let dragEnabled = $derived(!isMultiSelectMode && displayOptions.sortMode === 'manual');
+	// Dragging a chat onto a workspace panel stays available in every sort mode.
+	let dragEnabled = $derived(!isMultiSelectMode);
+	let reorderEnabled = $derived(dragEnabled && displayOptions.sortMode === 'manual');
 	let separatorLineHeight = $derived(1 / Math.max(separatorPixelRatio, 1));
 
 	type SidebarPointDropContext =
@@ -218,7 +220,7 @@
 				}
 				cleanup = module.autoScrollForElements({
 					element: viewportRef,
-					canScroll: ({ source }) => dragEnabled && isSidebarChatDragData(source.data),
+					canScroll: ({ source }) => reorderEnabled && isSidebarChatDragData(source.data),
 					getAllowedAxis: () => 'vertical',
 				});
 			});
@@ -241,7 +243,9 @@
 		if (touchDrag) cancelTouchDrag();
 		clearDragPresentation();
 		draggingChatId = row.chat.id;
-		reorder.begin(row.list, row.chat.id, { ids: row.reorderScopeIds });
+		if (reorderEnabled) {
+			reorder.begin(row.list, row.chat.id, { ids: row.reorderScopeIds });
+		}
 		splitLayout.startDrag(row.chat.id);
 	}
 
@@ -250,6 +254,12 @@
 		const ownsNativeDrag = draggingChatId === chatId && !(ownsTouchDrag && touchDrag?.activated);
 		if (ownsTouchDrag) cancelTouchDrag();
 		if (!ownsNativeDrag) return;
+		// Split-only drags (derived sort modes) survive a source row unmount: a
+		// real drop still reaches the list-level monitor and ends the drag there,
+		// and a cancelled drag is recovered by pragmatic's broken-drag detection.
+		// Reorder drags need eager cleanup because their preview state is tied to
+		// the mounted rows.
+		if (!reorderEnabled) return;
 		if (reorder.activeList) reorder.cancel(reorder.activeList);
 		clearDragPresentation();
 		if (splitLayout.draggedChatId === chatId) splitLayout.endDrag();
@@ -386,6 +396,7 @@
 	): void {
 		if (!isSidebarChatDragData(sourceData) || sourceData.instanceId !== instanceId) return;
 		if (draggingChatId !== sourceData.chatId) return;
+		if (!reorderEnabled) return;
 		if (!inputIsInsideViewport(input)) {
 			activeDrop = null;
 			lastValidDrop = null;
@@ -419,20 +430,22 @@
 	): void {
 		if (!isSidebarChatDragData(sourceData) || sourceData.instanceId !== instanceId) return;
 		if (draggingChatId !== sourceData.chatId) return;
-		const isInsideViewport = inputIsInsideViewport(input);
-		const currentInstruction = isInsideViewport
-			? resolveSidebarDropInstruction(sourceData, dropTargets)
-			: null;
-		const context = pointDropContext(sourceData, input.clientX, input.clientY);
-		const fallbackInstruction = fallbackInstructionForPointContext(sourceData, context);
-		// Uses the last valid row target when virtualization removes the current target at drop time.
-		const instruction = currentInstruction ?? fallbackInstruction;
+		if (reorderEnabled) {
+			const isInsideViewport = inputIsInsideViewport(input);
+			const currentInstruction = isInsideViewport
+				? resolveSidebarDropInstruction(sourceData, dropTargets)
+				: null;
+			const context = pointDropContext(sourceData, input.clientX, input.clientY);
+			const fallbackInstruction = fallbackInstructionForPointContext(sourceData, context);
+			// Uses the last valid row target when virtualization removes the current target at drop time.
+			const instruction = currentInstruction ?? fallbackInstruction;
 
-		if (instruction) {
-			applySidebarDropInstruction(instruction);
-			persistReorderRequest(reorder.finish(sourceData.list));
-		} else {
-			reorder.cancel(sourceData.list);
+			if (instruction) {
+				applySidebarDropInstruction(instruction);
+				persistReorderRequest(reorder.finish(sourceData.list));
+			} else {
+				reorder.cancel(sourceData.list);
+			}
 		}
 
 		clearDragPresentation();
@@ -644,7 +657,7 @@
 
 	function activateTouchDrag(): void {
 		const current = touchDrag;
-		if (!current || current.activated || !dragEnabled) return;
+		if (!current || current.activated || !reorderEnabled) return;
 		current.activated = true;
 		clearDocumentSelection();
 		clearDragPresentation();
@@ -658,7 +671,7 @@
 	}
 
 	function handleTouchStart(event: TouchEvent): void {
-		if (!dragEnabled || draggingChatId !== null || event.touches.length !== 1) return;
+		if (!reorderEnabled || draggingChatId !== null || event.touches.length !== 1) return;
 		const rowEl = rowElementFromTarget(event.target);
 		if (!rowEl) return;
 		const sourceChatId = rowEl.dataset.sidebarVirtualRow;
@@ -826,7 +839,7 @@
 	}
 
 	function getMoveToTop(row: SidebarVirtualChatRow): (() => void) | undefined {
-		if (!dragEnabled) return undefined;
+		if (!reorderEnabled) return undefined;
 		const order = row.reorderScopeIds;
 		const index = order.indexOf(row.chat.id);
 		if (index <= 0) return undefined;
@@ -834,7 +847,7 @@
 	}
 
 	function getMoveToBottom(row: SidebarVirtualChatRow): (() => void) | undefined {
-		if (!dragEnabled) return undefined;
+		if (!reorderEnabled) return undefined;
 		const order = row.reorderScopeIds;
 		const index = order.indexOf(row.chat.id);
 		if (index < 0 || index >= order.length - 1) return undefined;
@@ -881,7 +894,14 @@
 		};
 	});
 
-	onDestroy(() => virtual.destroy());
+	onDestroy(() => {
+		// The drag monitor is torn down with the list, so a drag the list still
+		// owns (its source row may already be unmounted) would leak otherwise.
+		if (draggingChatId && splitLayout.draggedChatId === draggingChatId) {
+			splitLayout.endDrag();
+		}
+		virtual.destroy();
+	});
 </script>
 
 <div
@@ -941,6 +961,7 @@
 							isMultiSelected={isMultiSelected?.(row.chat.id) ?? false}
 							{displayOptions}
 							{dragEnabled}
+							{reorderEnabled}
 							isDragging={draggingChatId === row.chat.id}
 							dropIndicatorEdge={activeDrop?.chatId === row.chat.id ? activeDrop.edge : null}
 							onDragStart={startSidebarDrag}

--- a/web/src/lib/components/sidebar/SidebarVirtualSortableChatRow.svelte
+++ b/web/src/lib/components/sidebar/SidebarVirtualSortableChatRow.svelte
@@ -34,7 +34,10 @@
 		isMultiSelectMode?: boolean;
 		isMultiSelected?: boolean;
 		displayOptions: SidebarDisplayOptions;
+		// The row can always be dragged to workspace panels when dragEnabled;
+		// reorderEnabled additionally allows it as a sidebar reorder target.
 		dragEnabled?: boolean;
+		reorderEnabled?: boolean;
 		isDragging?: boolean;
 		dropIndicatorEdge?: Edge | null;
 		onDragStart: (row: SidebarVirtualChatRow) => void;
@@ -69,6 +72,7 @@
 		isMultiSelected = false,
 		displayOptions,
 		dragEnabled = true,
+		reorderEnabled = true,
 		isDragging = false,
 		dropIndicatorEdge = null,
 		onDragStart,
@@ -116,7 +120,7 @@
 			dropTargetForElements({
 				element: rowEl,
 				canDrop: ({ source }) => {
-					if (!dragEnabled || !isSidebarChatDragData(source.data)) return false;
+					if (!reorderEnabled || !isSidebarChatDragData(source.data)) return false;
 					const target = getSidebarChatDropTargetData({
 						chatId: row.chat.id,
 						list: row.list,

--- a/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../sidebar-virtual-chat-list';
 import { sidebarProjectKey } from '../sidebar-row-model';
 import type { SidebarChatReorderState } from '../sidebar-chat-reorder-state.svelte';
+import type { SplitLayoutStore } from '$lib/chat/split/split-layout.svelte';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
 
 const rowHeight = 88;
@@ -986,6 +987,110 @@ describe('SidebarVirtualSortableChatList', () => {
 			touches: [],
 			changedTouches: [touchAt(1, 20, 150)],
 		});
+	});
+
+	it('drags a chat toward workspace panels without reordering under recent sort', async () => {
+		vi.useFakeTimers();
+		const persist = vi.fn();
+		const splitDragEnd = vi.fn();
+		const registered = {
+			reorder: null as SidebarChatReorderState | null,
+			splitLayout: null as SplitLayoutStore | null,
+		};
+
+		render(SidebarVirtualSortableChatListHost, {
+			rows: makeRows(20),
+			rowHeight,
+			displayOptions: {
+				groupByProject: false,
+				groupNestedProjectPaths: false,
+				chatItemLayout: 'default',
+				sortMode: 'recent',
+			},
+			onRegisterReorder: (value) => (registered.reorder = value),
+			onRegisterSplitLayout: (value) => (registered.splitLayout = value),
+			onPersistReorder: persist,
+			onSplitDragEnd: splitDragEnd,
+		});
+		await tick();
+
+		const row0 = document.querySelector<HTMLElement>('[data-sidebar-virtual-row="chat-0"]');
+		const row1 = document.querySelector<HTMLElement>('[data-sidebar-virtual-row="chat-1"]');
+		if (!row0 || !row1) throw new Error('expected source and target rows to be rendered');
+		expect(row0.dataset.sidebarDragDisabled).toBeUndefined();
+		const dataTransfer = new DataTransfer();
+
+		await fireEvent.dragStart(row0, { clientX: 20, clientY: 44, dataTransfer });
+		vi.advanceTimersByTime(17);
+		await tick();
+
+		expect(row0.className).toContain('opacity-45');
+		expect(registered.reorder?.activeList).toBeNull();
+		expect(registered.splitLayout?.draggedChatId).toBe('chat-0');
+
+		// Rows are not reorder targets under the derived recent sort, so a drop
+		// inside the sidebar persists nothing and only ends the split drag.
+		await fireEvent.drop(row1, { clientX: 20, clientY: rowHeight + 44, dataTransfer });
+		vi.advanceTimersByTime(17);
+		await tick();
+
+		expect(persist).not.toHaveBeenCalled();
+		expect(splitDragEnd).toHaveBeenCalledWith('chat-0');
+		expect(registered.splitLayout?.draggedChatId).toBeNull();
+	});
+
+	it('keeps a recent-sort split drag alive when virtualization unmounts its source', async () => {
+		vi.useFakeTimers();
+		const persist = vi.fn();
+		const splitDragEnd = vi.fn();
+		const registered = {
+			reorder: null as SidebarChatReorderState | null,
+			splitLayout: null as SplitLayoutStore | null,
+		};
+
+		render(SidebarVirtualSortableChatListHost, {
+			rows: makeRows(500),
+			rowHeight,
+			displayOptions: {
+				groupByProject: false,
+				groupNestedProjectPaths: false,
+				chatItemLayout: 'default',
+				sortMode: 'recent',
+			},
+			onRegisterReorder: (value) => (registered.reorder = value),
+			onRegisterSplitLayout: (value) => (registered.splitLayout = value),
+			onPersistReorder: persist,
+			onSplitDragEnd: splitDragEnd,
+		});
+		await tick();
+
+		const viewport = screen.getByTestId('virtual-sidebar-viewport');
+		const row0 = document.querySelector<HTMLElement>('[data-sidebar-virtual-row="chat-0"]');
+		if (!row0) throw new Error('expected source row to be rendered');
+		const dataTransfer = new DataTransfer();
+
+		await fireEvent.dragStart(row0, { clientX: 20, clientY: 44, dataTransfer });
+		vi.advanceTimersByTime(17);
+		await tick();
+		expect(registered.splitLayout?.draggedChatId).toBe('chat-0');
+
+		// The recent sort is derived from live activity, so a background update
+		// can push the dragged row out of the virtual window mid-drag. The split
+		// drag must survive so the drop on a workspace panel still lands.
+		viewport.scrollTop = rowHeight * 120;
+		await fireEvent.scroll(viewport);
+		await tick();
+
+		expect(row0.isConnected).toBe(false);
+		expect(splitDragEnd).not.toHaveBeenCalled();
+		expect(registered.splitLayout?.draggedChatId).toBe('chat-0');
+
+		await fireEvent.drop(window, { dataTransfer });
+		vi.advanceTimersByTime(17);
+		await tick();
+
+		expect(splitDragEnd).toHaveBeenCalledWith('chat-0');
+		expect(persist).not.toHaveBeenCalled();
 	});
 
 	it('cancels a native drag when virtualization unmounts its source', async () => {

--- a/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatListHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatListHost.svelte
@@ -22,6 +22,7 @@
 		onRegisterReorder?: (reorder: SidebarChatReorderState) => void;
 		onPersistReorder?: (request: SidebarChatReorderRequest) => void;
 		onSplitDragEnd?: (chatId: string) => void;
+		onRegisterSplitLayout?: (splitLayout: SplitLayoutStore) => void;
 		onToggleProjectCollapsed?: (projectKey: string) => void;
 	}
 
@@ -41,6 +42,7 @@
 		onRegisterReorder,
 		onPersistReorder = () => {},
 		onSplitDragEnd,
+		onRegisterSplitLayout,
 		onToggleProjectCollapsed,
 	}: SidebarVirtualSortableChatListHostProps = $props();
 
@@ -97,7 +99,9 @@
 			if (chatId) onSplitDragEnd?.(chatId);
 		}
 	}
-	setSplitLayout(new TestSplitLayoutStore());
+	const splitLayout = new TestSplitLayoutStore();
+	setSplitLayout(splitLayout);
+	onMount(() => onRegisterSplitLayout?.(splitLayout));
 </script>
 
 <div

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -163,6 +163,11 @@
 	const sidebarOverlayInert = $derived(
 		sidebarPresented && !sidebarFullscreen && sidebarMetrics.mode === 'overlay',
 	);
+	// Split panes render their own title bar at the top of the chat surface;
+	// drop the floating taskbar below it so they don't overlap.
+	const lowerMainToolbarForSplit = $derived(
+		!isMobile && activeMain === CHAT_SURFACE_ID && splitLayout.isEnabled,
+	);
 	const renderedPresentations = $derived(
 		renderedPortablePresentations(
 			snapshot,
@@ -351,7 +356,9 @@
 				{#if !isMobile}
 					<div
 						data-floating-workspace-toolbar
-						class="pointer-events-none absolute inset-x-2 top-2 z-40 min-w-0"
+						class="pointer-events-none absolute inset-x-2 z-40 min-w-0"
+						class:top-2={!lowerMainToolbarForSplit}
+						class:top-9={lowerMainToolbarForSplit}
 					>
 						<WorkspaceTaskBar
 							host="main"

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -20,6 +20,7 @@ import {
 	type WorkspaceLayoutSnapshot,
 } from '$lib/workspace/surface-types.js';
 import { surfaceRendererTestProbe } from './surface-renderer-test-probe.js';
+import { SplitLayoutStore } from '$lib/chat/split/split-layout.svelte.js';
 import type { DesktopLayoutOrder } from '$lib/layout/desktop-layout.js';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
 import * as m from '$lib/paraglide/messages.js';
@@ -781,6 +782,41 @@ describe('WorkspaceRoot', () => {
 		expect(
 			screen.getByTestId('chat-surface-stub').getAttribute('data-reserve-top-floating-toolbar'),
 		).toBe('false');
+	});
+
+	it('lowers the desktop taskbar below split pane headers while split view is active', async () => {
+		installContext(canonicalWorkspaceSnapshot());
+		const splitLayout = new SplitLayoutStore();
+		testContext.current!.splitLayout = splitLayout;
+		const { container } = render(WorkspaceRoot, { isMobile: false, chatActions });
+		const toolbar = () => container.querySelector<HTMLElement>('[data-floating-workspace-toolbar]');
+
+		expect(toolbar()?.classList.contains('top-2')).toBe(true);
+		expect(toolbar()?.classList.contains('top-9')).toBe(false);
+
+		splitLayout.enableWithChat('chat-1');
+		await tick();
+
+		expect(toolbar()?.classList.contains('top-9')).toBe(true);
+		expect(toolbar()?.classList.contains('top-2')).toBe(false);
+
+		splitLayout.disable();
+		await tick();
+
+		expect(toolbar()?.classList.contains('top-2')).toBe(true);
+		expect(toolbar()?.classList.contains('top-9')).toBe(false);
+	});
+
+	it('keeps the desktop taskbar raised when a non-chat main surface is active during split view', async () => {
+		installContext(minimalGitSnapshot());
+		const splitLayout = new SplitLayoutStore();
+		splitLayout.enableWithChat('chat-1');
+		testContext.current!.splitLayout = splitLayout;
+		const { container } = render(WorkspaceRoot, { isMobile: false, chatActions });
+		const toolbar = container.querySelector<HTMLElement>('[data-floating-workspace-toolbar]');
+
+		expect(toolbar?.classList.contains('top-2')).toBe(true);
+		expect(toolbar?.classList.contains('top-9')).toBe(false);
 	});
 
 	it('centers tabs independently from end-aligned desktop toolbar controls', () => {


### PR DESCRIPTION
Dragging chats from the sidebar onto workspace panels was impossible whenever the sidebar used the derived recent-activity sort, because one predicate gated both sidebar reordering and panel drops; the two are now separated so panel drops work in every sort mode while reordering stays manual-only, and a split drag now survives its source row being virtualized away mid-drag. Dragging a split pane's header onto another pane previously behaved like a sidebar drop - it resolved edge split zones, showed misleading split/replace labels, and was rejected by the 4-pane limit even though a swap adds no pane; pane-origin drags now target the whole pane with an explicit "Swap panes" affordance, never target the dragged pane itself, and bypass the pane-limit guard. Finally, the floating workspace toolbar (tabs and menu) overlapped the split panes' title bars, so it now drops below them while split view is active on the chat surface.