### PR TITLE
Move terminal controls into window menus

### DIFF
--- a/integration-tests/tests/e2e/terminal-window-lifecycle.test.ts
+++ b/integration-tests/tests/e2e/terminal-window-lifecycle.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+import type { Page } from 'puppeteer-core';
+import type { TerminalListResponse } from '../../../common/terminal.js';
+import { withE2eFixture } from '../../support/e2e-fixture.js';
+import { SpaDriver } from '../../support/spa-driver.js';
+
+describe('Lightpanda terminal window lifecycle', () => {
+  test('offers terminal actions and deletes an exited terminal when its tab closes', async () => {
+    await withE2eFixture(
+      'terminal-window-lifecycle',
+      async (fixture) => {
+        const app = new SpaDriver(fixture.page, fixture.integration);
+        await app.setViewport(1_440, 900);
+        await app.open();
+        await fixture.waitForSpaWebSocket();
+        await app.startOpenAiDirectChat('terminal-window-lifecycle');
+        const windowId = await app.currentWorkspaceWindowId();
+
+        await app.selectWorkspaceWindowSurface('New Terminal', windowId);
+        const terminalId = await activeTerminalId(fixture.page, windowId);
+        await waitForExitedTerminal(fixture.page, terminalId);
+        await waitForPersistedTerminalPlacement(fixture.page, terminalId);
+
+        expect(
+          await fixture.integration.client.get<TerminalListResponse>('/api/v1/terminals'),
+        ).toMatchObject({
+          success: true,
+          terminals: [{ terminalId, processStatus: 'exited', exitCode: 0 }],
+        });
+        expect(
+          await fixture.page.$(
+            `[data-workspace-surface-id="terminal:${terminalId}"] .surface-toolbar`,
+          ),
+        ).toBeNull();
+
+        await app.openWorkspaceWindowActions(windowId);
+        const menuItems = await fixture.page.$eval(
+          `[data-workspace-window-menu="${windowId}"]`,
+          (menu) =>
+            [...menu.querySelectorAll<HTMLElement>('[role="menuitem"]')].map(
+              (item) => item.textContent?.trim() ?? '',
+            ),
+        );
+        expect(menuItems).toContain('Paste into terminal');
+        expect(menuItems.some((item) => item.startsWith('Font size'))).toBe(true);
+        expect(menuItems).toContain('Terminate');
+        expect(menuItems).toContain('Close tab');
+        expect(menuItems).not.toContain('New Terminal');
+
+        await app.clickMenuItem('Close tab');
+        await waitForTerminatedTerminal(fixture.page, terminalId);
+        await waitForPersistedTerminalRemoval(fixture.page, terminalId);
+
+        expect(
+          await fixture.integration.client.get<TerminalListResponse>('/api/v1/terminals'),
+        ).toEqual({ success: true, terminals: [] });
+        expect(
+          await fixture.page.$(`[data-workspace-surface-id="terminal:${terminalId}"]`),
+        ).toBeNull();
+        fixture.assertNoBrowserErrors();
+      },
+      { serverEnvironment: { GARCON_TERMINAL_SHELL: '/bin/true' } },
+    );
+  });
+});
+
+async function activeTerminalId(page: Page, windowId: string): Promise<string> {
+  await page.waitForFunction(
+    (expectedWindowId) =>
+      document
+        .querySelector<HTMLElement>(`[data-workspace-window-id="${expectedWindowId}"]`)
+        ?.dataset.workspaceWindowActiveSurface?.startsWith('terminal:') === true,
+    { timeout: 20_000 },
+    windowId,
+  );
+  return page.$eval(`[data-workspace-window-id="${windowId}"]`, (workspaceWindow) => {
+    const surfaceId = (workspaceWindow as HTMLElement).dataset.workspaceWindowActiveSurface;
+    if (!surfaceId?.startsWith('terminal:')) throw new Error('Terminal surface is not active.');
+    return surfaceId.slice('terminal:'.length);
+  });
+}
+
+async function waitForExitedTerminal(page: Page, terminalId: string): Promise<void> {
+  await page.waitForFunction(
+    (expectedTerminalId) => {
+      const scope = globalThis as typeof globalThis & {
+        __garconSpaWsEvents?: unknown[];
+      };
+      return (scope.__garconSpaWsEvents ?? []).some((event) => {
+        if (!event || typeof event !== 'object' || Array.isArray(event)) return false;
+        const record = event as {
+          type?: unknown;
+          terminal?: { terminalId?: unknown; processStatus?: unknown };
+        };
+        return (
+          (record.type === 'terminal-attached' || record.type === 'terminal-status') &&
+          record.terminal?.terminalId === expectedTerminalId &&
+          record.terminal.processStatus === 'exited'
+        );
+      });
+    },
+    { timeout: 20_000 },
+    terminalId,
+  );
+}
+
+async function waitForTerminatedTerminal(page: Page, terminalId: string): Promise<void> {
+  await page.waitForFunction(
+    (expectedTerminalId) => {
+      const scope = globalThis as typeof globalThis & {
+        __garconSpaWsEvents?: unknown[];
+      };
+      return (scope.__garconSpaWsEvents ?? []).some((event) => {
+        if (!event || typeof event !== 'object' || Array.isArray(event)) return false;
+        const record = event as { type?: unknown; terminalId?: unknown };
+        return record.type === 'terminal-terminated' && record.terminalId === expectedTerminalId;
+      });
+    },
+    { timeout: 20_000 },
+    terminalId,
+  );
+}
+
+async function waitForPersistedTerminalPlacement(page: Page, terminalId: string): Promise<void> {
+  await page.waitForFunction(
+    (expectedTerminalId) => {
+      const raw = localStorage.getItem('workspace_layout_v2');
+      if (!raw) return false;
+      const parsed = JSON.parse(raw) as {
+        root?: unknown;
+        unplacedTerminalIds?: unknown;
+      };
+      return (
+        JSON.stringify(parsed.root).includes(`"terminalId":"${expectedTerminalId}"`) &&
+        Array.isArray(parsed.unplacedTerminalIds) &&
+        !parsed.unplacedTerminalIds.includes(expectedTerminalId)
+      );
+    },
+    { timeout: 20_000 },
+    terminalId,
+  );
+}
+
+async function waitForPersistedTerminalRemoval(page: Page, terminalId: string): Promise<void> {
+  await page.waitForFunction(
+    (expectedTerminalId) => {
+      const raw = localStorage.getItem('workspace_layout_v2');
+      if (!raw) return false;
+      const parsed = JSON.parse(raw) as {
+        root?: unknown;
+        unplacedTerminalIds?: unknown;
+      };
+      return (
+        !JSON.stringify(parsed.root).includes(`"terminalId":"${expectedTerminalId}"`) &&
+        Array.isArray(parsed.unplacedTerminalIds) &&
+        !parsed.unplacedTerminalIds.includes(expectedTerminalId)
+      );
+    },
+    { timeout: 20_000 },
+    terminalId,
+  );
+}

