### PR TITLE
Add project defaults for Git comparison ranges

### DIFF
--- a/integration-tests/tests/e2e/git-comparison.test.ts
+++ b/integration-tests/tests/e2e/git-comparison.test.ts
@@ -91,6 +91,14 @@ describe('Lightpanda Git comparison', () => {
       await app.clickSidebarChatContaining('git-comparison-chat-b');
       await app.waitForSelectedChat(chatB.id);
       await app.selectMainWorkspaceSurface('Compare');
+      await waitForComparisonMarkers(fixture.page, ['head comparison marker'], [
+        'working tree marker',
+      ]);
+      await app.clickEditComparison({ within: COMPARE_PANEL });
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      await app.fill('#git-comparison-from', 'HEAD');
+      await app.clickDialogButton('Working Tree');
+      await app.clickDialogButton('Compare');
       await waitForComparisonMarkers(fixture.page, ['working tree marker'], [
         'head comparison marker',
       ]);
@@ -130,7 +138,7 @@ describe('Lightpanda Git comparison', () => {
               version?: unknown;
               entries?: Array<{ chatId?: unknown }>;
             };
-            return parsed.version === 1
+            return parsed.version === 2
               && parsed.entries?.some((entry) => entry.chatId === chatId) === true;
           } catch {
             return false;
@@ -159,6 +167,91 @@ describe('Lightpanda Git comparison', () => {
         (element) => (element as HTMLInputElement).value,
       )).toBe('HEAD');
       await app.clickDialogButton('Cancel');
+      fixture.assertNoBrowserErrors();
+    });
+  });
+
+  test('inherits a persisted project range in a new linked-worktree chat', async () => {
+    await withE2eFixture('git-comparison-project-default', async (fixture) => {
+      const project = fixture.integration.dirs.project;
+      const worktree = join(project, '.worktrees', 'abc');
+      await runGit(project, ['init', '-b', 'main']);
+      await runGit(project, ['config', 'user.email', 'test@example.com']);
+      await runGit(project, ['config', 'user.name', 'E2E Test']);
+      await writeFile(join(project, '.gitignore'), '.worktrees/\n', 'utf8');
+      await writeFile(join(project, 'base.txt'), 'base marker\n', 'utf8');
+      await runGit(project, ['add', '.']);
+      await runGit(project, ['commit', '-m', 'base']);
+      await runGit(project, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+      await writeFile(join(project, 'head-only.txt'), 'inherited head marker\n', 'utf8');
+      await runGit(project, ['add', 'head-only.txt']);
+      await runGit(project, ['commit', '-m', 'head change']);
+      await runGit(project, ['worktree', 'add', '-b', 'feature', worktree, 'HEAD']);
+      await writeFile(join(project, 'root-working.txt'), 'root working marker\n', 'utf8');
+
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.setViewport(1_440, 900);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await app.startOpenAiDirectChat('git-comparison-root-default', { projectPath: project });
+      await app.waitForText('echo:git-comparison-root-default');
+      await app.selectMainWorkspaceSurface('Open Git Compare');
+      await fixture.page.waitForSelector(COMPARE_PANEL);
+      await waitForComparisonMarkers(fixture.page, ['root working marker'], [
+        'inherited head marker',
+      ]);
+      await app.clickEditComparison({ within: COMPARE_PANEL });
+      await fixture.page.waitForSelector('[role="dialog"][aria-label="Compare revisions"]');
+      await app.fill('#git-comparison-from', 'origin/main');
+      await app.clickDialogButton('Revision');
+      await app.fill('#git-comparison-to', 'HEAD');
+      await app.clickDialogButton('Compare');
+      await waitForComparisonMarkers(fixture.page, ['inherited head marker'], [
+        'root working marker',
+      ]);
+
+      await fixture.page.waitForFunction(
+        (projectPath) => {
+          const raw = localStorage.getItem('pref_git_comparison_ranges_v1');
+          if (!raw) return false;
+          try {
+            const parsed = JSON.parse(raw) as {
+              version?: unknown;
+              projectEntries?: Array<{ projectPath?: unknown }>;
+            };
+            return parsed.version === 2
+              && parsed.projectEntries?.some((entry) => entry.projectPath === projectPath) === true;
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 20_000 },
+        project,
+      );
+
+      await app.startOpenAiDirectChat('git-comparison-worktree-inherited', {
+        projectPath: worktree,
+      });
+      await app.waitForText('echo:git-comparison-worktree-inherited');
+      const chats = (await fixture.integration.client.listChats()).sessions;
+      const worktreeChat = chats.find(
+        (chat) => chat.preview.firstMessage === 'git-comparison-worktree-inherited',
+      );
+      if (!worktreeChat) throw new Error('The linked-worktree comparison chat must be listed.');
+      await app.selectMainWorkspaceSurface('Compare');
+      await waitForComparisonMarkers(fixture.page, ['inherited head marker'], [
+        'root working marker',
+      ]);
+
+      const beforeReloadConnections = await fixture.spaWebSocketConnectionCount();
+      await fixture.page.reload({ waitUntil: [] });
+      await fixture.waitForSpaWebSocket({ afterConnectionCount: beforeReloadConnections });
+      await app.waitForSelectedChat(worktreeChat.id);
+      await fixture.page.waitForSelector('[id="main-panel-singleton:git-compare"]');
+      await app.selectMainWorkspaceSurface('Compare');
+      await waitForComparisonMarkers(fixture.page, ['inherited head marker'], [
+        'root working marker',
+      ]);
       fixture.assertNoBrowserErrors();
     });
   });

--- a/web/src/lib/components/sidebar/sidebar-row-model.ts
+++ b/web/src/lib/components/sidebar/sidebar-row-model.ts
@@ -1,6 +1,7 @@
 import type { PersistedChatOrderGroup } from '$shared/chat-order-contracts';
 import { chatOrderGroupFor } from '$lib/sidebar/search/chat-order-group.js';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
+import { isProjectPathAncestor, normalizeProjectPath } from '$lib/utils/project-path.js';
 import type {
 	SidebarChatOrderMap,
 	SidebarRowModel,
@@ -77,22 +78,6 @@ function exactProjectGroup(projectPath: string): SidebarProjectGroup {
 	};
 }
 
-function normalizeProjectPathForGrouping(projectPath: string): string {
-	const trimmed = projectPath.trim().replace(/\\/g, '/');
-	if (!trimmed) return '';
-	const collapsed = trimmed.replace(/\/+/g, '/');
-	if (collapsed === '/') return '/';
-	const withoutTrailingSlash = collapsed.replace(/\/+$/g, '');
-	return withoutTrailingSlash.replace(/^([A-Za-z]:)/, (drive) => drive.toLowerCase());
-}
-
-function isProjectPathAncestor(ancestorPath: string, descendantPath: string): boolean {
-	if (!ancestorPath || !descendantPath) return false;
-	if (ancestorPath === descendantPath) return true;
-	const prefix = ancestorPath.endsWith('/') ? ancestorPath : `${ancestorPath}/`;
-	return descendantPath.startsWith(prefix);
-}
-
 function createExactProjectGroupingContext(chats: ChatSessionRecord[]): ProjectGroupingContext {
 	const distinctProjectPathsByKey = new Map<string, Set<string>>();
 	for (const chat of chats) {
@@ -113,7 +98,7 @@ function createExactProjectGroupingContext(chats: ChatSessionRecord[]): ProjectG
 function createNestedProjectGroupingContext(chats: ChatSessionRecord[]): ProjectGroupingContext {
 	const projectsByNormalizedPath = new Map<string, NormalizedProjectPath>();
 	for (const chat of chats) {
-		const normalizedPath = normalizeProjectPathForGrouping(chat.projectPath);
+		const normalizedPath = normalizeProjectPath(chat.projectPath);
 		if (projectsByNormalizedPath.has(normalizedPath)) continue;
 		projectsByNormalizedPath.set(normalizedPath, {
 			originalPath: chat.projectPath,
@@ -147,7 +132,7 @@ function createNestedProjectGroupingContext(chats: ChatSessionRecord[]): Project
 
 	return {
 		groupForProjectPath(projectPath) {
-			const normalizedPath = normalizeProjectPathForGrouping(projectPath);
+			const normalizedPath = normalizeProjectPath(projectPath);
 			const groupPath = groupPathByNormalizedPath.get(normalizedPath) ?? projectPath;
 			return exactProjectGroup(groupPath);
 		},

--- a/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
+++ b/web/src/lib/git/review/__tests__/git-compare-surface.test.ts
@@ -5,6 +5,7 @@ import type { GitTargetCandidate } from '$lib/api/git.js';
 import type { GitComparisonSpecification } from '$lib/git/review/git-comparison.svelte.js';
 import {
 	LocalGitComparisonPreferences,
+	type GitComparisonPreferences,
 	type GitComparisonPreferencePersistence,
 } from '$lib/git/review/git-comparison-preferences.js';
 
@@ -69,6 +70,14 @@ function createComparisonPersistence() {
 	return persistence;
 }
 
+function recallPreference(
+	preferences: GitComparisonPreferences,
+	chatId: string,
+	projectPath = '/project',
+): GitComparisonSpecification | null {
+	return preferences.recall({ chatId, projectPath });
+}
+
 const revisionComparison: GitComparisonSpecification = {
 	fromRevision: 'origin/main',
 	toKind: 'revision',
@@ -124,8 +133,8 @@ describe('GitCompareSurfaceController', () => {
 			toKind: 'working-tree',
 			mode: 'direct',
 		};
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
-		deps.comparisonPreferences.remember('chat-b', workingTreeComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-b', workingTreeComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 
@@ -151,7 +160,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('restores merge-base mode with revision endpoints', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', mergeBaseComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', mergeBaseComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 
@@ -166,6 +175,53 @@ describe('GitCompareSurfaceController', () => {
 		expect(controller.comparison.mode).toBe('merge-base');
 	});
 
+	it('inherits the nearest project default without pinning it to a new worktree chat', async () => {
+		const worktreePath = '/repo/.worktrees/abc';
+		api.getGitTargetCandidates.mockResolvedValue({
+			targets: [
+				candidate(worktreePath, {
+					repoRoot: '/repo',
+					worktreePath,
+					label: 'abc',
+					branch: 'feature',
+				}),
+			],
+		});
+		const deps = createGitSurfaceTestDeps();
+		deps.comparisonPreferences.rememberUserSelection(
+			{ chatId: 'seed-root', projectPath: '/repo' },
+			revisionComparison,
+		);
+		const rememberUserSelection = vi.spyOn(deps.comparisonPreferences, 'rememberUserSelection');
+		const controller = new GitCompareSurfaceController(deps);
+		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
+
+		setProject(controller, 'chat-a', worktreePath, '/canonical/repo');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+		expect(controller.comparison.fromRevision).toBe('origin/main');
+		expect(controller.comparison.toKind).toBe('revision');
+		expect(rememberUserSelection).not.toHaveBeenCalled();
+
+		const updatedDefault: GitComparisonSpecification = {
+			fromRevision: 'release',
+			toKind: 'working-tree',
+			mode: 'direct',
+		};
+		deps.comparisonPreferences.rememberUserSelection(
+			{ chatId: 'seed-updated', projectPath: '/repo' },
+			updatedDefault,
+		);
+		rememberUserSelection.mockClear();
+		setProject(controller, 'chat-b', worktreePath, '/canonical/repo');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+
+		expect(controller.comparison.fromRevision).toBe('release');
+		expect(controller.comparison.toKind).toBe('working-tree');
+		expect(rememberUserSelection).not.toHaveBeenCalled();
+	});
+
 	it('reuses the chat range across selected targets', async () => {
 		const projectTarget = candidate();
 		const otherTarget = candidate('/other', {
@@ -177,7 +233,7 @@ describe('GitCompareSurfaceController', () => {
 		});
 		api.getGitTargetCandidates.mockResolvedValue({ targets: [projectTarget, otherTarget] });
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		setProject(controller, 'chat-a');
@@ -225,7 +281,7 @@ describe('GitCompareSurfaceController', () => {
 		await controller.target.selectTarget(otherTarget);
 		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
 
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
 		expect(controller.comparison.fromRevision).toBe('origin/main');
 		expect(controller.comparison.toKind).toBe('revision');
 	});
@@ -242,15 +298,19 @@ describe('GitCompareSurfaceController', () => {
 			revisionComparison,
 		);
 		controller.comparison.setSpecification(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'new-chat', '/project/child')).toBeNull();
 
 		expect(await controller.compareCurrentSpecification()).toBe(true);
 
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'new-chat', '/project/child')).toEqual(
+			revisionComparison,
+		);
 	});
 
 	it('does not replace remembered success after a failed user comparison', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		setProject(controller, 'chat-a');
@@ -269,12 +329,13 @@ describe('GitCompareSurfaceController', () => {
 		compare.mockResolvedValueOnce(false);
 
 		expect(await controller.compareCurrentSpecification()).toBe(false);
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'new-chat', '/project')).toBeNull();
 	});
 
 	it('does not remember unsubmitted dialog fields', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		setProject(controller, 'chat-a');
@@ -289,7 +350,7 @@ describe('GitCompareSurfaceController', () => {
 		setProject(controller, 'chat-b');
 		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
 
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
 	});
 
 	it('restores a range after controller and preference service recreation', async () => {
@@ -319,7 +380,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('keeps separate browser storage areas isolated', async () => {
 		const firstClient = createGitSurfaceTestDeps();
-		firstClient.comparisonPreferences.remember('chat-a', revisionComparison);
+		firstClient.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const secondClient = createGitSurfaceTestDeps();
 		const controller = new GitCompareSurfaceController(secondClient);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
@@ -335,7 +396,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('defers restoration while the project identity is resolving', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		controller.setProjectState({
@@ -360,7 +421,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('does not load a restored chat while Compare is hidden', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-b', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-b', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		setProject(controller, 'chat-a');
@@ -382,7 +443,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('retries a failed automatic restore without deleting remembered intent', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi
 			.spyOn(controller.comparison, 'compare')
@@ -392,7 +453,7 @@ describe('GitCompareSurfaceController', () => {
 		controller.setPresentationVisible(true);
 		await controller.target.activate();
 		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
 
 		controller.setPresentationVisible(false);
 		controller.setPresentationVisible(true);
@@ -403,7 +464,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('does not retry a failed restore or discard a repair on project-state republish', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(false);
 		setProject(controller, 'chat-a');
@@ -450,6 +511,46 @@ describe('GitCompareSurfaceController', () => {
 		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(3));
 	});
 
+	it('does not persist a late explicit comparison after switching sessions', async () => {
+		api.getGitTargetCandidates.mockImplementation((projectPath: string) =>
+			Promise.resolve({
+				targets: [
+					candidate(projectPath, {
+						repoRoot: projectPath,
+						worktreePath: projectPath,
+					}),
+				],
+			}),
+		);
+		const deps = createGitSurfaceTestDeps();
+		const rememberUserSelection = vi.spyOn(deps.comparisonPreferences, 'rememberUserSelection');
+		const controller = new GitCompareSurfaceController(deps);
+		const pendingSubmission = deferred<boolean>();
+		const compare = vi
+			.spyOn(controller.comparison, 'compare')
+			.mockResolvedValueOnce(true)
+			.mockReturnValueOnce(pendingSubmission.promise)
+			.mockResolvedValueOnce(true);
+		vi.spyOn(controller.comparison, 'confirmedSpecification', 'get').mockReturnValue(
+			revisionComparison,
+		);
+		setProject(controller, 'chat-a', '/project-a', '/canonical/a');
+		controller.setPresentationVisible(true);
+		await controller.target.activate();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledOnce());
+
+		const submission = controller.compareCurrentSpecification();
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(2));
+		setProject(controller, 'chat-b', '/project-b', '/canonical/b');
+		await vi.waitFor(() => expect(compare).toHaveBeenCalledTimes(3));
+		pendingSubmission.resolve(true);
+
+		expect(await submission).toBe(false);
+		expect(rememberUserSelection).not.toHaveBeenCalled();
+		expect(recallPreference(deps.comparisonPreferences, 'new-a', '/project-a')).toBeNull();
+		expect(recallPreference(deps.comparisonPreferences, 'new-b', '/project-b')).toBeNull();
+	});
+
 	it('ignores a late comparison result after switching chats', async () => {
 		const deps = createGitSurfaceTestDeps();
 		const chatBComparison: GitComparisonSpecification = {
@@ -457,8 +558,8 @@ describe('GitCompareSurfaceController', () => {
 			toKind: 'working-tree',
 			mode: 'direct',
 		};
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
-		deps.comparisonPreferences.remember('chat-b', chatBComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-b', chatBComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const first = deferred<boolean>();
 		const second = deferred<boolean>();
@@ -482,7 +583,7 @@ describe('GitCompareSurfaceController', () => {
 		await first.promise;
 		await Promise.resolve();
 
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
 		second.resolve(true);
 		await second.promise;
 	});
@@ -499,8 +600,8 @@ describe('GitCompareSurfaceController', () => {
 			toKind: 'working-tree',
 			mode: 'direct',
 		};
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
-		deps.comparisonPreferences.remember('chat-b', chatBComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-b', chatBComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const firstA = deferred<boolean>();
 		const pendingB = deferred<boolean>();
@@ -527,7 +628,7 @@ describe('GitCompareSurfaceController', () => {
 		firstA.resolve(true);
 		await firstA.promise;
 		await Promise.resolve();
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
 
 		confirmed = revisionComparison;
 		finalA.resolve(true);
@@ -608,7 +709,7 @@ describe('GitCompareSurfaceController', () => {
 
 	it('restores the same symbolic range after branch checkout', async () => {
 		const deps = createGitSurfaceTestDeps();
-		deps.comparisonPreferences.remember('chat-a', revisionComparison);
+		deps.comparisonPreferences.rememberChat('chat-a', revisionComparison);
 		const controller = new GitCompareSurfaceController(deps);
 		const compare = vi.spyOn(controller.comparison, 'compare').mockResolvedValue(true);
 		setProject(controller, 'chat-a');
@@ -622,7 +723,7 @@ describe('GitCompareSurfaceController', () => {
 		expect(controller.comparison.fromRevision).toBe('origin/main');
 		expect(controller.comparison.toKind).toBe('revision');
 		expect(controller.comparison.toRevision).toBe('HEAD');
-		expect(deps.comparisonPreferences.recall('chat-a')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat-a')).toEqual(revisionComparison);
 	});
 
 	it('disposal remembers confirmed state and cancels future activation', async () => {
@@ -640,6 +741,6 @@ describe('GitCompareSurfaceController', () => {
 		controller.setPresentationVisible(true);
 		await controller.target.activate();
 		expect(compare).toHaveBeenCalledOnce();
-		expect(deps.comparisonPreferences.recall('chat')).toEqual(revisionComparison);
+		expect(recallPreference(deps.comparisonPreferences, 'chat')).toEqual(revisionComparison);
 	});
 });

--- a/web/src/lib/git/review/__tests__/git-comparison-preferences.logic.test.ts
+++ b/web/src/lib/git/review/__tests__/git-comparison-preferences.logic.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-	GIT_COMPARISON_PREFERENCE_LIMIT,
+	GIT_COMPARISON_CHAT_PREFERENCE_LIMIT,
+	GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT,
 	LocalGitComparisonPreferences,
+	type GitComparisonPreferences,
 	type GitComparisonPreferencePersistence,
 } from '$lib/git/review/git-comparison-preferences.js';
 import type { GitComparisonSpecification } from '$lib/git/review/git-comparison.svelte.js';
@@ -19,12 +21,21 @@ const workingTree: GitComparisonSpecification = {
 	mode: 'direct',
 };
 
+const mergeBase: GitComparisonSpecification = {
+	fromRevision: 'origin/main',
+	toKind: 'revision',
+	toRevision: 'feature',
+	mode: 'merge-base',
+};
+
 function createPersistence(initialValue: string | null = null) {
 	let value = initialValue;
+	let writeCount = 0;
 	const persistence = {
 		read: () => value,
 		write: (nextValue: string) => {
 			value = nextValue;
+			writeCount += 1;
 		},
 	} satisfies GitComparisonPreferencePersistence;
 	return {
@@ -35,7 +46,26 @@ function createPersistence(initialValue: string | null = null) {
 		set value(nextValue: string | null) {
 			value = nextValue;
 		},
+		get writeCount() {
+			return writeCount;
+		},
 	};
+}
+
+function recall(
+	preferences: GitComparisonPreferences,
+	chatId: string,
+	projectPath = '/project',
+): GitComparisonSpecification | null {
+	return preferences.recall({ chatId, projectPath });
+}
+
+function storedRecord(storage: ReturnType<typeof createPersistence>): {
+	version?: unknown;
+	entries?: Array<{ chatId?: unknown; specification?: unknown }>;
+	projectEntries?: Array<{ projectPath?: unknown; specification?: unknown }>;
+} {
+	return JSON.parse(storage.value ?? '{}');
 }
 
 describe('LocalGitComparisonPreferences', () => {
@@ -43,94 +73,246 @@ describe('LocalGitComparisonPreferences', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
 
-		expect(preferences.recall('chat-a')).toBeNull();
+		expect(recall(preferences, 'chat-a')).toBeNull();
 	});
 
 	it('persists ranges across preference service recreation', () => {
 		const storage = createPersistence();
-		new LocalGitComparisonPreferences(storage.persistence).remember('chat-a', revision);
+		new LocalGitComparisonPreferences(storage.persistence).rememberChat('chat-a', revision);
 
 		const reloaded = new LocalGitComparisonPreferences(storage.persistence);
 
-		expect(reloaded.recall('chat-a')).toEqual(revision);
-		expect(JSON.parse(storage.value ?? '{}')).toMatchObject({
-			version: 1,
+		expect(recall(reloaded, 'chat-a')).toEqual(revision);
+		expect(storedRecord(storage)).toMatchObject({
+			version: 2,
 			entries: [{ chatId: 'chat-a', specification: revision }],
+			projectEntries: [],
 		});
 	});
 
 	it('keeps one independent range per chat', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
-		preferences.remember('chat-a', revision);
-		preferences.remember('chat-b', workingTree);
+		preferences.rememberChat('chat-a', revision);
+		preferences.rememberChat('chat-b', workingTree);
 
-		expect(preferences.recall('chat-a')).toEqual(revision);
-		expect(preferences.recall('chat-b')).toEqual(workingTree);
+		expect(recall(preferences, 'chat-a')).toEqual(revision);
+		expect(recall(preferences, 'chat-b')).toEqual(workingTree);
 	});
 
 	it('replaces a chat range and keeps one persisted entry', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
-		preferences.remember('chat-a', revision);
-		preferences.remember('chat-a', workingTree);
+		preferences.rememberChat('chat-a', revision);
+		preferences.rememberChat('chat-a', workingTree);
 
-		expect(preferences.recall('chat-a')).toEqual(workingTree);
-		expect(JSON.parse(storage.value ?? '{}').entries).toHaveLength(1);
+		expect(recall(preferences, 'chat-a')).toEqual(workingTree);
+		expect(storedRecord(storage).entries).toHaveLength(1);
 	});
 
-	it('evicts the least recently used entry above twenty and touches reads', () => {
+	it('evicts the least recently used chat above the limit and touches reads', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
-		for (let index = 0; index < GIT_COMPARISON_PREFERENCE_LIMIT; index += 1) {
-			preferences.remember(`chat-${index}`, revision);
+		for (let index = 0; index < GIT_COMPARISON_CHAT_PREFERENCE_LIMIT; index += 1) {
+			preferences.rememberChat(`chat-${index}`, revision);
 		}
-		expect(preferences.recall('chat-0')).toEqual(revision);
+		expect(recall(preferences, 'chat-0')).toEqual(revision);
 
-		preferences.remember(`chat-${GIT_COMPARISON_PREFERENCE_LIMIT}`, workingTree);
+		preferences.rememberChat(`chat-${GIT_COMPARISON_CHAT_PREFERENCE_LIMIT}`, workingTree);
 
-		expect(preferences.recall('chat-0')).toEqual(revision);
-		expect(preferences.recall('chat-1')).toBeNull();
-		expect(preferences.recall(`chat-${GIT_COMPARISON_PREFERENCE_LIMIT}`)).toEqual(workingTree);
-		expect(JSON.parse(storage.value ?? '{}').entries).toHaveLength(GIT_COMPARISON_PREFERENCE_LIMIT);
+		expect(recall(preferences, 'chat-0')).toEqual(revision);
+		expect(recall(preferences, 'chat-1')).toBeNull();
+		expect(recall(preferences, `chat-${GIT_COMPARISON_CHAT_PREFERENCE_LIMIT}`)).toEqual(
+			workingTree,
+		);
+		expect(storedRecord(storage).entries).toHaveLength(GIT_COMPARISON_CHAT_PREFERENCE_LIMIT);
 	});
 
-	it('returns fresh specification objects', () => {
+	it('resolves chat, exact project, nearest ancestor, and farther ancestor in order', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
-		preferences.remember('chat-a', revision);
-		const recalled = preferences.recall('chat-a');
-		if (!recalled) throw new Error('Expected a persisted comparison preference.');
-		recalled.fromRevision = 'mutated';
+		preferences.rememberUserSelection({ chatId: 'seed-root', projectPath: '/repo' }, revision);
+		preferences.rememberUserSelection(
+			{ chatId: 'seed-nearest', projectPath: '/repo/.worktrees' },
+			workingTree,
+		);
+		preferences.rememberUserSelection(
+			{ chatId: 'seed-exact', projectPath: '/repo/.worktrees/abc' },
+			mergeBase,
+		);
+		preferences.rememberChat('chat-specific', revision);
 
-		expect(preferences.recall('chat-a')).toEqual(revision);
+		expect(recall(preferences, 'chat-specific', '/repo/.worktrees/abc')).toEqual(revision);
+		expect(recall(preferences, 'new-exact', '/repo/.worktrees/abc')).toEqual(mergeBase);
+		expect(recall(preferences, 'new-nearest', '/repo/.worktrees/def')).toEqual(workingTree);
+		expect(recall(preferences, 'new-farther', '/repo/packages/app')).toEqual(revision);
+		expect(recall(preferences, 'unrelated', '/other')).toBeNull();
+	});
+
+	it('chooses the nearest project path regardless of LRU order', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+		preferences.rememberUserSelection(
+			{ chatId: 'seed-nearest', projectPath: '/repo/packages' },
+			workingTree,
+		);
+		preferences.rememberUserSelection({ chatId: 'seed-root', projectPath: '/repo' }, revision);
+
+		expect(recall(preferences, 'new-chat', '/repo/packages/app')).toEqual(workingTree);
+	});
+
+	it('normalizes project keys for writes and inherited lookups', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+		preferences.rememberUserSelection(
+			{ chatId: 'seed-unix', projectPath: ' /repo//.worktrees/ ' },
+			revision,
+		);
+		preferences.rememberUserSelection(
+			{ chatId: 'seed-windows', projectPath: 'C:\\workspace\\repo\\' },
+			workingTree,
+		);
+
+		expect(recall(preferences, 'unix-child', '/repo/.worktrees/abc')).toEqual(revision);
+		expect(recall(preferences, 'windows-child', 'c:/workspace/repo/src')).toEqual(workingTree);
+		expect(storedRecord(storage).projectEntries?.map((entry) => entry.projectPath)).toEqual([
+			'c:/workspace/repo',
+			'/repo/.worktrees',
+		]);
+	});
+
+	it('writes an explicit selection to both maps atomically', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+
+		preferences.rememberUserSelection(
+			{ chatId: 'chat-a', projectPath: '/repo/.worktrees/abc' },
+			revision,
+		);
+
+		expect(storage.writeCount).toBe(1);
+		expect(storedRecord(storage)).toMatchObject({
+			entries: [{ chatId: 'chat-a', specification: revision }],
+			projectEntries: [{ projectPath: '/repo/.worktrees/abc', specification: revision }],
+		});
+	});
+
+	it('keeps chat and project LRU recency independent', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+		preferences.rememberUserSelection({ chatId: 'chat-a', projectPath: '/repo/a' }, revision);
+		preferences.rememberUserSelection({ chatId: 'chat-b', projectPath: '/repo/b' }, workingTree);
+
+		expect(recall(preferences, 'chat-a', '/repo/b')).toEqual(revision);
+		expect(storedRecord(storage).entries?.map((entry) => entry.chatId)).toEqual([
+			'chat-a',
+			'chat-b',
+		]);
+		expect(storedRecord(storage).projectEntries?.map((entry) => entry.projectPath)).toEqual([
+			'/repo/b',
+			'/repo/a',
+		]);
+
+		expect(recall(preferences, 'missing', '/repo/a')).toEqual(revision);
+		expect(storedRecord(storage).entries?.map((entry) => entry.chatId)).toEqual([
+			'chat-a',
+			'chat-b',
+		]);
+		expect(storedRecord(storage).projectEntries?.map((entry) => entry.projectPath)).toEqual([
+			'/repo/a',
+			'/repo/b',
+		]);
+	});
+
+	it('evicts the least recently used project above the limit and touches inherited reads', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+		for (let index = 0; index < GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT; index += 1) {
+			preferences.rememberUserSelection(
+				{ chatId: `seed-${index}`, projectPath: `/repo-${index}` },
+				revision,
+			);
+		}
+		expect(recall(preferences, 'touch', '/repo-0/child')).toEqual(revision);
+
+		preferences.rememberUserSelection(
+			{ chatId: 'seed-overflow', projectPath: '/repo-overflow' },
+			workingTree,
+		);
+
+		expect(recall(preferences, 'kept', '/repo-0/child')).toEqual(revision);
+		expect(recall(preferences, 'evicted', '/repo-1/child')).toBeNull();
+		expect(recall(preferences, 'newest', '/repo-overflow')).toEqual(workingTree);
+		expect(storedRecord(storage).projectEntries).toHaveLength(
+			GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT,
+		);
+	});
+
+	it('returns fresh specification objects from both preference maps', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+		preferences.rememberUserSelection({ chatId: 'chat-a', projectPath: '/repo' }, revision);
+		const recalledChat = recall(preferences, 'chat-a');
+		const recalledProject = recall(preferences, 'new-chat', '/repo');
+		if (!recalledChat || !recalledProject) {
+			throw new Error('Expected persisted comparison preferences.');
+		}
+		recalledChat.fromRevision = 'mutated-chat';
+		recalledProject.fromRevision = 'mutated-project';
+
+		expect(recall(preferences, 'chat-a')).toEqual(revision);
+		expect(recall(preferences, 'new-chat', '/repo')).toEqual(revision);
 	});
 
 	it('restores direct working-tree and merge-base revision specifications', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
-		const mergeBase: GitComparisonSpecification = {
-			fromRevision: 'origin/main',
-			toKind: 'revision',
-			toRevision: 'feature',
-			mode: 'merge-base',
-		};
-		preferences.remember('chat-working', workingTree);
-		preferences.remember('chat-merge-base', mergeBase);
+		preferences.rememberChat('chat-working', workingTree);
+		preferences.rememberUserSelection(
+			{ chatId: 'chat-merge-base', projectPath: '/merge-base' },
+			mergeBase,
+		);
 
 		const reloaded = new LocalGitComparisonPreferences(storage.persistence);
-		expect(reloaded.recall('chat-working')).toEqual(workingTree);
-		expect(reloaded.recall('chat-merge-base')).toEqual(mergeBase);
+		expect(recall(reloaded, 'chat-working')).toEqual(workingTree);
+		expect(recall(reloaded, 'chat-merge-base')).toEqual(mergeBase);
+		expect(recall(reloaded, 'new-chat', '/merge-base')).toEqual(mergeBase);
 	});
 
-	it('filters malformed entries, duplicate chats, and entries above the limit', () => {
-		const overflow = Array.from({ length: GIT_COMPARISON_PREFERENCE_LIMIT + 5 }, (_, index) => ({
-			chatId: `overflow-${index}`,
-			specification: revision,
-		}));
+	it('loads version one chat preferences and upgrades them on write', () => {
 		const storage = createPersistence(
 			JSON.stringify({
 				version: 1,
+				entries: [{ chatId: 'chat-a', specification: revision }],
+			}),
+		);
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+
+		expect(recall(preferences, 'chat-a')).toEqual(revision);
+		expect(recall(preferences, 'new-chat', '/repo')).toBeNull();
+		preferences.rememberChat('chat-b', workingTree);
+
+		expect(storedRecord(storage)).toMatchObject({
+			version: 2,
+			entries: [
+				{ chatId: 'chat-b', specification: workingTree },
+				{ chatId: 'chat-a', specification: revision },
+			],
+			projectEntries: [],
+		});
+	});
+
+	it('filters malformed, duplicate, and over-limit chat entries', () => {
+		const overflow = Array.from(
+			{ length: GIT_COMPARISON_CHAT_PREFERENCE_LIMIT + 5 },
+			(_, index) => ({
+				chatId: `overflow-${index}`,
+				specification: revision,
+			}),
+		);
+		const storage = createPersistence(
+			JSON.stringify({
+				version: 2,
 				entries: [
 					{ chatId: '', specification: revision },
 					{ chatId: 'chat-a', specification: revision },
@@ -139,38 +321,73 @@ describe('LocalGitComparisonPreferences', () => {
 					{ chatId: 'blank-ref', specification: { ...revision, fromRevision: ' ' } },
 					...overflow,
 				],
+				projectEntries: [],
 			}),
 		);
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
 
-		expect(preferences.recall('chat-a')).toEqual(revision);
-		expect(preferences.recall('invalid-mode')).toBeNull();
-		expect(preferences.recall('blank-ref')).toBeNull();
-		expect(preferences.recall('overflow-18')).toEqual(revision);
-		expect(preferences.recall('overflow-19')).toBeNull();
+		expect(recall(preferences, 'chat-a')).toEqual(revision);
+		expect(recall(preferences, 'invalid-mode')).toBeNull();
+		expect(recall(preferences, 'blank-ref')).toBeNull();
+		expect(recall(preferences, 'overflow-18')).toEqual(revision);
+		expect(recall(preferences, 'overflow-19')).toBeNull();
+	});
+
+	it('filters malformed and normalized duplicate project entries', () => {
+		const storage = createPersistence(
+			JSON.stringify({
+				version: 2,
+				entries: [],
+				projectEntries: [
+					{ projectPath: '', specification: revision },
+					{ projectPath: 'relative/path', specification: revision },
+					{ projectPath: '/repo/', specification: revision },
+					{ projectPath: '/repo', specification: workingTree },
+					{ projectPath: '/invalid', specification: { ...workingTree, mode: 'merge-base' } },
+				],
+			}),
+		);
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+
+		expect(recall(preferences, 'new-chat', '/repo/src')).toEqual(revision);
+		expect(recall(preferences, 'invalid', '/invalid')).toBeNull();
+	});
+
+	it('ignores invalid project paths while preserving the chat selection', () => {
+		const storage = createPersistence();
+		const preferences = new LocalGitComparisonPreferences(storage.persistence);
+
+		preferences.rememberUserSelection(
+			{ chatId: 'chat-a', projectPath: 'relative/project' },
+			revision,
+		);
+
+		expect(recall(preferences, 'chat-a', 'relative/project')).toEqual(revision);
+		expect(recall(preferences, 'new-chat', 'relative/project')).toBeNull();
+		expect(storedRecord(storage).projectEntries).toEqual([]);
 	});
 
 	it('ignores corrupt JSON, unknown versions, and invalid record shapes', () => {
 		const storage = createPersistence('{broken');
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
-		expect(preferences.recall('chat-a')).toBeNull();
+		expect(recall(preferences, 'chat-a')).toBeNull();
 
-		storage.value = JSON.stringify({ version: 2, entries: [{ chatId: 'chat-a' }] });
-		expect(preferences.recall('chat-a')).toBeNull();
+		storage.value = JSON.stringify({ version: 3, entries: [{ chatId: 'chat-a' }] });
+		expect(recall(preferences, 'chat-a')).toBeNull();
 
-		storage.value = JSON.stringify({ version: 1, entries: 'not-an-array' });
-		expect(preferences.recall('chat-a')).toBeNull();
+		storage.value = JSON.stringify({ version: 2, entries: 'not-an-array' });
+		expect(recall(preferences, 'chat-a')).toBeNull();
 	});
 
 	it('recovers from corrupt storage on the next successful write', () => {
 		const storage = createPersistence('{broken');
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
 
-		preferences.remember('chat-a', revision);
+		preferences.rememberUserSelection({ chatId: 'chat-a', projectPath: '/repo' }, revision);
 
-		expect(new LocalGitComparisonPreferences(storage.persistence).recall('chat-a')).toEqual(
-			revision,
-		);
+		const reloaded = new LocalGitComparisonPreferences(storage.persistence);
+		expect(recall(reloaded, 'chat-a')).toEqual(revision);
+		expect(recall(reloaded, 'new-chat', '/repo')).toEqual(revision);
 	});
 
 	it('keeps comparison behavior available when persistence throws', () => {
@@ -187,18 +404,21 @@ describe('LocalGitComparisonPreferences', () => {
 			},
 		});
 
-		expect(readFailure.recall('chat-a')).toBeNull();
-		expect(() => readFailure.remember('chat-a', revision)).not.toThrow();
-		expect(() => writeFailure.remember('chat-a', revision)).not.toThrow();
+		expect(recall(readFailure, 'chat-a')).toBeNull();
+		expect(() => readFailure.rememberChat('chat-a', revision)).not.toThrow();
+		expect(() =>
+			writeFailure.rememberUserSelection({ chatId: 'chat-a', projectPath: '/repo' }, revision),
+		).not.toThrow();
 	});
 
 	it('ignores empty chat identifiers', () => {
 		const storage = createPersistence();
 		const preferences = new LocalGitComparisonPreferences(storage.persistence);
 
-		preferences.remember(' ', revision);
+		preferences.rememberChat(' ', revision);
+		preferences.rememberUserSelection({ chatId: ' ', projectPath: '/repo' }, revision);
 
-		expect(preferences.recall(' ')).toBeNull();
+		expect(recall(preferences, ' ')).toBeNull();
 		expect(storage.value).toBeNull();
 	});
 });

--- a/web/src/lib/git/review/git-compare-surface.svelte.ts
+++ b/web/src/lib/git/review/git-compare-surface.svelte.ts
@@ -22,11 +22,11 @@ interface GitCompareSurfaceControllerDeps extends GitSurfaceControllerDeps {
 interface GitComparisonSessionIdentity {
 	readonly chatId: string;
 	readonly targetIdentity: string;
+	readonly projectPath: string;
 }
 
 interface ActiveGitComparisonSession {
 	identity: GitComparisonSessionIdentity;
-	projectPath: string;
 }
 
 export class GitCompareSurfaceController implements PortableSingletonController {
@@ -61,7 +61,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 					}
 					return;
 				}
-				this.#rememberConfirmedComparison();
+				this.#rememberConfirmedChatComparison();
 				this.comparison.reset();
 				this.#loadedSessionIdentity = null;
 				if (this.presentationVisible) {
@@ -86,7 +86,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		const nextChatId = projectStateChatId(projectState);
 		const chatChanged = nextChatId !== this.#chatId;
 		if (chatChanged) {
-			this.#rememberConfirmedComparison();
+			this.#rememberConfirmedChatComparison();
 			this.comparison.reset();
 			this.#loadedSessionIdentity = null;
 			this.#chatId = nextChatId;
@@ -121,9 +121,9 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 
 		const requestIdentity = active.identity;
 		this.#loadedSessionIdentity = requestIdentity;
-		const loaded = await this.comparison.compare(active.projectPath);
+		const loaded = await this.comparison.compare(requestIdentity.projectPath);
 		if (this.#loadedSessionIdentity !== requestIdentity) return false;
-		if (loaded) this.#rememberConfirmedComparison(requestIdentity);
+		if (loaded) this.#rememberConfirmedUserSelection(requestIdentity);
 		return loaded;
 	}
 
@@ -134,7 +134,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 	}
 
 	dispose(): void {
-		this.#rememberConfirmedComparison();
+		this.#rememberConfirmedChatComparison();
 		this.#unregisterReviewDisplay();
 		this.target.dispose();
 		this.comparison.reset();
@@ -149,7 +149,10 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		if (sameSession(this.#loadedSessionIdentity, active.identity)) return;
 
 		const specification =
-			this.deps.comparisonPreferences.recall(active.identity.chatId) ?? DEFAULT_GIT_COMPARISON;
+			this.deps.comparisonPreferences.recall({
+				chatId: active.identity.chatId,
+				projectPath: active.identity.projectPath,
+			}) ?? DEFAULT_GIT_COMPARISON;
 		this.comparison.setSpecification(specification, {
 			diffMode: this.deps.reviewDisplay.diffMode,
 			contextLines: this.deps.reviewDisplay.contextLines,
@@ -158,7 +161,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		// session does not start a second load.
 		const activationIdentity = active.identity;
 		this.#loadedSessionIdentity = activationIdentity;
-		const loaded = await this.comparison.compare(active.projectPath);
+		const loaded = await this.comparison.compare(activationIdentity.projectPath);
 		if (this.#loadedSessionIdentity !== activationIdentity) return;
 		// A failed default load must stay retryable on the next visibility or
 		// activation pass; a superseded session keeps the newer marker.
@@ -166,7 +169,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 			this.#loadedSessionIdentity = null;
 			return;
 		}
-		this.#rememberConfirmedComparison(activationIdentity);
+		this.#rememberConfirmedChatComparison(activationIdentity);
 	}
 
 	#activeSession(): ActiveGitComparisonSession | null {
@@ -183,15 +186,23 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 			return null;
 		}
 		return {
-			identity: { chatId, targetIdentity },
-			projectPath,
+			identity: { chatId, targetIdentity, projectPath },
 		};
 	}
 
-	#rememberConfirmedComparison(identity = this.#loadedSessionIdentity): void {
+	#rememberConfirmedChatComparison(identity = this.#loadedSessionIdentity): void {
 		const specification = this.comparison.confirmedSpecification;
 		if (!identity || !specification) return;
-		this.deps.comparisonPreferences.remember(identity.chatId, specification);
+		this.deps.comparisonPreferences.rememberChat(identity.chatId, specification);
+	}
+
+	#rememberConfirmedUserSelection(identity: GitComparisonSessionIdentity): void {
+		const specification = this.comparison.confirmedSpecification;
+		if (!specification) return;
+		this.deps.comparisonPreferences.rememberUserSelection(
+			{ chatId: identity.chatId, projectPath: identity.projectPath },
+			specification,
+		);
 	}
 }
 
@@ -206,5 +217,9 @@ function sameSession(
 	left: GitComparisonSessionIdentity | null,
 	right: GitComparisonSessionIdentity,
 ): boolean {
-	return left?.chatId === right.chatId && left.targetIdentity === right.targetIdentity;
+	return (
+		left?.chatId === right.chatId &&
+		left.targetIdentity === right.targetIdentity &&
+		left.projectPath === right.projectPath
+	);
 }

--- a/web/src/lib/git/review/git-compare-surface.svelte.ts
+++ b/web/src/lib/git/review/git-compare-surface.svelte.ts
@@ -25,10 +25,6 @@ interface GitComparisonSessionIdentity {
 	readonly projectPath: string;
 }
 
-interface ActiveGitComparisonSession {
-	identity: GitComparisonSessionIdentity;
-}
-
 export class GitCompareSurfaceController implements PortableSingletonController {
 	readonly comparison = new GitComparisonController();
 	readonly target: GitTargetSessionController;
@@ -116,14 +112,13 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 	}
 
 	async compareCurrentSpecification(): Promise<boolean> {
-		const active = this.#activeSession();
-		if (!active) return false;
+		const identity = this.#activeSessionIdentity();
+		if (!identity) return false;
 
-		const requestIdentity = active.identity;
-		this.#loadedSessionIdentity = requestIdentity;
-		const loaded = await this.comparison.compare(requestIdentity.projectPath);
-		if (this.#loadedSessionIdentity !== requestIdentity) return false;
-		if (loaded) this.#rememberConfirmedUserSelection(requestIdentity);
+		this.#loadedSessionIdentity = identity;
+		const loaded = await this.comparison.compare(identity.projectPath);
+		if (this.#loadedSessionIdentity !== identity) return false;
+		if (loaded) this.#rememberConfirmedUserSelection(identity);
 		return loaded;
 	}
 
@@ -144,14 +139,14 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 
 	async #activateComparison(): Promise<void> {
 		if (!this.presentationVisible) return;
-		const active = this.#activeSession();
-		if (!active) return;
-		if (sameSession(this.#loadedSessionIdentity, active.identity)) return;
+		const identity = this.#activeSessionIdentity();
+		if (!identity) return;
+		if (sameSession(this.#loadedSessionIdentity, identity)) return;
 
 		const specification =
 			this.deps.comparisonPreferences.recall({
-				chatId: active.identity.chatId,
-				projectPath: active.identity.projectPath,
+				chatId: identity.chatId,
+				projectPath: identity.projectPath,
 			}) ?? DEFAULT_GIT_COMPARISON;
 		this.comparison.setSpecification(specification, {
 			diffMode: this.deps.reviewDisplay.diffMode,
@@ -159,20 +154,19 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		});
 		// Marked before the await so a concurrent activation for the same
 		// session does not start a second load.
-		const activationIdentity = active.identity;
-		this.#loadedSessionIdentity = activationIdentity;
-		const loaded = await this.comparison.compare(activationIdentity.projectPath);
-		if (this.#loadedSessionIdentity !== activationIdentity) return;
+		this.#loadedSessionIdentity = identity;
+		const loaded = await this.comparison.compare(identity.projectPath);
+		if (this.#loadedSessionIdentity !== identity) return;
 		// A failed default load must stay retryable on the next visibility or
 		// activation pass; a superseded session keeps the newer marker.
 		if (!loaded) {
 			this.#loadedSessionIdentity = null;
 			return;
 		}
-		this.#rememberConfirmedChatComparison(activationIdentity);
+		this.#rememberConfirmedChatComparison(identity);
 	}
 
-	#activeSession(): ActiveGitComparisonSession | null {
+	#activeSessionIdentity(): GitComparisonSessionIdentity | null {
 		const chatId = this.#chatId;
 		const projectPath = this.target.activeProjectPath;
 		const targetIdentity = this.target.appliedIdentity;
@@ -185,9 +179,7 @@ export class GitCompareSurfaceController implements PortableSingletonController 
 		) {
 			return null;
 		}
-		return {
-			identity: { chatId, targetIdentity, projectPath },
-		};
+		return { chatId, targetIdentity, projectPath };
 	}
 
 	#rememberConfirmedChatComparison(identity = this.#loadedSessionIdentity): void {

--- a/web/src/lib/git/review/git-comparison-preferences.ts
+++ b/web/src/lib/git/review/git-comparison-preferences.ts
@@ -4,13 +4,25 @@ import {
 	LOCAL_STORAGE_KEYS,
 	setLocalStorageItem,
 } from '$lib/utils/local-persistence.js';
+import { projectPathAndAncestors } from '$lib/utils/project-path.js';
 
-const SCHEMA_VERSION = 1;
-export const GIT_COMPARISON_PREFERENCE_LIMIT = 20;
+const LEGACY_SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
+export const GIT_COMPARISON_CHAT_PREFERENCE_LIMIT = 20;
+export const GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT = 20;
+
+export interface GitComparisonPreferenceContext {
+	chatId: string;
+	projectPath: string;
+}
 
 export interface GitComparisonPreferences {
-	recall(chatId: string): GitComparisonSpecification | null;
-	remember(chatId: string, specification: GitComparisonSpecification): void;
+	recall(context: GitComparisonPreferenceContext): GitComparisonSpecification | null;
+	rememberChat(chatId: string, specification: GitComparisonSpecification): void;
+	rememberUserSelection(
+		context: GitComparisonPreferenceContext,
+		specification: GitComparisonSpecification,
+	): void;
 }
 
 export interface GitComparisonPreferencePersistence {
@@ -23,9 +35,15 @@ interface GitComparisonPreferenceEntry {
 	specification: GitComparisonSpecification;
 }
 
+interface GitComparisonProjectPreferenceEntry {
+	projectPath: string;
+	specification: GitComparisonSpecification;
+}
+
 interface GitComparisonPreferenceRecord {
 	version: typeof SCHEMA_VERSION;
 	entries: GitComparisonPreferenceEntry[];
+	projectEntries: GitComparisonProjectPreferenceEntry[];
 }
 
 const browserPersistence: GitComparisonPreferencePersistence = {
@@ -38,56 +56,122 @@ export class LocalGitComparisonPreferences implements GitComparisonPreferences {
 		private readonly persistence: GitComparisonPreferencePersistence = browserPersistence,
 	) {}
 
-	recall(chatId: string): GitComparisonSpecification | null {
-		if (!isNonEmptyString(chatId)) return null;
-		const entries = this.#readEntries();
-		const index = entries.findIndex((entry) => entry.chatId === chatId);
-		if (index < 0) return null;
+	recall(context: GitComparisonPreferenceContext): GitComparisonSpecification | null {
+		const record = this.#readRecord();
+		if (isNonEmptyString(context.chatId)) {
+			const chatIndex = record.entries.findIndex((entry) => entry.chatId === context.chatId);
+			const chatEntry = record.entries[chatIndex];
+			if (chatEntry) {
+				if (chatIndex > 0) {
+					record.entries = touchEntry(record.entries, chatIndex);
+					this.#writeRecord(record);
+				}
+				return cloneSpecification(chatEntry.specification);
+			}
+		}
 
-		const [entry] = entries.splice(index, 1);
-		if (!entry) return null;
-		if (index > 0) this.#writeEntries([entry, ...entries]);
-		return cloneSpecification(entry.specification);
+		for (const projectPath of projectPathAndAncestors(context.projectPath)) {
+			const projectIndex = record.projectEntries.findIndex(
+				(entry) => entry.projectPath === projectPath,
+			);
+			const projectEntry = record.projectEntries[projectIndex];
+			if (!projectEntry) continue;
+			if (projectIndex > 0) {
+				record.projectEntries = touchEntry(record.projectEntries, projectIndex);
+				this.#writeRecord(record);
+			}
+			return cloneSpecification(projectEntry.specification);
+		}
+		return null;
 	}
 
-	remember(chatId: string, specification: GitComparisonSpecification): void {
+	rememberChat(chatId: string, specification: GitComparisonSpecification): void {
 		if (!isNonEmptyString(chatId)) return;
-		const entries = this.#readEntries().filter((entry) => entry.chatId !== chatId);
-		this.#writeEntries([{ chatId, specification: cloneSpecification(specification) }, ...entries]);
+		const record = this.#readRecord();
+		record.entries = rememberEntry(
+			record.entries,
+			(entry) => entry.chatId === chatId,
+			{ chatId, specification: cloneSpecification(specification) },
+			GIT_COMPARISON_CHAT_PREFERENCE_LIMIT,
+		);
+		this.#writeRecord(record);
 	}
 
-	#readEntries(): GitComparisonPreferenceEntry[] {
+	rememberUserSelection(
+		context: GitComparisonPreferenceContext,
+		specification: GitComparisonSpecification,
+	): void {
+		if (!isNonEmptyString(context.chatId)) return;
+		const record = this.#readRecord();
+		record.entries = rememberEntry(
+			record.entries,
+			(entry) => entry.chatId === context.chatId,
+			{ chatId: context.chatId, specification: cloneSpecification(specification) },
+			GIT_COMPARISON_CHAT_PREFERENCE_LIMIT,
+		);
+		const [projectPath] = projectPathAndAncestors(context.projectPath);
+		if (projectPath) {
+			record.projectEntries = rememberEntry(
+				record.projectEntries,
+				(entry) => entry.projectPath === projectPath,
+				{ projectPath, specification: cloneSpecification(specification) },
+				GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT,
+			);
+		}
+		this.#writeRecord(record);
+	}
+
+	#readRecord(): GitComparisonPreferenceRecord {
 		try {
 			const raw = this.persistence.read();
-			if (!raw) return [];
+			if (!raw) return emptyRecord();
 			return parseRecord(JSON.parse(raw));
 		} catch {
-			return [];
+			return emptyRecord();
 		}
 	}
 
-	#writeEntries(entries: GitComparisonPreferenceEntry[]): void {
-		const record: GitComparisonPreferenceRecord = {
+	#writeRecord(record: GitComparisonPreferenceRecord): void {
+		const persistedRecord: GitComparisonPreferenceRecord = {
 			version: SCHEMA_VERSION,
-			entries: entries.slice(0, GIT_COMPARISON_PREFERENCE_LIMIT),
+			entries: record.entries.slice(0, GIT_COMPARISON_CHAT_PREFERENCE_LIMIT),
+			projectEntries: record.projectEntries.slice(0, GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT),
 		};
 		try {
-			this.persistence.write(JSON.stringify(record));
+			this.persistence.write(JSON.stringify(persistedRecord));
 		} catch {
 			// Comparison loading remains available when browser storage is unavailable.
 		}
 	}
 }
 
-function parseRecord(value: unknown): GitComparisonPreferenceEntry[] {
-	if (!isRecord(value) || value.version !== SCHEMA_VERSION || !Array.isArray(value.entries)) {
-		return [];
-	}
+function emptyRecord(): GitComparisonPreferenceRecord {
+	return { version: SCHEMA_VERSION, entries: [], projectEntries: [] };
+}
 
+function parseRecord(value: unknown): GitComparisonPreferenceRecord {
+	if (
+		!isRecord(value) ||
+		(value.version !== LEGACY_SCHEMA_VERSION && value.version !== SCHEMA_VERSION) ||
+		!Array.isArray(value.entries)
+	) {
+		return emptyRecord();
+	}
+	return {
+		version: SCHEMA_VERSION,
+		entries: parseChatEntries(value.entries),
+		projectEntries:
+			value.version === SCHEMA_VERSION && Array.isArray(value.projectEntries)
+				? parseProjectEntries(value.projectEntries)
+				: [],
+	};
+}
+
+function parseChatEntries(values: unknown[]): GitComparisonPreferenceEntry[] {
 	const entries: GitComparisonPreferenceEntry[] = [];
 	const seenChatIds = new Set<string>();
-	for (const valueEntry of value.entries) {
-		if (entries.length >= GIT_COMPARISON_PREFERENCE_LIMIT) break;
+	for (const valueEntry of values) {
+		if (entries.length >= GIT_COMPARISON_CHAT_PREFERENCE_LIMIT) break;
 		if (!isRecord(valueEntry) || !isNonEmptyString(valueEntry.chatId)) continue;
 		if (seenChatIds.has(valueEntry.chatId)) continue;
 		const specification = parseSpecification(valueEntry.specification);
@@ -96,6 +180,36 @@ function parseRecord(value: unknown): GitComparisonPreferenceEntry[] {
 		entries.push({ chatId: valueEntry.chatId, specification });
 	}
 	return entries;
+}
+
+function parseProjectEntries(values: unknown[]): GitComparisonProjectPreferenceEntry[] {
+	const entries: GitComparisonProjectPreferenceEntry[] = [];
+	const seenProjectPaths = new Set<string>();
+	for (const valueEntry of values) {
+		if (entries.length >= GIT_COMPARISON_PROJECT_PREFERENCE_LIMIT) break;
+		if (!isRecord(valueEntry) || !isNonEmptyString(valueEntry.projectPath)) continue;
+		const [projectPath] = projectPathAndAncestors(valueEntry.projectPath);
+		if (!projectPath || seenProjectPaths.has(projectPath)) continue;
+		const specification = parseSpecification(valueEntry.specification);
+		if (!specification) continue;
+		seenProjectPaths.add(projectPath);
+		entries.push({ projectPath, specification });
+	}
+	return entries;
+}
+
+function touchEntry<T>(entries: T[], index: number): T[] {
+	const entry = entries[index];
+	return entry ? [entry, ...entries.slice(0, index), ...entries.slice(index + 1)] : entries;
+}
+
+function rememberEntry<T>(
+	entries: T[],
+	matches: (entry: T) => boolean,
+	entry: T,
+	limit: number,
+): T[] {
+	return [entry, ...entries.filter((candidate) => !matches(candidate))].slice(0, limit);
 }
 
 function parseSpecification(value: unknown): GitComparisonSpecification | null {

--- a/web/src/lib/git/review/git-comparison-preferences.ts
+++ b/web/src/lib/git/review/git-comparison-preferences.ts
@@ -88,12 +88,7 @@ export class LocalGitComparisonPreferences implements GitComparisonPreferences {
 	rememberChat(chatId: string, specification: GitComparisonSpecification): void {
 		if (!isNonEmptyString(chatId)) return;
 		const record = this.#readRecord();
-		record.entries = rememberEntry(
-			record.entries,
-			(entry) => entry.chatId === chatId,
-			{ chatId, specification: cloneSpecification(specification) },
-			GIT_COMPARISON_CHAT_PREFERENCE_LIMIT,
-		);
+		this.#rememberChatEntry(record, chatId, specification);
 		this.#writeRecord(record);
 	}
 
@@ -103,12 +98,7 @@ export class LocalGitComparisonPreferences implements GitComparisonPreferences {
 	): void {
 		if (!isNonEmptyString(context.chatId)) return;
 		const record = this.#readRecord();
-		record.entries = rememberEntry(
-			record.entries,
-			(entry) => entry.chatId === context.chatId,
-			{ chatId: context.chatId, specification: cloneSpecification(specification) },
-			GIT_COMPARISON_CHAT_PREFERENCE_LIMIT,
-		);
+		this.#rememberChatEntry(record, context.chatId, specification);
 		const [projectPath] = projectPathAndAncestors(context.projectPath);
 		if (projectPath) {
 			record.projectEntries = rememberEntry(
@@ -119,6 +109,19 @@ export class LocalGitComparisonPreferences implements GitComparisonPreferences {
 			);
 		}
 		this.#writeRecord(record);
+	}
+
+	#rememberChatEntry(
+		record: GitComparisonPreferenceRecord,
+		chatId: string,
+		specification: GitComparisonSpecification,
+	): void {
+		record.entries = rememberEntry(
+			record.entries,
+			(entry) => entry.chatId === chatId,
+			{ chatId, specification: cloneSpecification(specification) },
+			GIT_COMPARISON_CHAT_PREFERENCE_LIMIT,
+		);
 	}
 
 	#readRecord(): GitComparisonPreferenceRecord {

--- a/web/src/lib/utils/__tests__/project-path.logic.test.ts
+++ b/web/src/lib/utils/__tests__/project-path.logic.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+	isProjectPathAncestor,
+	normalizeProjectPath,
+	projectPathAndAncestors,
+} from '../project-path.js';
+
+describe('normalizeProjectPath', () => {
+	it('normalizes separators, trailing slashes, and Windows drive casing', () => {
+		expect(normalizeProjectPath(' /workspace//repo/// ')).toBe('/workspace/repo');
+		expect(normalizeProjectPath('C:\\workspace\\repo\\')).toBe('c:/workspace/repo');
+	});
+
+	it('preserves filesystem roots', () => {
+		expect(normalizeProjectPath('/')).toBe('/');
+		expect(normalizeProjectPath('C:\\')).toBe('c:');
+	});
+
+	it('returns an empty path for blank input', () => {
+		expect(normalizeProjectPath('   ')).toBe('');
+	});
+});
+
+describe('isProjectPathAncestor', () => {
+	it('matches exact and separator-bounded descendant paths', () => {
+		expect(isProjectPathAncestor('/workspace/repo', '/workspace/repo')).toBe(true);
+		expect(isProjectPathAncestor('/workspace/repo/', '/workspace/repo/packages/app')).toBe(true);
+		expect(isProjectPathAncestor('/workspace/repo', '/workspace/repository')).toBe(false);
+	});
+
+	it('normalizes Windows separators and drive casing', () => {
+		expect(isProjectPathAncestor('C:\\workspace\\repo', 'c:/workspace/repo/src')).toBe(true);
+	});
+});
+
+describe('projectPathAndAncestors', () => {
+	it('returns the exact Unix path followed by nearest ancestors', () => {
+		expect(projectPathAndAncestors('/repo/.worktrees/abc/')).toEqual([
+			'/repo/.worktrees/abc',
+			'/repo/.worktrees',
+			'/repo',
+			'/',
+		]);
+	});
+
+	it('terminates at Unix and Windows roots', () => {
+		expect(projectPathAndAncestors('/')).toEqual(['/']);
+		expect(projectPathAndAncestors('C:\\repo\\src')).toEqual(['c:/repo/src', 'c:/repo', 'c:']);
+		expect(projectPathAndAncestors('c:')).toEqual(['c:']);
+	});
+
+	it('rejects blank and relative paths', () => {
+		expect(projectPathAndAncestors('')).toEqual([]);
+		expect(projectPathAndAncestors('repo/src')).toEqual([]);
+		expect(projectPathAndAncestors('C:repo\\src')).toEqual([]);
+	});
+});

--- a/web/src/lib/utils/project-path.ts
+++ b/web/src/lib/utils/project-path.ts
@@ -1,0 +1,40 @@
+export function normalizeProjectPath(projectPath: string): string {
+	const trimmed = projectPath.trim().replace(/\\/g, '/');
+	if (!trimmed) return '';
+	const collapsed = trimmed.replace(/\/+/g, '/');
+	if (collapsed === '/') return '/';
+	const withoutTrailingSlash = collapsed.replace(/\/+$/g, '');
+	return withoutTrailingSlash.replace(/^([A-Za-z]:)/, (drive) => drive.toLowerCase());
+}
+
+export function isProjectPathAncestor(ancestorPath: string, descendantPath: string): boolean {
+	const ancestor = normalizeProjectPath(ancestorPath);
+	const descendant = normalizeProjectPath(descendantPath);
+	if (!ancestor || !descendant) return false;
+	if (ancestor === descendant) return true;
+	const prefix = ancestor.endsWith('/') ? ancestor : `${ancestor}/`;
+	return descendant.startsWith(prefix);
+}
+
+export function projectPathAndAncestors(projectPath: string): string[] {
+	const normalized = normalizeProjectPath(projectPath);
+	if (!isAbsoluteProjectPath(normalized)) return [];
+
+	const paths = [normalized];
+	let current = normalized;
+	while (current !== '/' && !isWindowsDriveRoot(current)) {
+		const separatorIndex = current.lastIndexOf('/');
+		if (separatorIndex < 0) break;
+		current = separatorIndex === 0 ? '/' : current.slice(0, separatorIndex);
+		paths.push(current);
+	}
+	return paths;
+}
+
+function isAbsoluteProjectPath(projectPath: string): boolean {
+	return projectPath.startsWith('/') || /^[a-z]:($|\/)/.test(projectPath);
+}
+
+function isWindowsDriveRoot(projectPath: string): boolean {
+	return /^[a-z]:$/.test(projectPath);
+}

--- a/web/src/lib/workspace/__tests__/singleton-surfaces.test.ts
+++ b/web/src/lib/workspace/__tests__/singleton-surfaces.test.ts
@@ -215,14 +215,18 @@ describe('SingletonSurfaceRegistry', () => {
 			toRevision: 'HEAD',
 			mode: 'direct' as const,
 		};
-		comparisonPreferences.remember('chat-a', specification);
+		comparisonPreferences.rememberChat('chat-a', specification);
 		registry.gitCompare();
 
 		registry.disposeSurface('git-compare');
-		expect(comparisonPreferences.recall('chat-a')).toEqual(specification);
+		expect(comparisonPreferences.recall({ chatId: 'chat-a', projectPath: '/project-a' })).toEqual(
+			specification,
+		);
 
 		registry.destroy();
-		expect(comparisonPreferences.recall('chat-a')).toEqual(specification);
+		expect(comparisonPreferences.recall({ chatId: 'chat-a', projectPath: '/project-a' })).toEqual(
+			specification,
+		);
 	});
 
 	it('routes visibility for every singleton through one lifecycle owner', () => {


### PR DESCRIPTION
Git comparison preferences currently follow individual chats, so new chats in linked worktrees lose useful range defaults. This adds an independently bounded project-path preference LRU alongside chat preferences, resolves exact and nearest-ancestor defaults before the built-in fallback, preserves existing chat preferences, and records project defaults only after successful explicit comparisons while keeping normalized path handling and asynchronous session fencing consistent.