### PR TITLE
Restore composer status tray underlap

### DIFF
--- a/integration-tests/tests/chromium/composer-status-tray-layering.test.ts
+++ b/integration-tests/tests/chromium/composer-status-tray-layering.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import type { Locator, Page } from "playwright";
+import {
+  withChromiumFixture,
+  type ChromiumFixture,
+} from "../../support/chromium-fixture.js";
+import { withTimeout } from "../../support/deferred.js";
+
+const COMPOSER_SURFACE = "[data-composer]";
+const COMPOSER_SHELL = "[data-composer-shell]";
+const CONVERSATION_PANEL = "[data-conversation-panel]";
+const PROCESSING_STATUS = '[data-slot="chat-processing-status"]';
+
+type Rgba = [number, number, number, number];
+
+async function openSettledChat(fixture: ChromiumFixture): Promise<string> {
+  const chatId = fixture.integration.newChatId();
+  const started = await fixture.integration.client.startDirectChat({
+    chatId,
+    content: "composer-status-tray-prime",
+    projectPath: fixture.integration.dirs.project,
+    agent: fixture.integration.directAgents.openAi,
+  });
+  await fixture.integration.client.waitForTurnTerminal(chatId, started.turnId);
+
+  const response = await fixture.page.goto(
+    `${fixture.integration.garcon.baseUrl}/chat/${encodeURIComponent(chatId)}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  if (!response?.ok())
+    throw new Error(`SPA navigation failed with ${response?.status()}.`);
+  await fixture.page.locator(COMPOSER_SURFACE).waitFor({ state: "visible" });
+  return chatId;
+}
+
+async function bounds(locator: Locator) {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error("Missing composer status tray geometry.");
+  return box;
+}
+
+async function samplePixel(page: Page, x: number, y: number): Promise<Rgba> {
+  const screenshot = await page.screenshot({
+    animations: "disabled",
+    clip: {
+      x: Math.floor(x),
+      y: Math.floor(y),
+      width: 2,
+      height: 2,
+    },
+  });
+  return page.evaluate(
+    async (source) => {
+      const image = new Image();
+      image.src = source;
+      await image.decode();
+      const canvas = document.createElement("canvas");
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      const context = canvas.getContext("2d");
+      if (!context) throw new Error("Canvas context is unavailable.");
+      context.drawImage(image, 0, 0);
+      const pixels = context.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+      ).data;
+      const totals = [0, 0, 0, 0];
+      const pixelCount = pixels.length / 4;
+      for (let index = 0; index < pixels.length; index += 4) {
+        totals[0] += pixels[index] ?? 0;
+        totals[1] += pixels[index + 1] ?? 0;
+        totals[2] += pixels[index + 2] ?? 0;
+        totals[3] += pixels[index + 3] ?? 0;
+      }
+      return totals.map((total) => Math.round(total / pixelCount)) as Rgba;
+    },
+    `data:image/png;base64,${screenshot.toString("base64")}`,
+  );
+}
+
+function maximumChannelDifference(left: Rgba, right: Rgba): number {
+  return Math.max(
+    ...left.map((channel, index) => Math.abs(channel - right[index]!)),
+  );
+}
+
+describe("Chromium composer status tray layering", () => {
+  test("keeps the processing cap visible underneath the rounded composer corners", async () => {
+    await withChromiumFixture(
+      "composer-status-tray-layering",
+      async (fixture, markPhase) => {
+        markPhase("opening a settled chat");
+        const chatId = await openSettledChat(fixture);
+        const prompt = "composer-status-tray-held";
+        const held = fixture.integration.fakeProviders.openAi.holdNext({
+          lastUserText: prompt,
+        });
+        let turnId: string | null = null;
+
+        try {
+          markPhase("holding a processing turn");
+          const accepted = await fixture.integration.client.runDirectChat({
+            chatId,
+            content: prompt,
+            agent: fixture.integration.directAgents.openAi,
+          });
+          turnId = accepted.turnId ?? null;
+          await withTimeout(
+            held.received,
+            10_000,
+            () => "Timed out waiting for the held processing turn.",
+          );
+
+          const status = fixture.page.locator(PROCESSING_STATUS);
+          const composer = fixture.page.locator(COMPOSER_SURFACE);
+          await status.waitFor({ state: "visible" });
+          const [statusBox, composerBox] = await Promise.all([
+            bounds(status),
+            bounds(composer),
+          ]);
+
+          markPhase(
+            "checking the shared underlap geometry and paint ownership",
+          );
+          const overlap = statusBox.y + statusBox.height - composerBox.y;
+          expect(overlap).toBeGreaterThan(10);
+          expect(overlap).toBeLessThan(14);
+          expect(Math.abs(statusBox.x - composerBox.x)).toBeLessThan(1);
+          expect(
+            Math.abs(
+              statusBox.x +
+                statusBox.width -
+                (composerBox.x + composerBox.width),
+            ),
+          ).toBeLessThan(1);
+          expect(
+            await fixture.page
+              .locator(COMPOSER_SHELL)
+              .evaluate((shell) => {
+                const style = getComputedStyle(shell);
+                return (
+                  ["transparent", "rgba(0, 0, 0, 0)"].includes(
+                    style.backgroundColor,
+                  ) && style.backgroundImage === "none"
+                );
+              }),
+          ).toBe(true);
+          expect(
+            await fixture.page
+              .locator(CONVERSATION_PANEL)
+              .evaluate((panel) => getComputedStyle(panel).backgroundColor),
+          ).not.toBe("rgba(0, 0, 0, 0)");
+          expect(
+            await status.evaluate(
+              (element) =>
+                element.closest(".composer-thinking-active") !== null,
+            ),
+          ).toBe(true);
+
+          markPhase(
+            "sampling the visible cap below the composer's rounded corner",
+          );
+          const sampleX = composerBox.x + 2;
+          const visibleCapPixel = await samplePixel(
+            fixture.page,
+            sampleX,
+            composerBox.y - 4,
+          );
+          const underlapPixel = await samplePixel(
+            fixture.page,
+            sampleX,
+            composerBox.y + 2,
+          );
+          const backdropPixel = await samplePixel(
+            fixture.page,
+            composerBox.x - 4,
+            composerBox.y + 2,
+          );
+          expect(
+            maximumChannelDifference(underlapPixel, visibleCapPixel),
+          ).toBeLessThanOrEqual(2);
+          expect(
+            maximumChannelDifference(underlapPixel, backdropPixel),
+          ).toBeGreaterThan(5);
+        } finally {
+          held.releaseEcho();
+        }
+
+        if (turnId === null)
+          throw new Error("The held processing turn was not accepted.");
+        await fixture.integration.client.waitForTurnTerminal(chatId, turnId);
+        fixture.assertNoBrowserErrors();
+      },
+    );
+  });
+});

--- a/web/src/lib/chat/composer/composer-cap-layout.ts
+++ b/web/src/lib/chat/composer/composer-cap-layout.ts
@@ -1,11 +1,9 @@
-// The composer renders an absolutely positioned cap directly above itself: the
-// agent status tray while a turn is processing, or the git quick-commit tray
-// otherwise. Because the cap is out of flow, it floats up over whichever element
-// sits immediately above the composer, so that element must reserve vertical
-// space or the cap overlaps it. When inputs are queued the queue panel is the
-// element directly above the composer; otherwise the message feed is. Reserving
-// space in exactly the right place keeps the queue's dispatch controls visible
-// and clickable while a cap is shown.
+// The panel renders an absolutely positioned status cap above the detached
+// composer, which overlays the cap's bottom edge. Because the cap is out of
+// flow, the element above the composer must reserve vertical space or the cap
+// overlaps it. When inputs are queued that element is the queue panel;
+// otherwise it is the message feed. Reserving space in exactly the right place
+// keeps the queue's dispatch controls visible and clickable while a cap is shown.
 
 export interface ComposerCapReservation {
 	feed: boolean;

--- a/web/src/lib/chat/conversation/__tests__/chat-max-width.logic.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/chat-max-width.logic.test.ts
@@ -7,6 +7,7 @@ import {
 	CHAT_MAX_WIDTH_DOCK_FRAME_CLASS,
 	CHAT_MAX_WIDTH_DOCK_SHELL_CLASS,
 	CHAT_MAX_WIDTH_FEED_CONTENT_CLASS,
+	chatDockFrameClass,
 } from '$lib/chat/conversation/chat-max-width.js';
 
 // Maps Tailwind px utilities to pixel values so the feed-vs-composer inset
@@ -47,6 +48,10 @@ describe('chat max width classes', () => {
 		expect(CHAT_FEED_CONTENT_BASE_CLASS).not.toContain('px-');
 	});
 
+	it('keeps the elevated composer shell transparent', () => {
+		expect(CHAT_DOCK_SHELL_BASE_CLASS).not.toContain('bg-');
+	});
+
 	it('reduces the none transcript inset below the previous values', () => {
 		// Mobile reduced from 29px (px-[29px]) to 16px (px-4).
 		expect(extractPx(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS.none, '')).toBe(16);
@@ -83,6 +88,8 @@ describe('chat max width classes', () => {
 			medium: 'lg:mx-auto lg:max-w-4xl',
 			small: 'lg:mx-auto lg:max-w-3xl',
 		});
+		expect(chatDockFrameClass('none')).toBe('w-full');
+		expect(chatDockFrameClass('large')).toBe('w-full lg:mx-auto lg:max-w-5xl');
 		expect(CHAT_DOCK_SURFACE_CLASS).toContain('rounded-2xl');
 		expect(CHAT_DOCK_SURFACE_CLASS).toContain('border-border');
 		expect(CHAT_DOCK_SURFACE_CLASS).toContain('bg-card');

--- a/web/src/lib/chat/conversation/chat-max-width.ts
+++ b/web/src/lib/chat/conversation/chat-max-width.ts
@@ -1,10 +1,12 @@
 import type { ChatMaxWidth } from '$lib/stores/local-settings.svelte';
+import { cn } from '$lib/utils/cn';
 
 // Layout-only shell shared by every width option. Horizontal insets are owned
 // per-option so the "None" mode can reduce its inset independently.
 export const CHAT_FEED_CONTENT_BASE_CLASS = 'flex w-full flex-col gap-2 sm:gap-3';
 
-export const CHAT_DOCK_SHELL_BASE_CLASS = 'flex-shrink-0 bg-background px-2';
+// The elevated composer uses this shared layout shell without repainting panel-owned status caps.
+export const CHAT_DOCK_SHELL_BASE_CLASS = 'flex-shrink-0 px-2';
 
 export const CHAT_DOCK_SURFACE_CLASS =
 	'overflow-hidden rounded-2xl border border-border bg-card shadow-sm';
@@ -43,3 +45,7 @@ export const CHAT_MAX_WIDTH_DOCK_FRAME_CLASS: Record<ChatMaxWidth, string> = {
 	medium: 'lg:mx-auto lg:max-w-4xl',
 	small: 'lg:mx-auto lg:max-w-3xl',
 };
+
+export function chatDockFrameClass(chatMaxWidth: ChatMaxWidth): string {
+	return cn('w-full', CHAT_MAX_WIDTH_DOCK_FRAME_CLASS[chatMaxWidth]);
+}

--- a/web/src/lib/components/chat/ConversationPanel.svelte
+++ b/web/src/lib/components/chat/ConversationPanel.svelte
@@ -25,8 +25,8 @@
 	} from '$lib/context';
 	import {
 		CHAT_DOCK_SHELL_BASE_CLASS,
-		CHAT_MAX_WIDTH_DOCK_FRAME_CLASS,
 		CHAT_MAX_WIDTH_DOCK_SHELL_CLASS,
+		chatDockFrameClass,
 	} from '$lib/chat/conversation/chat-max-width.js';
 	import {
 		composerCapReservation,
@@ -104,9 +104,7 @@
 			capSpace.queue ? 'pb-14' : 'pb-2',
 		);
 	});
-	const queueFrameClass = $derived(
-		cn('w-full', CHAT_MAX_WIDTH_DOCK_FRAME_CLASS[localSettings.chatMaxWidth]),
-	);
+	const queueFrameClass = $derived(chatDockFrameClass(localSettings.chatMaxWidth));
 	const surfaceIdentity = $derived(`${surfaceId}:${panel.transcript.transcriptViewId}`);
 	const isPreparingInitialScroll = $derived(
 		panel.scroll.isPreparingInitialScroll && localSettings.autoScrollToBottom,
@@ -307,6 +305,7 @@
 		quickCommitError={quickGitError}
 		quickCommitBranchSelector={branchSelector}
 		isMobile={appShell.isMobile}
+		reduceMotion={localSettings.reduceMotion}
 		{announcementsEnabled}
 		onAbort={() => void actions?.stop(surfaceId, chatId)}
 		onQuickCommit={() => actions?.openCommit(surfaceId, chatId)}

--- a/web/src/lib/components/chat/ConversationPanelStatusDock.svelte
+++ b/web/src/lib/components/chat/ConversationPanelStatusDock.svelte
@@ -7,8 +7,8 @@
 	import type { ChatMaxWidth } from '$lib/stores/local-settings.svelte.js';
 	import {
 		CHAT_DOCK_SHELL_BASE_CLASS,
-		CHAT_MAX_WIDTH_DOCK_FRAME_CLASS,
 		CHAT_MAX_WIDTH_DOCK_SHELL_CLASS,
+		chatDockFrameClass,
 	} from '$lib/chat/conversation/chat-max-width.js';
 	import { cn } from '$lib/utils/cn';
 
@@ -25,6 +25,7 @@
 		quickCommitError: string | null;
 		quickCommitBranchSelector: GitQuickBranchSelectorControls | null;
 		isMobile: boolean;
+		reduceMotion: boolean;
 		onAbort: () => void;
 		onQuickCommit: () => void;
 		announcementsEnabled?: boolean;
@@ -43,6 +44,7 @@
 		quickCommitError,
 		quickCommitBranchSelector,
 		isMobile,
+		reduceMotion,
 		onAbort,
 		onQuickCommit,
 		announcementsEnabled = true,
@@ -51,9 +53,7 @@
 	const shellClass = $derived(
 		cn(CHAT_DOCK_SHELL_BASE_CLASS, CHAT_MAX_WIDTH_DOCK_SHELL_CLASS[chatMaxWidth]),
 	);
-	const frameClass = $derived(
-		cn('w-full', CHAT_MAX_WIDTH_DOCK_FRAME_CLASS[chatMaxWidth]),
-	);
+	const frameClass = $derived(chatDockFrameClass(chatMaxWidth));
 	const runningQuickCommitVisible = $derived(
 		quickCommitEnabled && Boolean(quickCommitSummary && quickCommitSummary.changedFiles > 0),
 	);
@@ -61,7 +61,15 @@
 
 <div class={shellClass} data-conversation-panel-status-dock>
 	<div class={frameClass}>
-		<div class="relative h-0 shrink-0" data-conversation-panel-status-anchor>
+		<!-- The detached composer and panel dock establish matching processing variables separately. -->
+		<div
+			class={cn(
+				'relative h-0 shrink-0',
+				isProcessing && 'composer-thinking-active',
+				isProcessing && reduceMotion && 'composer-reduce-motion',
+			)}
+			data-conversation-panel-status-anchor
+		>
 			{#if isProcessing}
 				<LoadingStatus
 					isVisible={true}
@@ -69,9 +77,9 @@
 					{agentId}
 					{spinnerSelectionKey}
 					quickCommitVisible={runningQuickCommitVisible}
-					quickCommitSummary={quickCommitSummary}
-					onQuickCommit={onQuickCommit}
-					onAbort={onAbort}
+					{quickCommitSummary}
+					{onQuickCommit}
+					{onAbort}
 					{announcementsEnabled}
 				/>
 			{:else}

--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -49,8 +49,8 @@
 		CHAT_DOCK_SHELL_BASE_CLASS,
 		CHAT_DOCK_SURFACE_CLASS,
 		CHAT_MAX_WIDTH_COMPOSER_SPACING_CLASS,
-		CHAT_MAX_WIDTH_DOCK_FRAME_CLASS,
 		CHAT_MAX_WIDTH_DOCK_SHELL_CLASS,
+		chatDockFrameClass,
 	} from '$lib/chat/conversation/chat-max-width.js';
 	import { applyFileMention, findFileMentionTrigger } from '$lib/chat/composer/file-mentions.js';
 	import {
@@ -675,9 +675,7 @@
 			CHAT_MAX_WIDTH_COMPOSER_SPACING_CLASS[localSettings.chatMaxWidth],
 		),
 	);
-	const composerFrameWrapperClass = $derived(
-		cn('w-full', CHAT_MAX_WIDTH_DOCK_FRAME_CLASS[localSettings.chatMaxWidth]),
-	);
+	const composerFrameWrapperClass = $derived(chatDockFrameClass(localSettings.chatMaxWidth));
 	const composerSurfaceClass = cn('relative z-20', CHAT_DOCK_SURFACE_CLASS, 'shadow-none');
 	const imageListClass = $derived(cn('p-2 bg-muted/40 rounded-lg mx-2 mt-2'));
 	const textareaClass = $derived(
@@ -897,7 +895,7 @@
 {/snippet}
 
 {#snippet composerFrame()}
-	<!-- The processing classes keep the composer and loading tray borders synchronized. -->
+	<!-- The detached composer and panel status dock apply the same processing treatment independently. -->
 	<div
 		class="relative"
 		class:composer-thinking-active={selectedIsProcessing}
@@ -936,7 +934,7 @@
 	</div>
 {/snippet}
 
-<div class={composerShellClass}>
+<div class={composerShellClass} data-composer-shell>
 	<div class={composerFrameWrapperClass}>
 		{@render composerFrame()}
 	</div>

--- a/web/src/lib/components/chat/__tests__/ConversationPanel.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationPanel.test.ts
@@ -19,6 +19,7 @@ import { UserMessage } from '$shared/chat-types';
 const runtime = vi.hoisted(() => ({
 	autoScrollToBottom: false,
 	processing: true,
+	reduceMotion: false,
 	queue: null as ChatQueueState | null,
 	summary: null as GitQuickSummaryReady | null,
 }));
@@ -47,6 +48,7 @@ vi.mock('$lib/context', () => ({
 	getLocalSettings: () => ({
 		autoScrollToBottom: runtime.autoScrollToBottom,
 		chatMaxWidth: 'default',
+		reduceMotion: runtime.reduceMotion,
 		showQuickCommitTray: true,
 	}),
 	getModelCatalog: () => ({ supportsSteering: () => true }),
@@ -202,6 +204,7 @@ describe('ConversationPanel', () => {
 		cleanup();
 		runtime.autoScrollToBottom = false;
 		runtime.processing = true;
+		runtime.reduceMotion = false;
 		runtime.queue = null;
 		runtime.summary = null;
 		vi.clearAllMocks();
@@ -288,6 +291,32 @@ describe('ConversationPanel', () => {
 
 		await fireEvent.click(screen.getByRole('button', { name: m.chat_queue_pause() }));
 		expect(actions.pauseQueue).toHaveBeenCalledWith(panel.surfaceId, 'chat-1');
+	});
+
+	it('restores reduced-motion processing decoration on the detached status dock', () => {
+		runtime.reduceMotion = true;
+		const { panel } = makePanel();
+		const { container } = render(ConversationPanel, {
+			surfaceId: panel.surfaceId,
+			chat: chat(),
+			panel,
+			isCommandOwner: true,
+			ownsComposer: true,
+			actions: makeActions(),
+			composerInsetPx: 96,
+		});
+
+		const anchor = container.querySelector('[data-conversation-panel-status-anchor]');
+		const spacer = container.querySelector('[data-conversation-panel-composer-spacer]');
+
+		expect(anchor?.className).toContain('composer-thinking-active');
+		expect(anchor?.className).toContain('composer-reduce-motion');
+		expect(spacer?.getAttribute('style')).toContain('height: 96px');
+		expect(
+			container
+				.querySelector('[data-slot="chat-processing-status"]')
+				?.closest('.composer-thinking-active'),
+		).toBe(anchor);
 	});
 
 	it('separates command ownership from composer inset and announcement ownership', async () => {

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -587,9 +587,12 @@ describe('PromptComposer focus', () => {
 			quickCommitTrayVisible: false,
 		});
 		const composer = container.querySelector('[data-composer]');
+		const composerShell = container.querySelector('[data-composer-shell]');
+		const statusAnchor = container.querySelector('[data-conversation-panel-status-anchor]');
 		const processingTray = screen.getByRole('status');
 
 		expect(composer).toBeTruthy();
+		expect(composerShell?.className).not.toMatch(/(^|\s)bg-/);
 		expect(composer?.className).toContain('rounded-2xl');
 		expect(composer?.className).toContain('z-20');
 		expect(composer?.className).not.toContain('rounded-t-none');
@@ -599,6 +602,7 @@ describe('PromptComposer focus', () => {
 		expect(processingTray.className).toContain('min-h-14');
 		expect(processingTray.className).toContain('border-b-0');
 		expect(processingTray.className).toContain('pb-5');
+		expect(statusAnchor?.className).toContain('composer-thinking-active');
 
 		await rerender({
 			selectedChatId: 'chat-1',
@@ -618,6 +622,7 @@ describe('PromptComposer focus', () => {
 		expect(gitTray.className).toContain('min-h-14');
 		expect(gitTray.className).toContain('border-b-0');
 		expect(gitTray.className).toContain('pb-5');
+		expect(statusAnchor?.className).not.toContain('composer-thinking-active');
 	});
 
 	it('always decorates processing and uses the static treatment when motion is reduced', async () => {
@@ -629,9 +634,12 @@ describe('PromptComposer focus', () => {
 			reduceMotion: false,
 		});
 		const frame = container.querySelector('[data-composer]')?.parentElement;
+		const statusAnchor = container.querySelector('[data-conversation-panel-status-anchor]');
 
 		expect(frame?.className).not.toContain('composer-thinking-active');
 		expect(frame?.className).not.toContain('composer-reduce-motion');
+		expect(statusAnchor?.className).not.toContain('composer-thinking-active');
+		expect(statusAnchor?.className).not.toContain('composer-reduce-motion');
 
 		await rerender({
 			selectedChatId: 'chat-1',
@@ -642,6 +650,8 @@ describe('PromptComposer focus', () => {
 		});
 		expect(frame?.className).toContain('composer-thinking-active');
 		expect(frame?.className).not.toContain('composer-reduce-motion');
+		expect(statusAnchor?.className).toContain('composer-thinking-active');
+		expect(statusAnchor?.className).not.toContain('composer-reduce-motion');
 
 		await rerender({
 			selectedChatId: 'chat-1',
@@ -652,6 +662,8 @@ describe('PromptComposer focus', () => {
 		});
 		expect(frame?.className).toContain('composer-thinking-active');
 		expect(frame?.className).toContain('composer-reduce-motion');
+		expect(statusAnchor?.className).toContain('composer-thinking-active');
+		expect(statusAnchor?.className).toContain('composer-reduce-motion');
 	});
 
 	it('defaults to static and pulses only when motion is allowed', () => {

--- a/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
@@ -405,6 +405,7 @@
 	quickCommitError={null}
 	quickCommitBranchSelector={null}
 	isMobile={false}
+	{reduceMotion}
 	{onAbort}
 	{onQuickCommit}
 />


### PR DESCRIPTION
The inactive-panel composer split moved status trays outside the singleton composer’s stacking context, leaving an opaque elevated shell that masked the tray beneath the rounded corners and disconnected processing styles. This restores the intended underlap by keeping the shared dock shell transparent, applying processing styling to the panel-owned status dock, centralizing frame alignment, and locking the geometry and paint contract with regression coverage.