--- a/web/src/lib/components/terminal/TerminalSurface.svelte
+++ b/web/src/lib/components/terminal/TerminalSurface.svelte
@@ -201,6 +201,15 @@
 		}
 	}
 
+	async function closeTerminal(): Promise<void> {
+		actionError = null;
+		try {
+			await workspace.closeSurface(terminalSurfaceId(terminalId));
+		} catch (error) {
+			actionError = error instanceof Error ? error.message : m.terminal_unavailable();
+		}
+	}
+
 	function toggleInputModifier(modifier: 'ctrl' | 'alt'): void {
 		runtime?.inputControls.toggleModifier(modifier);
 	}
@@ -259,7 +268,7 @@
 			<button
 				type="button"
 				class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-				onclick={() => void workspace.closeSurface(terminalSurfaceId(terminalId))}
+				onclick={() => void closeTerminal()}
 				disabled={workspace.isSurfaceCloseBlocked(terminalSurfaceId(terminalId))}
 				aria-label={m.terminal_close_tab()}
 				title={m.terminal_close_tab()}

--- a/web/src/lib/components/terminal/TerminalSurface.svelte
+++ b/web/src/lib/components/terminal/TerminalSurface.svelte
@@ -211,51 +211,51 @@
 </script>
 
 <div class="flex h-full min-h-0 flex-col bg-background text-foreground">
