### PR TITLE
Keep chat text-selection dialog open

### DIFF
--- a/integration-tests/tests/chromium/transcript-virtualization.test.ts
+++ b/integration-tests/tests/chromium/transcript-virtualization.test.ts
@@ -4227,6 +4227,16 @@ async function verifyHiddenPortalCleanup(fixture: ChromiumFixture, chatId: strin
   await openVisibleMessageMenu();
   const menu = fixture.page.locator('[data-slot="context-menu-content"]');
   await menu.waitFor({ state: 'visible' });
+
+  await menu.getByRole('menuitem', { name: 'Select text' }).click();
+  const selectionSurface = fixture.page.getByRole('region', { name: 'Select text' });
+  await selectionSurface.waitFor({ state: 'visible' });
+  expect(await selectionSurface.textContent()).not.toBe('');
+  await fixture.page.keyboard.press('Escape');
+  await selectionSurface.waitFor({ state: 'detached' });
+
+  await openVisibleMessageMenu();
+  await menu.waitFor({ state: 'visible' });
   await menu.getByRole('menuitem', { name: 'Copy text' }).focus();
 
   await selectWorkspaceWindowSurface(

--- a/web/src/lib/components/chat/ChatSurface.svelte
+++ b/web/src/lib/components/chat/ChatSurface.svelte
@@ -81,7 +81,8 @@
 	);
 	const canRenderConversation = $derived(chatSurfacePresentation === 'conversation');
 	const conversationWorkspacePresented = $derived(isVisible && canRenderConversation);
-	const conversationWorkspaceVisible = $derived(conversationWorkspacePresented && isInteractive);
+	// Keeps modal interactivity separate from visibility so row-owned dialogs remain mounted.
+	const conversationWorkspaceVisible = $derived(conversationWorkspacePresented);
 	const reserveMobileToolbar = $derived(isMobile && hasUsableChatContext);
 	const canUpdateSelectedProjectPath = $derived(
 		selectedChat

--- a/web/src/lib/components/chat/__tests__/ChatSurface.test.ts
+++ b/web/src/lib/components/chat/__tests__/ChatSurface.test.ts
@@ -93,11 +93,16 @@ function subagentModel(): SubagentManagementModel {
 	};
 }
 
-function props(subagentToolbar: SubagentToolbarState, isMobile = true, isVisible = true) {
+function props(
+	subagentToolbar: SubagentToolbarState,
+	isMobile = true,
+	isVisible = true,
+	isInteractive = true,
+) {
 	return {
 		isMobile,
 		isVisible,
-		isInteractive: true,
+		isInteractive,
 		subagentToolbar,
 	};
 }
@@ -166,5 +171,17 @@ describe('ChatSurface mobile toolbar', () => {
 		expect(workspace.getAttribute('data-prepare-hide-count')).toBe('0');
 		await rendered.rerender(props(subagentToolbar, true, false));
 		expect(workspace.getAttribute('data-prepare-hide-count')).toBe('1');
+	});
+
+	it('keeps row-owned transient UI visible while a modal makes the chat inert', async () => {
+		sessions.selectedChat = chat();
+		const subagentToolbar = new SubagentToolbarState();
+		const rendered = render(ChatSurface, props(subagentToolbar));
+		const workspace = screen.getByTestId('conversation-workspace-stub');
+
+		await rendered.rerender(props(subagentToolbar, true, true, false));
+
+		expect(workspace.getAttribute('data-visible')).toBe('true');
+		expect(workspace.getAttribute('data-prepare-hide-count')).toBe('0');
 	});
 });

--- a/web/src/lib/components/chat/__tests__/ChatSurfaceConversationTestStub.svelte
+++ b/web/src/lib/components/chat/__tests__/ChatSurfaceConversationTestStub.svelte
@@ -4,10 +4,12 @@
 	let {
 		subagentToolbar,
 		reserveMobileToolbar,
+		isVisible,
 		onRegisterPrepareHide,
 	}: {
 		subagentToolbar: SubagentToolbarState;
 		reserveMobileToolbar: boolean;
+		isVisible: boolean;
 		onRegisterPrepareHide?: (prepare: (() => void) | null) => void;
 	} = $props();
 
@@ -24,5 +26,6 @@
 	data-testid="conversation-workspace-stub"
 	data-has-subagent-toolbar={Boolean(subagentToolbar)}
 	data-reserve-mobile-toolbar={reserveMobileToolbar}
+	data-visible={isVisible}
 	data-prepare-hide-count={prepareHideCount}
 ></div>


### PR DESCRIPTION
Opening a chat modal was incorrectly treated as hiding the conversation, so row-owned dialogs such as Select text closed immediately. This separates conversation visibility from modal interactivity and adds component and Chromium coverage for dialog persistence while preserving cleanup when the chat actually hides.