### PR TITLE
Stabilize Claude native-history reload integration

### DIFF
--- a/integration-tests/support/live-agent.ts
+++ b/integration-tests/support/live-agent.ts
@@ -94,7 +94,8 @@ function expectVisibleResponseBeforeSettlement(input: {
 }
 
 // A turn's execution reservation outlives its terminal event, so a reload issued as soon as the
-// turn ends is briefly refused as CHAT_RUNNING. The refusal is retryable by contract.
+// turn ends is briefly refused as CHAT_RUNNING. This waits only for that reservation, not for
+// provider-native history to finish persisting.
 export async function reloadFromNativeHistory(
   fixture: IntegrationFixture,
   chatId: string,

--- a/integration-tests/tests/server/claude-scripted-inter-agent-messaging.test.ts
+++ b/integration-tests/tests/server/claude-scripted-inter-agent-messaging.test.ts
@@ -9,7 +9,6 @@ import { withIntegrationFixture } from '../../support/integration-fixture.js';
 import {
   expectFinished,
   LIVE_TURN_TIMEOUT_MS,
-  reloadFromNativeHistory,
   reloadUntilNativeContains,
 } from '../../support/live-agent.js';
 import { liveClaudeStartRequest } from '../../support/live-claude.js';
@@ -41,6 +40,7 @@ describe('scripted Claude inter-agent messaging', () => {
         const sourceChatId = fixture.newChatId();
         const targetPrompt = marker('TARGET_PROMPT');
         const sourcePrompt = marker('SOURCE_PROMPT');
+        const sourceReply = marker('SOURCE_REPLY');
         const body = marker('MESSAGE_BODY');
         const envelope = `<garcon-message from="${sourceChatId}">\n${body}\n</garcon-message>`;
         const command = `<garcon-send-message to="${targetChatId}" hide-sender="false">\n${body}\n</garcon-send-message>`;
@@ -53,7 +53,8 @@ describe('scripted Claude inter-agent messaging', () => {
             command: `touch "${startedPath}"; while [ ! -f "${releasePath}" ]; do sleep 0.05; done`,
           }),
         ]);
-        testEnvironment.model.scriptTurn([claudeText(command)]);
+        // Keeps a trailing visible block as the persistence witness for the preceding command.
+        testEnvironment.model.scriptTurn([claudeText(command), claudeText(sourceReply)]);
         continuation = testEnvironment.model.scriptHeldTurn([
           claudeText('Target received the message.'),
         ]);
@@ -126,7 +127,7 @@ describe('scripted Claude inter-agent messaging', () => {
           }),
         );
 
-        await reloadFromNativeHistory(fixture, sourceChatId);
+        await reloadUntilNativeContains(fixture, sourceChatId, sourceReply);
         const reloadedSource = await fixture.client.getMessages(sourceChatId);
         expect(messagesOfType(reloadedSource.messages, 'transcript-notice').filter(
           (message) => message.detail?.type === 'inter-agent-message-outcome',

--- a/server/ledger/__tests__/reload.test.js
+++ b/server/ledger/__tests__/reload.test.js
@@ -85,6 +85,55 @@ describe('TranscriptReloadService', () => {
     });
   });
 
+  it('preserves the current view while native history is absent and imports only what each retry can read', async () => {
+    await withReload(async ({ ledger, reload, integration, oldViewId }) => {
+      const command = [
+        '<garcon-send-message to="1787974832309199" hide-sender="false">',
+        'message body',
+        '</garcon-send-message>',
+      ].join('\n');
+      let attempt = 0;
+      integration.nativeHistoryImport.load = async function* load() {
+        attempt += 1;
+        if (attempt === 1) {
+          throw Object.assign(new Error('native history is not present yet'), { code: 'ENOENT' });
+        }
+        yield [{ message: new UserMessage(TS, 'native prompt') }];
+        if (attempt === 3) {
+          yield [{ message: new AssistantMessage(TS, command) }];
+        }
+      };
+
+      await expect(reload.reload('chat-1')).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(ledger.currentView('chat-1')?.viewId).toBe(oldViewId);
+
+      await reload.reload('chat-1');
+      expect(ledger.currentView('chat-1')?.viewId).not.toBe(oldViewId);
+      expect(ledger.conversationMessages('chat-1').map((message) => message.content)).toEqual([
+        'frozen prompt',
+        'frozen answer',
+        'native prompt',
+      ]);
+      expect(ledger.currentRows('chat-1').filter(
+        (row) => row.kind === 'notice' && row.detail.type === 'inter-agent-send-request',
+      )).toEqual([]);
+
+      await reload.reload('chat-1');
+      expect(ledger.currentRows('chat-1').filter(
+        (row) => row.kind === 'notice' && row.detail.type === 'inter-agent-send-request',
+      )).toEqual([
+        expect.objectContaining({
+          detail: {
+            type: 'inter-agent-send-request',
+            recipients: ['1787974832309199'],
+            hideSender: false,
+            body: 'message body',
+          },
+        }),
+      ]);
+    });
+  });
+
   it('[TLV5-ADOPT.08-RELOAD-CORE-UNIT-02] cuts over when the selected native session is validly empty', async () => {
     await withReload(async ({ ledger, reload, integration, oldViewId }) => {
       integration.nativeHistoryImport.load = async function* load() {

--- a/server/ws/__tests__/chat-contracts.test.js
+++ b/server/ws/__tests__/chat-contracts.test.js
@@ -692,4 +692,25 @@ describe('chat WebSocket handler', () => {
       retryable: true,
     });
   });
+
+  it('returns retryable HISTORY_LOAD_FAILED when native history is not present yet', async () => {
+    mockTranscriptReload.mockRejectedValueOnce(
+      Object.assign(new Error('native history is not present yet'), { code: 'ENOENT' }),
+    );
+
+    await chatHandler.message(ws, {
+      type: 'chat-reload',
+      chatId: '123',
+      clientRequestId: 'req-reload-history-pending',
+    });
+
+    expect(lastSentPayload()).toMatchObject({
+      type: 'client-request-error',
+      clientRequestId: 'req-reload-history-pending',
+      requestType: 'chat-reload',
+      chatId: '123',
+      code: 'HISTORY_LOAD_FAILED',
+      retryable: true,
+    });
+  });
 });


### PR DESCRIPTION
Claude can report turn completion before its native JSONL has finished materializing, causing inter-agent integration coverage to reload an absent or partial history. This change waits for an ordered persisted reply marker before validating reload reconstruction, documents the reload helper boundary, and adds ledger and WebSocket regression coverage for absent, partial, and complete native history.