### PR TITLE
Unify workspace window tab menus

### DIFF
--- a/web/src/lib/components/layout/CurrentChatMenuItems.svelte
+++ b/web/src/lib/components/layout/CurrentChatMenuItems.svelte
@@ -9,11 +9,15 @@
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Share2 from '@lucide/svelte/icons/share-2';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
-	import { DropdownMenuItem, DropdownMenuSeparator } from '$lib/components/ui/dropdown-menu';
+	import {
+		dropdownMenuPrimitives,
+		type MenuPrimitives,
+	} from '$lib/components/ui/menu-primitives.js';
 	import type { ChatSessionRecord } from '$lib/types/chat-session';
 	import * as m from '$lib/paraglide/messages.js';
 
 	let {
+		menu = dropdownMenuPrimitives,
 		selectedChat,
 		canReload,
 		canUpdateProjectPath,
@@ -30,6 +34,7 @@
 		onFork,
 		onDelete,
 	}: {
+		menu?: MenuPrimitives;
 		selectedChat: ChatSessionRecord;
 		canReload: boolean;
 		canUpdateProjectPath: boolean;
@@ -50,64 +55,64 @@
 
 {#if onOpenGitHistory || onOpenGitCompare}
 	{#if onOpenGitHistory}
-		<DropdownMenuItem onclick={onOpenGitHistory}>
+		<menu.Item onSelect={onOpenGitHistory}>
 			<History />
 			{m.workspace_open_git_history()}
-		</DropdownMenuItem>
+		</menu.Item>
 	{/if}
 	{#if onOpenGitCompare}
-		<DropdownMenuItem onclick={onOpenGitCompare}>
+		<menu.Item onSelect={onOpenGitCompare}>
 			<GitCompareArrows />
 			{m.workspace_open_git_compare()}
-		</DropdownMenuItem>
+		</menu.Item>
 	{/if}
-	<DropdownMenuSeparator />
+	<menu.Separator />
 {/if}
 
 {#if onOpenUserMessageNavigator}
-	<DropdownMenuItem onclick={onOpenUserMessageNavigator}>
+	<menu.Item onSelect={onOpenUserMessageNavigator}>
 		<ListIcon />
 		{m.chat_user_message_navigator_menu()}
-	</DropdownMenuItem>
+	</menu.Item>
 {/if}
-<DropdownMenuItem onclick={onShare}>
+<menu.Item onSelect={onShare}>
 	<Share2 />
 	{m.share_button()}
-</DropdownMenuItem>
-<DropdownMenuItem onclick={onDetails}>
+</menu.Item>
+<menu.Item onSelect={onDetails}>
 	<Info />
 	{m.sidebar_chats_details()}
-</DropdownMenuItem>
+</menu.Item>
 {#if canFork}
-	<DropdownMenuItem disabled={!canForkNow} onclick={() => canForkNow && onFork()}>
+	<menu.Item disabled={!canForkNow} onSelect={() => canForkNow && onFork()}>
 		<GitFork />
 		{m.sidebar_chats_fork()}
-	</DropdownMenuItem>
+	</menu.Item>
 {/if}
-<DropdownMenuItem onclick={onRename}>
+<menu.Item onSelect={onRename}>
 	<Edit2 />
 	{m.sidebar_tooltips_edit_chat_name()}
-</DropdownMenuItem>
+</menu.Item>
 {#if canUpdateProjectPath}
-	<DropdownMenuItem
+	<menu.Item
 		disabled={selectedChat.isProcessing}
-		onclick={() => !selectedChat.isProcessing && onProjectPath()}
+		onSelect={() => !selectedChat.isProcessing && onProjectPath()}
 	>
 		<FolderOpen />
 		{m.sidebar_project_path_menu_item()}
-	</DropdownMenuItem>
+	</menu.Item>
 {/if}
 {#if canReload}
-	<DropdownMenuItem
+	<menu.Item
 		disabled={selectedChat.isProcessing}
-		onclick={() => !selectedChat.isProcessing && onReload()}
+		onSelect={() => !selectedChat.isProcessing && onReload()}
 	>
 		<RefreshCw />
 		{m.sidebar_chats_reload()}
-	</DropdownMenuItem>
+	</menu.Item>
 {/if}
-<DropdownMenuSeparator />
-<DropdownMenuItem variant="destructive" onclick={onDelete}>
+<menu.Separator />
+<menu.Item variant="destructive" onSelect={onDelete}>
 	<Trash2 />
 	{m.sidebar_tooltips_delete_chat()}
-</DropdownMenuItem>
+</menu.Item>

--- a/web/src/lib/components/terminal/TerminalWindowMenuItems.svelte
+++ b/web/src/lib/components/terminal/TerminalWindowMenuItems.svelte
@@ -5,14 +5,9 @@
 	import Settings from '@lucide/svelte/icons/settings';
 	import Square from '@lucide/svelte/icons/square';
 	import {
-		DropdownMenuItem,
-		DropdownMenuRadioGroup,
-		DropdownMenuRadioItem,
-		DropdownMenuSeparator,
-		DropdownMenuSub,
-		DropdownMenuSubContent,
-		DropdownMenuSubTrigger,
-	} from '$lib/components/ui/dropdown-menu';
+		dropdownMenuPrimitives,
+		type MenuPrimitives,
+	} from '$lib/components/ui/menu-primitives.js';
 	import {
 		getLocalSettings,
 		getNotifications,
@@ -23,7 +18,15 @@
 	import { terminalSurfaceId } from '$lib/workspace/surface-types.js';
 	import * as m from '$lib/paraglide/messages.js';
 
-	let { terminalId, onRename }: { terminalId: string; onRename: () => void } = $props();
+	let {
+		menu = dropdownMenuPrimitives,
+		terminalId,
+		onRename,
+	}: {
+		menu?: MenuPrimitives;
+		terminalId: string;
+		onRename: () => void;
+	} = $props();
 
 	const terminals = getTerminalRegistry();
 	const workspace = getWorkspaceCoordinator();
@@ -63,43 +66,43 @@
 </script>
 
 {#if canReattach}
-	<DropdownMenuItem onSelect={() => terminals.reattach(terminalId)}>
+	<menu.Item onSelect={() => terminals.reattach(terminalId)}>
 		<RefreshCw />
 		{m.terminal_reattach()}
-	</DropdownMenuItem>
+	</menu.Item>
 {/if}
-<DropdownMenuItem disabled={!session} onSelect={onRename}>
+<menu.Item disabled={!session} onSelect={onRename}>
 	<Pencil />
 	{m.terminal_rename()}
-</DropdownMenuItem>
-<DropdownMenuItem disabled={!session} onSelect={() => void paste()}>
+</menu.Item>
+<menu.Item disabled={!session} onSelect={() => void paste()}>
 	<Clipboard />
 	{m.terminal_paste()}
-</DropdownMenuItem>
-<DropdownMenuSub>
-	<DropdownMenuSubTrigger>
+</menu.Item>
+<menu.Sub>
+	<menu.SubTrigger>
 		<Settings />
 		<span class="flex min-w-0 flex-1 items-center justify-between gap-4">
 			<span>{m.terminal_font_size()}</span>
 			<span class="text-xs text-muted-foreground">{localSettings.terminalFontSize}px</span>
 		</span>
-	</DropdownMenuSubTrigger>
-	<DropdownMenuSubContent class="w-36">
-		<DropdownMenuRadioGroup value={localSettings.terminalFontSize} onValueChange={setFontSize}>
+	</menu.SubTrigger>
+	<menu.SubContent class="w-36">
+		<menu.RadioGroup value={localSettings.terminalFontSize} onValueChange={setFontSize}>
 			{#each FONT_SIZE_OPTIONS as size (size)}
-				<DropdownMenuRadioItem value={size} closeOnSelect={false}>
+				<menu.RadioItem value={size} closeOnSelect={false}>
 					{size}px
-				</DropdownMenuRadioItem>
+				</menu.RadioItem>
 			{/each}
-		</DropdownMenuRadioGroup>
-	</DropdownMenuSubContent>
-</DropdownMenuSub>
-<DropdownMenuSeparator />
-<DropdownMenuItem
+		</menu.RadioGroup>
+	</menu.SubContent>
+</menu.Sub>
+<menu.Separator />
+<menu.Item
 	variant="destructive"
 	disabled={!session || workspace.isSurfaceCloseBlocked(terminalSurfaceId(terminalId))}
 	onSelect={terminate}
 >
 	<Square />
 	{m.terminal_terminate()}
-</DropdownMenuItem>
+</menu.Item>

--- a/web/src/lib/components/ui/menu-primitives.ts
+++ b/web/src/lib/components/ui/menu-primitives.ts
@@ -1,0 +1,46 @@
+import {
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from './dropdown-menu';
+import {
+	ContextMenuItem,
+	ContextMenuLabel,
+	ContextMenuRadioGroup,
+	ContextMenuRadioItem,
+	ContextMenuSeparator,
+	ContextMenuSub,
+	ContextMenuSubContent,
+	ContextMenuSubTrigger,
+} from './context-menu';
+
+export const dropdownMenuPrimitives = {
+	kind: 'dropdown',
+	Item: DropdownMenuItem,
+	Label: DropdownMenuLabel,
+	RadioGroup: DropdownMenuRadioGroup,
+	RadioItem: DropdownMenuRadioItem,
+	Separator: DropdownMenuSeparator,
+	Sub: DropdownMenuSub,
+	SubContent: DropdownMenuSubContent,
+	SubTrigger: DropdownMenuSubTrigger,
+} as const;
+
+export const contextMenuPrimitives = {
+	kind: 'context',
+	Item: ContextMenuItem,
+	Label: ContextMenuLabel,
+	RadioGroup: ContextMenuRadioGroup,
+	RadioItem: ContextMenuRadioItem,
+	Separator: ContextMenuSeparator,
+	Sub: ContextMenuSub,
+	SubContent: ContextMenuSubContent,
+	SubTrigger: ContextMenuSubTrigger,
+} as const;
+
+export type MenuPrimitives = typeof dropdownMenuPrimitives | typeof contextMenuPrimitives;

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -10,6 +10,7 @@
 	import TerminalWindowMenuItems from '$lib/components/terminal/TerminalWindowMenuItems.svelte';
 	import TerminalRenameDialog from '$lib/components/terminal/TerminalRenameDialog.svelte';
 	import NewBranchModal from '$lib/components/git/NewBranchModal.svelte';
+	import type { MenuPrimitives } from '$lib/components/ui/menu-primitives.js';
 	import PortableSurfaceFrame from './PortableSurfaceFrame.svelte';
 	import WorkspaceWindow from './WorkspaceWindow.svelte';
 	import WorkspaceWindowResizer from './WorkspaceWindowResizer.svelte';
@@ -349,12 +350,13 @@
 	}
 </script>
 
-{#snippet activeSurfaceMenuItems(surfaceId: string)}
+{#snippet surfaceMenuItems(surfaceId: string, menu: MenuPrimitives)}
 	{@const surface = snapshot.surfaces[surfaceId]}
 	{@const chat = surface?.type === 'chat' && surface.chatId ? sessions.byId[surface.chatId] : null}
 	{#if chat}
 		{@const supportsFork = modelCatalog.supportsFork(chat.agentId)}
 		<CurrentChatMenuItems
+			{menu}
 			selectedChat={chat}
 			canReload={chat.canReloadFromNativeHistory ?? false}
 			canUpdateProjectPath={modelCatalog.supportsUpdateProjectPath?.(chat.agentId) ?? false}
@@ -377,6 +379,7 @@
 		/>
 	{:else if surface?.type === 'terminal'}
 		<TerminalWindowMenuItems
+			{menu}
 			terminalId={surface.terminalId}
 			onRename={() => (renamingTerminalId = surface.terminalId)}
 		/>
@@ -427,7 +430,7 @@
 				panelActions={conversationPanelActions}
 				{composerInsetPx}
 				{subagentToolbar}
-				{activeSurfaceMenuItems}
+				{surfaceMenuItems}
 				frameBridge={(surfaceId) => rootState.frameBridge(surfaceId)}
 				surfaceStyle={PORTABLE_SURFACE_STYLE}
 				onSendToChat={sendToChat}

--- a/web/src/lib/components/workspace/WorkspaceWindow.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, type Snippet } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import ChatEmptyState from '$lib/components/chat/ChatEmptyState.svelte';
 	import ChatLoadingState from '$lib/components/chat/ChatLoadingState.svelte';
 	import ConversationPanel from '$lib/components/chat/ConversationPanel.svelte';
@@ -25,6 +25,7 @@
 	import type { ChatDraftAppend } from '$lib/chat/composer/chat-draft-append.js';
 	import PortableSurfaceFrame from './PortableSurfaceFrame.svelte';
 	import WorkspaceWindowTitleBar from './WorkspaceWindowTitleBar.svelte';
+	import type { WorkspaceWindowSurfaceMenuItems } from './workspace-window-menu-contract.js';
 	import { cn } from '$lib/utils/cn';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -38,7 +39,7 @@
 		panelActions,
 		composerInsetPx,
 		subagentToolbar,
-		activeSurfaceMenuItems,
+		surfaceMenuItems,
 		frameBridge,
 		surfaceStyle,
 		onSendToChat,
@@ -53,7 +54,7 @@
 		panelActions: ConversationPanelActions | null;
 		composerInsetPx: number;
 		subagentToolbar: SubagentToolbarState;
-		activeSurfaceMenuItems?: Snippet<[string]>;
+		surfaceMenuItems?: WorkspaceWindowSurfaceMenuItems;
 		frameBridge(surfaceId: string): SurfaceFrameBridge;
 		surfaceStyle: string;
 		onSendToChat(message: string): Promise<boolean>;
@@ -240,15 +241,7 @@
 	ondragleave={(event) => dnd.handleWindowDragLeave(event)}
 	ondrop={(event) => void handleDrop(event)}
 >
-	<WorkspaceWindowTitleBar
-		{workspaceWindow}
-		{labelFor}
-		{dnd}
-		{isCurrent}
-		menuItems={activeSurface?.type === 'chat' || activeSurface?.type === 'terminal'
-			? activeSurfaceMenuItems
-			: undefined}
-	>
+	<WorkspaceWindowTitleBar {workspaceWindow} {labelFor} {dnd} {isCurrent} {surfaceMenuItems}>
 		{#snippet auxiliaryActions()}
 			{#if activeChatIsLive && subagentToolbar.model}
 				<SubagentManagementControl

--- a/web/src/lib/components/workspace/WorkspaceWindowChatMetadata.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindowChatMetadata.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
 	import Copy from '@lucide/svelte/icons/copy';
 	import { formatCompactProjectPath } from '$lib/chat/project-paths/compact-project-path';
-	import { DropdownMenuItem } from '$lib/components/ui/dropdown-menu';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import {
+		dropdownMenuPrimitives,
+		type MenuPrimitives,
+	} from '$lib/components/ui/menu-primitives.js';
 	import * as m from '$lib/paraglide/messages.js';
 
 	type MetadataField = 'project-path' | 'chat-id';
 
-	let { projectPath, chatId }: { projectPath: string; chatId: string } = $props();
+	let {
+		menu = dropdownMenuPrimitives,
+		projectPath,
+		chatId,
+	}: {
+		menu?: MenuPrimitives;
+		projectPath: string;
+		chatId: string;
+	} = $props();
 	let displayProjectPath = $derived(formatCompactProjectPath(projectPath));
 </script>
 
@@ -17,7 +28,7 @@
 	value: string,
 	displayValue: string,
 )}
-	<DropdownMenuItem
+	<menu.Item
 		class="group items-start"
 		textValue={actionLabel}
 		aria-label={`${actionLabel}: ${value}`}
@@ -35,7 +46,7 @@
 				{displayValue}
 			</div>
 		</div>
-	</DropdownMenuItem>
+	</menu.Item>
 {/snippet}
 
 {@render metadataField(
@@ -44,9 +55,4 @@
 	projectPath,
 	displayProjectPath,
 )}
-{@render metadataField(
-	'chat-id',
-	m.workspace_chat_metadata_copy_chat_id(),
-	chatId,
-	chatId,
-)}
+{@render metadataField('chat-id', m.workspace_chat_metadata_copy_chat_id(), chatId, chatId)}

--- a/web/src/lib/components/workspace/WorkspaceWindowMenu.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindowMenu.svelte
@@ -1,37 +1,10 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
 	import EllipsisVertical from '@lucide/svelte/icons/ellipsis-vertical';
-	import Maximize2 from '@lucide/svelte/icons/maximize-2';
-	import PanelRight from '@lucide/svelte/icons/panel-right';
-	import PanelTop from '@lucide/svelte/icons/panel-top';
-	import X from '@lucide/svelte/icons/x';
-	import {
-		DropdownMenu,
-		DropdownMenuContent,
-		DropdownMenuItem,
-		DropdownMenuLabel,
-		DropdownMenuSeparator,
-		DropdownMenuTrigger,
-	} from '$lib/components/ui/dropdown-menu';
-	import {
-		getChatSessions,
-		getNotifications,
-		getWorkspaceCoordinator,
-	} from '$lib/context';
-	import type {
-		ActiveSurfaceKind,
-		WorkspaceWindowEdge,
-		WorkspaceWindowId,
-		WorkspaceWindowTabState,
-	} from '$lib/workspace/surface-types.js';
-	import {
-		moveWorkspaceTabToNewWindow,
-		resolveWorkspaceWindowTabActions,
-	} from '$lib/workspace/workspace-window-tab-actions.js';
-	import WorkspaceWindowChatMetadata from './WorkspaceWindowChatMetadata.svelte';
-	import WorkspaceSurfaceIcon from './WorkspaceSurfaceIcon.svelte';
+	import { DropdownMenu, DropdownMenuTrigger } from '$lib/components/ui/dropdown-menu';
+	import type { WorkspaceWindowId, WorkspaceWindowTabState } from '$lib/workspace/surface-types.js';
+	import { dropdownMenuPrimitives } from '$lib/components/ui/menu-primitives.js';
+	import WorkspaceWindowTabMenu from './WorkspaceWindowTabMenu.svelte';
+	import type { WorkspaceWindowSurfaceMenuItems } from './workspace-window-menu-contract.js';
 	import * as m from '$lib/paraglide/messages.js';
 
 	let {
@@ -40,61 +13,15 @@
 		hiddenSurfaceIds,
 		labelFor,
 		onSelect,
-		menuItems,
+		surfaceMenuItems,
 	}: {
 		windowId: WorkspaceWindowId;
 		tabs: WorkspaceWindowTabState;
 		hiddenSurfaceIds: readonly string[];
 		labelFor: (surfaceId: string) => string;
 		onSelect: (surfaceId: string) => void;
-		menuItems?: Snippet<[string]>;
+		surfaceMenuItems?: WorkspaceWindowSurfaceMenuItems;
 	} = $props();
-
-	const workspace = getWorkspaceCoordinator();
-	const sessions = getChatSessions();
-	const notifications = getNotifications();
-	const tabActions = $derived(
-		resolveWorkspaceWindowTabActions(workspace.layout.snapshot, windowId, tabs, tabs.activeId),
-	);
-	const activeSurface = $derived(tabActions.surface);
-	const activeChatMetadata = $derived.by(() => {
-		const surface = activeSurface;
-		if (surface?.type !== 'chat' || !surface.chatId) return null;
-		const chat = sessions.byId[surface.chatId];
-		return chat ? { chatId: surface.chatId, projectPath: chat.projectPath } : null;
-	});
-	const canOfferCloseTab = $derived(tabActions.surface !== null);
-
-	function surfaceKind(surfaceId: string): ActiveSurfaceKind {
-		const surface = workspace.layout.surface(surfaceId);
-		if (!surface) return 'file';
-		return surface.type === 'singleton' ? surface.kind : surface.type;
-	}
-
-	function notifyFailure(error: unknown): void {
-		notifications.error(error instanceof Error ? error.message : m.workspace_open_failed());
-	}
-
-	function moveTab(destinationWindowId: WorkspaceWindowId, index?: number): void {
-		void workspace.moveTabToWindow(tabs.activeId, destinationWindowId, index).catch(notifyFailure);
-	}
-
-	function moveTabLeft(): void {
-		if (tabActions.index > 0) moveTab(windowId, tabActions.index - 1);
-	}
-
-	function moveTabRight(): void {
-		if (tabActions.index >= 0 && tabActions.index < tabs.order.length - 1)
-			moveTab(windowId, tabActions.index + 1);
-	}
-
-	function moveToNewWindow(edge: WorkspaceWindowEdge): void {
-		void moveWorkspaceTabToNewWindow(workspace, tabs.activeId, windowId, edge).catch(notifyFailure);
-	}
-
-	function closeActiveTab(): void {
-		void workspace.closeSurface(tabs.activeId).catch(notifyFailure);
-	}
 </script>
 
 <DropdownMenu>
@@ -106,117 +33,14 @@
 	>
 		<EllipsisVertical class="h-3.5 w-3.5" />
 	</DropdownMenuTrigger>
-	<DropdownMenuContent
-		align="end"
-		class={activeChatMetadata ? 'w-80 max-w-[calc(100vw-1rem)]' : 'w-64'}
-		data-workspace-window-menu={windowId}
-	>
-		<DropdownMenuItem
-			data-workspace-window-tab-action="move-left"
-			disabled={!tabActions.canReorder || tabActions.index <= 0}
-			onSelect={moveTabLeft}
-		>
-			<ArrowLeft />
-			{m.workspace_move_tab_left()}
-		</DropdownMenuItem>
-		<DropdownMenuItem
-			data-workspace-window-tab-action="move-right"
-			disabled={!tabActions.canReorder ||
-				tabActions.index < 0 ||
-				tabActions.index >= tabs.order.length - 1}
-			onSelect={moveTabRight}
-		>
-			<ArrowRight />
-			{m.workspace_move_tab_right()}
-		</DropdownMenuItem>
-		{#if tabActions.canMoveBetweenWindows}
-			{#each tabActions.otherWindows as destination (destination.id)}
-				{@const moveLabel = m.workspace_move_to_window({
-					window: labelFor(destination.tabs.activeId),
-				})}
-				<DropdownMenuItem
-					class="min-w-0"
-					data-workspace-window-tab-action="move-to-window"
-					title={moveLabel}
-					onSelect={() => moveTab(destination.id)}
-				>
-					<PanelRight />
-					<span class="min-w-0 flex-1 truncate">{moveLabel}</span>
-				</DropdownMenuItem>
-			{/each}
-		{/if}
-		<DropdownMenuItem
-			data-workspace-window-tab-action="move-new-left"
-			disabled={!tabActions.canMoveToNewWindow}
-			onSelect={() => moveToNewWindow('left')}
-		>
-			<PanelRight class="rotate-180" />
-			{m.workspace_move_tab_to_new_window_left()}
-		</DropdownMenuItem>
-		<DropdownMenuItem
-			data-workspace-window-tab-action="move-new-right"
-			disabled={!tabActions.canMoveToNewWindow}
-			onSelect={() => moveToNewWindow('right')}
-		>
-			<PanelRight />
-			{m.workspace_move_tab_to_new_window_right()}
-		</DropdownMenuItem>
-		<DropdownMenuItem
-			data-workspace-window-tab-action="move-new-top"
-			disabled={!tabActions.canMoveToNewWindow}
-			onSelect={() => moveToNewWindow('top')}
-		>
-			<PanelTop />
-			{m.workspace_move_tab_to_new_window_above()}
-		</DropdownMenuItem>
-		<DropdownMenuItem
-			data-workspace-window-tab-action="move-new-bottom"
-			disabled={!tabActions.canMoveToNewWindow}
-			onSelect={() => moveToNewWindow('bottom')}
-		>
-			<PanelTop class="rotate-180" />
-			{m.workspace_move_tab_to_new_window_below()}
-		</DropdownMenuItem>
-		{#if canOfferCloseTab}
-			<DropdownMenuItem
-				data-workspace-window-tab-action="close-tab"
-				disabled={workspace.isSurfaceCloseBlocked(tabs.activeId)}
-				onSelect={closeActiveTab}
-			>
-				<X />
-				{m.workspace_close_tab()}
-			</DropdownMenuItem>
-		{/if}
-		<DropdownMenuSeparator data-workspace-window-tab-actions-separator />
-		{#if activeChatMetadata}
-			<WorkspaceWindowChatMetadata
-				projectPath={activeChatMetadata.projectPath}
-				chatId={activeChatMetadata.chatId}
-			/>
-			<DropdownMenuSeparator data-workspace-chat-metadata-separator />
-		{/if}
-		{#if hiddenSurfaceIds.length > 0}
-			<DropdownMenuLabel>{m.workspace_open_tabs()}</DropdownMenuLabel>
-			{#each hiddenSurfaceIds as surfaceId (surfaceId)}
-				<DropdownMenuItem
-					data-workspace-hidden-tab-id={surfaceId}
-					onSelect={() => onSelect(surfaceId)}
-				>
-					<WorkspaceSurfaceIcon kind={surfaceKind(surfaceId)} />
-					<span class="min-w-0 truncate">{labelFor(surfaceId)}</span>
-				</DropdownMenuItem>
-			{/each}
-			<DropdownMenuSeparator />
-		{/if}
-		{#if menuItems}
-			{@render menuItems(tabs.activeId)}
-		{/if}
-		{#if activeSurface?.type === 'file'}
-			{#if menuItems}<DropdownMenuSeparator />{/if}
-			<DropdownMenuItem onSelect={() => void workspace.popOutFile(activeSurface.id)}>
-				<Maximize2 />
-				{m.workspace_pop_out()}
-			</DropdownMenuItem>
-		{/if}
-	</DropdownMenuContent>
+	<WorkspaceWindowTabMenu
+		menu={dropdownMenuPrimitives}
+		{windowId}
+		{tabs}
+		surfaceId={tabs.activeId}
+		{hiddenSurfaceIds}
+		{labelFor}
+		{onSelect}
+		{surfaceMenuItems}
+	/>
 </DropdownMenu>

--- a/web/src/lib/components/workspace/WorkspaceWindowTabMenu.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindowTabMenu.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+	import ArrowRight from '@lucide/svelte/icons/arrow-right';
+	import Maximize2 from '@lucide/svelte/icons/maximize-2';
+	import PanelRight from '@lucide/svelte/icons/panel-right';
+	import PanelTop from '@lucide/svelte/icons/panel-top';
+	import X from '@lucide/svelte/icons/x';
+	import { DropdownMenuContent } from '$lib/components/ui/dropdown-menu';
+	import { ContextMenuContent } from '$lib/components/ui/context-menu';
+	import type { MenuPrimitives } from '$lib/components/ui/menu-primitives.js';
+	import { getChatSessions, getNotifications, getWorkspaceCoordinator } from '$lib/context';
+	import type {
+		ActiveSurfaceKind,
+		WorkspaceWindowEdge,
+		WorkspaceWindowId,
+		WorkspaceWindowTabState,
+	} from '$lib/workspace/surface-types.js';
+	import {
+		moveWorkspaceTabToNewWindow,
+		resolveWorkspaceWindowTabActions,
+	} from '$lib/workspace/workspace-window-tab-actions.js';
+	import WorkspaceSurfaceIcon from './WorkspaceSurfaceIcon.svelte';
+	import WorkspaceWindowChatMetadata from './WorkspaceWindowChatMetadata.svelte';
+	import type { WorkspaceWindowSurfaceMenuItems } from './workspace-window-menu-contract.js';
+	import * as m from '$lib/paraglide/messages.js';
+
+	let {
+		menu,
+		windowId,
+		tabs,
+		surfaceId,
+		hiddenSurfaceIds,
+		labelFor,
+		onSelect,
+		surfaceMenuItems,
+	}: {
+		menu: MenuPrimitives;
+		windowId: WorkspaceWindowId;
+		tabs: WorkspaceWindowTabState;
+		surfaceId: string;
+		hiddenSurfaceIds: readonly string[];
+		labelFor: (surfaceId: string) => string;
+		onSelect: (surfaceId: string) => void;
+		surfaceMenuItems?: WorkspaceWindowSurfaceMenuItems;
+	} = $props();
+
+	const workspace = getWorkspaceCoordinator();
+	const sessions = getChatSessions();
+	const notifications = getNotifications();
+	const tabActions = $derived(
+		resolveWorkspaceWindowTabActions(workspace.layout.snapshot, windowId, tabs, surfaceId),
+	);
+	const surface = $derived(tabActions.surface);
+	const chatMetadata = $derived.by(() => {
+		if (surface?.type !== 'chat' || !surface.chatId) return null;
+		const chat = sessions.byId[surface.chatId];
+		return chat ? { chatId: surface.chatId, projectPath: chat.projectPath } : null;
+	});
+	const contentClass = $derived(chatMetadata ? 'w-80 max-w-[calc(100vw-1rem)]' : 'w-64');
+
+	function surfaceKind(targetSurfaceId: string): ActiveSurfaceKind {
+		const targetSurface = workspace.layout.surface(targetSurfaceId);
+		if (!targetSurface) return 'file';
+		return targetSurface.type === 'singleton' ? targetSurface.kind : targetSurface.type;
+	}
+
+	function notifyFailure(error: unknown): void {
+		notifications.error(error instanceof Error ? error.message : m.workspace_open_failed());
+	}
+
+	function moveTab(destinationWindowId: WorkspaceWindowId, index?: number): void {
+		void workspace.moveTabToWindow(surfaceId, destinationWindowId, index).catch(notifyFailure);
+	}
+
+	function moveTabLeft(): void {
+		if (tabActions.canReorder && tabActions.index > 0) {
+			moveTab(windowId, tabActions.index - 1);
+		}
+	}
+
+	function moveTabRight(): void {
+		if (
+			tabActions.canReorder &&
+			tabActions.index >= 0 &&
+			tabActions.index < tabs.order.length - 1
+		) {
+			moveTab(windowId, tabActions.index + 1);
+		}
+	}
+
+	function moveToNewWindow(edge: WorkspaceWindowEdge): void {
+		void moveWorkspaceTabToNewWindow(workspace, surfaceId, windowId, edge).catch(notifyFailure);
+	}
+
+	function closeTab(): void {
+		void workspace.closeSurface(surfaceId).catch(notifyFailure);
+	}
+</script>
+
+{#snippet menuItems()}
+	<menu.Item
+		data-workspace-window-tab-action="move-left"
+		disabled={!tabActions.canReorder || tabActions.index <= 0}
+		onSelect={moveTabLeft}
+	>
+		<ArrowLeft />
+		{m.workspace_move_tab_left()}
+	</menu.Item>
+	<menu.Item
+		data-workspace-window-tab-action="move-right"
+		disabled={!tabActions.canReorder ||
+			tabActions.index < 0 ||
+			tabActions.index >= tabs.order.length - 1}
+		onSelect={moveTabRight}
+	>
+		<ArrowRight />
+		{m.workspace_move_tab_right()}
+	</menu.Item>
+	{#if tabActions.canMoveBetweenWindows}
+		{#each tabActions.otherWindows as destination (destination.id)}
+			{@const moveLabel = m.workspace_move_to_window({
+				window: labelFor(destination.tabs.activeId),
+			})}
+			<menu.Item
+				class="min-w-0"
+				data-workspace-window-tab-action="move-to-window"
+				title={moveLabel}
+				onSelect={() => moveTab(destination.id)}
+			>
+				<PanelRight />
+				<span class="min-w-0 flex-1 truncate">{moveLabel}</span>
+			</menu.Item>
+		{/each}
+	{/if}
+	<menu.Item
+		data-workspace-window-tab-action="move-new-left"
+		disabled={!tabActions.canMoveToNewWindow}
+		onSelect={() => moveToNewWindow('left')}
+	>
+		<PanelRight class="rotate-180" />
+		{m.workspace_move_tab_to_new_window_left()}
+	</menu.Item>
+	<menu.Item
+		data-workspace-window-tab-action="move-new-right"
+		disabled={!tabActions.canMoveToNewWindow}
+		onSelect={() => moveToNewWindow('right')}
+	>
+		<PanelRight />
+		{m.workspace_move_tab_to_new_window_right()}
+	</menu.Item>
+	<menu.Item
+		data-workspace-window-tab-action="move-new-top"
+		disabled={!tabActions.canMoveToNewWindow}
+		onSelect={() => moveToNewWindow('top')}
+	>
+		<PanelTop />
+		{m.workspace_move_tab_to_new_window_above()}
+	</menu.Item>
+	<menu.Item
+		data-workspace-window-tab-action="move-new-bottom"
+		disabled={!tabActions.canMoveToNewWindow}
+		onSelect={() => moveToNewWindow('bottom')}
+	>
+		<PanelTop class="rotate-180" />
+		{m.workspace_move_tab_to_new_window_below()}
+	</menu.Item>
+	{#if surface}
+		<menu.Item
+			data-workspace-window-tab-action="close-tab"
+			disabled={workspace.isSurfaceCloseBlocked(surfaceId)}
+			onSelect={closeTab}
+		>
+			<X />
+			{m.workspace_close_tab()}
+		</menu.Item>
+	{/if}
+	<menu.Separator data-workspace-window-tab-actions-separator />
+	{#if chatMetadata}
+		<WorkspaceWindowChatMetadata
+			{menu}
+			projectPath={chatMetadata.projectPath}
+			chatId={chatMetadata.chatId}
+		/>
+		<menu.Separator data-workspace-chat-metadata-separator />
+	{/if}
+	{#if hiddenSurfaceIds.length > 0}
+		<menu.Label>{m.workspace_open_tabs()}</menu.Label>
+		{#each hiddenSurfaceIds as hiddenSurfaceId (hiddenSurfaceId)}
+			<menu.Item
+				data-workspace-hidden-tab-id={hiddenSurfaceId}
+				onSelect={() => onSelect(hiddenSurfaceId)}
+			>
+				<WorkspaceSurfaceIcon kind={surfaceKind(hiddenSurfaceId)} />
+				<span class="min-w-0 truncate">{labelFor(hiddenSurfaceId)}</span>
+			</menu.Item>
+		{/each}
+		<menu.Separator />
+	{/if}
+	{@render surfaceMenuItems?.(surfaceId, menu)}
+	{#if surface?.type === 'file'}
+		<menu.Item onSelect={() => void workspace.popOutFile(surface.id)}>
+			<Maximize2 />
+			{m.workspace_pop_out()}
+		</menu.Item>
+	{/if}
+{/snippet}
+
+{#if menu.kind === 'dropdown'}
+	<DropdownMenuContent
+		align="end"
+		class={contentClass}
+		data-workspace-window-menu={windowId}
+		data-workspace-window-tab-menu="dropdown"
+	>
+		{@render menuItems()}
+	</DropdownMenuContent>
+{:else}
+	<ContextMenuContent
+		class={contentClass}
+		data-workspace-window-tab-context-menu={surfaceId}
+		data-workspace-window-tab-menu="context"
+	>
+		{@render menuItems()}
+	</ContextMenuContent>
+{/if}

--- a/web/src/lib/components/workspace/WorkspaceWindowTabStrip.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindowTabStrip.svelte
@@ -1,29 +1,12 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
-	import ArrowRight from '@lucide/svelte/icons/arrow-right';
-	import Maximize2 from '@lucide/svelte/icons/maximize-2';
-	import PanelRight from '@lucide/svelte/icons/panel-right';
-	import PanelTop from '@lucide/svelte/icons/panel-top';
-	import X from '@lucide/svelte/icons/x';
-	import {
-		ContextMenu,
-		ContextMenuContent,
-		ContextMenuItem,
-		ContextMenuSeparator,
-		ContextMenuTrigger,
-	} from '$lib/components/ui/context-menu';
+	import { ContextMenu, ContextMenuTrigger } from '$lib/components/ui/context-menu';
 	import { getChatSessions, getNotifications, getWorkspaceCoordinator } from '$lib/context';
 	import type {
 		ActiveSurfaceKind,
-		WorkspaceWindowEdge,
 		WorkspaceWindowId,
 		WorkspaceWindowTabState,
 	} from '$lib/workspace/surface-types.js';
-	import {
-		moveWorkspaceTabToNewWindow,
-		resolveWorkspaceWindowTabActions,
-	} from '$lib/workspace/workspace-window-tab-actions.js';
 	import type { WorkspaceWindowDndController } from '$lib/workspace/window-dnd.svelte.js';
 	import { cn } from '$lib/utils/cn';
 	import {
@@ -32,6 +15,9 @@
 		type WindowTabLabelMode,
 		type WindowTabPresentation,
 	} from './workspace-window-tab-layout.js';
+	import WorkspaceWindowTabMenu from './WorkspaceWindowTabMenu.svelte';
+	import { contextMenuPrimitives } from '$lib/components/ui/menu-primitives.js';
+	import type { WorkspaceWindowSurfaceMenuItems } from './workspace-window-menu-contract.js';
 	import WorkspaceSurfaceIcon from './WorkspaceSurfaceIcon.svelte';
 	import WorkspaceChatProcessingIndicator from './WorkspaceChatProcessingIndicator.svelte';
 	import * as m from '$lib/paraglide/messages.js';
@@ -39,6 +25,7 @@
 	let {
 		windowId,
 		tabs,
+		hiddenSurfaceIds,
 		labelFor,
 		onSelect,
 		onFocus,
@@ -46,9 +33,11 @@
 		isCurrent,
 		isChatProcessing = () => false,
 		onVisibleChange,
+		surfaceMenuItems,
 	}: {
 		windowId: WorkspaceWindowId;
 		tabs: WorkspaceWindowTabState;
+		hiddenSurfaceIds: readonly string[];
 		labelFor: (surfaceId: string) => string;
 		onSelect: (surfaceId: string) => void;
 		onFocus?: (surfaceId: string) => void;
@@ -56,6 +45,7 @@
 		isCurrent: boolean;
 		isChatProcessing?: (surfaceId: string) => boolean;
 		onVisibleChange?: (ids: readonly string[]) => void;
+		surfaceMenuItems?: WorkspaceWindowSurfaceMenuItems;
 	} = $props();
 
 	const workspace = getWorkspaceCoordinator();
@@ -118,18 +108,6 @@
 		return Boolean(surface && surface.type !== 'terminal-launcher');
 	}
 
-	function canMoveBetweenWindows(surfaceId: string): boolean {
-		return tabActions(surfaceId).canMoveBetweenWindows;
-	}
-
-	function canMoveToNewWindow(surfaceId: string): boolean {
-		return tabActions(surfaceId).canMoveToNewWindow;
-	}
-
-	function tabActions(surfaceId: string) {
-		return resolveWorkspaceWindowTabActions(workspace.layout.snapshot, windowId, tabs, surfaceId);
-	}
-
 	function recomputeVisibleTabs(): void {
 		if (!tabViewport || !measurementRail) return;
 		const widths = new Map<string, number>();
@@ -158,28 +136,6 @@
 
 	function notifyFailure(error: unknown): void {
 		notifications.error(error instanceof Error ? error.message : m.workspace_open_failed());
-	}
-
-	function moveTab(
-		surfaceId: string,
-		destinationWindowId: WorkspaceWindowId,
-		index?: number,
-	): void {
-		void workspace.moveTabToWindow(surfaceId, destinationWindowId, index).catch(notifyFailure);
-	}
-
-	function moveTabLeft(surfaceId: string): void {
-		const { index } = tabActions(surfaceId);
-		if (index > 0) moveTab(surfaceId, windowId, index - 1);
-	}
-
-	function moveTabRight(surfaceId: string): void {
-		const { index } = tabActions(surfaceId);
-		if (index >= 0 && index < tabs.order.length - 1) moveTab(surfaceId, windowId, index + 1);
-	}
-
-	function moveToNewWindow(surfaceId: string, edge: WorkspaceWindowEdge): void {
-		void moveWorkspaceTabToNewWindow(workspace, surfaceId, windowId, edge).catch(notifyFailure);
 	}
 
 	function handleKeydown(event: KeyboardEvent, surfaceId: string): void {
@@ -308,78 +264,16 @@
 					{@render tabButton(surfaceId, false, props)}
 				{/snippet}
 			</ContextMenuTrigger>
-			<ContextMenuContent class="w-64">
-				{@const actionState = tabActions(surfaceId)}
-				{@const index = actionState.index}
-				<ContextMenuItem disabled={index <= 0} onclick={() => moveTabLeft(surfaceId)}>
-					<ArrowLeft />
-					{m.workspace_move_tab_left()}
-				</ContextMenuItem>
-				<ContextMenuItem
-					disabled={index < 0 || index >= tabs.order.length - 1}
-					onclick={() => moveTabRight(surfaceId)}
-				>
-					<ArrowRight />
-					{m.workspace_move_tab_right()}
-				</ContextMenuItem>
-				{#if canMoveBetweenWindows(surfaceId)}
-					{#each actionState.otherWindows as destination (destination.id)}
-						{@const moveLabel = m.workspace_move_to_window({
-							window: labelFor(destination.tabs.activeId),
-						})}
-						<ContextMenuItem
-							class="min-w-0"
-							title={moveLabel}
-							onclick={() => moveTab(surfaceId, destination.id)}
-						>
-							<PanelRight />
-							<span class="min-w-0 flex-1 truncate">{moveLabel}</span>
-						</ContextMenuItem>
-					{/each}
-				{/if}
-				<ContextMenuItem
-					disabled={!canMoveToNewWindow(surfaceId)}
-					onclick={() => moveToNewWindow(surfaceId, 'left')}
-				>
-					<PanelRight class="rotate-180" />
-					{m.workspace_move_tab_to_new_window_left()}
-				</ContextMenuItem>
-				<ContextMenuItem
-					disabled={!canMoveToNewWindow(surfaceId)}
-					onclick={() => moveToNewWindow(surfaceId, 'right')}
-				>
-					<PanelRight />
-					{m.workspace_move_tab_to_new_window_right()}
-				</ContextMenuItem>
-				<ContextMenuItem
-					disabled={!canMoveToNewWindow(surfaceId)}
-					onclick={() => moveToNewWindow(surfaceId, 'top')}
-				>
-					<PanelTop />
-					{m.workspace_move_tab_to_new_window_above()}
-				</ContextMenuItem>
-				<ContextMenuItem
-					disabled={!canMoveToNewWindow(surfaceId)}
-					onclick={() => moveToNewWindow(surfaceId, 'bottom')}
-				>
-					<PanelTop class="rotate-180" />
-					{m.workspace_move_tab_to_new_window_below()}
-				</ContextMenuItem>
-				<ContextMenuItem
-					disabled={workspace.isSurfaceCloseBlocked(surfaceId)}
-					onclick={() => void workspace.closeSurface(surfaceId)}
-				>
-					<X />
-					{m.workspace_close_tab()}
-				</ContextMenuItem>
-				{#if workspace.layout.surface(surfaceId)?.type === 'file'}
-					<ContextMenuSeparator />
-					<ContextMenuItem onclick={() => void workspace.popOutFile(surfaceId)}>
-						<Maximize2 />
-						{m.workspace_pop_out()}
-					</ContextMenuItem>
-				{/if}
-			</ContextMenuContent>
+			<WorkspaceWindowTabMenu
+				menu={contextMenuPrimitives}
+				{windowId}
+				{tabs}
+				{surfaceId}
+				{hiddenSurfaceIds}
+				{labelFor}
+				{onSelect}
+				{surfaceMenuItems}
+			/>
 		</ContextMenu>
 	{/if}
 {/snippet}

--- a/web/src/lib/components/workspace/WorkspaceWindowTitleBar.svelte
+++ b/web/src/lib/components/workspace/WorkspaceWindowTitleBar.svelte
@@ -12,6 +12,7 @@
 	import WorkspaceWindowAddMenu from './WorkspaceWindowAddMenu.svelte';
 	import WorkspaceWindowMenu from './WorkspaceWindowMenu.svelte';
 	import WorkspaceWindowTabStrip from './WorkspaceWindowTabStrip.svelte';
+	import type { WorkspaceWindowSurfaceMenuItems } from './workspace-window-menu-contract.js';
 	import { cn } from '$lib/utils/cn';
 	import * as m from '$lib/paraglide/messages.js';
 
@@ -21,14 +22,14 @@
 		dnd,
 		isCurrent,
 		auxiliaryActions,
-		menuItems,
+		surfaceMenuItems,
 	}: {
 		workspaceWindow: WorkspaceWindowNode;
 		labelFor: (surfaceId: string) => string;
 		dnd: WorkspaceWindowDndController;
 		isCurrent: boolean;
 		auxiliaryActions?: Snippet;
-		menuItems?: Snippet<[string]>;
+		surfaceMenuItems?: WorkspaceWindowSurfaceMenuItems;
 	} = $props();
 
 	const workspace = getWorkspaceCoordinator();
@@ -104,6 +105,7 @@
 		<WorkspaceWindowTabStrip
 			windowId={workspaceWindow.id}
 			tabs={workspaceWindow.tabs}
+			{hiddenSurfaceIds}
 			{labelFor}
 			onSelect={(surfaceId) => void workspace.focusSurface(surfaceId)}
 			onFocus={(surfaceId) => workspace.noteWindowChromeFocus(workspaceWindow.id, surfaceId)}
@@ -111,6 +113,7 @@
 			{isCurrent}
 			isChatProcessing={isSurfaceChatProcessing}
 			onVisibleChange={(ids) => (visibleSurfaceIds = ids)}
+			{surfaceMenuItems}
 		/>
 	</div>
 	<div class="flex min-w-0 shrink-0 items-center gap-0.5">
@@ -122,7 +125,7 @@
 			{hiddenSurfaceIds}
 			{labelFor}
 			onSelect={(surfaceId) => void workspace.focusSurface(surfaceId)}
-			{menuItems}
+			{surfaceMenuItems}
 		/>
 		<button
 			type="button"

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -462,7 +462,22 @@ describe('WorkspaceRoot', () => {
 		expect(container.querySelector('[data-workspace-window-focus-ring]')).toBeNull();
 	});
 
-	it('adds active terminal actions to the window menu', async () => {
+	it('adds Chat actions to the tab context menu', async () => {
+		installContext();
+		renderRoot();
+
+		await fireEvent.contextMenu(screen.getByRole('tab', { name: 'Chat A' }));
+
+		const share = await screen.findByRole('menuitem', { name: m.share_button() });
+		expect(share.getAttribute('data-slot')).toBe('context-menu-item');
+		expect(screen.getByRole('menuitem', { name: m.sidebar_chats_details() })).toBeTruthy();
+		expect(
+			screen.getByRole('menuitem', { name: m.sidebar_tooltips_edit_chat_name() }),
+		).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: m.sidebar_tooltips_delete_chat() })).toBeTruthy();
+	});
+
+	it('adds terminal actions to both tab menus', async () => {
 		const { layout, workspace, terminals } = installContext();
 		const terminalId = 'terminal-1';
 		const surfaceId = terminalSurfaceId(terminalId);
@@ -507,7 +522,19 @@ describe('WorkspaceRoot', () => {
 		expect(screen.getByRole('menuitem', { name: m.terminal_rename() })).toBeTruthy();
 		expect(screen.getByRole('menuitem', { name: m.terminal_paste() })).toBeTruthy();
 		expect(screen.getByRole('menuitem', { name: /Font size 13px/ })).toBeTruthy();
-		await fireEvent.click(screen.getByRole('menuitem', { name: m.terminal_rename() }));
+		await fireEvent.keyDown(document, { key: 'Escape' });
+		await waitFor(() =>
+			expect(screen.queryByRole('menuitem', { name: m.terminal_rename() })).toBeNull(),
+		);
+
+		await fireEvent.contextMenu(screen.getByRole('tab', { name: 'Dev server' }));
+		const rename = await screen.findByRole('menuitem', { name: m.terminal_rename() });
+		expect(rename.getAttribute('data-slot')).toBe('context-menu-item');
+		expect(screen.getByRole('menuitem', { name: m.terminal_paste() })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: /Font size 13px/ }).getAttribute('data-slot')).toBe(
+			'context-menu-sub-trigger',
+		);
+		await fireEvent.click(rename);
 		const renameInput = await screen.findByRole('textbox', { name: m.terminal_name() });
 		expect((renameInput as HTMLInputElement).value).toBe('Dev server');
 		await fireEvent.input(renameInput, { target: { value: 'Build logs' } });

--- a/web/src/lib/components/workspace/__tests__/WorkspaceWindowTitleBar.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceWindowTitleBar.test.ts
@@ -131,6 +131,15 @@ const emptyChatSurface = {
 	type: 'chat',
 	chatId: null,
 } as const satisfies SurfaceDescriptor;
+const localTabActionOrder = [
+	'move-left',
+	'move-right',
+	'move-new-left',
+	'move-new-right',
+	'move-new-top',
+	'move-new-bottom',
+	'close-tab',
+] as const;
 
 function workspaceWindow(
 	order: readonly string[],
@@ -273,9 +282,7 @@ describe('WorkspaceWindowTitleBar', () => {
 		const chatTab = screen.getByRole('tab', { name: 'Chat A' });
 		expect(chatTab.textContent?.trim()).toBe('Chat A');
 		expect(chatTab.getAttribute('aria-label')).toBe('Chat A');
-		expect(chatTab.getAttribute('title')).toBe(
-			'Chat A\n/workspace/project-a\nchat-a',
-		);
+		expect(chatTab.getAttribute('title')).toBe('Chat A\n/workspace/project-a\nchat-a');
 		expect(screen.getByRole('tab', { name: 'Git' }).getAttribute('title')).toBe('Git');
 	});
 
@@ -598,6 +605,38 @@ describe('WorkspaceWindowTitleBar', () => {
 		await waitFor(() => expect(trigger.getAttribute('aria-expanded')).toBe('false'));
 	});
 
+	it('uses the clicked tab as the full context-menu target', async () => {
+		const projectPath = '/workspace/project-a';
+		runtime.chatSessions = { 'chat-a': { projectPath } };
+		renderTitleBar(workspaceWindow([chatSurface.id, gitSurface.id], gitSurface.id));
+
+		await fireEvent.click(screen.getByRole('button', { name: m.workspace_window_actions() }));
+		expect(screen.getByRole('menuitem', { name: m.workspace_pop_out() })).toBeTruthy();
+		expect(document.querySelector('[data-workspace-chat-metadata-field]')).toBeNull();
+		await fireEvent.keyDown(document, { key: 'Escape' });
+		await waitFor(() =>
+			expect(screen.queryByRole('menuitem', { name: m.workspace_pop_out() })).toBeNull(),
+		);
+
+		await fireEvent.contextMenu(screen.getByRole('tab', { name: 'Chat A' }));
+		const projectPathItem = await screen.findByRole('menuitem', {
+			name: `${m.workspace_chat_metadata_copy_project_path()}: ${projectPath}`,
+		});
+		const contextMenu = projectPathItem.closest<HTMLElement>(
+			`[data-workspace-window-tab-context-menu="${chatSurface.id}"]`,
+		)!;
+		expect(within(contextMenu).queryByRole('menuitem', { name: m.workspace_pop_out() })).toBeNull();
+		expect(
+			Array.from(
+				contextMenu.querySelectorAll<HTMLElement>('[data-workspace-window-tab-action]'),
+				(item) => item.dataset.workspaceWindowTabAction,
+			),
+		).toEqual(localTabActionOrder);
+
+		await fireEvent.click(projectPathItem);
+		await waitFor(() => expect(copyToClipboard).toHaveBeenCalledWith(projectPath));
+	});
+
 	it('closes the active movable tab from the window menu', async () => {
 		renderTitleBar(workspaceWindow([chatSurface.id, gitSurface.id], gitSurface.id));
 		await fireEvent.click(screen.getByRole('button', { name: m.workspace_window_actions() }));
@@ -615,15 +654,9 @@ describe('WorkspaceWindowTitleBar', () => {
 		const actions = Array.from(
 			menu.querySelectorAll<HTMLElement>('[data-workspace-window-tab-action]'),
 		);
-		expect(actions.map((item) => item.dataset.workspaceWindowTabAction)).toEqual([
-			'move-left',
-			'move-right',
-			'move-new-left',
-			'move-new-right',
-			'move-new-top',
-			'move-new-bottom',
-			'close-tab',
-		]);
+		expect(actions.map((item) => item.dataset.workspaceWindowTabAction)).toEqual(
+			localTabActionOrder,
+		);
 		const separator = menu.querySelector('[data-workspace-window-tab-actions-separator]');
 		expect(separator).toBeTruthy();
 		expect(actions.at(-1)?.nextElementSibling).toBe(separator);

--- a/web/src/lib/components/workspace/__tests__/WorkspaceWindowTitleBar.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceWindowTitleBar.test.ts
@@ -611,7 +611,6 @@ describe('WorkspaceWindowTitleBar', () => {
 		renderTitleBar(workspaceWindow([chatSurface.id, gitSurface.id], gitSurface.id));
 
 		await fireEvent.click(screen.getByRole('button', { name: m.workspace_window_actions() }));
-		expect(screen.getByRole('menuitem', { name: m.workspace_pop_out() })).toBeTruthy();
 		expect(document.querySelector('[data-workspace-chat-metadata-field]')).toBeNull();
 		await fireEvent.keyDown(document, { key: 'Escape' });
 		await waitFor(() =>

--- a/web/src/lib/components/workspace/workspace-window-menu-contract.ts
+++ b/web/src/lib/components/workspace/workspace-window-menu-contract.ts
@@ -1,0 +1,4 @@
+import type { Snippet } from 'svelte';
+import type { MenuPrimitives } from '$lib/components/ui/menu-primitives.js';
+
+export type WorkspaceWindowSurfaceMenuItems = Snippet<[surfaceId: string, menu: MenuPrimitives]>;


### PR DESCRIPTION
Unifies the window ellipsis menu and tab context menu around one target-aware action set so both expose consistent move, close, metadata, Chat, terminal, hidden-tab, and file actions while preserving their native dropdown and right-click interaction behavior. The ellipsis continues to act on the active tab, and right-click actions now apply to the tab that was clicked, including inactive tabs.