### PR TITLE
Polish empty states, chat markdown, and auth form metadata

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -36,6 +36,7 @@
 	"auth_errors_server": "Server error. Please try again later.",
 	"chat_empty_no_chat_selected": "No chat selected",
 	"chat_empty_press_new_chat": "Press New Chat to start.",
+	"chat_empty_shortcut_hint": "or press",
 	"chat_feed_failed_to_load": "Failed to load messages",
 	"chat_feed_failed_to_refresh": "Failed to refresh messages",
 	"chat_history_unavailable": "Archived history for this chat is unavailable.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1556,6 +1556,7 @@
 	"sidebar_chats_move_to_top": "Move to top",
 	"sidebar_chats_new_chat": "New Chat",
 	"sidebar_chats_no_chats": "No chats yet",
+	"sidebar_chats_no_chats_hint": "Create your first chat to get started.",
 	"sidebar_chats_no_matching_chats": "No matching chats",
 	"sidebar_chats_pin": "Pin",
 	"sidebar_chats_pinned_insert_position": "Pinned chats are added to",

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -728,13 +728,6 @@
 		margin: 0.5rem 0;
 	}
 
-	/* The typography plugin decorates inline code with literal backticks;
-	   chat inline code already renders as a bordered chip. */
-	.markdown-body :not(pre) > code::before,
-	.markdown-body :not(pre) > code::after {
-		content: none;
-	}
-
 	.markdown-body pre code {
 		background-color: transparent;
 		padding: 0;
@@ -943,6 +936,15 @@
 
 	.markdown-body thead {
 		background-color: hsl(var(--muted));
+	}
+}
+
+/* The typography plugin decorates inline code with literal backticks from the
+   utilities layer; chat inline code already renders as a bordered chip. */
+@layer utilities {
+	.markdown-body :not(pre) > code::before,
+	.markdown-body :not(pre) > code::after {
+		content: none;
 	}
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -728,6 +728,13 @@
 		margin: 0.5rem 0;
 	}
 
