### PR TITLE
Virtualize the Git workbench file tree

### DIFF
--- a/web/src/lib/components/git/GitFileTree.svelte
+++ b/web/src/lib/components/git/GitFileTree.svelte
@@ -1,20 +1,15 @@
 <script lang="ts">
-	// File tree panel for the git workbench. Renders a collapsible directory
-	// hierarchy with change-kind badges and selection highlighting.
-
-	import ChevronRight from '@lucide/svelte/icons/chevron-right';
-	import ChevronDown from '@lucide/svelte/icons/chevron-down';
-	import FileIcon from '@lucide/svelte/icons/file';
-	import FolderIcon from '@lucide/svelte/icons/folder';
-	import FolderOpen from '@lucide/svelte/icons/folder-open';
+	import { onDestroy } from 'svelte';
 	import Search from '@lucide/svelte/icons/search';
-	import Plus from '@lucide/svelte/icons/plus';
-	import Minus from '@lucide/svelte/icons/minus';
-	import Undo2 from '@lucide/svelte/icons/undo-2';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
-	import type { GitTreeNode, GitChangeKind, GitFileReviewCategory } from '$lib/api/git.js';
-	import { nativeWorkspaceScrollRegion } from '$lib/workspace/workspace-scroll-region.js';
+	import type { GitTreeNode } from '$lib/api/git.js';
+	import {
+		flattenGitWorkbenchTree,
+		type GitWorkbenchTreeRow,
+	} from '$lib/git/workbench/git-workbench-tree-rows.js';
 	import * as m from '$lib/paraglide/messages.js';
+	import { nativeWorkspaceScrollRegion } from '$lib/workspace/workspace-scroll-region.js';
+	import GitFileTreeRow from './GitFileTreeRow.svelte';
+	import { GitFileTreeVirtualController } from './GitFileTreeVirtualController.svelte.js';
 
 	interface GitFileTreeProps {
 		tree: GitTreeNode[];
@@ -41,7 +36,6 @@
 		visibleChangedFiles?: number;
 		onHideGeneratedChange?: (value: boolean) => void;
 		onHideOtherTabFilesChange?: (value: boolean) => void;
-		/** When true, stage/unstage buttons are always visible (for touch). */
 		alwaysShowActions?: boolean;
 	}
 
@@ -73,8 +67,14 @@
 		alwaysShowActions = false,
 	}: GitFileTreeProps = $props();
 
+	const treeId = $props.id();
+	const contextualScrollRegion = nativeWorkspaceScrollRegion('contextual');
+	let viewportElement = $state<HTMLDivElement | null>(null);
+	let rows = $derived(flattenGitWorkbenchTree(tree, collapsedDirs));
 	const actionVisibility = $derived(
-		alwaysShowActions ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+		alwaysShowActions
+			? 'opacity-100'
+			: 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
 	);
 	const fileCountLabel = $derived(
 		visibleChangedFiles !== undefined
@@ -84,84 +84,82 @@
 				})
 			: m.git_file_tree_files_count({ count: totalChangedFiles }),
 	);
-	const treeGuideIndentPx = 12;
-	const treeGuideStartPx = 8;
-	const treeGuideToggleCenterOffsetPx = 10;
-	const contextualScrollRegion = nativeWorkspaceScrollRegion('contextual');
 