-	<div
-		class="surface-toolbar flex h-10 shrink-0 items-center gap-2 border-b border-border px-2"
-		style="container-name: surface-toolbar; container-type: inline-size;"
-	>
-		<div class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-			<select
-				bind:this={sessionPicker}
-				class="min-w-24 max-w-56 truncate rounded-md border border-border bg-background px-2 py-1 text-xs"
-				value={terminalId}
-				onchange={(event) => selectTerminal(event.currentTarget.value)}
-				aria-label={m.terminal_session()}
-			>
-				{#each terminals.orderedSessions as item (item.metadata.terminalId)}
-					{@const placement = placementLabel(item.metadata.terminalId)}
-					<option value={item.metadata.terminalId}>
-						{m.terminal_session_status({
-							number: item.metadata.displaySequence,
-							status: item.metadata.processStatus,
-						})}{placement ? ` - ${placement}` : ''}
-					</option>
-				{/each}
-			</select>
-			{#if session}
-				<span
-					class="min-w-0 flex-1 truncate text-xs text-muted-foreground"
-					title={m.terminal_initial_working_directory({
-						path: session.metadata.initialWorkingDirectory,
-					})}
+	{#if host === 'mobile'}
+		<div
+			class="surface-toolbar flex h-10 shrink-0 items-center gap-2 border-b border-border px-2"
+			style="container-name: surface-toolbar; container-type: inline-size;"
+		>
+			<div class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+				<select
+					bind:this={sessionPicker}
+					class="min-w-24 max-w-56 truncate rounded-md border border-border bg-background px-2 py-1 text-xs"
+					value={terminalId}
+					onchange={(event) => selectTerminal(event.currentTarget.value)}
+					aria-label={m.terminal_session()}
 				>
-					{m.terminal_initial_working_directory({
-						path: session.metadata.initialWorkingDirectory,
-					})}
-				</span>
-				<span class="shrink-0 text-[11px] text-muted-foreground"
-					>{attachmentLabel(session.attachmentState)}</span
-				>
-			{/if}
-		</div>
-		<ResponsiveSurfaceActions
-			actions={toolbarActions}
-			menuLabel={m.workspace_surface_actions()}
-			class="max-w-28"
-		/>
-		<TerminalSettingsMenu />
-		{#if host === 'mobile'}
+					{#each terminals.orderedSessions as item (item.metadata.terminalId)}
+						{@const placement = placementLabel(item.metadata.terminalId)}
+						<option value={item.metadata.terminalId}>
+							{m.terminal_session_status({
+								number: item.metadata.displaySequence,
+								status: item.metadata.processStatus,
+							})}{placement ? ` - ${placement}` : ''}
+						</option>
+					{/each}
+				</select>
+				{#if session}
+					<span
+						class="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+						title={m.terminal_initial_working_directory({
+							path: session.metadata.initialWorkingDirectory,
+						})}
+					>
+						{m.terminal_initial_working_directory({
+							path: session.metadata.initialWorkingDirectory,
+						})}
+					</span>
+					<span class="shrink-0 text-[11px] text-muted-foreground"
+						>{attachmentLabel(session.attachmentState)}</span
+					>
+				{/if}
+			</div>
+			<ResponsiveSurfaceActions
+				actions={toolbarActions}
+				menuLabel={m.workspace_surface_actions()}
+				class="max-w-28"
+			/>
+			<TerminalSettingsMenu />
 			<button
 				type="button"
 				class="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
@@ -266,8 +266,8 @@
 			>
 				<X class="h-4 w-4" />
 			</button>
-		{/if}
-	</div>
+		</div>
+	{/if}
 	{#if actionError}
 		<div
 			class="border-b border-status-error-border bg-status-error px-3 py-1.5 text-xs text-status-error-foreground"

--- a/web/src/lib/components/terminal/TerminalWindowMenuItems.svelte
+++ b/web/src/lib/components/terminal/TerminalWindowMenuItems.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import Clipboard from '@lucide/svelte/icons/clipboard';
+	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+	import Settings from '@lucide/svelte/icons/settings';
+	import Square from '@lucide/svelte/icons/square';
+	import {
+		DropdownMenuItem,
+		DropdownMenuRadioGroup,
+		DropdownMenuRadioItem,
+		DropdownMenuSeparator,
+		DropdownMenuSub,
+		DropdownMenuSubContent,
+		DropdownMenuSubTrigger,
+	} from '$lib/components/ui/dropdown-menu';
+	import {
+		getLocalSettings,
+		getNotifications,
+		getTerminalRegistry,
+		getWorkspaceCoordinator,
+	} from '$lib/context';
+	import { FONT_SIZE_OPTIONS, isFontSizeOption } from '$lib/utils/font-size.js';
+	import { terminalSurfaceId } from '$lib/workspace/surface-types.js';
+	import * as m from '$lib/paraglide/messages.js';
+
+	let { terminalId }: { terminalId: string } = $props();
+
+	const terminals = getTerminalRegistry();
+	const workspace = getWorkspaceCoordinator();
+	const localSettings = getLocalSettings();
+	const notifications = getNotifications();
+	const session = $derived(terminals.sessions[terminalId] ?? null);
+	const canReattach = $derived(
+		session?.attachmentState === 'taken-over' ||
+			session?.attachmentState === 'unavailable' ||
+			session?.attachmentState === 'detached',
+	);
+
+	function notifyFailure(error: unknown): void {
+		notifications.error(error instanceof Error ? error.message : m.terminal_unavailable());
+	}
+
+	async function paste(): Promise<void> {
+		if (!session) return;
+		try {
+			const terminalRuntime = terminals.ensureRuntime(terminalId);
+			if (!(await terminalRuntime.pasteFromClipboard())) {
+				notifications.error(terminalRuntime.clipboardMessage || m.shell_errors_clipboard_failed());
+			}
+		} catch (error) {
+			notifyFailure(error);
+		}
+	}
+
+	function setFontSize(size: string): void {
+		if (!isFontSizeOption(size)) return;
+		localSettings.set('terminalFontSize', size);
+	}
+
+	function terminate(): void {
+		void workspace.terminateTerminalSession(terminalId).catch(notifyFailure);
+	}
+</script>
+
+{#if canReattach}
+	<DropdownMenuItem onSelect={() => terminals.reattach(terminalId)}>
+		<RefreshCw />
+		{m.terminal_reattach()}
+	</DropdownMenuItem>
+{/if}
+<DropdownMenuItem disabled={!session} onSelect={() => void paste()}>
+	<Clipboard />
+	{m.terminal_paste()}
+</DropdownMenuItem>
+<DropdownMenuSub>
+	<DropdownMenuSubTrigger>
+		<Settings />
+		<span class="flex min-w-0 flex-1 items-center justify-between gap-4">
+			<span>{m.terminal_font_size()}</span>
+			<span class="text-xs text-muted-foreground">{localSettings.terminalFontSize}px</span>
+		</span>
+	</DropdownMenuSubTrigger>
+	<DropdownMenuSubContent class="w-36">
+		<DropdownMenuRadioGroup value={localSettings.terminalFontSize} onValueChange={setFontSize}>
+			{#each FONT_SIZE_OPTIONS as size (size)}
+				<DropdownMenuRadioItem value={size} closeOnSelect={false}>
+					{size}px
+				</DropdownMenuRadioItem>
+			{/each}
+		</DropdownMenuRadioGroup>
+	</DropdownMenuSubContent>
+</DropdownMenuSub>
+<DropdownMenuSeparator />
+<DropdownMenuItem
+	variant="destructive"
+	disabled={!session || workspace.isSurfaceCloseBlocked(terminalSurfaceId(terminalId))}
+	onSelect={terminate}
+>
+	<Square />
+	{m.terminal_terminate()}
+</DropdownMenuItem>

--- a/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
@@ -85,6 +85,17 @@ describe('TerminalSurface', () => {
 		expect(onClose).toHaveBeenCalledWith('terminal:terminal-1');
 	});
 
+	it('shows an exited-terminal cleanup failure from mobile Close', async () => {
+		render(TerminalSurfaceTestHost, {
+			host: 'mobile',
+			closeError: new Error('Terminal cleanup failed'),
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Close terminal tab' }));
+
+		expect(await screen.findByText('Terminal cleanup failed')).toBeTruthy();
+	});
+
 	it('adds the mobile renderer inset only in mobile presentation', async () => {
 		const { container, rerender } = render(TerminalSurfaceTestHost, { host: 'window-main' });
 		const terminalHost = container.querySelector<HTMLElement>('[data-terminal-host]');

--- a/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurface.test.ts
@@ -14,13 +14,13 @@ describe('TerminalSurface', () => {
 	});
 
 	it('labels the terminal path as its initial directory rather than its current directory', () => {
-		render(TerminalSurfaceTestHost, { host: 'window-main' });
+		render(TerminalSurfaceTestHost, { host: 'mobile' });
 
 		expect(screen.getByText('Started in /workspace/project')).toBeTruthy();
 	});
 
 	it('labels placed sessions with their workspace window number', () => {
-		render(TerminalSurfaceTestHost, { host: 'window-main' });
+		render(TerminalSurfaceTestHost, { host: 'mobile' });
 
 		expect(screen.getByRole('option', { name: 'Terminal 1 - running - Window 1' })).toBeTruthy();
 		expect(screen.getByRole('option', { name: 'Terminal 2 - running' })).toBeTruthy();
@@ -50,6 +50,15 @@ describe('TerminalSurface', () => {
 				value: originalMatchMedia,
 			});
 		}
+	});
+
+	it('omits the session toolbar from desktop window presentation', () => {
+		render(TerminalSurfaceTestHost, { host: 'window-main' });
+
+		expect(screen.queryByRole('combobox', { name: 'Terminal session' })).toBeNull();
+		expect(screen.queryByRole('button', { name: 'New terminal' })).toBeNull();
+		expect(screen.queryByRole('button', { name: 'Terminate' })).toBeNull();
+		expect(screen.queryByRole('button', { name: 'Terminal settings' })).toBeNull();
 	});
 
 	it('shows input helpers and guarded tab Close only in mobile presentation', async () => {
@@ -91,9 +100,9 @@ describe('TerminalSurface', () => {
 		expect(terminalHost?.classList.contains('bg-terminal-bg')).toBe(true);
 	});
 
-	it('terminates the session only from the explicit toolbar action', async () => {
+	it('terminates the session only from the explicit mobile toolbar action', async () => {
 		const onTerminate = vi.fn();
-		render(TerminalSurfaceTestHost, { host: 'window-main', onTerminate });
+		render(TerminalSurfaceTestHost, { host: 'mobile', onTerminate });
 
 		await fireEvent.click(screen.getByRole('button', { name: 'Terminate' }));
 
@@ -102,7 +111,7 @@ describe('TerminalSurface', () => {
 
 	it('focuses the session picker when the server reports the terminal cap', async () => {
 		render(TerminalSurfaceTestHost, {
-			host: 'window-main',
+			host: 'mobile',
 			createError: new ApiError(409, 'Limit reached', 'terminal-limit'),
 		});
 
@@ -113,7 +122,7 @@ describe('TerminalSurface', () => {
 
 	it('switches the current terminal tab instead of opening another tab', async () => {
 		const onSwitch = vi.fn();
-		render(TerminalSurfaceTestHost, { host: 'window-main', onSwitch });
+		render(TerminalSurfaceTestHost, { host: 'mobile', onSwitch });
 
 		await fireEvent.change(screen.getByRole('combobox', { name: 'Terminal session' }), {
 			target: { value: 'terminal-2' },
@@ -124,7 +133,7 @@ describe('TerminalSurface', () => {
 
 	it('creates a terminal by replacing the current terminal tab', async () => {
 		const onCreateReplacing = vi.fn();
-		render(TerminalSurfaceTestHost, { host: 'window-main', onCreateReplacing });
+		render(TerminalSurfaceTestHost, { host: 'mobile', onCreateReplacing });
 
 		await fireEvent.click(screen.getByRole('button', { name: 'New terminal' }));
 
@@ -146,7 +155,7 @@ describe('TerminalSurface', () => {
 
 	it('changes and persists the terminal font size from the toolbar settings', async () => {
 		const onFontSize = vi.fn();
-		render(TerminalSurfaceTestHost, { host: 'window-main', onFontSize });
+		render(TerminalSurfaceTestHost, { host: 'mobile', onFontSize });
 
 		await waitFor(() => expect(onFontSize).toHaveBeenLastCalledWith(13));
 		await fireEvent.click(screen.getByRole('button', { name: 'Terminal settings' }));

--- a/web/src/lib/components/terminal/__tests__/TerminalSurfaceTestHost.svelte
+++ b/web/src/lib/components/terminal/__tests__/TerminalSurfaceTestHost.svelte
@@ -28,6 +28,7 @@
 		onFontSize?: (fontSize: number) => void;
 		focusRequestToken?: number;
 		createError?: Error | null;
+		closeError?: Error | null;
 	}
 
 	let {
@@ -42,6 +43,7 @@
 		onFontSize = () => undefined,
 		focusRequestToken = 0,
 		createError = null,
+		closeError = null,
 	}: Props = $props();
 	const terminalId = 'terminal-1';
 	const localSettings = createLocalSettingsStore();
@@ -118,6 +120,7 @@
 		},
 		closeSurface: async (surfaceId: string) => {
 			onClose(surfaceId);
+			if (closeError) throw closeError;
 			return true;
 		},
 		isSurfaceCloseBlocked: () => false,

--- a/web/src/lib/components/terminal/__tests__/TerminalWindowMenuItems.test.ts
+++ b/web/src/lib/components/terminal/__tests__/TerminalWindowMenuItems.test.ts
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+	TerminalAttachmentState,
+	TerminalClientSession,
+} from '$lib/terminal/sessions/terminal-registry.svelte.js';
+import * as m from '$lib/paraglide/messages.js';
+import TerminalWindowMenuItemsTestHost from './TerminalWindowMenuItemsTestHost.svelte';
+
+const fakes = vi.hoisted(() => ({
+	sessions: {} as Record<string, TerminalClientSession>,
+	fontSize: '13',
+	clipboardMessage: '',
+	closeBlocked: false,
+	pasteFromClipboard: vi.fn<() => Promise<boolean>>(),
+	ensureRuntime: vi.fn(),
+	reattach: vi.fn(),
+	terminateTerminalSession: vi.fn<(terminalId: string) => Promise<boolean>>(),
+	isSurfaceCloseBlocked: vi.fn<(surfaceId: string) => boolean>(),
+	setLocalSetting: vi.fn(),
+	notifyError: vi.fn(),
+}));
+
+vi.mock('$lib/context', () => ({
+	getTerminalRegistry: () => ({
+		get sessions() {
+			return fakes.sessions;
+		},
+		ensureRuntime: fakes.ensureRuntime,
+		reattach: fakes.reattach,
+	}),
+	getWorkspaceCoordinator: () => ({
+		terminateTerminalSession: fakes.terminateTerminalSession,
+		isSurfaceCloseBlocked: fakes.isSurfaceCloseBlocked,
+	}),
+	getLocalSettings: () => ({
+		get terminalFontSize() {
+			return fakes.fontSize;
+		},
+		set: fakes.setLocalSetting,
+	}),
+	getNotifications: () => ({ error: fakes.notifyError }),
+	getOptionalTransientLayers: () => null,
+}));
+
+function terminalSession(attachmentState: TerminalAttachmentState): TerminalClientSession {
+	return {
+		metadata: {
+			terminalId: 'terminal-1',
+			displaySequence: 1,
+			initialWorkingDirectory: '/workspace/project',
+			processStatus: 'running',
+			attachmentStatus: 'attached',
+			createdAt: '2026-08-31T00:00:00.000Z',
+			exitCode: null,
+			latestOutputSequence: 0,
+		},
+		attachmentState,
+		lastReceivedSequence: 0,
+		replayTruncatedAt: null,
+	};
+}
+
+async function openMenu(): Promise<void> {
+	await fireEvent.click(screen.getByRole('button', { name: m.workspace_window_actions() }));
+}
+
+describe('TerminalWindowMenuItems', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fakes.sessions = { 'terminal-1': terminalSession('attached') };
+		fakes.fontSize = '13';
+		fakes.clipboardMessage = '';
+		fakes.closeBlocked = false;
+		fakes.pasteFromClipboard.mockResolvedValue(true);
+		fakes.ensureRuntime.mockImplementation(() => ({
+			pasteFromClipboard: fakes.pasteFromClipboard,
+			get clipboardMessage() {
+				return fakes.clipboardMessage;
+			},
+		}));
+		fakes.terminateTerminalSession.mockResolvedValue(true);
+		fakes.isSurfaceCloseBlocked.mockImplementation(() => fakes.closeBlocked);
+	});
+
+	afterEach(cleanup);
+
+	it('offers active terminal actions without duplicating terminal creation', async () => {
+		render(TerminalWindowMenuItemsTestHost, { terminalId: 'terminal-1' });
+		await openMenu();
+
+		expect(screen.getByRole('menuitem', { name: m.terminal_paste() })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: /Font size 13px/ })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: m.terminal_terminate() })).toBeTruthy();
+		expect(screen.queryByRole('menuitem', { name: m.terminal_reattach() })).toBeNull();
+		expect(screen.queryByRole('menuitem', { name: m.workspace_new_terminal() })).toBeNull();
+
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.terminal_paste() }));
+		await waitFor(() => expect(fakes.ensureRuntime).toHaveBeenCalledWith('terminal-1'));
+		expect(fakes.pasteFromClipboard).toHaveBeenCalledOnce();
+	});
+
+	it('reattaches a detached terminal', async () => {
+		fakes.sessions = { 'terminal-1': terminalSession('detached') };
+		render(TerminalWindowMenuItemsTestHost, { terminalId: 'terminal-1' });
+		await openMenu();
+
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.terminal_reattach() }));
+
+		expect(fakes.reattach).toHaveBeenCalledWith('terminal-1');
+	});
+
+	it('persists font size from the terminal submenu', async () => {
+		render(TerminalWindowMenuItemsTestHost, { terminalId: 'terminal-1' });
+		await openMenu();
+
+		const fontSize = screen.getByRole('menuitem', { name: /Font size 13px/ });
+		fontSize.focus();
+		await fireEvent.keyDown(fontSize, { key: 'ArrowRight' });
+		await fireEvent.click(await screen.findByRole('menuitemradio', { name: '18px' }));
+
+		expect(fakes.setLocalSetting).toHaveBeenCalledWith('terminalFontSize', '18');
+	});
+
+	it('terminates explicitly and reports clipboard feedback', async () => {
+		fakes.clipboardMessage = m.shell_errors_clipboard_empty();
+		fakes.pasteFromClipboard.mockResolvedValue(false);
+		render(TerminalWindowMenuItemsTestHost, { terminalId: 'terminal-1' });
+		await openMenu();
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.terminal_paste() }));
+
+		await waitFor(() =>
+			expect(fakes.notifyError).toHaveBeenCalledWith(m.shell_errors_clipboard_empty()),
+		);
+		await openMenu();
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.terminal_terminate() }));
+
+		expect(fakes.terminateTerminalSession).toHaveBeenCalledWith('terminal-1');
+	});
+});

--- a/web/src/lib/components/terminal/__tests__/TerminalWindowMenuItemsTestHost.svelte
+++ b/web/src/lib/components/terminal/__tests__/TerminalWindowMenuItemsTestHost.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import {
+		DropdownMenu,
+		DropdownMenuContent,
+		DropdownMenuTrigger,
+	} from '$lib/components/ui/dropdown-menu';
+	import TerminalWindowMenuItems from '../TerminalWindowMenuItems.svelte';
+	import * as m from '$lib/paraglide/messages.js';
+
+	let { terminalId }: { terminalId: string } = $props();
+</script>
+
+<DropdownMenu>
+	<DropdownMenuTrigger>{m.workspace_window_actions()}</DropdownMenuTrigger>
+	<DropdownMenuContent class="w-64">
+		<TerminalWindowMenuItems {terminalId} />
+	</DropdownMenuContent>
+</DropdownMenu>

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -2,6 +2,7 @@
 	import { onDestroy, untrack } from 'svelte';
 	import ChatSurface from '$lib/components/chat/ChatSurface.svelte';
 	import CurrentChatMenuItems from '$lib/components/layout/CurrentChatMenuItems.svelte';
+	import TerminalWindowMenuItems from '$lib/components/terminal/TerminalWindowMenuItems.svelte';
 	import NewBranchModal from '$lib/components/git/NewBranchModal.svelte';
 	import PortableSurfaceFrame from './PortableSurfaceFrame.svelte';
 	import WorkspaceWindow from './WorkspaceWindow.svelte';
@@ -234,7 +235,7 @@
 	}
 </script>
 
-{#snippet chatMenuItems(surfaceId: string)}
+{#snippet activeSurfaceMenuItems(surfaceId: string)}
 	{@const surface = snapshot.surfaces[surfaceId]}
 	{@const chat = surface?.type === 'chat' && surface.chatId ? sessions.byId[surface.chatId] : null}
 	{#if chat}
@@ -260,6 +261,8 @@
 			onFork={() => chatActions.fork(chat)}
 			onDelete={() => chatActions.requestDelete(chat)}
 		/>
+	{:else if surface?.type === 'terminal'}
+		<TerminalWindowMenuItems terminalId={surface.terminalId} />
 	{/if}
 {/snippet}
 
@@ -307,7 +310,7 @@
 				labelFor={label}
 				previewStore={chatWindowPreviews}
 				{subagentToolbar}
-				{chatMenuItems}
+				{activeSurfaceMenuItems}
 				frameBridge={(surfaceId) => rootState.frameBridge(surfaceId)}
 				surfaceStyle={PORTABLE_SURFACE_STYLE}
 				onSendToChat={sendToChat}

--- a/web/src/lib/components/workspace/WorkspaceWindow.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindow.svelte
@@ -29,7 +29,7 @@
 		labelFor,
 		previewStore,
 		subagentToolbar,
-		chatMenuItems,
+		activeSurfaceMenuItems,
 		frameBridge,
 		surfaceStyle,
 		onSendToChat,
@@ -44,7 +44,7 @@
 		labelFor: (surfaceId: string) => string;
 		previewStore: ChatWindowPreviewStore;
 		subagentToolbar: SubagentToolbarState;
-		chatMenuItems?: Snippet<[string]>;
+		activeSurfaceMenuItems?: Snippet<[string]>;
 		frameBridge(surfaceId: string): SurfaceFrameBridge;
 		surfaceStyle: string;
 		onSendToChat(message: string): Promise<boolean>;
@@ -190,7 +190,9 @@
 		{labelFor}
 		{dnd}
 		{isCurrent}
-		menuItems={activeSurface?.type === 'chat' ? chatMenuItems : undefined}
+		menuItems={activeSurface?.type === 'chat' || activeSurface?.type === 'terminal'
+			? activeSurfaceMenuItems
+			: undefined}
 	>
 		{#snippet auxiliaryActions()}
 			{#if activeChatIsLive && subagentToolbar.model}

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -11,6 +11,7 @@ import { SurfaceFrameRegistry } from '$lib/workspace/surface-frame-registry.svel
 import {
 	chatViewSurfaceId,
 	portableSingletonDescriptor,
+	terminalSurfaceId,
 	type PortableSingletonKind,
 	type WorkspaceLayoutMutation,
 	type WorkspaceWindowEdge,
@@ -18,6 +19,7 @@ import {
 } from '$lib/workspace/surface-types.js';
 import { collectWindowNodes, windowIdOfSurface } from '$lib/workspace/window-tree.js';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
+import type { TerminalClientSession } from '$lib/terminal/sessions/terminal-registry.svelte.js';
 import * as m from '$lib/paraglide/messages.js';
 
 const testContext = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
@@ -27,6 +29,7 @@ vi.mock('$lib/context', () => ({
 	getFileSessions: () => testContext.current?.fileSessions,
 	getGhCapability: () => testContext.current?.ghCapability,
 	getGitBranchActions: () => testContext.current?.gitBranchActions,
+	getLocalSettings: () => testContext.current?.localSettings,
 	getModelCatalog: () => testContext.current?.modelCatalog,
 	getNotifications: () => testContext.current?.notifications,
 	getSurfaceFrames: () => testContext.current?.surfaceFrames,
@@ -204,10 +207,25 @@ function installContext() {
 			);
 		}),
 		createTerminal: vi.fn(async () => 'terminal-created'),
+		terminateTerminalSession: vi.fn(async () => true),
 		openTerminalSession: vi.fn(async () => undefined),
 		retryPresentation: vi.fn(async () => undefined),
 		mobileBack: vi.fn(async () => undefined),
 		focusChat: vi.fn(async () => undefined),
+	};
+	const terminals = {
+		orderedSessions: [] as TerminalClientSession[],
+		sessions: {} as Record<string, TerminalClientSession>,
+		listStatus: 'ready' as const,
+		ensureRuntime: vi.fn(() => ({
+			clipboardMessage: '',
+			pasteFromClipboard: vi.fn(async () => true),
+		})),
+		reattach: vi.fn(),
+	};
+	const localSettings = {
+		terminalFontSize: '13',
+		set: vi.fn(),
 	};
 	const windowDnd = new WorkspaceWindowDndController(layout);
 	testContext.current = {
@@ -215,7 +233,8 @@ function installContext() {
 		windowDnd,
 		surfaceFrames: new SurfaceFrameRegistry(),
 		fileSessions: { get: () => null },
-		terminals: { orderedSessions: [], sessions: {}, listStatus: 'ready' },
+		terminals,
+		localSettings,
 		sessions: {
 			selectedChatId: 'chat-a',
 			selectedChat: chat('chat-a', 'Chat A'),
@@ -231,7 +250,7 @@ function installContext() {
 		ghCapability: { hasChecked: true, available: true },
 		notifications: { error: vi.fn() },
 	};
-	return { layout, runtime, workspace, windowDnd };
+	return { layout, runtime, workspace, windowDnd, terminals, localSettings };
 }
 
 const chatActions = {
@@ -284,6 +303,52 @@ describe('WorkspaceRoot', () => {
 		expect(panel.getAttribute('aria-labelledby')).toBe('window-main-tab-chat-view:window-main');
 		expect(document.getElementById('window-main-tab-chat-view:window-main')).not.toBeNull();
 		expect(container.querySelector('[data-workspace-window-focus-ring]')).toBeNull();
+	});
+
+	it('adds active terminal actions to the window menu', async () => {
+		const { layout, workspace, terminals } = installContext();
+		const terminalId = 'terminal-1';
+		const surfaceId = terminalSurfaceId(terminalId);
+		const terminal: TerminalClientSession = {
+			metadata: {
+				terminalId,
+				displaySequence: 1,
+				initialWorkingDirectory: '/workspace/project',
+				processStatus: 'running',
+				attachmentStatus: 'attached',
+				createdAt: '2026-08-31T00:00:00.000Z',
+				exitCode: null,
+				latestOutputSequence: 0,
+			},
+			attachmentState: 'attached',
+			lastReceivedSequence: 0,
+			replayTruncatedAt: null,
+		};
+		terminals.sessions[terminalId] = terminal;
+		terminals.orderedSessions = [terminal];
+		layout.publish(
+			layout.revision,
+			reduceWorkspaceLayout(layout.snapshot, [
+				{
+					type: 'register-surface',
+					surface: { id: surfaceId, type: 'terminal', terminalId },
+					windowId: 'window-main',
+				},
+				{
+					type: 'activate-window-tab',
+					windowId: 'window-main',
+					surfaceId,
+				},
+			]),
+		);
+		renderRoot();
+
+		await fireEvent.click(screen.getByRole('button', { name: m.workspace_window_actions() }));
+
+		expect(screen.getByRole('menuitem', { name: m.terminal_paste() })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: /Font size 13px/ })).toBeTruthy();
+		await fireEvent.click(screen.getByRole('menuitem', { name: m.terminal_terminate() }));
+		expect(workspace.terminateTerminalSession).toHaveBeenCalledWith(terminalId);
 	});
 
 	it('labels an occupied Chat center drop as replacement', async () => {

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -15,6 +15,7 @@ import {
 import { CANONICAL_CHAT_SURFACE_ID } from '../canonical-layout';
 import { windowIdOfSurface, windowNodeById, collectWindowNodes } from '../window-tree';
 import type { TerminalMetadata } from '$shared/terminal';
+import type { TerminalAttachmentState } from '$lib/terminal/sessions/terminal-registry.svelte.js';
 import { SurfaceFrameRegistry } from '../surface-frame-registry.svelte';
 import { SurfaceFrameBridge } from '../surface-frame-context';
 import { WorkspaceShortcutDispatcher } from '../workspace-shortcuts';
@@ -123,7 +124,7 @@ function createHarness(
 			string,
 			{
 				metadata: TerminalMetadata;
-				attachmentState: 'attached';
+				attachmentState: TerminalAttachmentState;
 			}
 		>,
 		requestTermination: options.terminate ?? vi.fn(async () => undefined),
@@ -717,7 +718,7 @@ describe('WorkspaceCoordinator', () => {
 		expect(layout.snapshot.dialogFileSurfaceId).toBe(fileSurfaceId('dialog-stale-window'));
 	});
 
-	it('closes a terminal tab without terminating its session and can reopen it', async () => {
+	it('closes a running terminal tab without terminating its session and can reopen it', async () => {
 		const { coordinator, layout, terminals } = createHarness();
 		const terminalId = 'terminal-unplaced';
 		terminals.sessions[terminalId] = {
@@ -747,6 +748,128 @@ describe('WorkspaceCoordinator', () => {
 		await coordinator.openTerminalSession(terminalId, historyWindowId);
 		expect(windowTabs(layout.snapshot, historyWindowId).order).toContain(surfaceId);
 		expect(layout.snapshot.unplacedTerminalIds).not.toContain(terminalId);
+	});
+
+	it('deletes an exited terminal when its tab closes', async () => {
+		const { coordinator, layout, terminals } = createHarness();
+		const terminalId = 'terminal-exited';
+		terminals.sessions[terminalId] = {
+			metadata: { ...terminalMetadata(terminalId), processStatus: 'exited', exitCode: 0 },
+			attachmentState: 'detached',
+		};
+		await coordinator.openTerminalSession(terminalId, 'window-main');
+		const surfaceId = terminalSurfaceId(terminalId);
+
+		await expect(coordinator.closeSurface(surfaceId)).resolves.toBe(true);
+
+		expect(terminals.requestTermination).toHaveBeenCalledWith(terminalId, expect.any(String));
+		expect(terminals.disposeTerminatedSession).toHaveBeenCalledWith(terminalId);
+		expect(layout.surface(surfaceId)).toBeNull();
+		expect(layout.snapshot.unplacedTerminalIds).not.toContain(terminalId);
+	});
+
+	it('keeps an exited terminal unplaced and reuses its cleanup request after a network failure', async () => {
+		const requestIds: string[] = [];
+		const terminate = vi
+			.fn()
+			.mockImplementationOnce(async (_terminalId: string, requestId: string) => {
+				requestIds.push(requestId);
+				throw new TypeError('network lost');
+			})
+			.mockImplementationOnce(async (_terminalId: string, requestId: string) => {
+				requestIds.push(requestId);
+			});
+		const { coordinator, layout, terminals } = createHarness({ terminate });
+		const terminalId = 'terminal-cleanup-retry';
+		terminals.sessions[terminalId] = {
+			metadata: { ...terminalMetadata(terminalId), processStatus: 'exited', exitCode: 1 },
+			attachmentState: 'detached',
+		};
+		await coordinator.openTerminalSession(terminalId, 'window-main');
+		const surfaceId = terminalSurfaceId(terminalId);
+
+		await expect(coordinator.closeSurface(surfaceId)).rejects.toThrow('network lost');
+
+		expect(layout.surface(surfaceId)).toBeNull();
+		expect(layout.snapshot.unplacedTerminalIds).toContain(terminalId);
+		expect(terminals.disposeTerminatedSession).not.toHaveBeenCalled();
+
+		await coordinator.openTerminalSession(terminalId, 'window-main');
+		await expect(coordinator.closeSurface(surfaceId)).resolves.toBe(true);
+
+		expect(requestIds[1]).toBe(requestIds[0]);
+		expect(layout.snapshot.unplacedTerminalIds).not.toContain(terminalId);
+	});
+
+	it('does not delete an exited terminal when its tab fails to close', async () => {
+		const { coordinator, layout, terminals } = createHarness({ failLayoutPublishAt: 2 });
+		const terminalId = 'terminal-close-failed';
+		terminals.sessions[terminalId] = {
+			metadata: { ...terminalMetadata(terminalId), processStatus: 'exited', exitCode: 1 },
+			attachmentState: 'detached',
+		};
+		await coordinator.openTerminalSession(terminalId, 'window-main');
+		const surfaceId = terminalSurfaceId(terminalId);
+
+		await expect(coordinator.closeSurface(surfaceId)).rejects.toThrow('layout publication failed');
+
+		expect(layout.surface(surfaceId)).not.toBeNull();
+		expect(terminals.requestTermination).not.toHaveBeenCalled();
+		expect(terminals.disposeTerminatedSession).not.toHaveBeenCalled();
+	});
+
+	it('joins remote deletion while cleaning up an exited terminal tab', async () => {
+		const deletion = deferred<void>();
+		const terminate = vi.fn(() => deletion.promise);
+		const { coordinator, layout, terminals } = createHarness({ terminate });
+		const terminalId = 'terminal-cleanup-remote-race';
+		terminals.sessions[terminalId] = {
+			metadata: { ...terminalMetadata(terminalId), processStatus: 'exited', exitCode: 0 },
+			attachmentState: 'detached',
+		};
+		await coordinator.openTerminalSession(terminalId, 'window-main');
+		const surfaceId = terminalSurfaceId(terminalId);
+
+		const closing = coordinator.closeSurface(surfaceId);
+		await vi.waitFor(() => expect(terminate).toHaveBeenCalledOnce());
+		await coordinator.handleTerminalSessionTerminated(terminalId);
+		deletion.resolve();
+		await expect(closing).resolves.toBe(true);
+
+		expect(terminate).toHaveBeenCalledOnce();
+		expect(layout.surface(surfaceId)).toBeNull();
+		expect(layout.snapshot.unplacedTerminalIds).not.toContain(terminalId);
+	});
+
+	it('deletes only exited terminals when their whole window closes', async () => {
+		const { coordinator, layout, terminals } = createHarness();
+		await coordinator.openSingletonInNewWindow('git-history');
+		const windowId = windowIdOfSurface(layout.snapshot.desktopRoot, 'singleton:git-history')!;
+		const runningTerminalId = 'terminal-window-running';
+		const exitedTerminalId = 'terminal-window-exited';
+		terminals.sessions[runningTerminalId] = {
+			metadata: terminalMetadata(runningTerminalId),
+			attachmentState: 'attached',
+		};
+		terminals.sessions[exitedTerminalId] = {
+			metadata: {
+				...terminalMetadata(exitedTerminalId),
+				processStatus: 'exited',
+				exitCode: 2,
+			},
+			attachmentState: 'detached',
+		};
+		await coordinator.openTerminalSession(runningTerminalId, windowId);
+		await coordinator.openTerminalSession(exitedTerminalId, windowId);
+
+		await expect(coordinator.closeWindow(windowId)).resolves.toBe(true);
+
+		expect(terminals.requestTermination).toHaveBeenCalledOnce();
+		expect(terminals.requestTermination).toHaveBeenCalledWith(exitedTerminalId, expect.any(String));
+		expect(terminals.disposeTerminatedSession).toHaveBeenCalledWith(exitedTerminalId);
+		expect(terminals.disposeTerminatedSession).not.toHaveBeenCalledWith(runningTerminalId);
+		expect(layout.snapshot.unplacedTerminalIds).toContain(runningTerminalId);
+		expect(layout.snapshot.unplacedTerminalIds).not.toContain(exitedTerminalId);
 	});
 
 	it('rejects tab moves while explicit terminal termination owns the destructive reservation', async () => {

--- a/web/src/lib/workspace/terminal-placement-service.ts
+++ b/web/src/lib/workspace/terminal-placement-service.ts
@@ -339,11 +339,7 @@ export class TerminalPlacementService {
 			) {
 				return false;
 			}
-			if (!this.#pendingTerminatedTerminalIds.has(terminalId)) {
-				await this.#requestTermination(terminalId);
-			}
-			this.#terminalTerminateRequestIds.delete(terminalId);
-			this.deps.terminals.disposeTerminatedSession(terminalId);
+			await this.#requestAndDisposeTermination(terminalId);
 			terminationAccepted = true;
 			return true;
 		} finally {
@@ -402,6 +398,23 @@ export class TerminalPlacementService {
 	async afterPlacementReleased(terminalId: string): Promise<void> {
 		if (this.#pendingTerminatedTerminalIds.delete(terminalId)) {
 			await this.handleTerminated(terminalId);
+			return;
+		}
+		const surfaceId = terminalSurfaceId(terminalId);
+		if (this.deps.layout.surface(surfaceId) || this.deps.reservations.has(surfaceId)) return;
+		const session = this.deps.terminals.sessions[terminalId];
+		if (session?.metadata.processStatus !== 'exited') return;
+		this.deps.reservations.add(surfaceId);
+		let terminationAccepted = false;
+		try {
+			await this.#requestAndDisposeTermination(terminalId);
+			terminationAccepted = true;
+		} finally {
+			this.deps.reservations.delete(surfaceId);
+			const terminatedRemotely = this.#pendingTerminatedTerminalIds.delete(terminalId);
+			if (terminationAccepted || terminatedRemotely) {
+				await this.handleTerminated(terminalId);
+			}
 		}
 	}
 
@@ -598,6 +611,14 @@ export class TerminalPlacementService {
 			this.#terminalTerminateRequestIds.set(terminalId, requestId);
 		}
 		await this.deps.terminals.requestTermination(terminalId, requestId);
+	}
+
+	async #requestAndDisposeTermination(terminalId: string): Promise<void> {
+		if (!this.#pendingTerminatedTerminalIds.has(terminalId)) {
+			await this.#requestTermination(terminalId);
+		}
+		this.#terminalTerminateRequestIds.delete(terminalId);
+		this.deps.terminals.disposeTerminatedSession(terminalId);
 	}
 
 	async #rollbackUnplaced(terminalId: string, placementError: unknown): Promise<never> {


### PR DESCRIPTION
Terminal windows no longer need a dedicated desktop toolbar: terminal-specific controls now live in the active window overflow menu alongside existing chat actions, while mobile retains its compact toolbar. Closing an exited terminal now deletes its session and placement automatically with retry-safe handling for failures and deletion races, while running terminals remain reopenable; lifecycle coverage verifies the complete browser flow.