### PR TITLE
Align inter-agent participant labels

### DIFF
--- a/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
@@ -207,7 +207,13 @@ describe('ConversationMessage chat rows', () => {
 		});
 
 		expect(screen.getByText('Sent Message')).toBeTruthy();
-		expect(screen.getByText('To')).toBeTruthy();
+		const participantLabel = screen.getByText('To');
+		const participantList = participantLabel.nextElementSibling;
+		expect(participantLabel.parentElement?.className).toContain(
+			'grid-cols-[auto_minmax(0,1fr)]',
+		);
+		expect(participantList?.tagName).toBe('UL');
+		expect(participantList?.querySelectorAll('li')).toHaveLength(2);
 		const deliveredRecipient = screen.getByText('Build verification').closest('li');
 		const failedRecipient = screen.getByText('Release coordinator').closest('li');
 		expect(deliveredRecipient?.textContent).toContain(`(${TARGET_CHAT_ID})`);

--- a/web/src/lib/components/chat/rows/InterAgentMessageRow.svelte
+++ b/web/src/lib/components/chat/rows/InterAgentMessageRow.svelte
@@ -98,9 +98,11 @@
 						{displayTitle}
 					</span>
 				</div>
-				<div class="mt-2">
-					<div class="text-xs font-medium text-muted-foreground">{participantLabel}</div>
-					<ul class="mt-1 space-y-1.5">
+				<div
+					class="inter-agent-message-participants mt-2 grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2"
+				>
+					<div class="text-xs font-medium leading-5 text-muted-foreground">{participantLabel}</div>
+					<ul class="min-w-0 space-y-1.5">
 						{#each participants as participant}
 							<li class="flex min-w-0 items-center gap-1.5 leading-5">
 								<span class="min-w-0 truncate text-sm" title={participant.label}>


### PR DESCRIPTION
Inter-agent message cards now place the To or From label beside the first participant and align additional recipients beneath that participant, producing a more compact, scannable layout while preserving chat IDs and delivery status indicators; structural regression coverage locks the new alignment.