### PR TITLE
Defer draft chat transcript hydration

### DIFF
--- a/integration-tests/tests/e2e/direct-chat.test.ts
+++ b/integration-tests/tests/e2e/direct-chat.test.ts
@@ -1,10 +1,93 @@
 import { describe, expect, test } from 'bun:test';
+import type { Page } from 'puppeteer-core';
 import { withE2eFixture } from '../../support/e2e-fixture.js';
 import { SpaDriver } from '../../support/spa-driver.js';
 import {
   acceptedResponseRequestBodies,
   replaceFirstAcceptedResponse,
 } from '../../support/accepted-response-loss.js';
+
+interface DraftStartRequestGate {
+  startRequestCount: number;
+  messageRequests: Array<{ chatId: string | null; purpose: string | null }>;
+  releaseStart: (() => void) | null;
+}
+
+type DraftStartRequestGateGlobal = typeof globalThis & {
+  __garconDraftStartRequestGate?: DraftStartRequestGate;
+};
+
+async function holdFirstChatStart(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    const scope = globalThis as DraftStartRequestGateGlobal;
+    scope.__garconDraftStartRequestGate = {
+      startRequestCount: 0,
+      messageRequests: [],
+      releaseStart: null,
+    };
+    const gatedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      let inputUrl: string;
+      if (typeof input === 'string') inputUrl = input;
+      else if (input instanceof URL) inputUrl = input.href;
+      else inputUrl = input.url;
+
+      const url = new URL(inputUrl, globalThis.location.href);
+      const gate = scope.__garconDraftStartRequestGate;
+      if (gate && url.pathname === '/api/v1/chats/messages') {
+        gate.messageRequests.push({
+          chatId: url.searchParams.get('chatId'),
+          purpose: url.searchParams.get('purpose'),
+        });
+      }
+      if (gate && url.pathname === '/api/v1/chats/start') {
+        gate.startRequestCount += 1;
+        if (gate.startRequestCount === 1) {
+          await new Promise<void>((resolve) => {
+            gate.releaseStart = resolve;
+          });
+          gate.releaseStart = null;
+        }
+      }
+      return originalFetch(input, init);
+    };
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: gatedFetch,
+    });
+  });
+}
+
+async function waitForHeldChatStart(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const gate = (globalThis as DraftStartRequestGateGlobal).__garconDraftStartRequestGate;
+      return gate?.startRequestCount === 1 && gate.releaseStart !== null;
+    },
+    { timeout: 10_000 },
+  );
+}
+
+async function releaseHeldChatStart(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const gate = (globalThis as DraftStartRequestGateGlobal).__garconDraftStartRequestGate;
+    if (!gate?.releaseStart) throw new Error('No Chat start request is waiting for release.');
+    gate.releaseStart();
+  });
+}
+
+async function draftStartRequestGate(page: Page): Promise<DraftStartRequestGate> {
+  return page.evaluate(() => {
+    const gate = (globalThis as DraftStartRequestGateGlobal).__garconDraftStartRequestGate;
+    if (!gate) throw new Error('Draft Chat start request gate is not installed.');
+    return {
+      startRequestCount: gate.startRequestCount,
+      messageRequests: gate.messageRequests,
+      releaseStart: null,
+    };
+  });
+}
 
 describe('Lightpanda direct chat', () => {
   test('creates a direct chat and renders one user and assistant row', async () => {
@@ -19,6 +102,44 @@ describe('Lightpanda direct chat', () => {
       expect(await app.exactTextCount('echo:ui-direct-hello')).toBe(1);
       expect(fixture.integration.fakeProviders.openAi.requests().filter((request) =>
         request.lastUserText === 'ui-direct-hello')).toHaveLength(1);
+      fixture.assertNoBrowserErrors();
+    });
+  });
+
+  test('defers transcript hydration until a new Chat is admitted by the server', async () => {
+    await withE2eFixture('direct-chat-draft-admission', async (fixture) => {
+      const app = new SpaDriver(fixture.page, fixture.integration);
+      await app.open();
+      await fixture.waitForSpaWebSocket();
+      await holdFirstChatStart(fixture.page);
+
+      const starting = app.startOpenAiDirectChat('ui-direct-draft-admission');
+      await waitForHeldChatStart(fixture.page);
+      await app.waitForText('ui-direct-draft-admission');
+
+      expect((await draftStartRequestGate(fixture.page)).messageRequests).toEqual([]);
+      expect(await app.exactTextCount('Failed to refresh messages')).toBe(0);
+      expect(await app.exactTextCount('Session not found')).toBe(0);
+
+      await releaseHeldChatStart(fixture.page);
+      await starting;
+      await app.waitForText('echo:ui-direct-draft-admission');
+      await fixture.page.waitForFunction(
+        () =>
+          (globalThis as DraftStartRequestGateGlobal).__garconDraftStartRequestGate
+            ?.messageRequests.length === 1,
+        { timeout: 10_000 },
+      );
+
+      const gate = await draftStartRequestGate(fixture.page);
+      expect(gate.startRequestCount).toBe(1);
+      expect(gate.messageRequests).toHaveLength(1);
+      expect(gate.messageRequests[0]).toEqual({
+        chatId: expect.any(String),
+        purpose: null,
+      });
+      expect(await app.exactTextCount('Failed to refresh messages')).toBe(0);
+      expect(await app.exactTextCount('Session not found')).toBe(0);
       fixture.assertNoBrowserErrors();
     });
   });

--- a/web/src/lib/chat/conversation/__tests__/conversation-panel-registry.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-panel-registry.test.ts
@@ -7,11 +7,12 @@ import { ConversationTranscriptOverlayStore } from '$lib/chat/transcript/convers
 import { ConversationLifecycleState } from '../conversation-lifecycle-state.svelte.js';
 import {
 	ConversationPanelRegistry,
+	type ConversationPanelDescriptor,
+	type ConversationPanelSnapshotAdmission,
 	type ConversationPanelPresentationPort,
 } from '../conversation-panel-registry.svelte.js';
 import { CurrentConversationPanelTranscript } from '../current-conversation-panel-transcript.js';
 import type { ChatViewSurfaceId } from '$lib/workspace/surface-types.js';
-import type { VisibleChatPresentation } from '$lib/workspace/visible-presentations.js';
 
 function message(ordinal: number): TranscriptMessage {
 	return {
@@ -27,9 +28,10 @@ function candidate(ordinal: number): ResendCandidate {
 function presentation(
 	surfaceId: `chat-view:window-${string}`,
 	chatId: string,
-): VisibleChatPresentation {
+	snapshotAdmission: ConversationPanelSnapshotAdmission = 'admitted',
+): ConversationPanelDescriptor {
 	const windowId = surfaceId.slice('chat-view:'.length) as `window-${string}`;
-	return { surfaceId, chatId, presentation: windowId, windowId };
+	return { surfaceId, chatId, presentation: windowId, windowId, snapshotAdmission };
 }
 
 function fixture(
@@ -233,6 +235,115 @@ describe('ConversationPanelRegistry', () => {
 
 		anchorSurfaceId = 'chat-view:window-missing';
 		expect(registry.composerPanel).toBeNull();
+		registry.destroy();
+		cache.flush();
+	});
+
+	it('keeps duplicate draft panels deferred from transcript snapshots', async () => {
+		const loadTranscriptSnapshot = vi.fn(async () => {
+			throw new Error('Draft panels must not request a server transcript');
+		});
+		const { cache, registry } = fixture({ loadTranscriptSnapshot });
+
+		registry.reconcile([
+			presentation('chat-view:window-left', 'chat-1', 'deferred'),
+			presentation('chat-view:window-right', 'chat-1', 'deferred'),
+		]);
+		await Promise.resolve();
+
+		expect(registry.panel('chat-view:window-left')).not.toBeNull();
+		expect(registry.panel('chat-view:window-right')).not.toBeNull();
+		await expect(registry.loadChatSnapshot('chat-1')).resolves.toBe(false);
+		expect(loadTranscriptSnapshot).not.toHaveBeenCalled();
+		registry.destroy();
+		cache.flush();
+	});
+
+	it('hydrates retained duplicate panels once when their draft becomes admitted', async () => {
+		const loadTranscriptSnapshot = vi.fn(
+			async (transcript, chatId: string, options: ChatLoadMessagesOptions) => {
+				transcript.transcriptCache.replace(chatId, 'view-1', [message(1)], 1, null);
+				transcript.installCachedSnapshot(chatId);
+				expect(options).toEqual({});
+			},
+		);
+		const { cache, registry } = fixture({ loadTranscriptSnapshot });
+		const deferredPresentations = [
+			presentation('chat-view:window-left', 'chat-1', 'deferred'),
+			presentation('chat-view:window-right', 'chat-1', 'deferred'),
+		];
+		registry.reconcile(deferredPresentations);
+		await Promise.resolve();
+		await Promise.resolve();
+		const left = registry.panel('chat-view:window-left');
+		const right = registry.panel('chat-view:window-right');
+		if (!left || !right) throw new Error('Expected duplicate draft panels');
+		left.scroll.setPinnedToBottom(false);
+
+		registry.reconcile([
+			presentation('chat-view:window-left', 'chat-1'),
+			presentation('chat-view:window-right', 'chat-1'),
+		]);
+
+		expect(registry.panel('chat-view:window-left')).toBe(left);
+		expect(registry.panel('chat-view:window-right')).toBe(right);
+		await vi.waitFor(() => {
+			expect(loadTranscriptSnapshot).toHaveBeenCalledOnce();
+			expect(left.transcript.entries.map((entry) => entry.ordinal)).toEqual([1]);
+			expect(right.transcript.entries.map((entry) => entry.ordinal)).toEqual([1]);
+		});
+		expect(loadTranscriptSnapshot).toHaveBeenCalledWith(left.transcript, 'chat-1', {});
+		expect(left.scroll.isPinnedToBottom).toBe(false);
+		expect(right.scroll.isPinnedToBottom).toBe(true);
+		registry.destroy();
+		cache.flush();
+	});
+
+	it('hands admission hydration to a retained duplicate when its loader is removed', async () => {
+		const release = deferred<void>();
+		const loadTranscriptSnapshot = vi.fn(
+			async (transcript, chatId: string, _options: ChatLoadMessagesOptions) => {
+				const epoch = transcript.beginSnapshotLoad();
+				await release.promise;
+				transcript.setFromPage(
+					chatId,
+					{
+						transcriptViewId: 'view-1',
+						messages: [message(1)],
+						lastOrdinal: 1,
+						pageOldestOrdinal: 1,
+						pageNewestOrdinal: 1,
+						nextBeforeOrdinal: null,
+						hasMore: false,
+						resendCandidates: [],
+					},
+					epoch,
+				);
+			},
+		);
+		const { cache, registry } = fixture({ loadTranscriptSnapshot });
+		registry.reconcile([
+			presentation('chat-view:window-left', 'chat-1', 'deferred'),
+			presentation('chat-view:window-right', 'chat-1', 'deferred'),
+		]);
+		await Promise.resolve();
+		const retained = registry.panel('chat-view:window-right');
+		if (!retained) throw new Error('Expected retained draft panel');
+
+		registry.reconcile([
+			presentation('chat-view:window-left', 'chat-1'),
+			presentation('chat-view:window-right', 'chat-1'),
+		]);
+		await vi.waitFor(() => expect(loadTranscriptSnapshot).toHaveBeenCalledOnce());
+		registry.reconcile([presentation('chat-view:window-right', 'chat-1')]);
+		release.resolve();
+
+		await vi.waitFor(() => {
+			expect(loadTranscriptSnapshot).toHaveBeenCalledTimes(2);
+			expect(retained.transcript.entries.map((entry) => entry.ordinal)).toEqual([1]);
+		});
+		expect(registry.panel('chat-view:window-right')).toBe(retained);
+		expect(loadTranscriptSnapshot.mock.calls.map((call) => call[2])).toEqual([{}, {}]);
 		registry.destroy();
 		cache.flush();
 	});

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -1215,6 +1215,7 @@ describe('ConversationSessionController', () => {
 		controller.handleChatSwitch('chat-1');
 
 		expect(deps.setInitialBottomRestorePending).toHaveBeenCalledWith(null);
+		expect(deps.chatState.loadMessages).not.toHaveBeenCalled();
 	});
 
 	it('clears transient state without discarding the selected chat draft when project data is absent', () => {

--- a/web/src/lib/chat/conversation/conversation-panel-registry.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-panel-registry.svelte.ts
@@ -33,6 +33,12 @@ import type {
 } from '$lib/workspace/chat-surface-transfer.js';
 import type { WorkspacePublication } from '$lib/workspace/workspace-commit.js';
 
+export type ConversationPanelSnapshotAdmission = 'deferred' | 'admitted';
+
+export interface ConversationPanelDescriptor extends VisibleChatPresentation {
+	readonly snapshotAdmission: ConversationPanelSnapshotAdmission;
+}
+
 export interface CommittedTranscriptBatch {
 	readonly chatId: string;
 	readonly transcriptViewId: string;
@@ -105,6 +111,7 @@ class PanelRegistration implements ConversationPanelRegistration {
 	#applyingRestoreEpoch: number | null = null;
 	#restoreResumeRequested = false;
 	#destroyed = false;
+	#snapshotAdmission: ConversationPanelSnapshotAdmission;
 
 	readonly transcript: ActiveTranscriptState;
 	readonly lifecycle: ConversationLifecycleState;
@@ -113,11 +120,13 @@ class PanelRegistration implements ConversationPanelRegistration {
 	constructor(
 		readonly surfaceId: ChatViewSurfaceId,
 		readonly chatId: string,
+		snapshotAdmission: ConversationPanelSnapshotAdmission,
 		cache: ChatTranscriptCache,
 		lifecycle: Pick<ConversationLifecycleRegistry, 'forChat'>,
 		overlays: ConversationTranscriptOverlayStore,
 		onSnapshotResendCandidates: (chatId: string, candidates: readonly ResendCandidate[]) => void,
 	) {
+		this.#snapshotAdmission = snapshotAdmission;
 		this.transcript = new ActiveTranscriptState(cache, overlays.forChat(chatId), {
 			onSnapshotResendCandidates,
 		});
@@ -130,6 +139,17 @@ class PanelRegistration implements ConversationPanelRegistration {
 			chatState: this.transcript,
 			getChatId: () => (this.#destroyed ? null : this.chatId),
 		});
+	}
+
+	get snapshotAdmission(): ConversationPanelSnapshotAdmission {
+		return this.#snapshotAdmission;
+	}
+
+	updateSnapshotAdmission(snapshotAdmission: ConversationPanelSnapshotAdmission): boolean {
+		const becameAdmitted =
+			this.#snapshotAdmission === 'deferred' && snapshotAdmission === 'admitted';
+		this.#snapshotAdmission = snapshotAdmission;
+		return becameAdmitted;
 	}
 
 	attachPresentation(port: ConversationPanelPresentationPort): () => void {
@@ -262,7 +282,7 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 	#reconnectReplayEpoch = 0;
 	#reconnectReplays = new Map<string, ActivePanelReconnectReplay>();
 	// Reconciliation updates this reactive revision after mutating the plain panel map.
-	#visible = $state.raw<readonly VisibleChatPresentation[]>([]);
+	#visible = $state.raw<readonly ConversationPanelDescriptor[]>([]);
 
 	constructor(
 		private readonly options: {
@@ -283,7 +303,7 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 		return this.options.cache;
 	}
 
-	prepareForReconcile(visible: readonly VisibleChatPresentation[]): void {
+	prepareForReconcile(visible: readonly ConversationPanelDescriptor[]): void {
 		const desired = new Map(visible.map((item) => [item.surfaceId, item]));
 		for (const [surfaceId, panel] of this.#panels) {
 			const next = desired.get(surfaceId);
@@ -328,8 +348,9 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 		return this.options.overlays.noticeRevisionFor(chatId);
 	}
 
-	reconcile(visible: readonly VisibleChatPresentation[]): void {
+	reconcile(visible: readonly ConversationPanelDescriptor[]): void {
 		const desired = new Map(visible.map((item) => [item.surfaceId, item]));
+		const admittedChatIds = new Set<string>();
 		for (const [surfaceId, panel] of this.#panels) {
 			const next = desired.get(surfaceId);
 			if (next?.chatId === panel.chatId) continue;
@@ -344,13 +365,18 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 			this.#panels.delete(surfaceId);
 		}
 		for (const item of visible) {
-			if (this.#panels.has(item.surfaceId)) {
+			const existing = this.#panels.get(item.surfaceId);
+			if (existing) {
+				if (existing.updateSnapshotAdmission(item.snapshotAdmission)) {
+					admittedChatIds.add(item.chatId);
+				}
 				this.#pendingSurfaceTransfers.delete(item.surfaceId);
 				continue;
 			}
 			const panel = new PanelRegistration(
 				item.surfaceId,
 				item.chatId,
+				item.snapshotAdmission,
 				this.options.cache,
 				this.options.lifecycle,
 				this.options.overlays,
@@ -376,6 +402,11 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 				});
 		}
 		this.#visible = [...visible];
+		for (const chatId of admittedChatIds) {
+			void this.loadChatSnapshot(chatId).catch(() => {
+				this.options.cache.markStale(chatId);
+			});
+		}
 	}
 
 	pruneRemovedSurfaces(existingSurfaceIds: ReadonlySet<ChatViewSurfaceId>): void {
@@ -413,6 +444,7 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 	}
 
 	loadChatSnapshot(chatId: string, options: ChatLoadMessagesOptions = {}): Promise<boolean> {
+		if (!this.#hasAdmittedPanel(chatId)) return Promise.resolve(false);
 		const minimumLimit = Math.max(0, Math.floor(options.minimumLimit ?? 0));
 		const pending = this.#snapshotLoads.get(chatId);
 		if (pending) {
@@ -434,8 +466,11 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 	async #performChatSnapshotLoad(
 		chatId: string,
 		options: ChatLoadMessagesOptions,
+		retryAfterLoaderRemoval = true,
 	): Promise<boolean> {
-		const loader = this.panelsForChat(chatId)[0];
+		const loader = [...this.#panels.values()].find(
+			(panel) => panel.chatId === chatId && panel.snapshotAdmission === 'admitted',
+		);
 		if (!loader) return false;
 		if (this.options.loadTranscriptSnapshot) {
 			await this.options.loadTranscriptSnapshot(loader.transcript, chatId, options);
@@ -443,13 +478,25 @@ export class ConversationPanelRegistry implements ChatSurfaceTransferPort {
 			await loader.transcript.loadMessages(chatId, options);
 		}
 		const cursor = this.options.cache.readAppliedCursor(chatId);
-		if (!cursor || cursor.stale) return false;
+		if (!cursor || cursor.stale) {
+			const loaderWasRemoved = this.#panels.get(loader.surfaceId) !== loader;
+			if (retryAfterLoaderRemoval && loaderWasRemoved) {
+				return this.#performChatSnapshotLoad(chatId, options, false);
+			}
+			return false;
+		}
 		const currentPanels = this.panelsForChat(chatId);
 		if (currentPanels.length === 0) return false;
 		for (const panel of currentPanels) {
 			if (panel !== loader) panel.transcript.installCachedSnapshot(chatId);
 		}
 		return true;
+	}
+
+	#hasAdmittedPanel(chatId: string): boolean {
+		return [...this.#panels.values()].some(
+			(panel) => panel.chatId === chatId && panel.snapshotAdmission === 'admitted',
+		);
 	}
 
 	visibleChatIds(): readonly string[] {

--- a/web/src/lib/components/chat/__tests__/ConversationWorkspaceEscapeHost.svelte
+++ b/web/src/lib/components/chat/__tests__/ConversationWorkspaceEscapeHost.svelte
@@ -226,6 +226,7 @@
 		{
 			surfaceId: CANONICAL_CHAT_SURFACE_ID,
 			chatId: 'chat-1',
+			snapshotAdmission: 'admitted',
 			presentation: 'window-main',
 			windowId: 'window-main',
 		},

--- a/web/src/lib/components/workspace/WorkspaceRoot.svelte
+++ b/web/src/lib/components/workspace/WorkspaceRoot.svelte
@@ -40,7 +40,10 @@
 	import { INITIAL_VISIBLE_MESSAGES } from '$lib/chat/transcript/active-transcript-state.svelte.js';
 	import { ConversationUiState } from '$lib/chat/conversation/conversation-ui-state.svelte.js';
 	import { ConversationLifecycleRegistry } from '$lib/chat/conversation/conversation-lifecycle-registry.svelte.js';
-	import { ConversationPanelRegistry } from '$lib/chat/conversation/conversation-panel-registry.svelte.js';
+	import {
+		ConversationPanelRegistry,
+		type ConversationPanelDescriptor,
+	} from '$lib/chat/conversation/conversation-panel-registry.svelte.js';
 	import { ConversationTranscriptOverlayStore } from '$lib/chat/transcript/conversation-transcript-overlay-store.svelte.js';
 	import type { GitQuickProjectLease } from '$lib/git/surface/git-quick-summary.svelte.js';
 	import {
@@ -123,11 +126,20 @@
 
 	const snapshot = $derived(workspace.layout.snapshot);
 	const portablePresentations = $derived(visiblePortablePresentations(snapshot, isMobile));
-	const chatPresentations = $derived(
-		visibleChatPresentations(snapshot, isMobile ? 'mobile' : 'desktop').filter(
-			({ chatId }) =>
-				resolveChatSurfacePresentation(sessions.byId[chatId] ?? null, sessions.isLoadingChats) ===
-				'conversation',
+	const chatPresentations = $derived.by<ConversationPanelDescriptor[]>(() =>
+		visibleChatPresentations(snapshot, isMobile ? 'mobile' : 'desktop').flatMap(
+			(presentation) => {
+				const chat = sessions.byId[presentation.chatId] ?? null;
+				if (resolveChatSurfacePresentation(chat, sessions.isLoadingChats) !== 'conversation') {
+					return [];
+				}
+				return [
+					{
+						...presentation,
+						snapshotAdmission: chat?.status === 'draft' ? 'deferred' : 'admitted',
+					},
+				];
+			},
 		),
 	);
 	const existingChatSurfaceIds = $derived.by(

--- a/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
+++ b/web/src/lib/components/workspace/__tests__/WorkspaceRoot.test.ts
@@ -26,9 +26,11 @@ import type {
 	ConversationPanelPresentationPort,
 	ConversationPanelRegistry,
 } from '$lib/chat/conversation/conversation-panel-registry.svelte.js';
+import type { ChatMessagesRequest } from '$lib/api/chats.js';
 import * as m from '$lib/paraglide/messages.js';
 
 const testContext = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+const chatApiMocks = vi.hoisted(() => ({ getChatMessages: vi.fn() }));
 
 vi.mock('$lib/context', () => ({
 	getAppShell: () => testContext.current?.appShell,
@@ -71,25 +73,17 @@ vi.mock('$lib/api/chats.js', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('$lib/api/chats.js')>();
 	return {
 		...actual,
-		getChatMessages: vi.fn(async (request) => ({
-			historyState: { kind: 'complete' as const },
-			chatId: request.chatId,
-			transcriptViewId: `view-${request.chatId}`,
-			messages: [],
-			lastOrdinal: 0,
-			pageOldestOrdinal: 0,
-			pageNewestOrdinal: 0,
-			nextBeforeOrdinal: null,
-			hasMore: false,
-			limit: request.limit ?? 50,
-			resendCandidates: [],
-		})),
+		getChatMessages: chatApiMocks.getChatMessages,
 	};
 });
 
 const WorkspaceRoot = (await import('../WorkspaceRoot.svelte')).default;
 
-function chat(id: string, title: string): ChatSessionRecord {
+function chat(
+	id: string,
+	title: string,
+	overrides: Partial<ChatSessionRecord> = {},
+): ChatSessionRecord {
 	return {
 		id,
 		parentChat: null,
@@ -112,9 +106,26 @@ function chat(id: string, title: string): ChatSessionRecord {
 		processingPhase: null,
 		isUnread: false,
 		canReloadFromNativeHistory: false,
-		status: 'draft',
+		status: 'running',
 		agentOwnershipEpoch: null,
 		tags: [],
+		...overrides,
+	};
+}
+
+function emptyChatHistory(request: ChatMessagesRequest) {
+	return {
+		historyState: { kind: 'complete' as const },
+		chatId: request.chatId,
+		transcriptViewId: `view-${request.chatId}`,
+		messages: [],
+		lastOrdinal: 0,
+		pageOldestOrdinal: 0,
+		pageNewestOrdinal: 0,
+		nextBeforeOrdinal: null,
+		hasMore: false,
+		limit: request.limit ?? 50,
+		resendCandidates: [],
 	};
 }
 
@@ -436,6 +447,10 @@ function panelPresentation(
 describe('WorkspaceRoot', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		chatApiMocks.getChatMessages.mockReset();
+		chatApiMocks.getChatMessages.mockImplementation(async (request: ChatMessagesRequest) =>
+			emptyChatHistory(request),
+		);
 		vi.stubGlobal('ResizeObserver', undefined);
 	});
 
@@ -460,6 +475,29 @@ describe('WorkspaceRoot', () => {
 		expect(panel.getAttribute('aria-labelledby')).toBe('window-main-tab-chat-view:window-main');
 		expect(document.getElementById('window-main-tab-chat-view:window-main')).not.toBeNull();
 		expect(container.querySelector('[data-workspace-window-focus-ring]')).toBeNull();
+	});
+
+	it('renders a draft conversation panel without requesting a server transcript', async () => {
+		installContext();
+		const sessions = testContext.current?.sessions as {
+			selectedChat: ChatSessionRecord | null;
+			byId: Record<string, ChatSessionRecord>;
+		};
+		const draft = chat('chat-a', 'Chat A', {
+			status: 'draft',
+			orderGroup: null,
+			effectiveProjectKey: null,
+			projectIdentityState: 'pending',
+		});
+		sessions.selectedChat = draft;
+		sessions.byId['chat-a'] = draft;
+		chatApiMocks.getChatMessages.mockRejectedValue(new Error('Session not found'));
+
+		renderRoot();
+		await tick();
+
+		expect(screen.getByTestId('conversation-panel').dataset.chatId).toBe('chat-a');
+		expect(chatApiMocks.getChatMessages).not.toHaveBeenCalled();
 	});
 
 	it('adds Chat actions to the tab context menu', async () => {

--- a/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
+++ b/web/src/lib/ws/__tests__/reconnect-coordinator.test.ts
@@ -417,12 +417,14 @@ describe('ChatReconnectCoordinator', () => {
 			{
 				surfaceId: 'chat-view:window-left',
 				chatId: 'chat-1',
+				snapshotAdmission: 'admitted',
 				presentation: 'window-left',
 				windowId: 'window-left',
 			},
 			{
 				surfaceId: 'chat-view:window-right',
 				chatId: 'chat-1',
+				snapshotAdmission: 'admitted',
 				presentation: 'window-right',
 				windowId: 'window-right',
 			},
@@ -471,12 +473,14 @@ describe('ChatReconnectCoordinator', () => {
 			{
 				surfaceId: 'chat-view:window-left',
 				chatId: 'chat-1',
+				snapshotAdmission: 'admitted',
 				presentation: 'window-left',
 				windowId: 'window-left',
 			},
 			{
 				surfaceId: 'chat-view:window-right',
 				chatId: 'chat-1',
+				snapshotAdmission: 'admitted',
 				presentation: 'window-right',
 				windowId: 'window-right',
 			},
@@ -590,6 +594,7 @@ describe('ChatReconnectCoordinator', () => {
 			{
 				surfaceId: 'chat-view:window-left',
 				chatId: 'chat-1',
+				snapshotAdmission: 'admitted',
 				presentation: 'window-left',
 				windowId: 'window-left',
 			},
@@ -1361,6 +1366,7 @@ describe('ChatReconnectCoordinator', () => {
 			{
 				surfaceId: 'chat-view:window-left',
 				chatId: 'chat-1',
+				snapshotAdmission: 'admitted',
 				presentation: 'window-left',
 				windowId: 'window-left',
 			},
@@ -1566,6 +1572,7 @@ describe('ChatReconnectCoordinator', () => {
 				{
 					surfaceId: 'chat-view:window-background',
 					chatId: 'chat-background',
+					snapshotAdmission: 'admitted',
 					presentation: 'window-background',
 					windowId: 'window-background',
 				},


### PR DESCRIPTION
Prevent newly created Chat panels from requesting transcript history before the server admits the session by deriving snapshot admission from session status, coalescing hydration after a draft becomes server-backed, and handing an in-flight load to a surviving duplicate panel when needed. Adds focused unit and browser coverage for the held-start race that previously surfaced "Failed to refresh messages / Session not found".