### PR TITLE
Close chat metadata menu after copying

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -890,7 +890,6 @@
 	"workspace_window_actions": "Window actions",
 	"workspace_chat_metadata_copy_project_path": "Copy project path",
 	"workspace_chat_metadata_copy_chat_id": "Copy chat ID",
-	"workspace_chat_metadata_copied": "{field} copied",
 	"workspace_surface_actions": "View actions",
 	"workspace_new_terminal": "New Terminal",
 	"workspace_open_git_history": "Open Git History",

--- a/web/src/lib/components/workspace/WorkspaceWindowChatMetadata.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindowChatMetadata.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
-	import Check from '@lucide/svelte/icons/check';
 	import Copy from '@lucide/svelte/icons/copy';
 	import { formatCompactProjectPath } from '$lib/chat/project-paths/compact-project-path';
 	import { DropdownMenuItem } from '$lib/components/ui/dropdown-menu';
@@ -11,50 +9,22 @@
 
 	let { projectPath, chatId }: { projectPath: string; chatId: string } = $props();
 	let displayProjectPath = $derived(formatCompactProjectPath(projectPath));
-	let copiedField = $state<MetadataField | null>(null);
-	let resetTimer: ReturnType<typeof setTimeout> | null = null;
-	let copyGeneration = 0;
-
-	async function copyField(field: MetadataField, value: string): Promise<void> {
-		const generation = ++copyGeneration;
-		if (!(await copyToClipboard(value)) || generation !== copyGeneration) return;
-		copiedField = field;
-		if (resetTimer) clearTimeout(resetTimer);
-		resetTimer = setTimeout(() => {
-			copiedField = null;
-			resetTimer = null;
-		}, 2000);
-	}
-
-	onDestroy(() => {
-		copyGeneration++;
-		if (resetTimer) clearTimeout(resetTimer);
-	});
 </script>
 
 {#snippet metadataField(
 	field: MetadataField,
 	actionLabel: string,
-	copiedLabel: string,
 	value: string,
 	displayValue: string,
 )}
-	{@const copied = copiedField === field}
-	{@const feedbackLabel = copied ? copiedLabel : actionLabel}
 	<DropdownMenuItem
 		class="group items-start"
-		closeOnSelect={false}
 		textValue={actionLabel}
-		title={feedbackLabel}
-		aria-label={`${feedbackLabel}: ${value}`}
+		aria-label={`${actionLabel}: ${value}`}
 		data-workspace-chat-metadata-field={field}
-		onSelect={() => void copyField(field, value)}
+		onSelect={() => void copyToClipboard(value)}
 	>
-		{#if copied}
-			<Check class="mt-0.5 size-4 text-status-success-foreground" />
-		{:else}
-			<Copy class="mt-0.5 size-4" />
-		{/if}
+		<Copy class="mt-0.5 size-4" />
 		<div class="min-w-0 flex-1">
 			<div class="font-medium">{actionLabel}</div>
 			<div
@@ -71,14 +41,12 @@
 {@render metadataField(
 	'project-path',
 	m.workspace_chat_metadata_copy_project_path(),
-	m.workspace_chat_metadata_copied({ field: m.sidebar_details_project_path() }),
 	projectPath,
 	displayProjectPath,
 )}
 {@render metadataField(
 	'chat-id',
 	m.workspace_chat_metadata_copy_chat_id(),
-	m.workspace_chat_metadata_copied({ field: m.sidebar_details_chat_id() }),
 	chatId,
 	chatId,
 )}

--- a/web/src/lib/components/workspace/__tests__/WorkspaceWindowTitleBar.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceWindowTitleBar.test.ts
@@ -584,21 +584,18 @@ describe('WorkspaceWindowTitleBar', () => {
 
 		await fireEvent.click(projectPathItem);
 		await waitFor(() => expect(copyToClipboard).toHaveBeenCalledWith(fullProjectPath));
-		expect(trigger.getAttribute('aria-expanded')).toBe('true');
-		await waitFor(() =>
-			expect(projectPathItem.getAttribute('title')).toBe(
-				m.workspace_chat_metadata_copied({ field: 'Project path' }),
-			),
-		);
+		await waitFor(() => expect(trigger.getAttribute('aria-expanded')).toBe('false'));
 
-		await fireEvent.click(chatId);
+		await fireEvent.click(trigger);
+		const reopenedMenu = document.querySelector<HTMLElement>(
+			'[data-workspace-window-menu="window-main"]',
+		)!;
+		const reopenedChatId = within(reopenedMenu).getByRole('menuitem', {
+			name: `${m.workspace_chat_metadata_copy_chat_id()}: chat-a`,
+		});
+		await fireEvent.click(reopenedChatId);
 		await waitFor(() => expect(copyToClipboard).toHaveBeenCalledWith('chat-a'));
-		expect(trigger.getAttribute('aria-expanded')).toBe('true');
-		await waitFor(() =>
-			expect(chatId.getAttribute('title')).toBe(
-				m.workspace_chat_metadata_copied({ field: 'Chat ID' }),
-			),
-		);
+		await waitFor(() => expect(trigger.getAttribute('aria-expanded')).toBe('false'));
 	});
 
 	it('closes the active movable tab from the window menu', async () => {


### PR DESCRIPTION
Make the chat metadata rows behave consistently with other window-menu actions by closing the popup after copying the project path or chat ID, while removing the now-unneeded transient copied-state and checkmark feedback.