-	function treeGuideColumnLeft(depthIndex: number): number {
-		return treeGuideStartPx + depthIndex * treeGuideIndentPx + treeGuideToggleCenterOffsetPx;
+	const controller = new GitFileTreeVirtualController({
+		get rows() {
+			return rows;
+		},
+		get collapsedDirs() {
+			return collapsedDirs;
+		},
+		get selectedFile() {
+			return selectedFile;
+		},
+		get viewportElement() {
+			return viewportElement;
+		},
+		get onSelectFile() {
+			return onSelectFile;
+		},
+		get onToggleDir() {
+			return onToggleDir;
+		},
+	});
+	let virtualSnapshot = $derived(controller.snapshot);
+	let renderedItems = $derived(controller.renderedItems(virtualSnapshot));
+	let totalHeight = $derived(virtualSnapshot.sizerSize);
+	let activeFocusKey = $derived(controller.activeFocusKey);
+	let activeRowIndex = $derived(controller.activeRowIndex);
+	let activeDescendantId = $derived(
+		activeRowIndex >= 0 && renderedItems.some((item) => item.index === activeRowIndex)
+			? rowElementId(activeRowIndex)
+			: undefined,
+	);
+
+	function rowElementId(index: number): string {
+		return `${treeId}-row-${index}`;
 	}
 
-	function changeKindColor(kind?: GitChangeKind): string {
-		switch (kind) {
-			case 'modified':
-				return 'text-git-modified';
-			case 'added':
-				return 'text-git-added';
-			case 'deleted':
-				return 'text-git-deleted';
-			case 'untracked':
-				return 'text-git-untracked';
-			case 'renamed':
-				return 'text-git-renamed';
-			default:
-				return 'text-muted-foreground';
-		}
+	function isDirectory(row: GitWorkbenchTreeRow): boolean {
+		return row.node.kind === 'directory';
 	}
 
-	function changeKindBadge(kind?: GitChangeKind): string {
-		switch (kind) {
-			case 'modified':
-				return 'M';
-			case 'added':
-				return 'A';
-			case 'deleted':
-				return 'D';
-			case 'untracked':
-				return 'U';
-			case 'renamed':
-				return 'R';
-			default:
-				return '';
-		}
+	function rowIsCollapsed(row: GitWorkbenchTreeRow): boolean {
+		return isDirectory(row) && collapsedDirs.has(row.node.path);
 	}
 
-	function categoryBadge(category?: GitFileReviewCategory): string {
-		if (category === 'generated') return 'GEN';
-		if (category === 'lockfile') return 'LOCK';
-		if (category === 'binary') return 'BIN';
-		if (category === 'large') return 'LARGE';
-		return '';
+	function rowIsSelected(row: GitWorkbenchTreeRow): boolean {
+		return !isDirectory(row) && selectedFile === row.node.path;
 	}
 
-	function handleKeyDown(e: KeyboardEvent, path: string, isDir: boolean): void {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			if (isDir) onToggleDir(path);
-			else onSelectFile(path);
-		}
+	function stageIsPending(row: GitWorkbenchTreeRow): boolean {
+		if (isDirectory(row)) return isStageDirPending?.(row.node.path) ?? false;
+		return isStageFilePending?.(row.node.path) ?? false;
 	}
+
+	function unstageIsPending(row: GitWorkbenchTreeRow): boolean {
+		if (isDirectory(row)) return isUnstageDirPending?.(row.node.path) ?? false;
+		return isUnstageFilePending?.(row.node.path) ?? false;
+	}
+
+	onDestroy(() => controller.destroy());
 </script>
 
-<div class="flex flex-col h-full bg-background">
-	<!-- Header with count and search -->
-	<div class="px-3 py-2 border-b border-border">
-		<div class="flex items-center justify-between gap-2 mb-2">
-			<span class="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
+<div class="flex h-full flex-col bg-background">
+	<div class="border-b border-border px-3 py-2">
+		<div class="mb-2 flex items-center justify-between gap-2">
+			<span class="truncate text-xs font-medium uppercase tracking-wider text-muted-foreground">
 				{fileCountLabel}
 			</span>
 		</div>
-
-		<!-- Search -->
 		<div class="relative">
-			<Search class="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+			<Search class="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
 			<input
 				type="text"
 				placeholder={m.git_filter_files_placeholder()}
 				value={treeSearchQuery}
-				oninput={(e) => onSearchChange(e.currentTarget.value)}
-				class="w-full pl-7 pr-2 py-1 text-xs bg-muted border border-border rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+				oninput={(event) => onSearchChange(event.currentTarget.value)}
+				class="w-full rounded border border-border bg-muted py-1 pl-7 pr-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
 			/>
 		</div>
 		<div class="mt-2 flex items-center gap-3 text-[11px] text-muted-foreground">
@@ -169,7 +167,7 @@
 				<input
 					type="checkbox"
 					checked={hideOtherTabFiles}
-					onchange={(e) => onHideOtherTabFilesChange?.(e.currentTarget.checked)}
+					onchange={(event) => onHideOtherTabFilesChange?.(event.currentTarget.checked)}
 					class="size-3 accent-current"
 				/>
 				<span>{hideOtherTabFilesLabel}</span>
@@ -178,7 +176,7 @@
 				<input
 					type="checkbox"
 					checked={hideGenerated}
-					onchange={(e) => onHideGeneratedChange?.(e.currentTarget.checked)}
+					onchange={(event) => onHideGeneratedChange?.(event.currentTarget.checked)}
 					class="size-3 accent-current"
 				/>
 				<span>{m.git_file_tree_hide_generated()}</span>
@@ -186,224 +184,90 @@
 		</div>
 	</div>
 
-	<!-- Tree content -->
-	<div class="flex-1 overflow-y-auto py-1" {@attach contextualScrollRegion}>
-		{#if tree.length === 0}
-			<div class="px-3 py-4 text-xs text-muted-foreground text-center">
+	<div
+		bind:this={viewportElement}
+		{@attach controller.viewport}
+		{@attach contextualScrollRegion}
+		class="min-h-0 flex-1 overflow-y-auto py-1 focus-visible:outline-none"
+		style:overflow-anchor="none"
+		role="tree"
+		tabindex="0"
+		aria-label={m.git_diff_document_files()}
+		aria-activedescendant={activeDescendantId}
+		data-git-workbench-file-tree
+		onkeydown={(event) => controller.handleTreeKeydown(event)}
+	>
+		{#if rows.length === 0}
+			<div class="px-3 py-4 text-center text-xs text-muted-foreground">
 				{m.git_file_tree_no_changed_files()}
 			</div>
 		{:else}
-			{#each tree as node}
-				{@render treeNode(node, 0)}
-			{/each}
+			<div
+				class="relative w-full"
+				style:height={`${totalHeight}px`}
+				role="none"
+				data-git-workbench-file-tree-sizer
+				{@attach controller.sizer}
+			>
+				{#each renderedItems as virtualItem (virtualItem.key)}
+					{@const row = rows[virtualItem.index]}
+					{#if row}
+						<div
+							id={rowElementId(virtualItem.index)}
+							role="treeitem"
+							aria-label={row.node.name}
+							aria-level={row.depth + 1}
+							aria-expanded={isDirectory(row) ? !rowIsCollapsed(row) : undefined}
+							aria-selected={rowIsSelected(row)}
+							aria-posinset={row.positionInSet}
+							aria-setsize={row.setSize}
+							tabindex="-1"
+							class="group absolute left-0 top-0 w-full overflow-hidden focus-visible:outline-none"
+							style:height={`${virtualItem.size}px`}
+							style:transform={`translateY(${virtualItem.start}px)`}
+							title={row.node.path}
+							data-git-workbench-file-tree-row
+							data-git-tree-row-key={row.key}
+							data-git-tree-row-active={activeFocusKey === row.key ? '' : undefined}
+							data-git-file-tree-directory={isDirectory(row) ? '' : undefined}
+							data-git-file-tree-file={!isDirectory(row) ? '' : undefined}
+						>
+							<svelte:boundary>
+								<GitFileTreeRow
+									{row}
+									selected={rowIsSelected(row)}
+									collapsed={rowIsCollapsed(row)}
+									{actionVisibility}
+									stagePending={stageIsPending(row)}
+									unstagePending={unstageIsPending(row)}
+									onFocusRow={() => controller.setFocusedRow(row.key)}
+									{onSelectFile}
+									{onSelectDirectory}
+									{onToggleDir}
+									{onStageFile}
+									{onUnstageFile}
+									{onStageDir}
+									{onUnstageDir}
+									{onDiscardFile}
+								/>
+
+								{#snippet failed()}
+									<div class="flex h-full items-center px-3 text-xs text-status-error-foreground">
+										{m.git_diff_document_file_row_failed()}
+									</div>
+								{/snippet}
+							</svelte:boundary>
+						</div>
+					{/if}
+				{/each}
+			</div>
 		{/if}
 	</div>
 </div>
 
-{#snippet treeNode(node: GitTreeNode, depth: number)}
-	{#if node.kind === 'directory'}
-		{@const isCollapsed = collapsedDirs.has(node.path)}
-		{@const stageDirPending = isStageDirPending?.(node.path) ?? false}
-		{@const unstageDirPending = isUnstageDirPending?.(node.path) ?? false}
-		<div
-			class="relative flex items-center w-full px-2 py-1 text-xs hover:bg-muted/50 transition-colors group"
-			style="padding-left: {depth * 12 + 8}px"
-		>
-			{#if depth > 0}
-				<div class="absolute inset-y-0 left-0 pointer-events-none" aria-hidden="true">
-					{#each Array(depth) as _, depthIndex}
-						<span
-							class="absolute inset-y-0 w-px bg-border/70"
-							style="left: {treeGuideColumnLeft(depthIndex)}px"
-						></span>
-					{/each}
-				</div>
-			{/if}
-			<button
-				type="button"
-				onclick={() => onToggleDir(node.path)}
-				onkeydown={(e) => handleKeyDown(e, node.path, true)}
-				class="w-5 h-5 flex items-center justify-center rounded hover:bg-muted shrink-0"
-				aria-label={isCollapsed ? m.editor_actions_expand() : m.editor_actions_collapse()}
-			>
-				{#if isCollapsed}
-					<ChevronRight class="w-3.5 h-3.5 text-muted-foreground" />
-				{:else}
-					<ChevronDown class="w-3.5 h-3.5 text-muted-foreground" />
-				{/if}
-			</button>
-			<button
-				type="button"
-				onclick={() => onSelectDirectory?.(node.path)}
-				class="flex items-center flex-1 min-w-0 ml-0.5"
-			>
-				<span class="w-4 h-4 flex items-center justify-center mr-1 text-muted-foreground">
-					{#if isCollapsed}
-						<FolderIcon class="w-3.5 h-3.5" />
-					{:else}
-						<FolderOpen class="w-3.5 h-3.5" />
-					{/if}
-				</span>
-				<span class="truncate text-foreground">{node.name}</span>
-			</button>
-			{#if (node.hasUnstaged || node.changeKind === 'untracked') && onStageDir}
-				<button
-					type="button"
-					disabled={stageDirPending}
-					onclick={(e) => {
-						e.stopPropagation();
-						onStageDir(node.path);
-					}}
-					class="ml-1 p-0.5 rounded {actionVisibility} hover:bg-muted transition-opacity shrink-0 disabled:opacity-50"
-					title={m.git_action_stage_directory()}
-				>
-					{#if stageDirPending}
-						<LoaderCircle class="w-3 h-3 text-git-added animate-spin" />
-					{:else}
-						<Plus class="w-3 h-3 text-git-added" />
-					{/if}
-				</button>
-			{/if}
-			{#if node.staged && onUnstageDir}
-				<button
-					type="button"
-					disabled={unstageDirPending}
-					onclick={(e) => {
-						e.stopPropagation();
-						onUnstageDir(node.path);
-					}}
-					class="ml-1 p-0.5 rounded {actionVisibility} hover:bg-muted transition-opacity shrink-0 disabled:opacity-50"
-					title={m.git_action_unstage_directory()}
-				>
-					{#if unstageDirPending}
-						<LoaderCircle class="w-3 h-3 text-git-deleted animate-spin" />
-					{:else}
-						<Minus class="w-3 h-3 text-git-deleted" />
-					{/if}
-				</button>
-			{/if}
-		</div>
-
-		{#if !isCollapsed && node.children}
-			{#each node.children as child}
-				{@render treeNode(child, depth + 1)}
-			{/each}
-		{/if}
-	{:else}
-		{@const isSelected = selectedFile === node.path}
-		{@const stageFilePending = isStageFilePending?.(node.path) ?? false}
-		{@const unstageFilePending = isUnstageFilePending?.(node.path) ?? false}
-		{@const badge = categoryBadge(node.category)}
-		<div
-			class="relative flex items-center w-full px-2 py-1 text-xs transition-colors group
-				{isSelected
-				? 'bg-interactive-accent/10 text-interactive-accent'
-				: 'hover:bg-muted/50 text-foreground'}"
-			style="padding-left: {depth * 12 + 8}px"
-		>
-			{#if depth > 0}
-				<div class="absolute inset-y-0 left-0 pointer-events-none" aria-hidden="true">
-					{#each Array(depth) as _, depthIndex}
-						<span
-							class="absolute inset-y-0 w-px bg-border/70"
-							style="left: {treeGuideColumnLeft(depthIndex)}px"
-						></span>
-					{/each}
-				</div>
-			{/if}
-			<button
-				type="button"
-				onclick={() => onSelectFile(node.path)}
-				onkeydown={(e) => handleKeyDown(e, node.path, false)}
-				class="flex items-center flex-1 min-w-0"
-			>
-				<span class="w-4 h-4 flex items-center justify-center mr-1">
-					<!-- Spacer to align with directory chevrons -->
-				</span>
-				<span class="w-4 h-4 flex items-center justify-center mr-1.5 text-muted-foreground">
-					<FileIcon class="w-3.5 h-3.5" />
-				</span>
-				<span class="truncate flex-1 text-left">{node.name}</span>
-			</button>
-			{#if node.additions || node.deletions}
-				<span class="ml-1 flex gap-1 text-[10px] shrink-0">
-					{#if node.additions}
-						<span class="text-git-added">+{node.additions}</span>
-					{/if}
-					{#if node.deletions}
-						<span class="text-git-deleted">-{node.deletions}</span>
-					{/if}
-				</span>
-			{/if}
-			{#if node.changeKind}
-				<span class="ml-1.5 text-[10px] font-bold shrink-0 {changeKindColor(node.changeKind)}">
-					{changeKindBadge(node.changeKind)}
-				</span>
-			{/if}
-			{#if badge}
-				<span
-					class="ml-1 rounded bg-muted px-1 text-[9px] font-medium text-muted-foreground shrink-0"
-				>
-					{badge}
-				</span>
-			{/if}
-			{#if (node.hasUnstaged || node.changeKind === 'untracked') && onStageFile}
-				{#if onDiscardFile}
-					<button
-						type="button"
-						onclick={(e) => {
-							e.stopPropagation();
-							onDiscardFile(node.path);
-						}}
-						class="ml-1 p-0.5 rounded {actionVisibility} hover:bg-status-error/20 transition-opacity shrink-0"
-						title={node.changeKind === 'untracked'
-							? m.git_file_item_delete_untracked()
-							: m.git_file_item_discard_changes()}
-					>
-						<Undo2 class="w-3 h-3 text-muted-foreground hover:text-status-error-foreground" />
-					</button>
-				{/if}
-				<button
-					type="button"
-					disabled={stageFilePending}
-					onclick={(e) => {
-						e.stopPropagation();
-						onStageFile(node.path);
-					}}
-					class="ml-1 p-0.5 rounded {actionVisibility} hover:bg-muted transition-opacity shrink-0 disabled:opacity-50"
-					title={m.git_action_stage_file()}
-				>
-					{#if stageFilePending}
-						<LoaderCircle class="w-3 h-3 text-git-added animate-spin" />
-					{:else}
-						<Plus class="w-3 h-3 text-git-added" />
-					{/if}
-				</button>
-			{/if}
-			{#if node.staged && onUnstageFile}
-				<button
-					type="button"
-					disabled={unstageFilePending}
-					onclick={(e) => {
-						e.stopPropagation();
-						onUnstageFile(node.path);
-					}}
-					class="ml-1 p-0.5 rounded {actionVisibility} hover:bg-muted transition-opacity shrink-0 disabled:opacity-50"
-					title={m.git_action_unstage_file()}
-				>
-					{#if unstageFilePending}
-						<LoaderCircle class="w-3 h-3 text-git-deleted animate-spin" />
-					{:else}
-						<Minus class="w-3 h-3 text-git-deleted" />
-					{/if}
-				</button>
-			{/if}
-			{#if node.staged}
-				<span
-					class="ml-1 w-1.5 h-1.5 rounded-full bg-git-added shrink-0"
-					title={m.git_action_staged()}
-				></span>
-			{/if}
-		</div>
-	{/if}
-{/snippet}
+<style>
+	[data-git-workbench-file-tree]:focus-visible [data-git-tree-row-active] {
+		outline: 1px solid var(--color-interactive-accent);
+		outline-offset: -1px;
+	}
+</style>

--- a/web/src/lib/components/git/GitFileTreeRow.svelte
+++ b/web/src/lib/components/git/GitFileTreeRow.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
+	import FileIcon from '@lucide/svelte/icons/file';
+	import FolderIcon from '@lucide/svelte/icons/folder';
+	import FolderOpen from '@lucide/svelte/icons/folder-open';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import Minus from '@lucide/svelte/icons/minus';
+	import Plus from '@lucide/svelte/icons/plus';
+	import Undo2 from '@lucide/svelte/icons/undo-2';
+	import type { GitChangeKind, GitFileReviewCategory } from '$lib/api/git.js';
+	import type { GitWorkbenchTreeRow } from '$lib/git/workbench/git-workbench-tree-rows.js';
+	import * as m from '$lib/paraglide/messages.js';
+
+	interface GitFileTreeRowProps {
+		row: GitWorkbenchTreeRow;
+		selected: boolean;
+		collapsed: boolean;
+		actionVisibility: string;
+		stagePending: boolean;
+		unstagePending: boolean;
+		onFocusRow: () => void;
+		onSelectFile: (path: string) => void;
+		onSelectDirectory?: (path: string) => void;
+		onToggleDir: (path: string) => void;
+		onStageFile?: (path: string) => void;
+		onUnstageFile?: (path: string) => void;
+		onStageDir?: (path: string) => void;
+		onUnstageDir?: (path: string) => void;
+		onDiscardFile?: (path: string) => void;
+	}
+
+	let {
+		row,
+		selected,
+		collapsed,
+		actionVisibility,
+		stagePending,
+		unstagePending,
+		onFocusRow,
+		onSelectFile,
+		onSelectDirectory,
+		onToggleDir,
+		onStageFile,
+		onUnstageFile,
+		onStageDir,
+		onUnstageDir,
+		onDiscardFile,
+	}: GitFileTreeRowProps = $props();
+	let node = $derived(row.node);
+
+	const treeGuideIndentPx = 12;
+	const treeGuideStartPx = 8;
+	const treeGuideToggleCenterOffsetPx = 10;
+
+	function treeGuideColumnLeft(depthIndex: number): number {
+		return treeGuideStartPx + depthIndex * treeGuideIndentPx + treeGuideToggleCenterOffsetPx;
+	}
+
+	function changeKindColor(kind?: GitChangeKind): string {
+		switch (kind) {
+			case 'modified':
+				return 'text-git-modified';
+			case 'added':
+				return 'text-git-added';
+			case 'deleted':
+				return 'text-git-deleted';
+			case 'untracked':
+				return 'text-git-untracked';
+			case 'renamed':
+				return 'text-git-renamed';
+			default:
+				return 'text-muted-foreground';
+		}
+	}
+
+	function changeKindBadge(kind?: GitChangeKind): string {
+		switch (kind) {
+			case 'modified':
+				return 'M';
+			case 'added':
+				return 'A';
+			case 'deleted':
+				return 'D';
+			case 'untracked':
+				return 'U';
+			case 'renamed':
+				return 'R';
+			default:
+				return '';
+		}
+	}
+
+	function categoryBadge(category?: GitFileReviewCategory): string {
+		if (category === 'generated') return 'GEN';
+		if (category === 'lockfile') return 'LOCK';
+		if (category === 'binary') return 'BIN';
+		if (category === 'large') return 'LARGE';
+		return '';
+	}
+</script>
+
+<div
+	class="relative flex h-full min-w-0 items-center overflow-hidden px-2 text-xs transition-colors
+		{selected ? 'bg-interactive-accent/10 text-interactive-accent' : 'hover:bg-muted/50'}"
+	style:padding-left={`${row.depth * treeGuideIndentPx + 8}px`}
+>
+	{#if row.depth > 0}
+		<span class="pointer-events-none absolute inset-y-0 left-0" aria-hidden="true">
+			{#each Array(row.depth) as _, depthIndex}
+				<span
+					class="absolute inset-y-0 w-px bg-border/70"
+					style:left={`${treeGuideColumnLeft(depthIndex)}px`}
+				></span>
+			{/each}
+		</span>
+	{/if}
+
+	{#if node.kind === 'directory'}
+		<button
+			type="button"
+			onfocus={onFocusRow}
+			onclick={() => {
+				onFocusRow();
+				onToggleDir(node.path);
+			}}
+			class="relative z-10 flex size-5 shrink-0 items-center justify-center rounded hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+			aria-label={collapsed ? m.editor_actions_expand() : m.editor_actions_collapse()}
+		>
+			{#if collapsed}
+				<ChevronRight class="size-3.5 text-muted-foreground" />
+			{:else}
+				<ChevronDown class="size-3.5 text-muted-foreground" />
+			{/if}
+		</button>
+		<button
+			type="button"
+			onfocus={onFocusRow}
+			onclick={() => {
+				onFocusRow();
+				onSelectDirectory?.(node.path);
+			}}
+			class="relative z-10 ml-0.5 flex min-w-0 flex-1 items-center rounded-sm text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+		>
+			<span class="mr-1 flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+				{#if collapsed}
+					<FolderIcon class="size-3.5" />
+				{:else}
+					<FolderOpen class="size-3.5" />
+				{/if}
+			</span>
+			<span class="truncate text-foreground">{node.name}</span>
+		</button>
+		{#if (node.hasUnstaged || node.changeKind === 'untracked') && onStageDir}
+			<button
+				type="button"
+				disabled={stagePending}
+				onfocus={onFocusRow}
+				onclick={() => onStageDir?.(node.path)}
+				class="relative z-10 ml-1 shrink-0 rounded p-0.5 {actionVisibility} transition-opacity hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent disabled:opacity-50"
+				title={m.git_action_stage_directory()}
+			>
+				{#if stagePending}
+					<LoaderCircle class="size-3 animate-spin text-git-added" />
+				{:else}
+					<Plus class="size-3 text-git-added" />
+				{/if}
+			</button>
+		{/if}
+		{#if node.staged && onUnstageDir}
+			<button
+				type="button"
+				disabled={unstagePending}
+				onfocus={onFocusRow}
+				onclick={() => onUnstageDir?.(node.path)}
+				class="relative z-10 ml-1 shrink-0 rounded p-0.5 {actionVisibility} transition-opacity hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent disabled:opacity-50"
+				title={m.git_action_unstage_directory()}
+			>
+				{#if unstagePending}
+					<LoaderCircle class="size-3 animate-spin text-git-deleted" />
+				{:else}
+					<Minus class="size-3 text-git-deleted" />
+				{/if}
+			</button>
+		{/if}
+	{:else}
+		{@const badge = categoryBadge(node.category)}
+		<button
+			type="button"
+			onfocus={onFocusRow}
+			onclick={() => {
+				onFocusRow();
+				onSelectFile(node.path);
+			}}
+			class="relative z-10 flex min-w-0 flex-1 items-center rounded-sm text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+		>
+			<span class="mr-1 size-4 shrink-0"></span>
+			<span class="mr-1.5 flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+				<FileIcon class="size-3.5" />
+			</span>
+			<span class="min-w-0 flex-1 truncate">{node.name}</span>
+		</button>
+		{#if node.additions || node.deletions}
+			<span class="relative z-10 ml-1 flex shrink-0 gap-1 text-[10px]">
+				{#if node.additions}<span class="text-git-added">+{node.additions}</span>{/if}
+				{#if node.deletions}<span class="text-git-deleted">-{node.deletions}</span>{/if}
+			</span>
+		{/if}
+		{#if node.changeKind}
+			<span
+				class="relative z-10 ml-1.5 shrink-0 text-[10px] font-bold {changeKindColor(
+					node.changeKind,
+				)}"
+			>
+				{changeKindBadge(node.changeKind)}
+			</span>
+		{/if}
+		{#if badge}
+			<span
+				class="relative z-10 ml-1 shrink-0 rounded bg-muted px-1 text-[9px] font-medium text-muted-foreground"
+			>
+				{badge}
+			</span>
+		{/if}
+		{#if (node.hasUnstaged || node.changeKind === 'untracked') && onStageFile}
+			{#if onDiscardFile}
+				<button
+					type="button"
+					onfocus={onFocusRow}
+					onclick={() => onDiscardFile?.(node.path)}
+					class="relative z-10 ml-1 shrink-0 rounded p-0.5 {actionVisibility} transition-opacity hover:bg-status-error/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent"
+					title={node.changeKind === 'untracked'
+						? m.git_file_item_delete_untracked()
+						: m.git_file_item_discard_changes()}
+				>
+					<Undo2 class="size-3 text-muted-foreground hover:text-status-error-foreground" />
+				</button>
+			{/if}
+			<button
+				type="button"
+				disabled={stagePending}
+				onfocus={onFocusRow}
+				onclick={() => onStageFile?.(node.path)}
+				class="relative z-10 ml-1 shrink-0 rounded p-0.5 {actionVisibility} transition-opacity hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent disabled:opacity-50"
+				title={m.git_action_stage_file()}
+			>
+				{#if stagePending}
+					<LoaderCircle class="size-3 animate-spin text-git-added" />
+				{:else}
+					<Plus class="size-3 text-git-added" />
+				{/if}
+			</button>
+		{/if}
+		{#if node.staged && onUnstageFile}
+			<button
+				type="button"
+				disabled={unstagePending}
+				onfocus={onFocusRow}
+				onclick={() => onUnstageFile?.(node.path)}
+				class="relative z-10 ml-1 shrink-0 rounded p-0.5 {actionVisibility} transition-opacity hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-accent disabled:opacity-50"
+				title={m.git_action_unstage_file()}
+			>
+				{#if unstagePending}
+					<LoaderCircle class="size-3 animate-spin text-git-deleted" />
+				{:else}
+					<Minus class="size-3 text-git-deleted" />
+				{/if}
+			</button>
+		{/if}
+		{#if node.staged}
+			<span
+				class="relative z-10 ml-1 size-1.5 shrink-0 rounded-full bg-git-added"
+				title={m.git_action_staged()}
+			></span>
+		{/if}
+	{/if}
+</div>

--- a/web/src/lib/components/git/GitFileTreeVirtualController.svelte.ts
+++ b/web/src/lib/components/git/GitFileTreeVirtualController.svelte.ts
@@ -1,0 +1,280 @@
+import { untrack } from 'svelte';
+import type { Attachment } from 'svelte/attachments';
+import {
+	GIT_WORKBENCH_TREE_OVERSCAN,
+	GIT_WORKBENCH_TREE_ROW_HEIGHT,
+	gitWorkbenchTreeRowKey,
+	type GitWorkbenchTreeRow,
+} from '$lib/git/workbench/git-workbench-tree-rows.js';
+import { VirtualListController } from '$lib/virt/virtual-list-controller.svelte.js';
+import {
+	virtualItems as selectVirtualItems,
+	type VirtualItem,
+	type VirtualListSnapshot,
+	type VirtualMutationAnchor,
+	type VirtualRange,
+} from '$lib/virt/virtual-list-types.js';
+
+interface GitFileTreeVirtualControllerOptions {
+	get rows(): readonly GitWorkbenchTreeRow[];
+	get collapsedDirs(): ReadonlySet<string>;
+	get selectedFile(): string | null;
+	get viewportElement(): HTMLElement | null;
+	get onSelectFile(): (path: string) => void;
+	get onToggleDir(): (path: string) => void;
+}
+
+function indexesInRange(range: VirtualRange | null): number[] {
+	if (!range) return [];
+	return Array.from(
+		{ length: range.endIndex - range.startIndex + 1 },
+		(_, offset) => range.startIndex + offset,
+	);
+}
+
+function indexWithinRange(index: number, range: VirtualRange): number {
+	return Math.min(range.endIndex, Math.max(range.startIndex, index));
+}
+
+function focusWasLostFromDocument(): boolean {
+	const activeElement = document.activeElement;
+	return (
+		!activeElement || activeElement === document.body || activeElement === document.documentElement
+	);
+}
+
+export class GitFileTreeVirtualController {
+	readonly viewport: Attachment<HTMLElement>;
+	readonly sizer: Attachment<HTMLElement>;
+	focusedRowKey = $state<string | null>(null);
+
+	#virtual: VirtualListController;
+	#lastRevealedSelectionKey: string | null = null;
+	#virtualRenderHadTreeFocus = false;
+
+	constructor(private readonly options: GitFileTreeVirtualControllerOptions) {
+		this.#virtual = new VirtualListController({
+			initialViewportSize: 720,
+			get overscan() {
+				return GIT_WORKBENCH_TREE_OVERSCAN;
+			},
+			get measurementAnchor() {
+				return 'geometric' as const;
+			},
+		});
+		this.viewport = this.#virtual.viewport;
+		this.sizer = this.#virtual.sizer;
+
+		$effect.pre(() => {
+			const rows = options.rows;
+			untrack(() => {
+				const result = this.#virtual.apply({
+					kind: 'update',
+					keys: rows.map((row) => row.key),
+					estimates: rows.map(() => GIT_WORKBENCH_TREE_ROW_HEIGHT),
+					anchor: this.#currentAnchor(),
+				});
+				if (result.kind === 'rejected') {
+					console.error(`Git file tree virtualization rejected source geometry: ${result.reason}`);
+				}
+			});
+		});
+
+		$effect.pre(() => {
+			void this.#virtual.snapshot.revision;
+			const viewportElement = options.viewportElement;
+			this.#virtualRenderHadTreeFocus = Boolean(
+				viewportElement &&
+				document.activeElement &&
+				viewportElement.contains(document.activeElement),
+			);
+		});
+
+		$effect(() => {
+			void this.#virtual.snapshot.revision;
+			untrack(() => this.#restoreTreeFocusAfterVirtualRender());
+		});
+
+		$effect(() => {
+			const selectedFile = options.selectedFile;
+			const rows = options.rows;
+			if (!selectedFile) {
+				this.#lastRevealedSelectionKey = null;
+				return;
+			}
+			const key = gitWorkbenchTreeRowKey({ kind: 'file', path: selectedFile });
+			const index = rows.findIndex((row) => row.key === key);
+			// Keeps the reveal pending when selection arrives before its row becomes renderable.
+			if (index < 0) {
+				this.#lastRevealedSelectionKey = null;
+				return;
+			}
+			if (key === this.#lastRevealedSelectionKey) return;
+			this.#lastRevealedSelectionKey = key;
+			untrack(() => this.#revealSelectedRow(index));
+		});
+	}
+
+	get snapshot(): VirtualListSnapshot {
+		return this.#virtual.snapshot;
+	}
+
+	get activeFocusKey(): string | null {
+		const rows = this.options.rows;
+		if (this.focusedRowKey && rows.some((row) => row.key === this.focusedRowKey)) {
+			return this.focusedRowKey;
+		}
+		const selectedKey = this.options.selectedFile
+			? gitWorkbenchTreeRowKey({ kind: 'file', path: this.options.selectedFile })
+			: null;
+		if (selectedKey && rows.some((row) => row.key === selectedKey)) return selectedKey;
+		return rows[0]?.key ?? null;
+	}
+
+	get activeRowIndex(): number {
+		const activeFocusKey = this.activeFocusKey;
+		return this.options.rows.findIndex((row) => row.key === activeFocusKey);
+	}
+
+	renderedItems(snapshot: VirtualListSnapshot): readonly VirtualItem[] {
+		const items = selectVirtualItems(snapshot, indexesInRange(snapshot.overscanRange));
+		if (items.length > 0 || this.options.rows.length === 0) return items;
+		return this.options.rows.slice(0, 24).map((row, index) => ({
+			index,
+			key: row.key,
+			start: index * GIT_WORKBENCH_TREE_ROW_HEIGHT,
+			size: GIT_WORKBENCH_TREE_ROW_HEIGHT,
+			end: (index + 1) * GIT_WORKBENCH_TREE_ROW_HEIGHT,
+		}));
+	}
+
+	setFocusedRow(key: string): void {
+		this.focusedRowKey = key;
+	}
+
+	handleTreeKeydown(event: KeyboardEvent): void {
+		const activatedFromTreeRoot = event.target === this.options.viewportElement;
+		const index = this.activeRowIndex;
+		const row = this.options.rows[index];
+		if (!row) return;
+		switch (event.key) {
+			case 'ArrowDown':
+				event.preventDefault();
+				this.#focusRowAt(Math.min(this.options.rows.length - 1, index + 1));
+				break;
+			case 'ArrowUp':
+				event.preventDefault();
+				this.#focusRowAt(Math.max(0, index - 1));
+				break;
+			case 'Home':
+				event.preventDefault();
+				this.#focusRowAt(0);
+				break;
+			case 'End':
+				event.preventDefault();
+				this.#focusRowAt(this.options.rows.length - 1);
+				break;
+			case 'ArrowRight':
+				if (row.node.kind !== 'directory') break;
+				event.preventDefault();
+				if (this.options.collapsedDirs.has(row.node.path)) {
+					this.options.onToggleDir(row.node.path);
+				} else {
+					this.#focusRowAt(index + 1);
+				}
+				break;
+			case 'ArrowLeft':
+				event.preventDefault();
+				if (row.node.kind === 'directory' && !this.options.collapsedDirs.has(row.node.path)) {
+					this.options.onToggleDir(row.node.path);
+				} else {
+					this.#focusParent(row);
+				}
+				break;
+			case 'Enter':
+			case ' ':
+				if (!activatedFromTreeRoot) break;
+				event.preventDefault();
+				this.#activateRow(row);
+				break;
+		}
+	}
+
+	destroy(): void {
+		this.#virtual.destroy();
+	}
+
+	#currentAnchor(): VirtualMutationAnchor {
+		const position = this.#virtual.viewportPosition;
+		const item = position
+			? this.#virtual.snapshot.positions.itemAtOffset(position.paintedOffset)
+			: undefined;
+		return item ? { kind: 'item', key: item.key } : { kind: 'none' };
+	}
+
+	#revealSelectedRow(index: number): void {
+		const item = this.#virtual.snapshot.positions.itemAt(index);
+		const position = this.#virtual.viewportPosition;
+		const viewportElement = this.options.viewportElement;
+		if (!item || !position || !viewportElement) {
+			this.#virtual.scrollToIndex(index, { align: 'center' });
+			return;
+		}
+		if (
+			item.start < position.paintedOffset ||
+			item.end > position.paintedOffset + viewportElement.clientHeight
+		) {
+			this.#virtual.scrollToIndex(index, { align: 'center' });
+		}
+	}
+
+	#focusRowAt(index: number): void {
+		const row = this.options.rows[index];
+		if (!row) return;
+		this.focusedRowKey = row.key;
+		this.options.viewportElement?.focus({ preventScroll: true });
+		const item = this.#virtual.snapshot.positions.itemAt(index);
+		const position = this.#virtual.viewportPosition;
+		const viewportElement = this.options.viewportElement;
+		if (!item || !position || !viewportElement) return;
+		if (item.start < position.paintedOffset) {
+			this.#virtual.scrollToIndex(index, { align: 'start' });
+		} else if (item.end > position.paintedOffset + viewportElement.clientHeight) {
+			this.#virtual.scrollToIndex(index, { align: 'end' });
+		}
+	}
+
+	#restoreTreeFocusAfterVirtualRender(): void {
+		const hadTreeFocus = this.#virtualRenderHadTreeFocus;
+		this.#virtualRenderHadTreeFocus = false;
+		const viewportElement = this.options.viewportElement;
+		if (!hadTreeFocus || !viewportElement || !focusWasLostFromDocument()) return;
+
+		const visibleRange = this.#virtual.snapshot.visibleRange;
+		if (visibleRange) {
+			const activeIndex = this.activeRowIndex;
+			const targetIndex = indexWithinRange(
+				activeIndex < 0 ? visibleRange.startIndex : activeIndex,
+				visibleRange,
+			);
+			const row = this.options.rows[targetIndex];
+			if (row) this.focusedRowKey = row.key;
+		}
+		viewportElement.focus({ preventScroll: true });
+	}
+
+	#focusParent(row: GitWorkbenchTreeRow): void {
+		if (!row.parentDirectoryPath) return;
+		const parentIndex = this.options.rows.findIndex(
+			(candidate) =>
+				candidate.node.kind === 'directory' && candidate.node.path === row.parentDirectoryPath,
+		);
+		if (parentIndex >= 0) this.#focusRowAt(parentIndex);
+	}
+
+	#activateRow(row: GitWorkbenchTreeRow): void {
+		this.focusedRowKey = row.key;
+		if (row.node.kind === 'directory') this.options.onToggleDir(row.node.path);
+		else this.options.onSelectFile(row.node.path);
+	}
+}

--- a/web/src/lib/components/git/__tests__/GitFileTree.test.ts
+++ b/web/src/lib/components/git/__tests__/GitFileTree.test.ts
@@ -2,6 +2,31 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/sve
 import { describe, expect, it, vi } from 'vitest';
 import GitFileTree from '../GitFileTree.svelte';
 import type { GitTreeNode } from '$lib/api/git';
+import { GIT_WORKBENCH_TREE_ROW_HEIGHT } from '$lib/git/workbench/git-workbench-tree-rows.js';
+
+function configureVirtualTreeViewport(container: HTMLElement, height = 120): HTMLElement {
+	const viewport = container.querySelector<HTMLElement>('[data-git-workbench-file-tree]');
+	const sizer = container.querySelector<HTMLElement>('[data-git-workbench-file-tree-sizer]');
+	if (!viewport || !sizer) throw new Error('Expected virtual Git file tree elements');
+
+	Object.defineProperties(viewport, {
+		clientHeight: { configurable: true, value: height },
+		scrollHeight: {
+			configurable: true,
+			get: () => Number.parseFloat(sizer.style.height) || 0,
+		},
+	});
+	viewport.getBoundingClientRect = () => new DOMRect(0, 0, 300, height);
+	sizer.getBoundingClientRect = () =>
+		new DOMRect(0, -viewport.scrollTop, 300, Number.parseFloat(sizer.style.height) || 0);
+	return viewport;
+}
+
+function renderedRowStart(row: HTMLElement): number {
+	const match = /^translateY\(([-\d.]+)px\)$/.exec(row.style.transform);
+	if (!match) throw new Error(`Expected translated virtual row, received: ${row.style.transform}`);
+	return Number(match[1]);
+}
 
 describe('GitFileTree', () => {
 	it('renders stage and unstage actions for a file with mixed index and working-tree changes', async () => {
@@ -117,26 +142,27 @@ describe('GitFileTree', () => {
 		const onSelectDirectory = vi.fn();
 		const onToggleDir = vi.fn();
 		const onStageDir = vi.fn();
+		const onUnstageDir = vi.fn();
 		const tree: GitTreeNode[] = [
 			{
 				path: 'src',
 				name: 'src',
 				kind: 'directory',
-				staged: false,
+				staged: true,
 				hasUnstaged: true,
 				children: [
 					{
 						path: 'src/a.ts',
 						name: 'a.ts',
 						kind: 'file',
-						staged: false,
+						staged: true,
 						hasUnstaged: true,
 					},
 				],
 			},
 		];
 
-		render(GitFileTree, {
+		const props = {
 			tree,
 			selectedFile: null,
 			collapsedDirs: new Set<string>(),
@@ -148,16 +174,29 @@ describe('GitFileTree', () => {
 			onToggleDir,
 			onSearchChange: vi.fn(),
 			onStageDir,
-		});
+			onUnstageDir,
+		};
+		const { rerender } = render(GitFileTree, props);
 
 		const directoryRow = screen.getByRole('treeitem', { name: 'src' });
 		await fireEvent.click(within(directoryRow).getByRole('button', { name: 'Collapse' }));
 		await fireEvent.click(within(directoryRow).getByRole('button', { name: 'src' }));
 		await fireEvent.click(within(directoryRow).getByTitle('Stage directory'));
+		await fireEvent.click(within(directoryRow).getByTitle('Unstage directory'));
 
 		expect(onToggleDir).toHaveBeenCalledWith('src');
 		expect(onSelectDirectory).toHaveBeenCalledWith('src');
 		expect(onStageDir).toHaveBeenCalledWith('src');
+		expect(onUnstageDir).toHaveBeenCalledWith('src');
+
+		await rerender({
+			...props,
+			isStageDirPending: () => true,
+			isUnstageDirPending: () => true,
+		});
+
+		expect((screen.getByTitle('Stage directory') as HTMLButtonElement).disabled).toBe(true);
+		expect((screen.getByTitle('Unstage directory') as HTMLButtonElement).disabled).toBe(true);
 
 		onToggleDir.mockClear();
 		const treeRoot = screen.getByRole('tree', { name: 'Files' });
@@ -213,6 +252,66 @@ describe('GitFileTree', () => {
 		expect(onStageFile).not.toHaveBeenCalled();
 	});
 
+	it('preserves the top-visible row when a directory above the viewport collapses', async () => {
+		const filesPerDirectory = 100;
+		const files = (directory: string) =>
+			Array.from({ length: filesPerDirectory }, (_, index): GitTreeNode => ({
+				path: `${directory}/file-${index}.ts`,
+				name: `file-${index}.ts`,
+				kind: 'file',
+				staged: false,
+				hasUnstaged: true,
+			}));
+		const tree: GitTreeNode[] = ['before', 'after'].map((directory) => ({
+			path: directory,
+			name: directory,
+			kind: 'directory',
+			staged: false,
+			hasUnstaged: true,
+			children: files(directory),
+		}));
+		const props = {
+			tree,
+			selectedFile: null,
+			collapsedDirs: new Set<string>(),
+			treeSearchQuery: '',
+			totalChangedFiles: filesPerDirectory * 2,
+			onSelectFile: vi.fn(),
+			onToggleDir: vi.fn(),
+			onSearchChange: vi.fn(),
+		};
+		const { container, rerender } = render(GitFileTree, props);
+		const viewport = configureVirtualTreeViewport(container);
+		const anchorFileIndex = 20;
+		const anchorPath = `after/file-${anchorFileIndex}.ts`;
+		const anchorIndex = filesPerDirectory + anchorFileIndex + 2;
+		const offsetWithinRow = 7;
+		viewport.scrollTop = anchorIndex * GIT_WORKBENCH_TREE_ROW_HEIGHT + offsetWithinRow;
+		await fireEvent.scroll(viewport);
+
+		const initialOffset = await waitFor(() => {
+			const row = container.querySelector<HTMLElement>(
+				`[data-git-file-tree-file][title="${anchorPath}"]`,
+			);
+			expect(row).toBeTruthy();
+			return renderedRowStart(row!) - viewport.scrollTop;
+		});
+		expect(initialOffset).toBe(-offsetWithinRow);
+
+		await rerender({ ...props, collapsedDirs: new Set(['before']) });
+
+		await waitFor(() => {
+			const row = container.querySelector<HTMLElement>(
+				`[data-git-file-tree-file][title="${anchorPath}"]`,
+			);
+			expect(row).toBeTruthy();
+			expect(renderedRowStart(row!) - viewport.scrollTop).toBe(initialOffset);
+		});
+		expect(viewport.scrollTop).toBe(
+			(anchorIndex - filesPerDirectory) * GIT_WORKBENCH_TREE_ROW_HEIGHT + offsetWithinRow,
+		);
+	});
+
 	it('keeps mounted rows bounded and preserves actions after virtual navigation', async () => {
 		const onSelectFile = vi.fn();
 		const onStageFile = vi.fn();
@@ -247,18 +346,7 @@ describe('GitFileTree', () => {
 			onStageFile,
 		};
 		const { container, rerender } = render(GitFileTree, props);
-		const treeRoot = screen.getByRole('tree', { name: 'Files' }) as HTMLElement;
-		const sizer = container.querySelector<HTMLElement>('[data-git-workbench-file-tree-sizer]')!;
-		Object.defineProperties(treeRoot, {
-			clientHeight: { configurable: true, value: 120 },
-			scrollHeight: {
-				configurable: true,
-				get: () => Number.parseFloat(sizer.style.height) || 0,
-			},
-		});
-		treeRoot.getBoundingClientRect = () => new DOMRect(0, 0, 300, 120);
-		sizer.getBoundingClientRect = () =>
-			new DOMRect(0, -treeRoot.scrollTop, 300, Number.parseFloat(sizer.style.height) || 0);
+		const treeRoot = configureVirtualTreeViewport(container);
 		await waitFor(() =>
 			expect(
 				container.querySelectorAll('[data-git-workbench-file-tree-row]').length,

--- a/web/src/lib/components/git/__tests__/GitFileTree.test.ts
+++ b/web/src/lib/components/git/__tests__/GitFileTree.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import GitFileTree from '../GitFileTree.svelte';
 import type { GitTreeNode } from '$lib/api/git';
@@ -18,7 +18,7 @@ describe('GitFileTree', () => {
 			changeKind: 'modified',
 		};
 
-		render(GitFileTree, {
+		const props = {
 			tree: [node],
 			selectedFile: null,
 			collapsedDirs: new Set<string>(),
@@ -30,13 +30,23 @@ describe('GitFileTree', () => {
 			onSearchChange: vi.fn(),
 			onStageFile,
 			onUnstageFile,
-		});
+		};
+		const { rerender } = render(GitFileTree, props);
 
 		await fireEvent.click(screen.getByTitle('Stage file'));
 		await fireEvent.click(screen.getByTitle('Unstage file'));
 
 		expect(onStageFile).toHaveBeenCalledWith('src/a.ts');
 		expect(onUnstageFile).toHaveBeenCalledWith('src/a.ts');
+
+		await rerender({
+			...props,
+			isStageFilePending: () => true,
+			isUnstageFilePending: () => true,
+		});
+
+		expect((screen.getByTitle('Stage file') as HTMLButtonElement).disabled).toBe(true);
+		expect((screen.getByTitle('Unstage file') as HTMLButtonElement).disabled).toBe(true);
 	});
 
 	it('renders hide-generated as an unchecked opt-in filter by default', async () => {
@@ -100,5 +110,230 @@ describe('GitFileTree', () => {
 		await fireEvent.click(checkbox);
 
 		expect(onHideOtherTabFilesChange).toHaveBeenCalledWith(false);
+	});
+
+	it('keeps directory selection separate from disclosure and directory actions', async () => {
+		const onSelectFile = vi.fn();
+		const onSelectDirectory = vi.fn();
+		const onToggleDir = vi.fn();
+		const onStageDir = vi.fn();
+		const tree: GitTreeNode[] = [
+			{
+				path: 'src',
+				name: 'src',
+				kind: 'directory',
+				staged: false,
+				hasUnstaged: true,
+				children: [
+					{
+						path: 'src/a.ts',
+						name: 'a.ts',
+						kind: 'file',
+						staged: false,
+						hasUnstaged: true,
+					},
+				],
+			},
+		];
+
+		render(GitFileTree, {
+			tree,
+			selectedFile: null,
+			collapsedDirs: new Set<string>(),
+			treeSearchQuery: '',
+			totalChangedFiles: 1,
+			alwaysShowActions: true,
+			onSelectFile,
+			onSelectDirectory,
+			onToggleDir,
+			onSearchChange: vi.fn(),
+			onStageDir,
+		});
+
+		const directoryRow = screen.getByRole('treeitem', { name: 'src' });
+		await fireEvent.click(within(directoryRow).getByRole('button', { name: 'Collapse' }));
+		await fireEvent.click(within(directoryRow).getByRole('button', { name: 'src' }));
+		await fireEvent.click(within(directoryRow).getByTitle('Stage directory'));
+
+		expect(onToggleDir).toHaveBeenCalledWith('src');
+		expect(onSelectDirectory).toHaveBeenCalledWith('src');
+		expect(onStageDir).toHaveBeenCalledWith('src');
+
+		onToggleDir.mockClear();
+		const treeRoot = screen.getByRole('tree', { name: 'Files' });
+		treeRoot.focus();
+		await fireEvent.keyDown(treeRoot, { key: 'ArrowRight' });
+		expect(
+			screen.getByRole('treeitem', { name: 'a.ts' }).hasAttribute('data-git-tree-row-active'),
+		).toBe(true);
+		await fireEvent.keyDown(treeRoot, { key: 'Enter' });
+		await fireEvent.keyDown(treeRoot, { key: 'ArrowLeft' });
+		await fireEvent.keyDown(treeRoot, { key: 'ArrowLeft' });
+
+		expect(onSelectFile).toHaveBeenCalledWith('src/a.ts');
+		expect(onToggleDir).toHaveBeenCalledWith('src');
+	});
+
+	it('moves tree focus when keyboard navigation starts from a row action', async () => {
+		const onStageFile = vi.fn();
+		const tree: GitTreeNode[] = ['a.ts', 'b.ts'].map((name) => ({
+			path: `src/${name}`,
+			name,
+			kind: 'file',
+			staged: false,
+			hasUnstaged: true,
+		}));
+
+		render(GitFileTree, {
+			tree,
+			selectedFile: null,
+			collapsedDirs: new Set<string>(),
+			treeSearchQuery: '',
+			totalChangedFiles: tree.length,
+			alwaysShowActions: true,
+			onSelectFile: vi.fn(),
+			onToggleDir: vi.fn(),
+			onSearchChange: vi.fn(),
+			onStageFile,
+		});
+
+		const firstRow = screen.getByRole('treeitem', { name: 'a.ts' });
+		const firstStageAction = within(firstRow).getByTitle('Stage file');
+		const treeRoot = screen.getByRole('tree', { name: 'Files' });
+		firstStageAction.focus();
+
+		await fireEvent.keyDown(firstStageAction, { key: 'ArrowDown' });
+
+		await waitFor(() => {
+			expect(document.activeElement).toBe(treeRoot);
+			expect(
+				screen.getByRole('treeitem', { name: 'b.ts' }).hasAttribute('data-git-tree-row-active'),
+			).toBe(true);
+		});
+		expect(onStageFile).not.toHaveBeenCalled();
+	});
+
+	it('keeps mounted rows bounded and preserves actions after virtual navigation', async () => {
+		const onSelectFile = vi.fn();
+		const onStageFile = vi.fn();
+		const children = Array.from({ length: 5_000 }, (_, index): GitTreeNode => ({
+			path: `src/file-${index}.ts`,
+			name: `file-${index}.ts`,
+			kind: 'file',
+			staged: false,
+			hasUnstaged: true,
+			changeKind: 'untracked',
+		}));
+		const tree: GitTreeNode[] = [
+			{
+				path: 'src',
+				name: 'src',
+				kind: 'directory',
+				staged: false,
+				hasUnstaged: true,
+				children,
+			},
+		];
+		const props = {
+			tree,
+			selectedFile: null as string | null,
+			collapsedDirs: new Set<string>(),
+			treeSearchQuery: '',
+			totalChangedFiles: children.length,
+			alwaysShowActions: true,
+			onSelectFile,
+			onToggleDir: vi.fn(),
+			onSearchChange: vi.fn(),
+			onStageFile,
+		};
+		const { container, rerender } = render(GitFileTree, props);
+		const treeRoot = screen.getByRole('tree', { name: 'Files' }) as HTMLElement;
+		const sizer = container.querySelector<HTMLElement>('[data-git-workbench-file-tree-sizer]')!;
+		Object.defineProperties(treeRoot, {
+			clientHeight: { configurable: true, value: 120 },
+			scrollHeight: {
+				configurable: true,
+				get: () => Number.parseFloat(sizer.style.height) || 0,
+			},
+		});
+		treeRoot.getBoundingClientRect = () => new DOMRect(0, 0, 300, 120);
+		sizer.getBoundingClientRect = () =>
+			new DOMRect(0, -treeRoot.scrollTop, 300, Number.parseFloat(sizer.style.height) || 0);
+		await waitFor(() =>
+			expect(
+				container.querySelectorAll('[data-git-workbench-file-tree-row]').length,
+			).toBeGreaterThan(0),
+		);
+
+		await rerender({ ...props, selectedFile: 'src/file-4999.ts' });
+		await waitFor(() =>
+			expect(
+				container
+					.querySelector('[data-git-file-tree-file][title="src/file-4999.ts"]')
+					?.getAttribute('aria-selected'),
+			).toBe('true'),
+		);
+
+		const filteredTree: GitTreeNode[] = [{ ...tree[0], children: [children[0]] }];
+		await rerender({
+			...props,
+			tree: filteredTree,
+			selectedFile: 'src/file-4999.ts',
+			treeSearchQuery: 'file-0',
+		});
+		await waitFor(() =>
+			expect(
+				container.querySelector('[data-git-file-tree-file][title="src/file-4999.ts"]'),
+			).toBeNull(),
+		);
+		treeRoot.scrollTop = 0;
+		await fireEvent.scroll(treeRoot);
+
+		await rerender({ ...props, selectedFile: 'src/file-4999.ts' });
+		await waitFor(() =>
+			expect(
+				container
+					.querySelector('[data-git-file-tree-file][title="src/file-4999.ts"]')
+					?.getAttribute('aria-selected'),
+			).toBe('true'),
+		);
+
+		treeRoot.focus();
+		await fireEvent.keyDown(treeRoot, { key: 'Home' });
+		await waitFor(() =>
+			expect(container.querySelector<HTMLElement>('[data-git-tree-row-active]')?.title).toBe('src'),
+		);
+		await fireEvent.keyDown(treeRoot, { key: 'End' });
+
+		const activeRow = await waitFor(() => {
+			const row = container.querySelector<HTMLElement>('[data-git-tree-row-active]');
+			expect(row?.title).toBe('src/file-4999.ts');
+			return row!;
+		});
+		expect(container.querySelectorAll('[data-git-workbench-file-tree-row]').length).toBeLessThan(
+			40,
+		);
+		expect(treeRoot.getAttribute('aria-activedescendant')).toBe(activeRow.id);
+		expect(document.activeElement).toBe(treeRoot);
+
+		await fireEvent.keyDown(treeRoot, { key: 'Enter' });
+		const stageAction = within(activeRow).getByTitle('Stage file');
+		await fireEvent.click(stageAction);
+
+		expect(onSelectFile).toHaveBeenCalledWith('src/file-4999.ts');
+		expect(onStageFile).toHaveBeenCalledWith('src/file-4999.ts');
+
+		stageAction.focus();
+		treeRoot.scrollTop = 0;
+		await fireEvent.scroll(treeRoot);
+
+		const restoredActiveRow = await waitFor(() => {
+			expect(document.activeElement).toBe(treeRoot);
+			const row = container.querySelector<HTMLElement>('[data-git-tree-row-active]');
+			expect(row).toBeTruthy();
+			expect(treeRoot.getAttribute('aria-activedescendant')).toBe(row?.id);
+			return row!;
+		});
+		expect(restoredActiveRow).not.toBe(activeRow);
 	});
 });

--- a/web/src/lib/git/workbench/__tests__/git-workbench-tree-rows.logic.test.ts
+++ b/web/src/lib/git/workbench/__tests__/git-workbench-tree-rows.logic.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { GitTreeNode } from '$lib/api/git.js';
+import {
+	flattenGitWorkbenchTree,
+	gitWorkbenchTreeRowKey,
+} from '$lib/git/workbench/git-workbench-tree-rows.js';
+
+function file(path: string): GitTreeNode {
+	return {
+		kind: 'file',
+		path,
+		name: path.split('/').at(-1) ?? path,
+		staged: false,
+		hasUnstaged: true,
+	};
+}
+
+function directory(path: string, children: GitTreeNode[]): GitTreeNode {
+	return {
+		kind: 'directory',
+		path,
+		name: path,
+		staged: false,
+		hasUnstaged: true,
+		children,
+	};
+}
+
+describe('git workbench tree rows', () => {
+	it('preserves workbench ordering while adding hierarchy metadata', () => {
+		const tree = [
+			directory('src', [file('src/a.ts'), directory('src/lib', [file('src/lib/b.ts')])]),
+			file('README.md'),
+		];
+
+		const rows = flattenGitWorkbenchTree(tree, new Set());
+
+		expect(rows.map((row) => row.key)).toEqual([
+			'directory:src',
+			'file:src/a.ts',
+			'directory:src/lib',
+			'file:src/lib/b.ts',
+			'file:README.md',
+		]);
+		expect(
+			rows.map(({ depth, parentDirectoryPath, positionInSet, setSize }) => ({
+				depth,
+				parentDirectoryPath,
+				positionInSet,
+				setSize,
+			})),
+		).toEqual([
+			{ depth: 0, parentDirectoryPath: null, positionInSet: 1, setSize: 2 },
+			{ depth: 1, parentDirectoryPath: 'src', positionInSet: 1, setSize: 2 },
+			{ depth: 1, parentDirectoryPath: 'src', positionInSet: 2, setSize: 2 },
+			{ depth: 2, parentDirectoryPath: 'src/lib', positionInSet: 1, setSize: 1 },
+			{ depth: 0, parentDirectoryPath: null, positionInSet: 2, setSize: 2 },
+		]);
+	});
+
+	it('omits descendants of collapsed directories without mutating the source tree', () => {
+		const child = file('src/a.ts');
+		const tree = [directory('src', [child]), file('README.md')];
+
+		const rows = flattenGitWorkbenchTree(tree, new Set(['src']));
+
+		expect(rows.map((row) => row.node.path)).toEqual(['src', 'README.md']);
+		expect(tree[0]?.children).toEqual([child]);
+	});
+
+	it('keys compacted directory paths by their rendered identity', () => {
+		expect(gitWorkbenchTreeRowKey({ kind: 'directory', path: 'src/lib/git' })).toBe(
+			'directory:src/lib/git',
+		);
+	});
+});

--- a/web/src/lib/git/workbench/git-workbench-tree-rows.ts
+++ b/web/src/lib/git/workbench/git-workbench-tree-rows.ts
@@ -1,0 +1,47 @@
+import type { GitTreeNode } from '$lib/api/git.js';
+
+export const GIT_WORKBENCH_TREE_ROW_HEIGHT = 28;
+export const GIT_WORKBENCH_TREE_OVERSCAN = 12;
+
+export interface GitWorkbenchTreeRow {
+	readonly key: string;
+	readonly node: GitTreeNode;
+	readonly depth: number;
+	readonly parentDirectoryPath: string | null;
+	readonly positionInSet: number;
+	readonly setSize: number;
+}
+
+export function gitWorkbenchTreeRowKey(node: Pick<GitTreeNode, 'kind' | 'path'>): string {
+	return `${node.kind}:${node.path}`;
+}
+
+export function flattenGitWorkbenchTree(
+	nodes: readonly GitTreeNode[],
+	collapsedDirectories: ReadonlySet<string>,
+): GitWorkbenchTreeRow[] {
+	const rows: GitWorkbenchTreeRow[] = [];
+
+	const append = (
+		children: readonly GitTreeNode[],
+		depth: number,
+		parentDirectoryPath: string | null,
+	): void => {
+		for (const [index, node] of children.entries()) {
+			rows.push({
+				key: gitWorkbenchTreeRowKey(node),
+				node,
+				depth,
+				parentDirectoryPath,
+				positionInSet: index + 1,
+				setSize: children.length,
+			});
+			if (node.kind === 'directory' && node.children && !collapsedDirectories.has(node.path)) {
+				append(node.children, depth + 1, node.path);
+			}
+		}
+	};
+
+	append(nodes, 0, null);
+	return rows;
+}


### PR DESCRIPTION
The Git workbench currently mounts every expanded changed-file row, which can freeze the UI for repositories with thousands of changes. This change flattens the workbench hierarchy into stable virtual rows, renders only the visible window while preserving selection, disclosure, staging actions, focus, and accessibility behavior, and adds regression coverage for large trees, selection reveal, mutation anchoring, and pending directory actions.