+	/* The typography plugin decorates inline code with literal backticks;
+	   chat inline code already renders as a bordered chip. */
+	.markdown-body :not(pre) > code::before,
+	.markdown-body :not(pre) > code::after {
+		content: none;
+	}
+
 	.markdown-body pre code {
 		background-color: transparent;
 		padding: 0;

--- a/web/src/lib/components/chat/ChatEmptyState.svelte
+++ b/web/src/lib/components/chat/ChatEmptyState.svelte
@@ -2,11 +2,23 @@
 	// Empty-state panel shown when no chat is selected. Provides a CTA
 	// to open the new-chat dialog.
 
+	import MessageSquarePlus from '@lucide/svelte/icons/message-square-plus';
 	import { Button } from '$lib/components/ui/button';
-	import { getAppShell } from '$lib/context';
+	import { getAppShell, getLocalSettings } from '$lib/context';
 	import * as m from '$lib/paraglide/messages.js';
+	import {
+		formatGlobalShortcut,
+		getEffectiveGlobalShortcut,
+	} from '$lib/workspace/global-shortcuts.js';
 
 	const appShell = getAppShell();
+	const localSettings = getLocalSettings();
+
+	const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
+	const newChatShortcut = $derived.by(() => {
+		const binding = getEffectiveGlobalShortcut('new-chat', localSettings.globalShortcuts);
+		return binding ? formatGlobalShortcut(binding, isMac) : null;
+	});
 
 	function openNewChat() {
 		appShell.openNewChatDialog();
@@ -15,8 +27,30 @@
 
 <div class="h-full grid place-items-center px-6">
 	<div class="max-w-md text-center space-y-4">
+		<div
+			class="mx-auto flex h-14 w-14 items-center justify-center rounded-xl border border-border bg-muted"
+		>
+			<MessageSquarePlus class="h-7 w-7 text-muted-foreground" />
+		</div>
 		<h2 class="text-xl font-semibold text-foreground">{m.chat_empty_no_chat_selected()}</h2>
 		<p class="text-sm text-muted-foreground">{m.chat_empty_press_new_chat()}</p>
-		<Button onclick={openNewChat}>{m.command_new_chat()}</Button>
+		<div class="space-y-2">
+			<Button onclick={openNewChat}>{m.command_new_chat()}</Button>
+			{#if newChatShortcut}
+				<p
+					class="hidden items-center justify-center gap-1 text-xs text-muted-foreground pointer-fine:flex"
+				>
+					{m.chat_empty_shortcut_hint()}
+					{#each newChatShortcut as key, index (index)}
+						{#if index > 0}
+							<span>+</span>
+						{/if}
+						<kbd class="px-1.5 py-0.5 text-[10px] font-mono bg-muted rounded border border-border"
+							>{key}</kbd
+						>
+					{/each}
+				</p>
+			{/if}
+		</div>
 	</div>
 </div>

--- a/web/src/lib/components/chat/ChatEmptyState.svelte
+++ b/web/src/lib/components/chat/ChatEmptyState.svelte
@@ -16,7 +16,7 @@
 
 	const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 	const newChatShortcut = $derived.by(() => {
-		const binding = getEffectiveGlobalShortcut('new-chat', localSettings.globalShortcuts);
+		const binding = getEffectiveGlobalShortcut('new-chat', localSettings.globalShortcuts ?? {});
 		return binding ? formatGlobalShortcut(binding, isMac) : null;
 	});
 

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -497,6 +497,7 @@
 			{isMobile}
 			{currentTime}
 			searchFilter={sidebarSearch.activeQuery}
+			{onNewChat}
 			isMultiSelectMode={selection.isActive}
 			isMultiSelected={(id) => selection.isSelected(id)}
 			{displayOptions}

--- a/web/src/lib/components/sidebar/SidebarChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import Search from '@lucide/svelte/icons/search';
+	import MessageSquarePlus from '@lucide/svelte/icons/message-square-plus';
+	import { Button } from '$lib/components/ui/button';
 	import SidebarVirtualSortableChatList from './SidebarVirtualSortableChatList.svelte';
 	import {
 		SidebarChatReorderState,
@@ -32,6 +34,7 @@
 		isMobile?: boolean;
 		currentTime: Date;
 		searchFilter: string;
+		onNewChat?: () => void;
 		isMultiSelectMode?: boolean;
 		isMultiSelected?: (chatId: string) => boolean;
 		displayOptions?: SidebarDisplayOptions;
@@ -69,6 +72,7 @@
 		isMobile = false,
 		currentTime,
 		searchFilter,
+		onNewChat,
 		isMultiSelectMode = false,
 		isMultiSelected,
 		displayOptions = DEFAULT_SIDEBAR_DISPLAY_OPTIONS,
@@ -163,6 +167,23 @@
 			</h3>
 			<p class="text-sm text-muted-foreground">{m.sidebar_chats_fetching_chats()}</p>
 		</div>
+	</div>
+{:else if !showChats && !isFiltered}
+	<div class="px-4 py-12 text-center md:py-8">
+		<div
+			class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-muted md:mb-3"
+		>
+			<MessageSquarePlus class="h-6 w-6 text-muted-foreground" />
+		</div>
+		<h3 class="mb-2 text-base font-medium text-foreground md:mb-1">
+			{m.sidebar_chats_no_chats()}
+		</h3>
+		<p class="text-sm text-muted-foreground">{m.sidebar_chats_no_chats_hint()}</p>
+		{#if onNewChat}
+			<Button variant="outline" size="sm" class="mt-4" onclick={onNewChat}>
+				{m.sidebar_chats_new_chat()}
+			</Button>
+		{/if}
 	</div>
 {:else if !showChats}
 	<div class="px-4 py-12 text-center md:py-8">

--- a/web/src/lib/components/sidebar/SidebarContent.svelte
+++ b/web/src/lib/components/sidebar/SidebarContent.svelte
@@ -21,6 +21,7 @@
 		isMobile?: boolean;
 		currentTime: Date;
 		searchFilter: string;
+		onNewChat?: () => void;
 		isMultiSelectMode?: boolean;
 		isMultiSelected?: (chatId: string) => boolean;
 		displayOptions?: SidebarDisplayOptions;
@@ -57,6 +58,7 @@
 		isMobile = false,
 		currentTime,
 		searchFilter,
+		onNewChat,
 		isMultiSelectMode,
 		isMultiSelected,
 		displayOptions = DEFAULT_SIDEBAR_DISPLAY_OPTIONS,
@@ -102,6 +104,7 @@
 		{isMobile}
 		{currentTime}
 		{searchFilter}
+		{onNewChat}
 		{isMultiSelectMode}
 		{isMultiSelected}
 		{displayOptions}

--- a/web/src/lib/components/sidebar/__tests__/SidebarChatListHost.svelte
+++ b/web/src/lib/components/sidebar/__tests__/SidebarChatListHost.svelte
@@ -13,6 +13,7 @@
 		chats: ChatSessionRecord[];
 		filteredChats?: ChatSessionRecord[];
 		searchFilter?: string;
+		onNewChat?: () => void;
 		selectedChatId?: string | null;
 		isMobile?: boolean;
 		displayOptions?: SidebarDisplayOptions;
@@ -31,6 +32,7 @@
 		chats,
 		filteredChats = chats,
 		searchFilter = '',
+		onNewChat,
 		selectedChatId = null,
 		isMobile = false,
 		displayOptions = {
@@ -100,6 +102,7 @@
 		{isMobile}
 		currentTime={new Date('2025-01-01T03:00:00.000Z')}
 		{searchFilter}
+		{onNewChat}
 		{displayOptions}
 		collapsedProjectKeys={effectiveCollapsedKeys}
 		onToggleProjectCollapsed={handleProjectCollapseToggle}

--- a/web/src/lib/components/sidebar/__tests__/sidebar-chat-list-empty-state.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-chat-list-empty-state.test.ts
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import SidebarChatListHost from './SidebarChatListHost.svelte';
+import type { ChatSessionRecord } from '$lib/types/chat-session';
+
+function makeChat(index: number): ChatSessionRecord {
+	return {
+		id: `chat-${index}`,
+		projectPath: '/tmp/project',
+		effectiveProjectKey: '/tmp/project',
+		projectIdentityState: 'available',
+		orderGroup: 'normal',
+		title: `Chat ${index}`,
+		agentId: 'claude',
+		model: 'sonnet',
+		permissionMode: 'default',
+		thinkingMode: 'low',
+		agentSettings: { ownerId: 'claude', schemaVersion: 1, values: {} },
+		createdAt: '2025-01-01T00:00:00.000Z',
+		lastActivityAt: '2025-01-01T00:00:00.000Z',
+		lastReadAt: '2025-01-01T00:00:00.000Z',
+		isPinned: false,
+		isArchived: false,
+		isProcessing: false,
+		processingPhase: null,
+		isUnread: false,
+		canReloadFromNativeHistory: false,
+		status: 'draft',
+		lastMessage: `Chat ${index} preview`,
+		tags: [],
+		firstMessage: `Chat ${index} first`,
+		parentChat: null,
+		agentOwnershipEpoch: null,
+	};
+}
+
+describe('SidebarChatList empty states', () => {
+	it('shows the no-chats state with a New Chat action when the workspace is empty', async () => {
+		const onNewChat = vi.fn();
+		render(SidebarChatListHost, { props: { chats: [], onNewChat } });
+
+		expect(screen.getByText('No chats yet')).toBeTruthy();
+		expect(screen.getByText('Create your first chat to get started.')).toBeTruthy();
+		expect(screen.queryByText('No matching chats')).toBeNull();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'New Chat' }));
+		expect(onNewChat).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the New Chat action when no handler is provided', () => {
+		render(SidebarChatListHost, { props: { chats: [] } });
+
+		expect(screen.getByText('No chats yet')).toBeTruthy();
+		expect(screen.queryByRole('button', { name: 'New Chat' })).toBeNull();
+	});
+
+	it('shows the search-empty state only when a filter is active', () => {
+		render(SidebarChatListHost, {
+			props: { chats: [makeChat(1)], filteredChats: [], searchFilter: 'zzz' },
+		});
+
+		expect(screen.getByText('No matching chats')).toBeTruthy();
+		expect(screen.queryByText('No chats yet')).toBeNull();
+	});
+
+	it('renders rows when chats exist', () => {
+		render(SidebarChatListHost, { props: { chats: [makeChat(1)] } });
+
+		expect(screen.queryByText('No chats yet')).toBeNull();
+		expect(screen.queryByText('No matching chats')).toBeNull();
+		expect(screen.getByText('Chat 1')).toBeTruthy();
+	});
+});

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -55,14 +55,17 @@
 				<label for="username" class="mb-1 block text-sm font-medium text-foreground">
 					{m.auth_login_username()}
 				</label>
-				<Input
-					type="text"
-					id="username"
-					bind:value={username}
-					placeholder={m.auth_login_placeholders_username()}
-					required
-					disabled={isSubmitting}
-				/>
+			<Input
+				type="text"
+				id="username"
+				bind:value={username}
+				placeholder={m.auth_login_placeholders_username()}
+				autocomplete="username"
+				autocapitalize="none"
+				spellcheck="false"
+				required
+				disabled={isSubmitting}
+			/>
 			</div>
 
 			<div>
@@ -70,15 +73,16 @@
 					{m.auth_login_password()}
 				</label>
 				<div class="relative">
-					<Input
-						type={showPassword ? 'text' : 'password'}
-						id="password"
-						bind:value={password}
-						placeholder={m.auth_login_placeholders_password()}
-						required
-						disabled={isSubmitting}
-						class="pr-10"
-					/>
+				<Input
+					type={showPassword ? 'text' : 'password'}
+					id="password"
+					bind:value={password}
+					placeholder={m.auth_login_placeholders_password()}
+					autocomplete="current-password"
+					required
+					disabled={isSubmitting}
+					class="pr-10"
+				/>
 					<Button
 						type="button"
 						variant="ghost"

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -55,17 +55,17 @@
 				<label for="username" class="mb-1 block text-sm font-medium text-foreground">
 					{m.auth_login_username()}
 				</label>
-			<Input
-				type="text"
-				id="username"
-				bind:value={username}
-				placeholder={m.auth_login_placeholders_username()}
-				autocomplete="username"
-				autocapitalize="none"
-				spellcheck="false"
-				required
-				disabled={isSubmitting}
-			/>
+				<Input
+					type="text"
+					id="username"
+					bind:value={username}
+					placeholder={m.auth_login_placeholders_username()}
+					autocomplete="username"
+					autocapitalize="none"
+					spellcheck="false"
+					required
+					disabled={isSubmitting}
+				/>
 			</div>
 
 			<div>
@@ -73,16 +73,16 @@
 					{m.auth_login_password()}
 				</label>
 				<div class="relative">
-				<Input
-					type={showPassword ? 'text' : 'password'}
-					id="password"
-					bind:value={password}
-					placeholder={m.auth_login_placeholders_password()}
-					autocomplete="current-password"
-					required
-					disabled={isSubmitting}
-					class="pr-10"
-				/>
+					<Input
+						type={showPassword ? 'text' : 'password'}
+						id="password"
+						bind:value={password}
+						placeholder={m.auth_login_placeholders_password()}
+						autocomplete="current-password"
+						required
+						disabled={isSubmitting}
+						class="pr-10"
+					/>
 					<Button
 						type="button"
 						variant="ghost"

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -93,17 +93,17 @@
 					<label for="username" class="mb-1 block text-sm font-medium text-foreground">
 						{m.auth_login_username()}
 					</label>
-				<Input
-					type="text"
-					id="username"
-					bind:value={username}
-					placeholder={m.auth_login_placeholders_username()}
-					autocomplete="username"
-					autocapitalize="none"
-					spellcheck="false"
-					required
-					disabled={isSubmitting}
-				/>
+					<Input
+						type="text"
+						id="username"
+						bind:value={username}
+						placeholder={m.auth_login_placeholders_username()}
+						autocomplete="username"
+						autocapitalize="none"
+						spellcheck="false"
+						required
+						disabled={isSubmitting}
+					/>
 				</div>
 
 				<div>
@@ -111,16 +111,16 @@
 						{m.auth_login_password()}
 					</label>
 					<div class="relative">
-					<Input
-						type={showPassword ? 'text' : 'password'}
-						id="password"
-						bind:value={password}
-						placeholder={m.auth_login_placeholders_password()}
-						autocomplete="new-password"
-						required
-						disabled={isSubmitting}
-						class="pr-10"
-					/>
+						<Input
+							type={showPassword ? 'text' : 'password'}
+							id="password"
+							bind:value={password}
+							placeholder={m.auth_login_placeholders_password()}
+							autocomplete="new-password"
+							required
+							disabled={isSubmitting}
+							class="pr-10"
+						/>
 						<Button
 							type="button"
 							variant="ghost"
@@ -143,16 +143,16 @@
 						{m.auth_setup_confirm_password()}
 					</label>
 					<div class="relative">
-					<Input
-						type={showConfirmPassword ? 'text' : 'password'}
-						id="confirmPassword"
-						bind:value={confirmPassword}
-						placeholder={m.auth_setup_confirm_password_placeholder()}
-						autocomplete="new-password"
-						required
-						disabled={isSubmitting}
-						class="pr-10"
-					/>
+						<Input
+							type={showConfirmPassword ? 'text' : 'password'}
+							id="confirmPassword"
+							bind:value={confirmPassword}
+							placeholder={m.auth_setup_confirm_password_placeholder()}
+							autocomplete="new-password"
+							required
+							disabled={isSubmitting}
+							class="pr-10"
+						/>
 						<Button
 							type="button"
 							variant="ghost"

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -93,14 +93,17 @@
 					<label for="username" class="mb-1 block text-sm font-medium text-foreground">
 						{m.auth_login_username()}
 					</label>
-					<Input
-						type="text"
-						id="username"
-						bind:value={username}
-						placeholder={m.auth_login_placeholders_username()}
-						required
-						disabled={isSubmitting}
-					/>
+				<Input
+					type="text"
+					id="username"
+					bind:value={username}
+					placeholder={m.auth_login_placeholders_username()}
+					autocomplete="username"
+					autocapitalize="none"
+					spellcheck="false"
+					required
+					disabled={isSubmitting}
+				/>
 				</div>
 
 				<div>
@@ -108,15 +111,16 @@
 						{m.auth_login_password()}
 					</label>
 					<div class="relative">
-						<Input
-							type={showPassword ? 'text' : 'password'}
-							id="password"
-							bind:value={password}
-							placeholder={m.auth_login_placeholders_password()}
-							required
-							disabled={isSubmitting}
-							class="pr-10"
-						/>
+					<Input
+						type={showPassword ? 'text' : 'password'}
+						id="password"
+						bind:value={password}
+						placeholder={m.auth_login_placeholders_password()}
+						autocomplete="new-password"
+						required
+						disabled={isSubmitting}
+						class="pr-10"
+					/>
 						<Button
 							type="button"
 							variant="ghost"
@@ -139,15 +143,16 @@
 						{m.auth_setup_confirm_password()}
 					</label>
 					<div class="relative">
-						<Input
-							type={showConfirmPassword ? 'text' : 'password'}
-							id="confirmPassword"
-							bind:value={confirmPassword}
-							placeholder={m.auth_setup_confirm_password_placeholder()}
-							required
-							disabled={isSubmitting}
-							class="pr-10"
-						/>
+					<Input
+						type={showConfirmPassword ? 'text' : 'password'}
+						id="confirmPassword"
+						bind:value={confirmPassword}
+						placeholder={m.auth_setup_confirm_password_placeholder()}
+						autocomplete="new-password"
+						required
+						disabled={isSubmitting}
+						class="pr-10"
+					/>
 						<Button
 							type="button"
 							variant="ghost"


### PR DESCRIPTION
Several small UI/UX fixes from a visual pass over the app. An empty workspace previously rendered the sidebar's search-empty state ("No matching chats / Try a different search term") with no active search; it now shows a dedicated "No chats yet" state with a working New Chat action, with tests covering the empty, filtered, and populated cases. Inline code in chat markdown no longer shows literal backtick characters injected by the Tailwind typography plugin — the override lives in the utilities cascade layer so it actually wins, and fenced code blocks are unaffected. The "No chat selected" panel gains an icon treatment and shows the effective new-chat keyboard shortcut (respecting custom bindings) on keyboard-capable devices. Finally, the login and setup forms carry proper autocomplete metadata (username, current-password, new-password, plus no-autocapitalize/no-spellcheck on usernames) so password managers and mobile keyboards behave correctly.