### PR TITLE
Let OpenCode forks finish replaying large sessions

### DIFF
--- a/integration-tests/support/opencode-process-supervisor.ts
+++ b/integration-tests/support/opencode-process-supervisor.ts
@@ -2,7 +2,8 @@
 // executes this module; it verifies the pinned binary hermetically, records the exact provider
 // process tree, and stops every recorded descendant when a crashed Garcon parent disappears.
 // It optionally reverse-proxies the real server so transport tests can hold selected stream
-// frames or reset the real /global/event socket. It records and signals only PIDs it created.
+// frames or HTTP responses and reset the real /global/event socket. It records and signals only
+// PIDs it created.
 
 import { createServer, request as httpRequest, type Server } from 'node:http';
 import { createServer as createTcpServer } from 'node:net';
@@ -53,8 +54,11 @@ export interface BackendReadinessProcess {
 
 interface TransportDirective {
   seq: number;
-  action: 'hold' | 'hold-through-markers' | 'release' | 'reset';
+  action: 'hold' | 'hold-through-markers' | 'release' | 'reset'
+    | 'hold-response' | 'release-response';
   connectionId?: number;
+  responseId?: number;
+  path?: string;
   startMarker?: string;
   endMarker?: string;
 }
@@ -74,6 +78,14 @@ interface GlobalConnectionObservation {
   closed: boolean;
 }
 
+interface HeldResponseObservation {
+  id: number;
+  path: string;
+  held: boolean;
+  released: boolean;
+  closed: boolean;
+}
+
 // Live per-connection proxy state; directives act on it immediately instead of waiting for
 // the next upstream chunk.
 interface GlobalConnectionRuntime {
@@ -90,10 +102,16 @@ interface GlobalConnectionRuntime {
   reset(): void;
 }
 
+interface HeldResponseRuntime {
+  observation: HeldResponseObservation;
+  release(): void;
+}
+
 interface TransportObservations {
   appliedSeq: number;
   requests: Array<{ method: string; path: string }>;
   connections: GlobalConnectionObservation[];
+  responses: HeldResponseObservation[];
 }
 
 const MAX_OBSERVED_REQUESTS = 500;
@@ -727,9 +745,17 @@ function startTransportProxy(input: {
   const directivesPath = join(input.proxyDir, 'directives.json');
   const observationsPath = join(input.proxyDir, 'observations.json');
   const backend = new URL(input.backendUrl);
-  const observations: TransportObservations = { appliedSeq: 0, requests: [], connections: [] };
+  const observations: TransportObservations = {
+    appliedSeq: 0,
+    requests: [],
+    connections: [],
+    responses: [],
+  };
   const runtimes = new Map<number, GlobalConnectionRuntime>();
+  const responseRuntimes = new Map<number, HeldResponseRuntime>();
+  const heldResponsePaths = new Set<string>();
   let nextConnectionId = 0;
+  let nextResponseId = 0;
   let lastAppliedSeq = 0;
   let holdArmed = false;
   let observationsDirty = false;
@@ -767,6 +793,10 @@ function startTransportProxy(input: {
       lastAppliedSeq = directive.seq;
       if (directive.action === 'hold') {
         holdArmed = true;
+      } else if (directive.action === 'hold-response' && typeof directive.path === 'string') {
+        heldResponsePaths.add(directive.path);
+      } else if (directive.action === 'release-response') {
+        responseRuntimes.get(directive.responseId ?? -1)?.release();
       } else {
         const runtime = runtimes.get(directive.connectionId ?? -1);
         if (runtime) {
@@ -796,6 +826,7 @@ function startTransportProxy(input: {
 
   return createServer((request, response) => {
     const path = (request.url ?? '/').split('?')[0];
+    const holdResponse = heldResponsePaths.delete(path);
     recordRequest(request.method ?? 'GET', path);
     const upstream = httpRequest({
       hostname: backend.hostname,
@@ -806,7 +837,52 @@ function startTransportProxy(input: {
     }, (backendResponse) => {
       response.writeHead(backendResponse.statusCode ?? 502, backendResponse.headers);
       if (path !== '/global/event') {
-        backendResponse.pipe(response);
+        if (!holdResponse) {
+          backendResponse.pipe(response);
+          return;
+        }
+        const observation: HeldResponseObservation = {
+          id: ++nextResponseId,
+          path,
+          held: true,
+          released: false,
+          closed: false,
+        };
+        observations.responses.push(observation);
+        markObservationsDirty();
+        const buffered: Buffer[] = [];
+        let upstreamEnded = false;
+        const runtime: HeldResponseRuntime = {
+          observation,
+          release() {
+            if (observation.released || observation.closed) return;
+            observation.released = true;
+            for (const chunk of buffered) response.write(chunk);
+            buffered.length = 0;
+            if (upstreamEnded) response.end();
+            markObservationsDirty();
+          },
+        };
+        responseRuntimes.set(observation.id, runtime);
+        backendResponse.on('data', (chunk: Buffer) => {
+          if (observation.closed) return;
+          if (observation.released) response.write(chunk);
+          else buffered.push(chunk);
+        });
+        backendResponse.on('end', () => {
+          upstreamEnded = true;
+          if (observation.released && !observation.closed) response.end();
+        });
+        backendResponse.on('error', () => {
+          observation.closed = true;
+          markObservationsDirty();
+          response.destroy();
+        });
+        response.on('close', () => {
+          observation.closed = true;
+          markObservationsDirty();
+          backendResponse.destroy();
+        });
         return;
       }
 

--- a/integration-tests/support/opencode-transport-controller.ts
+++ b/integration-tests/support/opencode-transport-controller.ts
@@ -208,6 +208,16 @@ export class OpenCodeTransportController {
     return (await this.#observations())?.requests ?? [];
   }
 
+  async waitForRequest(method: string, pathPrefix: string): Promise<{ method: string; path: string }> {
+    return this.#waitForObservation(
+      (observations) => observations.requests.find(
+        (request) => request.method === method && request.path.startsWith(pathPrefix),
+      ),
+      `${method} request below ${pathPrefix} was never observed`,
+      DEFAULT_TIMEOUT_MS,
+    );
+  }
+
   async connections(): Promise<GlobalConnectionObservation[]> {
     return (await this.#observations())?.connections ?? [];
   }

--- a/integration-tests/support/opencode-transport-controller.ts
+++ b/integration-tests/support/opencode-transport-controller.ts
@@ -1,7 +1,7 @@
 // Test-side control of the supervisor's optional reverse proxy. The controller appends
-// directives (hold selected stream frames, release them, or reset an exact active global
-// connection) and waits on proxy observations; both files are atomic JSON snapshots below the
-// fixture proxy directory. Tests synchronize on observed state, never on guessed sleeps.
+// directives (hold selected stream frames or HTTP responses, release them, or reset an exact
+// active global connection) and waits on proxy observations; both files are atomic JSON snapshots
+// below the fixture proxy directory. Tests synchronize on observed state, never on guessed sleeps.
 
 import { join } from 'node:path';
 import type { IntegrationDirectories } from './integration-fixture.js';
@@ -10,8 +10,11 @@ import { readJsonFile, writeJsonAtomic } from './opencode-process-supervisor.js'
 
 interface TransportDirective {
   seq: number;
-  action: 'hold' | 'hold-through-markers' | 'release' | 'reset';
+  action: 'hold' | 'hold-through-markers' | 'release' | 'reset'
+    | 'hold-response' | 'release-response';
   connectionId?: number;
+  responseId?: number;
+  path?: string;
   startMarker?: string;
   endMarker?: string;
 }
@@ -31,10 +34,19 @@ export interface GlobalConnectionObservation {
   closed: boolean;
 }
 
+export interface HeldResponseObservation {
+  id: number;
+  path: string;
+  held: boolean;
+  released: boolean;
+  closed: boolean;
+}
+
 interface TransportObservations {
   appliedSeq: number;
   requests: Array<{ method: string; path: string }>;
   connections: GlobalConnectionObservation[];
+  responses: HeldResponseObservation[];
 }
 
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -144,6 +156,37 @@ export class OpenCodeTransportController {
         (entry) => entry.id === connectionId && entry.reset,
       ),
       `connection ${connectionId} was never reset`,
+      DEFAULT_TIMEOUT_MS,
+    );
+  }
+
+  async holdNextResponse(path: string): Promise<void> {
+    const seq = await this.#append({ action: 'hold-response', path });
+    await this.#waitForObservation(
+      (observations) => observations.appliedSeq >= seq ? observations.appliedSeq : null,
+      `response hold directive ${seq} was never applied`,
+      DEFAULT_TIMEOUT_MS,
+    );
+  }
+
+  async waitForResponseHeld(path: string): Promise<number> {
+    const response = await this.#waitForObservation(
+      (observations) => observations.responses.find(
+        (entry) => entry.path === path && entry.held && !entry.released,
+      ),
+      `response for ${path} was never held`,
+      DEFAULT_TIMEOUT_MS,
+    );
+    return response.id;
+  }
+
+  async releaseResponse(responseId: number): Promise<void> {
+    await this.#append({ action: 'release-response', responseId });
+    await this.#waitForObservation(
+      (observations) => observations.responses.find(
+        (entry) => entry.id === responseId && entry.released,
+      ),
+      `response ${responseId} was never released`,
       DEFAULT_TIMEOUT_MS,
     );
   }

--- a/integration-tests/tests/server/opencode-scripted-fork-timeout.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-fork-timeout.test.ts
@@ -9,6 +9,7 @@ import { waitForVisibleResponse } from '../../support/live-agent.js';
 import { OpenCodeTransportController } from '../../support/opencode-transport-controller.js';
 import {
   openCodeNativeSession,
+  scriptedOpenCodeRunRequest,
   scriptedOpenCodeStartRequest,
   startScriptedOpenCodeTestEnvironment,
   type ScriptedOpenCodeTestEnvironment,
@@ -85,6 +86,50 @@ describeOnLinux('scripted OpenCode long-running fork', () => {
       testEnvironment.model.assertSettled();
     }, withScriptedOpenCode());
   }, 120_000);
+
+  test('finishes replay and deletes the native child when fork-run admission is stopped', async () => {
+    const testEnvironment = requireEnvironment();
+    const prompt = marker('CANCEL_SOURCE_PROMPT');
+    const reply = marker('CANCEL_SOURCE_REPLY');
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+
+    await withIntegrationFixture('opencode-cancelled-fork', async (fixture) => {
+      const sourceChatId = fixture.newChatId();
+      const sourceTurn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId: sourceChatId,
+        projectPath: fixture.dirs.project,
+        command: prompt,
+      }));
+      await fixture.client.waitForTurnTerminal(sourceChatId, sourceTurn.turnId);
+
+      const sourceNative = await openCodeNativeSession(fixture, sourceChatId);
+      const forkPath = `/session/${encodeURIComponent(sourceNative.agentSessionId)}/fork`;
+      const transport = OpenCodeTransportController.forFixture(fixture.dirs);
+      await transport.holdNextResponse(forkPath);
+      const forkChatId = fixture.newChatId();
+      const outcome = fixture.client.forkRunChat({
+        ...scriptedOpenCodeRunRequest({
+          chatId: forkChatId,
+          command: marker('CANCELLED_FORK_PROMPT'),
+        }),
+        sourceChatId,
+      }).then(
+        (value) => ({ status: 'fulfilled' as const, value }),
+        (error) => ({ status: 'rejected' as const, error }),
+      );
+      const responseId = await transport.waitForResponseHeld(forkPath);
+
+      const stopping = fixture.garcon.stop();
+      await waitForGarconLog(() => fixture.garcon.logs, 'server: shutting down...');
+      expect((await transport.requests()).some((request) => request.method === 'DELETE')).toBe(false);
+      await transport.releaseResponse(responseId);
+      const deleted = await transport.waitForRequest('DELETE', '/session/');
+      expect(deleted.path).not.toBe(`/session/${encodeURIComponent(sourceNative.agentSessionId)}`);
+      await stopping;
+      expect((await outcome).status).toBe('rejected');
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
 });
 
 function requireEnvironment(): ScriptedOpenCodeTestEnvironment {
@@ -117,4 +162,16 @@ function unroutedWarningSessionIds(lines: readonly string[]): string[] {
     if (match?.[1]) sessionIds.push(match[1]);
   }
   return sessionIds;
+}
+
+async function waitForGarconLog(
+  readLines: () => readonly string[],
+  marker: string,
+): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (readLines().some((line) => line.includes(marker))) return;
+    await Bun.sleep(15);
+  }
+  throw new Error(`Garcon never logged ${marker}.`);
 }

--- a/integration-tests/tests/server/opencode-scripted-fork-timeout.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-fork-timeout.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { assistantContents, userContents } from '../../support/chat-assertions.js';
+import { chatCompletionsText } from '../../support/fake-chat-completions-model.js';
+import {
+  withIntegrationFixture,
+  type IntegrationFixtureOptions,
+} from '../../support/integration-fixture.js';
+import { waitForVisibleResponse } from '../../support/live-agent.js';
+import { OpenCodeTransportController } from '../../support/opencode-transport-controller.js';
+import {
+  openCodeNativeSession,
+  scriptedOpenCodeStartRequest,
+  startScriptedOpenCodeTestEnvironment,
+  type ScriptedOpenCodeTestEnvironment,
+} from '../../support/scripted-opencode.js';
+
+let environment: ScriptedOpenCodeTestEnvironment | undefined;
+
+const describeOnLinux = process.platform === 'linux' ? describe : describe.skip;
+const FORMER_OPENCODE_REQUEST_TIMEOUT_MS = 10_000;
+
+describeOnLinux('scripted OpenCode long-running fork', () => {
+  beforeEach(() => {
+    environment = startScriptedOpenCodeTestEnvironment({ proxy: true });
+  });
+
+  afterEach(() => {
+    environment?.dispose();
+    environment = undefined;
+  });
+
+  test('waits for native replay beyond the ordinary request timeout without warning spam', async () => {
+    const testEnvironment = requireEnvironment();
+    const prompt = marker('SOURCE_PROMPT');
+    const reply = marker('SOURCE_REPLY');
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+
+    await withIntegrationFixture('opencode-long-fork', async (fixture) => {
+      const sourceChatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const sourceTurn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId: sourceChatId,
+        projectPath: fixture.dirs.project,
+        command: prompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId: sourceChatId,
+        turnId: sourceTurn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+
+      const sourceNative = await openCodeNativeSession(fixture, sourceChatId);
+      const forkPath = `/session/${encodeURIComponent(sourceNative.agentSessionId)}/fork`;
+      const transport = OpenCodeTransportController.forFixture(fixture.dirs);
+      await transport.holdNextResponse(forkPath);
+      const forkChatId = fixture.newChatId();
+      const outcome = fixture.client.forkChat({ sourceChatId, chatId: forkChatId }).then(
+        (value) => ({ status: 'fulfilled' as const, value }),
+        (error) => ({ status: 'rejected' as const, error }),
+      );
+      const responseId = await transport.waitForResponseHeld(forkPath);
+
+      try {
+        const beforeRelease = await Promise.race([
+          outcome,
+          Bun.sleep(FORMER_OPENCODE_REQUEST_TIMEOUT_MS + 250).then(() => 'still-pending' as const),
+        ]);
+        expect(beforeRelease).toBe('still-pending');
+      } finally {
+        await transport.releaseResponse(responseId);
+      }
+
+      const forkResult = await outcome;
+      if (forkResult.status === 'rejected') throw forkResult.error;
+      expect(forkResult.value.chat.id).toBe(forkChatId);
+      const fork = await fixture.client.getMessages(forkChatId);
+      expect(userContents(fork.messages)).toEqual([prompt]);
+      expect(assistantContents(fork.messages)).toEqual([reply]);
+      const forkNative = await openCodeNativeSession(fixture, forkChatId);
+      expect(unroutedWarningSessionIds(
+        fixture.diagnostics().processRuns.flatMap((run) => run.serverLogs),
+      )).not.toContain(forkNative.agentSessionId);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+});
+
+function requireEnvironment(): ScriptedOpenCodeTestEnvironment {
+  if (!environment) throw new Error('Scripted OpenCode environment was not initialized.');
+  return environment;
+}
+
+function withScriptedOpenCode(): IntegrationFixtureOptions {
+  const testEnvironment = requireEnvironment();
+  return {
+    resolveServerEnvironment: testEnvironment.resolveServerEnvironment,
+    prepareWorkspace: testEnvironment.prepareWorkspace,
+    afterGarconStop: testEnvironment.afterGarconStop,
+    extraDiagnostics: testEnvironment.extraDiagnostics,
+  };
+}
+
+function marker(label: string): string {
+  return `SCRIPTED_OPENCODE_FORK_${label}_${crypto.randomUUID().replaceAll('-', '')}`;
+}
+
+function unroutedWarningSessionIds(lines: readonly string[]): string[] {
+  const sessionIds: string[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!lines[index]?.includes('Ignoring an OpenCode event without an operation identity')) {
+      continue;
+    }
+    const detail = lines.slice(index + 1, index + 12).find((line) => line.includes('sessionId:'));
+    const match = detail?.match(/sessionId: "([^"]+)"/);
+    if (match?.[1]) sessionIds.push(match[1]);
+  }
+  return sessionIds;
+}

--- a/server-agents/common/src/forking/__tests__/jsonl-forking.test.ts
+++ b/server-agents/common/src/forking/__tests__/jsonl-forking.test.ts
@@ -299,6 +299,47 @@ describe('createJsonlNativeForking prefix protection', () => {
     })).rejects.toBe(failure);
     expect(await readdir(fixture.root)).toEqual(filesBeforeFork);
   });
+
+  it('removes an untransformed whole-session fork cancelled during receipt verification', async () => {
+    const fixture = await createFixture();
+    const filesBeforeFork = await readdir(fixture.root);
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const nativeEvidence = {
+      ...fixture.options.nativeEvidence,
+      async load(input: Parameters<AgentNativeEvidenceSource['load']>[0]) {
+        const native = fixture.nativeSessions.decode(input.chat.nativeSession);
+        if (native.path !== fixture.sourcePath) {
+          controller.abort(reason);
+          input.signal.throwIfAborted();
+        }
+        return fixture.options.nativeEvidence.load(input);
+      },
+    } satisfies Pick<AgentNativeEvidenceSource, 'load' | 'resolveNativeSession'>;
+    const forking = createJsonlNativeForking({
+      ...fixture.options,
+      nativeEvidence,
+    });
+    const receipt = createNativeSeedReceipt({
+      agentSessionId: sourceAgentSessionId,
+      placement: 'user-prefix',
+      prefix: 'first',
+    });
+
+    await expect(forking.fork({
+      ...fixture.request,
+      providerMeta: null,
+      admission: {
+        ...fixture.request.admission,
+        signal: controller.signal,
+      },
+      source: {
+        ...fixture.request.source,
+        nativeSeedReceipt: receipt,
+      },
+    })).rejects.toBe(reason);
+    expect(await readdir(fixture.root)).toEqual(filesBeforeFork);
+  });
 });
 
 describe('createJsonlNativeForking empty native prefixes', () => {

--- a/server-agents/common/src/forking/jsonl-forking.ts
+++ b/server-agents/common/src/forking/jsonl-forking.ts
@@ -139,9 +139,7 @@ async function forkJsonlAtProviderPoint(
       },
     };
   } catch (error) {
-    if (request.providerMeta || options.transformEntries) {
-      await fs.rm(result.nativePath, { force: true }).catch(() => undefined);
-    }
+    await fs.rm(result.nativePath, { force: true }).catch(() => undefined);
     throw error;
   }
 }

--- a/server-agents/opencode/src/__tests__/integration.test.js
+++ b/server-agents/opencode/src/__tests__/integration.test.js
@@ -1,5 +1,19 @@
 import { describe, expect, it, mock } from 'bun:test';
-import OpenCodeAgentIntegration from '../index.js';
+import OpenCodeAgentIntegration, { createOpenCodeNativeEvidence } from '../index.js';
+import { OpenCodeRuntime } from '../agents/opencode/opencode.js';
+
+async function* neverEndingStream() {
+  yield { payload: { id: 'evt_connected', type: 'server.connected', properties: {} } };
+  await new Promise(() => {});
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 function createHost() {
   return {
@@ -78,5 +92,61 @@ describe('OpenCodeAgentIntegration', () => {
         agentSessionId: 'session-1',
       },
     });
+  });
+
+  it('cancels native-history lease acquisition without cancelling shared startup', async () => {
+    const startupStarted = deferred();
+    const pendingInstance = deferred();
+    const get = mock(() => Promise.resolve({ data: { id: 'session-1' } }));
+    const messages = mock(() => Promise.resolve({ data: [] }));
+    let startupSignal;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(({ signal }) => {
+        startupSignal = signal;
+        startupStarted.resolve();
+        return pendingInstance.promise;
+      }),
+    });
+    const nativeEvidence = createOpenCodeNativeEvidence(
+      runtime,
+      { encode: mock(() => null), decode: mock(() => ({ agentSessionId: null, path: null })) },
+      (chat) => chat.agentSessionId ?? null,
+    );
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = nativeEvidence.load({
+      chat: {
+        chatId: 'target-chat',
+        agentId: 'opencode',
+        agentSessionId: 'session-1',
+        projectPath: '/repo',
+        model: '',
+        nativeSession: null,
+        carryOverRevision: '',
+        settings: { ownerId: 'opencode', schemaVersion: 1, values: {} },
+      },
+      signal: controller.signal,
+    });
+
+    await startupStarted.promise;
+    controller.abort(reason);
+
+    await expect(Promise.race([
+      outcome.then(() => 'fulfilled', (error) => error),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ])).resolves.toBe(reason);
+    expect(startupSignal.aborted).toBe(false);
+
+    pendingInstance.resolve({
+      client: {
+        permission: { reply: mock(() => Promise.resolve({})) },
+        global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+        session: { get, messages },
+      },
+      server: { close: mock(() => {}) },
+    });
+    await runtime.shutdown();
+    expect(get).not.toHaveBeenCalled();
+    expect(messages).not.toHaveBeenCalled();
   });
 });

--- a/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
@@ -6,7 +6,7 @@ async function* neverEndingStream() {
   await new Promise(() => {});
 }
 
-function createRuntimeWithClient(client) {
+function createRuntimeWithClient(client, options = {}) {
   const createInstance = mock(() => Promise.resolve({
     client: {
       permission: { reply: mock(() => Promise.resolve({})) },
@@ -19,7 +19,7 @@ function createRuntimeWithClient(client) {
   }));
   return {
     createInstance,
-    runtime: new OpenCodeRuntime({ createInstance }),
+    runtime: new OpenCodeRuntime({ createInstance, ...options }),
   };
 }
 
@@ -62,6 +62,43 @@ describe('OpenCodeRuntime fork', () => {
     expect(fork).toHaveBeenCalledTimes(1);
     expect(fork.mock.calls[0][0]).toEqual({ sessionID: 'source-session' });
     expect(fork.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('lets a native fork outlive the ordinary OpenCode request timeout', async () => {
+    const pendingFork = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const { runtime } = createRuntimeWithClient({ session: { fork } }, { requestTimeoutMs: 5 });
+    const outcome = runtime.forkSession('source-session').then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
+
+    await waitForMockCall(fork);
+    const beforeRelease = await Promise.race([
+      outcome,
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ]);
+    expect(beforeRelease).toBe('still-pending');
+    expect(fork.mock.calls[0][1].signal.aborted).toBe(false);
+
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+    await expect(outcome).resolves.toEqual({ status: 'fulfilled', value: 'forked-session' });
+  });
+
+  it('still cancels a timeout-free native fork from its admission signal', async () => {
+    const fork = mock((_input, options) => new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+    }));
+    const { runtime } = createRuntimeWithClient({ session: { fork } }, { requestTimeoutMs: 5 });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const pending = runtime.forkSession('source-session', { signal: controller.signal });
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+    expect(fork.mock.calls[0][1].signal.aborted).toBe(true);
   });
 
   it('routes native fork requests through the source project directory', async () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/fork.test.js
@@ -7,6 +7,7 @@ async function* neverEndingStream() {
 }
 
 function createRuntimeWithClient(client, options = {}) {
+  const close = mock(() => {});
   const createInstance = mock(() => Promise.resolve({
     client: {
       permission: { reply: mock(() => Promise.resolve({})) },
@@ -15,9 +16,10 @@ function createRuntimeWithClient(client, options = {}) {
       },
       ...client,
     },
-    server: { close: mock(() => {}) },
+    server: { close },
   }));
   return {
+    close,
     createInstance,
     runtime: new OpenCodeRuntime({ createInstance, ...options }),
   };
@@ -85,20 +87,325 @@ describe('OpenCodeRuntime fork', () => {
     await expect(outcome).resolves.toEqual({ status: 'fulfilled', value: 'forked-session' });
   });
 
-  it('still cancels a timeout-free native fork from its admission signal', async () => {
-    const fork = mock((_input, options) => new Promise((_resolve, reject) => {
-      options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
-    }));
-    const { runtime } = createRuntimeWithClient({ session: { fork } }, { requestTimeoutMs: 5 });
+  it('rejects admission during cold startup without later calling the provider fork', async () => {
+    const startupStarted = deferred();
+    const pendingInstance = deferred();
+    const close = mock(() => {});
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    let startupSignal;
+    const runtime = new OpenCodeRuntime({
+      createInstance: mock(({ signal }) => {
+        startupSignal = signal;
+        startupStarted.resolve();
+        return pendingInstance.promise;
+      }),
+    });
     const controller = new AbortController();
     const reason = new Error('fork admission cancelled');
-    const pending = runtime.forkSession('source-session', { signal: controller.signal });
+    const outcome = runtime.forkSession('source-session', { signal: controller.signal });
+
+    await startupStarted.promise;
+    controller.abort(reason);
+
+    await expect(Promise.race([
+      outcome.then(() => 'fulfilled', (error) => error),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ])).resolves.toBe(reason);
+    expect(startupSignal.aborted).toBe(false);
+
+    pendingInstance.resolve({
+      client: {
+        permission: { reply: mock(() => Promise.resolve({})) },
+        global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+        session: { fork },
+      },
+      server: { close },
+    });
+    await runtime.shutdown();
+    expect(fork).not.toHaveBeenCalled();
+  });
+
+  it('waits for an admitted native fork and deletes its child after cancellation', async () => {
+    const pendingFork = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const remove = mock(() => Promise.resolve({ data: true }));
+    const { runtime } = createRuntimeWithClient({
+      session: { fork, delete: remove },
+    }, { requestTimeoutMs: 5 });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.runProtectedNativeFork(() => (
+      runtime.forkSession('source-session', { signal: controller.signal })
+    )).then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
 
     await waitForMockCall(fork);
     controller.abort(reason);
+    const beforeForkCompletes = await Promise.race([
+      outcome,
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ]);
+    expect(beforeForkCompletes).toBe('still-pending');
+    expect(fork.mock.calls[0][1].signal.aborted).toBe(false);
+    expect(remove).not.toHaveBeenCalled();
 
-    await expect(pending).rejects.toBe(reason);
-    expect(fork.mock.calls[0][1].signal.aborted).toBe(true);
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+
+    await expect(outcome).resolves.toEqual({ status: 'rejected', error: reason });
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+  });
+
+  it('preserves cancellation when the native fork request rejects without a child', async () => {
+    const pendingFork = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const { runtime } = createRuntimeWithClient({ session: { fork } });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.forkSession('source-session', { signal: controller.signal });
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+    pendingFork.reject(new Error('fork transport failed'));
+
+    await expect(outcome).rejects.toBe(reason);
+  });
+
+  it('preserves cancellation when the native fork returns an error without a child', async () => {
+    const pendingFork = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const { runtime } = createRuntimeWithClient({ session: { fork } });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.forkSession('source-session', { signal: controller.signal });
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+    pendingFork.resolve({ error: { message: 'fork rejected' } });
+
+    await expect(outcome).rejects.toBe(reason);
+  });
+
+  it('keeps the endpoint alive through shutdown until a cancelled native fork is cleaned up', async () => {
+    const pendingFork = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const remove = mock(() => Promise.resolve({ data: true }));
+    const { close, runtime } = createRuntimeWithClient({
+      session: { fork, delete: remove },
+    }, { shutdownStartupGraceMs: 5 });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.runProtectedNativeFork(() => (
+      runtime.forkSession('source-session', { signal: controller.signal })
+    )).then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+    const shutdown = runtime.shutdown();
+    const beforeForkCompletes = await Promise.race([
+      shutdown.then(() => 'stopped'),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ]);
+    expect(beforeForkCompletes).toBe('still-pending');
+    expect(close).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+
+    await expect(outcome).resolves.toEqual({ status: 'rejected', error: reason });
+    await shutdown;
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds shutdown when a native fork never produces a child id', async () => {
+    const fork = mock(() => new Promise(() => {}));
+    const warn = mock(() => {});
+    const { close, runtime } = createRuntimeWithClient({ session: { fork } }, {
+      shutdownNativeForkGraceMs: 5,
+      logger: { debug() {}, info() {}, warn, error() {} },
+    });
+    const pendingFork = runtime.runProtectedNativeFork(() => runtime.forkSession('source-session'));
+
+    await waitForMockCall(fork);
+    await runtime.shutdown();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'OpenCode shutdown abandoned native session cleanup',
+      { pendingOperations: 1, retainedDeletions: 0, timeoutMs: 5 },
+    );
+    await expect(Promise.race([
+      pendingFork.then(() => 'settled', () => 'settled'),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 10)),
+    ])).resolves.toBe('still-pending');
+  });
+
+  it('warns when shutdown loses a retained child deletion after fast cleanup failure', async () => {
+    const pendingFork = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const remove = mock(() => Promise.reject(new Error('delete failed')));
+    const warn = mock(() => {});
+    const { close, runtime } = createRuntimeWithClient({
+      session: { fork, delete: remove },
+    }, {
+      logger: { debug() {}, info() {}, warn, error() {} },
+      shutdownNativeForkGraceMs: 100,
+    });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.runProtectedNativeFork(() => (
+      runtime.forkSession('source-session', { signal: controller.signal })
+    ));
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+    const shutdown = runtime.shutdown();
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+
+    await expect(outcome).rejects.toBe(reason);
+    await shutdown;
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'OpenCode shutdown abandoned native session cleanup',
+      { pendingOperations: 0, retainedDeletions: 1, timeoutMs: 100 },
+    );
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds shutdown around an explicit child deletion still in flight', async () => {
+    const pendingDelete = deferred();
+    const remove = mock(() => pendingDelete.promise);
+    const warn = mock(() => {});
+    const { close, runtime } = createRuntimeWithClient({
+      session: { delete: remove },
+    }, {
+      logger: { debug() {}, info() {}, warn, error() {} },
+      shutdownNativeForkGraceMs: 5,
+    });
+    await runtime.withClientLease(async () => undefined);
+    const discard = runtime.discardSession('forked-session');
+
+    await waitForMockCall(remove);
+    await runtime.shutdown();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'OpenCode shutdown abandoned native session cleanup',
+      { pendingOperations: 1, retainedDeletions: 0, timeoutMs: 5 },
+    );
+
+    pendingDelete.reject(new Error('endpoint closed'));
+    await discard;
+  });
+
+  it('deletes a cancelled late fork through an already-installed replacement endpoint', async () => {
+    const pendingFork = deferred();
+    const termination = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const retiredDelete = mock(() => Promise.reject(new Error('retired endpoint')));
+    const replacementDelete = mock(() => Promise.resolve({ data: true }));
+    let factoryCalls = 0;
+    const createInstance = mock(() => {
+      factoryCalls += 1;
+      return Promise.resolve(factoryCalls === 1
+        ? {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { fork, delete: retiredDelete },
+          },
+          server: { close: mock(() => {}), termination: termination.promise },
+        }
+        : {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { delete: replacementDelete },
+          },
+          server: { close: mock(() => {}) },
+        });
+    });
+    const runtime = new OpenCodeRuntime({ createInstance });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.forkSession('source-session', { signal: controller.signal }).then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+    termination.resolve({ kind: 'exit', code: 1, signal: null });
+    await waitForCondition(() => runtime.getClientIfInitialized() === null);
+    await runtime.getClient();
+
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+
+    await expect(outcome).resolves.toEqual({ status: 'rejected', error: reason });
+    await waitForMockCall(replacementDelete);
+    expect(retiredDelete).not.toHaveBeenCalled();
+    expect(replacementDelete.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+    await runtime.shutdown();
+  });
+
+  it('retries a cancelled fork deletion that rejects after endpoint replacement', async () => {
+    const pendingFork = deferred();
+    const pendingDelete = deferred();
+    const termination = deferred();
+    const fork = mock(() => pendingFork.promise);
+    const retiredDelete = mock(() => pendingDelete.promise);
+    const replacementDelete = mock(() => Promise.resolve({ data: true }));
+    let factoryCalls = 0;
+    const createInstance = mock(() => {
+      factoryCalls += 1;
+      return Promise.resolve(factoryCalls === 1
+        ? {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { fork, delete: retiredDelete },
+          },
+          server: { close: mock(() => {}), termination: termination.promise },
+        }
+        : {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { delete: replacementDelete },
+          },
+          server: { close: mock(() => {}) },
+        });
+    });
+    const runtime = new OpenCodeRuntime({ createInstance });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.forkSession('source-session', { signal: controller.signal }).then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
+
+    await waitForMockCall(fork);
+    controller.abort(reason);
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+    await waitForMockCall(retiredDelete);
+
+    termination.resolve({ kind: 'exit', code: 1, signal: null });
+    await waitForCondition(() => runtime.getClientIfInitialized() === null);
+    await runtime.getClient();
+    expect(replacementDelete).not.toHaveBeenCalled();
+
+    pendingDelete.reject(new Error('retired endpoint'));
+
+    await expect(outcome).resolves.toEqual({ status: 'rejected', error: reason });
+    await waitForMockCall(replacementDelete);
+    expect(replacementDelete.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+    await runtime.shutdown();
   });
 
   it('routes native fork requests through the source project directory', async () => {
@@ -202,6 +509,67 @@ describe('OpenCodeRuntime fork', () => {
     expect(payload.permission).toContainEqual({ permission: 'plan_enter', pattern: '*', action: 'deny' });
   });
 
+  it('lets the fork permission update outlive the ordinary request timeout', async () => {
+    const pendingUpdate = deferred();
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => pendingUpdate.promise);
+    const { runtime } = createRuntimeWithClient({ session: { fork, update } }, { requestTimeoutMs: 5 });
+    const outcome = runtime.forkSession('source-session', {
+      permissionMode: 'bypassPermissions',
+    });
+
+    await waitForMockCall(update);
+    await expect(Promise.race([
+      outcome.then(() => 'settled', () => 'settled'),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ])).resolves.toBe('still-pending');
+    expect(update.mock.calls[0][1].signal.aborted).toBe(false);
+
+    pendingUpdate.resolve({ data: { id: 'forked-session' } });
+    await expect(outcome).resolves.toBe('forked-session');
+  });
+
+  it('deletes the child and preserves cancellation during the permission update', async () => {
+    const pendingUpdate = deferred();
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => pendingUpdate.promise);
+    const remove = mock(() => Promise.resolve({ data: true }));
+    const { runtime } = createRuntimeWithClient({ session: { fork, update, delete: remove } });
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const outcome = runtime.forkSession('source-session', {
+      permissionMode: 'bypassPermissions',
+      signal: controller.signal,
+    });
+
+    await waitForMockCall(update);
+    controller.abort(reason);
+
+    await expect(outcome).rejects.toBe(reason);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+  });
+
+  it('deletes the child when a successful permission update races admission cancellation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const update = mock(() => {
+      controller.abort(reason);
+      return Promise.resolve({ data: { id: 'forked-session' } });
+    });
+    const remove = mock(() => Promise.resolve({ data: true }));
+    const { runtime } = createRuntimeWithClient({ session: { fork, update, delete: remove } });
+
+    await expect(runtime.forkSession('source-session', {
+      permissionMode: 'bypassPermissions',
+      signal: controller.signal,
+    })).rejects.toBe(reason);
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+  });
+
   it('deletes the forked session when the permission update fails', async () => {
     const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
     const update = mock(() => Promise.resolve({ error: { message: 'update rejected' } }));
@@ -280,6 +648,52 @@ describe('OpenCodeRuntime fork', () => {
     await runtime.getClient();
     await waitForCondition(() => replacementDelete.mock.calls.length > 0);
     expect(replacementDelete.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+    await runtime.shutdown();
+  });
+
+  it('retains an explicit fork discard and replays it on a replacement endpoint', async () => {
+    const termination = deferred();
+    const deadDelete = mock(() => Promise.reject(new Error('dead endpoint')));
+    const replacementDelete = mock(() => Promise.resolve({ data: true }));
+    let factoryCalls = 0;
+    const createInstance = mock(() => {
+      factoryCalls += 1;
+      return Promise.resolve(factoryCalls === 1
+        ? {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { delete: deadDelete },
+          },
+          server: {
+            close: mock(() => {}),
+            termination: termination.promise,
+          },
+        }
+        : {
+          client: {
+            permission: { reply: mock(() => Promise.resolve({})) },
+            global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+            session: { delete: replacementDelete },
+          },
+          server: { close: mock(() => {}) },
+        });
+    });
+    const runtime = new OpenCodeRuntime({ createInstance });
+
+    await runtime.getClient();
+    await runtime.discardSession('forked-session', '/repo');
+    expect(deadDelete).toHaveBeenCalledTimes(1);
+
+    termination.resolve({ kind: 'exit', code: 1, signal: null });
+    await waitForCondition(() => runtime.getClientIfInitialized() === null);
+    await runtime.getClient();
+    await waitForMockCall(replacementDelete);
+
+    expect(replacementDelete.mock.calls[0][0]).toMatchObject({
+      sessionID: 'forked-session',
+      directory: '/repo',
+    });
     await runtime.shutdown();
   });
 

--- a/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
@@ -9,8 +9,19 @@ async function* neverEndingStream() {
   await new Promise(() => {});
 }
 
-function createForking(session) {
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createForking(session, runtimeOptions = {}) {
   const update = mock(() => Promise.resolve({ data: {} }));
+  const close = mock(() => {});
   const runtime = new OpenCodeRuntime({
     createInstance: mock(() => Promise.resolve({
       client: {
@@ -18,14 +29,16 @@ function createForking(session) {
         global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
         session: { update, ...session },
       },
-      server: { close: mock(() => {}) },
+      server: { close },
     })),
+    ...runtimeOptions,
   });
   const nativeSessions = createPathNativeSessionCodec('opencode');
   return {
     runtime,
     nativeSessions,
     update,
+    close,
     forking: createOpenCodeNativeForking({
       runtime,
       nativeSessions,
@@ -96,21 +109,32 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
     });
   });
 
-  it('propagates admission cancellation into the native fork request', async () => {
+  it('deletes a native child before surfacing post-start admission cancellation', async () => {
     const controller = new AbortController();
     const reason = new Error('fork admission cancelled');
-    let providerSignal;
-    const fork = mock((_input, options) => {
-      providerSignal = options.signal;
+    const started = deferred();
+    const pendingFork = deferred();
+    const remove = mock(() => Promise.resolve({ data: true }));
+    const fork = mock(() => {
       controller.abort(reason);
-      return Promise.reject(options.signal.reason);
+      started.resolve();
+      return pendingFork.promise;
     });
-    const { forking } = createForking({ fork });
-
-    await expect(forking.fork(forkRequest({
+    const { forking } = createForking({ fork, delete: remove });
+    const outcome = forking.fork(forkRequest({
       admission: { signal: controller.signal, markStarted: () => Promise.resolve() },
-    }))).rejects.toBe(reason);
-    expect(providerSignal.aborted).toBe(true);
+    })).then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
+
+    await started.promise;
+    expect(remove).not.toHaveBeenCalled();
+    pendingFork.resolve({ data: { id: 'forked-session' } });
+
+    await expect(outcome).resolves.toEqual({ status: 'rejected', error: reason });
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
   });
 
   it('applies the request permission mode to the forked native session', async () => {
@@ -143,6 +167,86 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
       messageID: 'msg_a0',
       directory: '/repo',
     });
+  });
+
+  it('preserves admission cancellation during boundary lookup', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const started = deferred();
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const messages = mock((_input, requestOptions) => new Promise((_resolve, reject) => {
+      started.resolve();
+      requestOptions.signal.addEventListener('abort', () => reject(requestOptions.signal.reason), { once: true });
+    }));
+    const { forking } = createForking({ fork, messages });
+    const outcome = forking.fork(forkRequest({
+      admission: { signal: controller.signal, markStarted: () => Promise.resolve() },
+      providerMeta: { entryId: 'prt_b1' },
+    }));
+
+    await started.promise;
+    controller.abort(reason);
+
+    await expect(outcome).rejects.toBe(reason);
+    expect(fork).not.toHaveBeenCalled();
+  });
+
+  it('rejects boundary admission during cold startup without later reading or forking', async () => {
+    const startupStarted = deferred();
+    const pendingInstance = deferred();
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const messages = mock(() => Promise.resolve({ data: STORED_SOURCE_MESSAGES }));
+    let startupSignal;
+    const createInstance = mock(({ signal }) => {
+      startupSignal = signal;
+      startupStarted.resolve();
+      return pendingInstance.promise;
+    });
+    const { forking, runtime } = createForking({ fork, messages }, { createInstance });
+    const outcome = forking.fork(forkRequest({
+      admission: { signal: controller.signal, markStarted: () => Promise.resolve() },
+      providerMeta: { entryId: 'prt_b1' },
+    }));
+
+    await startupStarted.promise;
+    controller.abort(reason);
+
+    await expect(Promise.race([
+      outcome.then(() => 'fulfilled', (error) => error),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ])).resolves.toBe(reason);
+    expect(startupSignal.aborted).toBe(false);
+
+    pendingInstance.resolve({
+      client: {
+        permission: { reply: mock(() => Promise.resolve({})) },
+        global: { event: mock(() => Promise.resolve({ stream: neverEndingStream() })) },
+        session: { fork, messages },
+      },
+      server: { close: mock(() => {}) },
+    });
+    await runtime.shutdown();
+    expect(messages).not.toHaveBeenCalled();
+    expect(fork).not.toHaveBeenCalled();
+  });
+
+  it('preserves cancellation when boundary lookup resolves without a usable anchor', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const messages = mock(() => {
+      controller.abort(reason);
+      return Promise.resolve({ data: [] });
+    });
+    const { forking } = createForking({ fork, messages });
+
+    await expect(forking.fork(forkRequest({
+      admission: { signal: controller.signal, markStarted: () => Promise.resolve() },
+      providerMeta: { entryId: 'prt_b1' },
+    }))).rejects.toBe(reason);
+    expect(fork).not.toHaveBeenCalled();
   });
 
   it('bounds message anchors chronologically and omits the boundary at the tip', async () => {
@@ -190,7 +294,52 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
 
     expect(failure).not.toBeNull();
     expect(sessionDelete).toHaveBeenCalledTimes(1);
-    expect(sessionDelete.mock.calls[0][0]).toEqual({ sessionID: 'forked-session' });
+    expect(sessionDelete.mock.calls[0][0]).toEqual({
+      sessionID: 'forked-session',
+      directory: '/repo',
+    });
+  });
+
+  it('keeps shutdown from closing the endpoint before failed receipt retargeting deletes the child', async () => {
+    const receipt = receiptForCarriedContext({ prefix: 'SEED::' }, 'source-session');
+    const messagesStarted = deferred();
+    const pendingMessages = deferred();
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const sessionDelete = mock(() => Promise.resolve({ data: true }));
+    const get = mock(() => Promise.resolve({ data: { directory: '/repo' } }));
+    const messages = mock(() => {
+      messagesStarted.resolve();
+      return pendingMessages.promise;
+    });
+    const { close, forking, runtime } = createForking(
+      { fork, delete: sessionDelete, get, messages },
+      { shutdownNativeForkGraceMs: 100 },
+    );
+    const outcome = forking.fork(forkRequest({
+      source: {
+        chatId: 'source-chat',
+        agentId: 'opencode',
+        agentSessionId: 'source-session',
+        nativeSession: null,
+        nativeSeedReceipt: receipt,
+      },
+    }));
+
+    await messagesStarted.promise;
+    const shutdown = runtime.shutdown();
+    await expect(Promise.race([
+      shutdown.then(() => 'stopped'),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 25)),
+    ])).resolves.toBe('still-pending');
+    expect(close).not.toHaveBeenCalled();
+    expect(sessionDelete).not.toHaveBeenCalled();
+
+    pendingMessages.resolve({ error: { message: 'fork history unavailable' } });
+
+    await expect(outcome).rejects.toThrow();
+    await shutdown;
+    expect(sessionDelete).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('refuses a point fork of a session with no stored messages as source-missing', async () => {
@@ -267,9 +416,45 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
     });
   });
 
+  it('deletes the child when successful seed loading races admission cancellation', async () => {
+    const receipt = receiptForCarriedContext({ prefix: 'SEED::' }, 'source-session');
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
+    const sessionDelete = mock(() => Promise.resolve({ data: true }));
+    const get = mock(() => Promise.resolve({ data: { directory: '/repo' } }));
+    const messages = mock(() => {
+      controller.abort(reason);
+      return Promise.resolve({
+        data: [
+          storedMessage('msg_f1', 'user', [{ type: 'text', text: 'SEED::first prompt' }]),
+          storedMessage('msg_f2', 'assistant', [
+            { id: 'prt_f2', type: 'text', text: 'first reply' },
+          ]),
+        ],
+      });
+    });
+    const { forking } = createForking({ fork, delete: sessionDelete, get, messages });
+
+    await expect(forking.fork(forkRequest({
+      admission: { signal: controller.signal, markStarted: () => Promise.resolve() },
+      source: {
+        chatId: 'source-chat',
+        agentId: 'opencode',
+        agentSessionId: 'source-session',
+        nativeSession: null,
+        nativeSeedReceipt: receipt,
+      },
+    }))).rejects.toBe(reason);
+
+    expect(sessionDelete).toHaveBeenCalledTimes(1);
+    expect(sessionDelete.mock.calls[0][0]).toMatchObject({ sessionID: 'forked-session' });
+  });
+
   it('deletes the forked session on discard', async () => {
     const sessionDelete = mock(() => Promise.resolve({}));
-    const { forking } = createForking({ delete: sessionDelete });
+    const { forking, runtime } = createForking({ delete: sessionDelete });
+    await runtime.getClient();
 
     await forking.discard(
       { agentSessionId: 'forked-session', nativeSession: null, nativeSeedReceipt: null },

--- a/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/forking.test.js
@@ -81,8 +81,9 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
   it('forks the whole session without a boundary and encodes the forked session', async () => {
     const fork = mock(() => Promise.resolve({ data: { id: 'forked-session' } }));
     const { forking, nativeSessions } = createForking({ fork });
+    const request = forkRequest();
 
-    const outcome = await forking.fork(forkRequest());
+    const outcome = await forking.fork(request);
 
     expect(outcome.kind).toBe('materialized');
     expect(outcome.session.agentSessionId).toBe('forked-session');
@@ -93,6 +94,23 @@ describe('[TLV5-FORK.01-OPENCODE-UNIT-01] OpenCode native forking facet', () => 
       sessionID: 'source-session',
       directory: '/repo',
     });
+  });
+
+  it('propagates admission cancellation into the native fork request', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    let providerSignal;
+    const fork = mock((_input, options) => {
+      providerSignal = options.signal;
+      controller.abort(reason);
+      return Promise.reject(options.signal.reason);
+    });
+    const { forking } = createForking({ fork });
+
+    await expect(forking.fork(forkRequest({
+      admission: { signal: controller.signal, markStarted: () => Promise.resolve() },
+    }))).rejects.toBe(reason);
+    expect(providerSignal.aborted).toBe(true);
   });
 
   it('applies the request permission mode to the forked native session', async () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/history-loader.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/history-loader.test.js
@@ -20,6 +20,16 @@ import { convertOpenCodeEventToChatMessages } from '../event-converter.js';
 let originalError;
 let originalWarn;
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 const invalidImportPartCases = [
   ['user text missing', 'user', { type: 'text' }],
   ['user text non-string', 'user', { type: 'text', text: 17 }],
@@ -784,6 +794,50 @@ describe('OpenCode history loader', () => {
     expect(outcomes).toEqual(invalidImportPartCases.map(([label]) => [label, 'rejected']));
     expect(get).toHaveBeenCalledTimes(invalidImportPartCases.length + 3);
     expect(messages).toHaveBeenCalledTimes(invalidImportPartCases.length + 3);
+  });
+
+  it('preserves cancellation when the scoped session request rejects', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const pendingGet = deferred();
+    const get = mock((_args, options) => pendingGet.promise);
+    const messages = mock(() => Promise.resolve({ data: [] }));
+    const getClient = mock(() => Promise.resolve({ session: { get, messages } }));
+    const outcome = loadRequiredOpenCodeChatMessages('session-1', getClient, {
+      directory: '/repo',
+      signal: controller.signal,
+    });
+
+    await Promise.resolve();
+    controller.abort(reason);
+    pendingGet.reject(new Error('session transport failed'));
+
+    await expect(outcome).rejects.toBe(reason);
+    expect(get).toHaveBeenCalledWith(
+      { sessionID: 'session-1', directory: '/repo' },
+      { signal: controller.signal },
+    );
+    expect(messages).not.toHaveBeenCalled();
+  });
+
+  it('preserves cancellation when the scoped session request resolves with an error', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const pendingGet = deferred();
+    const get = mock(() => pendingGet.promise);
+    const messages = mock(() => Promise.resolve({ data: [] }));
+    const getClient = mock(() => Promise.resolve({ session: { get, messages } }));
+    const outcome = loadRequiredOpenCodeChatMessages('session-1', getClient, {
+      directory: '/repo',
+      signal: controller.signal,
+    });
+
+    await Promise.resolve();
+    controller.abort(reason);
+    pendingGet.resolve({ error: { message: 'session unavailable' } });
+
+    await expect(outcome).rejects.toBe(reason);
+    expect(messages).not.toHaveBeenCalled();
   });
 
   it('passes directory when loading transcript messages', async () => {

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -362,6 +362,65 @@ describe('OpenCode operation routing', () => {
     await runtime.shutdown();
   });
 
+  it('quietly drops fork replay from unknown sessions but warns for managed sessions', async () => {
+    const debugLogs = [];
+    const warnings = [];
+    const { eventStream, runtime } = createRuntime(['session-1'], {
+      logger: {
+        debug(...args) { debugLogs.push(args); },
+        info() {},
+        warn(...args) { warnings.push(args); },
+        error() {},
+      },
+    });
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: operation('run-a', events),
+    });
+
+    eventStream.push({
+      id: 'event-fork-message',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'forked-session',
+        info: { id: 'message-forked', role: 'user' },
+      },
+    });
+    eventStream.push({
+      id: 'event-fork-part',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'forked-session',
+        part: { id: 'part-forked', messageID: 'message-forked', type: 'text', text: 'copied' },
+      },
+    });
+    await waitFor(() => debugLogs.filter((entry) => (
+      entry[0] === 'Ignoring an OpenCode event without an operation identity'
+    )).length === 2);
+    expect(warnings).toEqual([]);
+
+    eventStream.push({
+      id: 'event-managed-orphan',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session-1',
+        part: { id: 'part-orphan', messageID: 'message-orphan', type: 'text', text: 'orphan' },
+      },
+    });
+    await waitFor(() => warnings.length === 1);
+    expect(warnings[0]).toEqual([
+      'Ignoring an OpenCode event without an operation identity',
+      expect.objectContaining({ eventId: 'event-managed-orphan', sessionId: 'session-1' }),
+    ]);
+    expect(events).toEqual([]);
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
   it('[TLV5-PERM.09-OPENCODE-UNIT-01] logs and drops a permission without an operation identity', async () => {
     const warnings = [];
     const { eventStream, runtime } = createRuntime(['session-1'], {

--- a/server-agents/opencode/src/agents/opencode/endpoint-coordinator.ts
+++ b/server-agents/opencode/src/agents/opencode/endpoint-coordinator.ts
@@ -12,6 +12,11 @@ interface OpenCodeEndpointInstance {
   readonly client: unknown;
 }
 
+interface OpenCodeClientLease {
+  readonly client: any;
+  release(): void;
+}
+
 interface OpenCodeEndpointCoordinatorOptions {
   readonly assertAvailable: () => void;
   readonly ensureUnlocked: () => Promise<OpenCodeEndpointInstance>;
@@ -36,6 +41,7 @@ export class OpenCodeEndpointCoordinator {
   readonly #options: OpenCodeEndpointCoordinatorOptions;
   #requestLeases = 0;
   #turnAdmissions = 0;
+  readonly #protectedNativeWork = new Set<Promise<unknown>>();
   #transitionTail: Promise<void> = Promise.resolve();
 
   constructor(options: OpenCodeEndpointCoordinatorOptions) {
@@ -58,19 +64,42 @@ export class OpenCodeEndpointCoordinator {
     }
   }
 
-  async withClientLease<T>(operation: (client: any) => Promise<T>): Promise<T> {
-    let client: any;
-    await this.runTransition(async () => {
+  async withClientLease<T>(
+    operation: (client: any) => Promise<T>,
+    admissionSignal?: AbortSignal,
+  ): Promise<T> {
+    const pendingLease = this.runTransition(async (): Promise<OpenCodeClientLease> => {
+      admissionSignal?.throwIfAborted();
       this.#options.assertAvailable();
-      client = (await this.#options.ensureUnlocked()).client;
+      const client = (await this.#options.ensureUnlocked()).client;
+      admissionSignal?.throwIfAborted();
       this.#requestLeases += 1;
       this.#options.onActivity();
+      let released = false;
+      return {
+        client,
+        release: () => {
+          if (released) return;
+          released = true;
+          this.#requestLeases -= 1;
+          this.#options.onActivity();
+        },
+      };
     });
+    let lease: OpenCodeClientLease;
     try {
-      return await operation(client);
+      lease = admissionSignal
+        ? await waitForPromiseOrAbort(pendingLease, admissionSignal)
+        : await pendingLease;
+      admissionSignal?.throwIfAborted();
+    } catch (error) {
+      void pendingLease.then((lateLease) => lateLease.release(), () => undefined);
+      throw error;
+    }
+    try {
+      return await operation(lease.client);
     } finally {
-      this.#requestLeases -= 1;
-      this.#options.onActivity();
+      lease.release();
     }
   }
 
@@ -94,46 +123,115 @@ export class OpenCodeEndpointCoordinator {
     this.#options.onActivity();
   }
 
+  runProtectedNativeFork<T>(operation: () => Promise<T>): Promise<T> {
+    return this.#trackProtectedNativeWork(operation);
+  }
+
+  runProtectedNativeCleanup<T>(operation: () => Promise<T>): Promise<T> {
+    return this.#trackProtectedNativeWork(operation);
+  }
+
+  #trackProtectedNativeWork<T>(operation: () => Promise<T>): Promise<T> {
+    const pending = operation();
+    this.#protectedNativeWork.add(pending);
+    void pending.then(
+      () => this.#protectedNativeWork.delete(pending),
+      () => this.#protectedNativeWork.delete(pending),
+    );
+    return pending;
+  }
+
+  async waitForProtectedNativeWork(
+    timeoutMs: number,
+    retainedDeletionCount: () => number,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let pendingOperations = 0;
+    while (this.#protectedNativeWork.size > 0) {
+      const remainingMs = Math.max(0, deadline - Date.now());
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      const completed = await Promise.race([
+        Promise.allSettled([...this.#protectedNativeWork]).then(() => true),
+        new Promise<false>((resolve) => {
+          timeout = setTimeout(() => resolve(false), remainingMs);
+          timeout.unref?.();
+        }),
+      ]);
+      if (timeout) clearTimeout(timeout);
+      if (!completed) {
+        pendingOperations = this.#protectedNativeWork.size;
+        break;
+      }
+    }
+    const retainedDeletions = retainedDeletionCount();
+    if (pendingOperations > 0 || retainedDeletions > 0) {
+      this.#options.logger.warn('OpenCode shutdown abandoned native session cleanup', {
+        pendingOperations,
+        retainedDeletions,
+        timeoutMs,
+      });
+    }
+  }
+
   async forkSession(
     sourceSessionId: string,
     options: { projectPath?: string | null; messageId?: string; signal?: AbortSignal },
     runScopedRequest: ScopedSessionRequest,
+    discardCancelledFork: (
+      client: any,
+      forkedSessionId: string,
+      scope: OpenCodeRequestScope,
+    ) => Promise<void>,
   ): Promise<string> {
     const sessionID = sourceSessionId.trim();
     if (!sessionID) throw new Error('Cannot fork OpenCode session: missing source session id');
     const scope = createOpenCodeRequestScope(options.projectPath);
-    const result: any = await this.withClientLease((client) => runScopedRequest(
-      'OpenCode session fork',
-      scope,
-      (signal, requestScope) => client.session.fork(
-        withOpenCodeRequestScope({
-          sessionID,
-          ...(options.messageId ? { messageID: options.messageId } : {}),
-        }, requestScope),
-        { signal },
-      ),
-      { signal: options.signal, timeoutMs: null },
-    ));
-    // A source session the provider cannot return has no native fork position;
-    // the typed source-level refusal keeps the handoff-fork consent flow
-    // reachable instead of dead-ending the request in an untyped failure.
-    if (isOpenCodeNotFoundResult(result)) {
-      throw new AgentIntegrationError(
-        'TRANSCRIPT_UNAVAILABLE',
-        'The OpenCode source session is unavailable',
-        true,
-        { nativeForkReason: 'source-missing' },
-      );
-    }
-    if (result?.error) {
-      throw new AgentIntegrationError(
-        'TRANSCRIPT_UNAVAILABLE',
-        openCodeResultErrorMessage(result, 'OpenCode session fork failed'),
-        true,
-      );
-    }
-    const forkedSessionId = typeof result?.data?.id === 'string' ? result.data.id.trim() : '';
-    if (!forkedSessionId) throw new Error('OpenCode session fork did not return a session id');
+    const forkedSessionId = await this.withClientLease(async (client) => {
+      options.signal?.throwIfAborted();
+      let result: any;
+      try {
+        result = await runScopedRequest(
+          'OpenCode session fork',
+          scope,
+          (signal, requestScope) => client.session.fork(
+            withOpenCodeRequestScope({
+              sessionID,
+              ...(options.messageId ? { messageID: options.messageId } : {}),
+            }, requestScope),
+            { signal },
+          ),
+          { timeoutMs: null },
+        );
+      } catch (error) {
+        options.signal?.throwIfAborted();
+        throw error;
+      }
+      const forkedSessionId = typeof result?.data?.id === 'string' ? result.data.id.trim() : '';
+      if (options.signal?.aborted) {
+        if (forkedSessionId) await discardCancelledFork(client, forkedSessionId, scope);
+        options.signal.throwIfAborted();
+      }
+      // A source session the provider cannot return has no native fork position;
+      // the typed source-level refusal keeps the handoff-fork consent flow
+      // reachable instead of dead-ending the request in an untyped failure.
+      if (isOpenCodeNotFoundResult(result)) {
+        throw new AgentIntegrationError(
+          'TRANSCRIPT_UNAVAILABLE',
+          'The OpenCode source session is unavailable',
+          true,
+          { nativeForkReason: 'source-missing' },
+        );
+      }
+      if (result?.error) {
+        throw new AgentIntegrationError(
+          'TRANSCRIPT_UNAVAILABLE',
+          openCodeResultErrorMessage(result, 'OpenCode session fork failed'),
+          true,
+        );
+      }
+      if (!forkedSessionId) throw new Error('OpenCode session fork did not return a session id');
+      return forkedSessionId;
+    }, options.signal);
     this.#options.logger.info('OpenCode session forked', { sourceSessionId: sessionID, forkedSessionId });
     return forkedSessionId;
   }
@@ -169,4 +267,23 @@ export class OpenCodeEndpointCoordinator {
       throwOpenCodeResultError(result, 'OpenCode session move failed');
     });
   }
+}
+
+function waitForPromiseOrAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (settle: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      settle();
+    };
+    const onAbort = () => finish(() => reject(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+    if (signal.aborted) onAbort();
+  });
 }

--- a/server-agents/opencode/src/agents/opencode/endpoint-coordinator.ts
+++ b/server-agents/opencode/src/agents/opencode/endpoint-coordinator.ts
@@ -23,12 +23,13 @@ type ScopedSessionRequest = <T>(
   label: string,
   scope: OpenCodeRequestScope,
   operation: (signal: AbortSignal, scope: OpenCodeRequestScope) => Promise<T>,
+  control?: { signal?: AbortSignal; timeoutMs?: number | null },
 ) => Promise<T>;
 
 type OpenCodeRequest = <T>(
   label: string,
   operation: (signal: AbortSignal) => Promise<T>,
-  control?: { signal?: AbortSignal; timeoutMs?: number },
+  control?: { signal?: AbortSignal; timeoutMs?: number | null },
 ) => Promise<T>;
 
 export class OpenCodeEndpointCoordinator {
@@ -95,7 +96,7 @@ export class OpenCodeEndpointCoordinator {
 
   async forkSession(
     sourceSessionId: string,
-    options: { projectPath?: string | null; messageId?: string },
+    options: { projectPath?: string | null; messageId?: string; signal?: AbortSignal },
     runScopedRequest: ScopedSessionRequest,
   ): Promise<string> {
     const sessionID = sourceSessionId.trim();
@@ -111,6 +112,7 @@ export class OpenCodeEndpointCoordinator {
         }, requestScope),
         { signal },
       ),
+      { signal: options.signal, timeoutMs: null },
     ));
     // A source session the provider cannot return has no native fork position;
     // the typed source-level refusal keeps the handoff-fork consent flow

--- a/server-agents/opencode/src/agents/opencode/forking.ts
+++ b/server-agents/opencode/src/agents/opencode/forking.ts
@@ -2,6 +2,7 @@ import {
   AgentIntegrationError,
   type AgentChatReference,
   type AgentNativeFork,
+  type AgentNativeForkOutcome,
   type AgentNativeForkRequest,
 } from '@garcon/server-agent-interface';
 import { retargetNativeSeedReceiptIfPreserved } from '@garcon/common/transcript-seed';
@@ -32,54 +33,63 @@ export function createOpenCodeNativeForking(
   options: OpenCodeForkingOptions,
 ): AgentNativeFork {
   return {
-    async fork(request) {
-      request.admission.signal.throwIfAborted();
-      const sourceSessionId = options.sessionId(request.source);
-      if (!sourceSessionId) {
-        if (request.providerMeta) throw notSettled();
-        return { kind: 'unmaterialized' };
-      }
-      const boundaryMessageId = request.providerMeta
-        ? await resolveExclusiveBoundaryMessageId(options.runtime, request, sourceSessionId)
-        : null;
-      const forkedSessionId = await options.runtime.forkSession(sourceSessionId, {
-        projectPath: request.projectPath,
-        // The forked native session must carry the chat's ruleset; OpenCode's fork
-        // does not inherit it from the source session.
-        permissionMode: request.permissionMode,
-        signal: request.admission.signal,
-        // OpenCode resolves the boundary by exact identity and clones its
-        // chronological prefix.
-        // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/session/session.ts#L704-L706
-        ...(boundaryMessageId ? { messageId: boundaryMessageId } : {}),
-      });
-      try {
-        return {
-          kind: 'materialized',
-          session: {
-            agentSessionId: forkedSessionId,
-            nativeSession: options.nativeSessions.encode({
-              path: createArtificialNativePath('opencode', forkedSessionId),
-              agentSessionId: forkedSessionId,
-              modelEndpointId: null,
-            }),
-            nativeSeedReceipt: await retargetForkedSeedReceipt(
-              options.runtime,
-              request,
-              forkedSessionId,
-            ),
-          },
-        };
-      } catch (error) {
-        await options.runtime.deleteSession(forkedSessionId).catch(() => undefined);
-        throw error;
-      }
+    fork(request) {
+      return options.runtime.runProtectedNativeFork(() => forkOpenCodeSession(options, request));
     },
     async discard(session, signal) {
       signal.throwIfAborted();
-      await options.runtime.deleteSession(session.agentSessionId, signal);
+      await options.runtime.discardSession(session.agentSessionId);
     },
   };
+}
+
+async function forkOpenCodeSession(
+  options: OpenCodeForkingOptions,
+  request: AgentNativeForkRequest,
+): Promise<AgentNativeForkOutcome> {
+  request.admission.signal.throwIfAborted();
+  const sourceSessionId = options.sessionId(request.source);
+  if (!sourceSessionId) {
+    if (request.providerMeta) throw notSettled();
+    return { kind: 'unmaterialized' };
+  }
+  const boundaryMessageId = request.providerMeta
+    ? await resolveExclusiveBoundaryMessageId(options.runtime, request, sourceSessionId)
+    : null;
+  const forkedSessionId = await options.runtime.forkSession(sourceSessionId, {
+    projectPath: request.projectPath,
+    // The forked native session must carry the chat's ruleset; OpenCode's fork
+    // does not inherit it from the source session.
+    permissionMode: request.permissionMode,
+    signal: request.admission.signal,
+    // OpenCode resolves the boundary by exact identity and clones its
+    // chronological prefix.
+    // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/session/session.ts#L704-L706
+    ...(boundaryMessageId ? { messageId: boundaryMessageId } : {}),
+  });
+  try {
+    const nativeSeedReceipt = await retargetForkedSeedReceipt(
+      options.runtime,
+      request,
+      forkedSessionId,
+    );
+    request.admission.signal.throwIfAborted();
+    return {
+      kind: 'materialized',
+      session: {
+        agentSessionId: forkedSessionId,
+        nativeSession: options.nativeSessions.encode({
+          path: createArtificialNativePath('opencode', forkedSessionId),
+          agentSessionId: forkedSessionId,
+          modelEndpointId: null,
+        }),
+        nativeSeedReceipt,
+      },
+    };
+  } catch (error) {
+    await options.runtime.discardSession(forkedSessionId, request.projectPath);
+    throw error;
+  }
 }
 
 // Locates the stored message owning the anchor's provider identity; an
@@ -99,7 +109,8 @@ async function resolveExclusiveBoundaryMessageId(
       signal: request.admission.signal,
       throwOnError: true,
     })
-  )).catch((error) => {
+  ), request.admission.signal).catch((error) => {
+    request.admission.signal.throwIfAborted();
     if (error instanceof AgentIntegrationError) throw error;
     throw new AgentIntegrationError(
       'TRANSCRIPT_UNAVAILABLE',
@@ -107,6 +118,7 @@ async function resolveExclusiveBoundaryMessageId(
       true,
     );
   });
+  request.admission.signal.throwIfAborted();
   if (messages.length === 0) throw missingSource();
   const anchorIndex = messages.findIndex((message) => ownsEntry(message, entryId));
   if (anchorIndex < 0) throw notSettled();
@@ -129,7 +141,8 @@ async function retargetForkedSeedReceipt(
       directory: request.projectPath,
       signal: request.admission.signal,
     })
-  ));
+  ), request.admission.signal);
+  request.admission.signal.throwIfAborted();
   return retargetNativeSeedReceiptIfPreserved(receipt, forkedSessionId, forkedMessages);
 }
 

--- a/server-agents/opencode/src/agents/opencode/forking.ts
+++ b/server-agents/opencode/src/agents/opencode/forking.ts
@@ -47,6 +47,7 @@ export function createOpenCodeNativeForking(
         // The forked native session must carry the chat's ruleset; OpenCode's fork
         // does not inherit it from the source session.
         permissionMode: request.permissionMode,
+        signal: request.admission.signal,
         // OpenCode resolves the boundary by exact identity and clones its
         // chronological prefix.
         // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/session/session.ts#L704-L706

--- a/server-agents/opencode/src/agents/opencode/history-loader.ts
+++ b/server-agents/opencode/src/agents/opencode/history-loader.ts
@@ -52,7 +52,10 @@ export interface OpenCodeMessage {
 
 interface OpenCodeClient {
   session: {
-    get(args: { sessionID: string; directory?: string }): Promise<{ data?: OpenCodeSession | null }>;
+    get(
+      args: { sessionID: string; directory?: string },
+      options?: { signal?: AbortSignal },
+    ): Promise<{ data?: OpenCodeSession | null }>;
     messages(
       args: { sessionID: string; limit?: number; directory?: string },
       options?: { signal?: AbortSignal },
@@ -263,7 +266,16 @@ async function requestScopedOpenCodeStoredMessages(
   const client = await getClient();
   const scope = createOpenCodeRequestScope(options.directory);
   const sessionArgs = withOpenCodeRequestScope({ sessionID: sessionId }, scope);
-  const sessionResult = await client.session.get(sessionArgs);
+  let sessionResult;
+  try {
+    sessionResult = options.signal
+      ? await client.session.get(sessionArgs, { signal: options.signal })
+      : await client.session.get(sessionArgs);
+  } catch (error) {
+    options.signal?.throwIfAborted();
+    throw error;
+  }
+  options.signal?.throwIfAborted();
   if (isOpenCodeNotFoundResult(sessionResult)) {
     return { kind: 'not-found' };
   }

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -114,7 +114,8 @@ const RETAINED_SESSION_DELETION_LIMIT = 256;
 const DEFAULT_OPENCODE_SSE_HEARTBEAT_TIMEOUT_MS = 30_000;
 const DEFAULT_OPENCODE_MODEL_CACHE_TTL_MS = 5 * 60_000;
 const DEFAULT_OPENCODE_SHUTDOWN_STARTUP_GRACE_MS = 100;
-
+const DEFAULT_OPENCODE_SHUTDOWN_FORK_GRACE_MS = 3_000;
+type OpenCodeForkSessionOptions = { projectPath?: string | null; messageId?: string; permissionMode?: string; signal?: AbortSignal };
 interface PendingTurnWaiter {
   promise: Promise<Error | null>;
   settle: (failure: Error | null) => void;
@@ -131,12 +132,11 @@ interface OpenCodeRuntimeOptions {
   sseHeartbeatTimeoutMs?: number;
   modelCacheTtlMs?: number;
   shutdownStartupGraceMs?: number;
+  shutdownNativeForkGraceMs?: number;
   idleRetirementDelayMs?: number;
   idleRetirementCheckIntervalMs?: number;
   now?: () => number;
-  createInstance?: (input: {
-    signal: AbortSignal;
-  }) => Promise<OpenCodeInstance>;
+  createInstance?: (input: { signal: AbortSignal }) => Promise<OpenCodeInstance>;
 }
 
 interface NormalizedOpenCodeRuntimeOptions {
@@ -148,11 +148,10 @@ interface NormalizedOpenCodeRuntimeOptions {
   sseHeartbeatTimeoutMs: number;
   modelCacheTtlMs: number;
   shutdownStartupGraceMs: number;
+  shutdownNativeForkGraceMs: number;
   now: () => number;
   requiresExecutable: boolean;
-  createInstance: (input: {
-    signal: AbortSignal;
-  }) => Promise<OpenCodeInstance>;
+  createInstance: (input: { signal: AbortSignal }) => Promise<OpenCodeInstance>;
 }
 
 function normalizeOptions(options: OpenCodeRuntimeOptions): NormalizedOpenCodeRuntimeOptions {
@@ -162,11 +161,12 @@ function normalizeOptions(options: OpenCodeRuntimeOptions): NormalizedOpenCodeRu
     requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS,
     unavailableRetryMs: options.unavailableRetryMs ?? DEFAULT_OPENCODE_UNAVAILABLE_RETRY_MS,
     sseRetryDelayMs: options.sseRetryDelayMs ?? DEFAULT_OPENCODE_SSE_RETRY_DELAY_MS,
-    sseHeartbeatTimeoutMs:
-      options.sseHeartbeatTimeoutMs ?? DEFAULT_OPENCODE_SSE_HEARTBEAT_TIMEOUT_MS,
+    sseHeartbeatTimeoutMs: options.sseHeartbeatTimeoutMs ?? DEFAULT_OPENCODE_SSE_HEARTBEAT_TIMEOUT_MS,
     modelCacheTtlMs: options.modelCacheTtlMs ?? DEFAULT_OPENCODE_MODEL_CACHE_TTL_MS,
     shutdownStartupGraceMs:
       options.shutdownStartupGraceMs ?? DEFAULT_OPENCODE_SHUTDOWN_STARTUP_GRACE_MS,
+    shutdownNativeForkGraceMs:
+      options.shutdownNativeForkGraceMs ?? DEFAULT_OPENCODE_SHUTDOWN_FORK_GRACE_MS,
     now: options.now ?? (() => Date.now()),
     requiresExecutable: options.createInstance === undefined,
     createInstance: options.createInstance ?? createOpenCodeInstance,
@@ -316,8 +316,10 @@ export class OpenCodeRuntime {
     this.#decisions.clear();
     const startup = this.#initPromise;
     this.#startupAbortController?.abort(new Error('OpenCode runtime shutting down'));
-    this.#closeInstance();
     const shutdown = (async () => {
+      // The response carries the only child ID available to clean up a fork after disconnect.
+      await this.#endpointCoordinator.waitForProtectedNativeWork(this.#options.shutdownNativeForkGraceMs, () => this.#pendingSessionDeletions.length);
+      this.#closeInstance();
       await startup?.catch(() => undefined);
       await this.#instanceCreations.waitForCleanup(this.#options.shutdownStartupGraceMs);
       this.#closeInstance();
@@ -497,50 +499,44 @@ export class OpenCodeRuntime {
     }
   }
 
-  // Deletes a native session when possible and retains the deletion for the
-  // next instance otherwise: the provider persists sessions in its own
-  // database, so a leak survives the respawn. A not-found result means the
-  // session is already gone and satisfies the deletion.
-  // Deletes a native session when possible and retains the deletion for the
-  // next instance otherwise: the provider persists sessions in its own
-  // database, so a leak survives the respawn. A not-found result means the
-  // session is already gone and satisfies the deletion. Cleanup carrying a
-  // retired generation never contacts the stale client: a hanging deletion
-  // through a dead endpoint would time out against the current generation and
-  // wrongly arm the cooldown the death path just disarmed.
-  async #deleteSessionBestEffort(
+  // Deletes through the current instance when possible and retains the
+  // deletion otherwise; cleanup must never target a retired client.
+  #deleteSessionBestEffort(
     sessionId: string,
     scope: OpenCodeRequestScope,
     cleanup: { client?: any; generation?: number } = {},
   ): Promise<void> {
-    const retired = cleanup.generation !== undefined
-      && cleanup.generation !== this.#instanceGeneration;
-    const deleteThrough = retired ? null : (cleanup.client ?? (() => this.getClientIfInitialized())());
-    if (!deleteThrough) {
-      this.#retainSessionDeletion(sessionId, scope);
-      return;
-    }
-    try {
-      const result = await this.#runScopedSessionRequest(
-        'OpenCode cancelled session delete',
-        scope,
-        (signal, requestScope) => deleteThrough.session.delete(
-          withOpenCodeRequestScope({ sessionID: sessionId }, requestScope),
-          { signal },
-        ),
-      );
-      if (!isOpenCodeNotFoundResult(result)) {
-        throwOpenCodeResultError(result, 'OpenCode cancelled session delete failed');
+    return this.#endpointCoordinator.runProtectedNativeCleanup(async () => {
+      const currentClient = this.getClientIfInitialized();
+      const originalIsCurrent = cleanup.client === currentClient
+        && (cleanup.generation === undefined || cleanup.generation === this.#instanceGeneration);
+      const deleteThrough = originalIsCurrent ? cleanup.client : currentClient;
+      if (!deleteThrough) {
+        this.#retainSessionDeletion(sessionId, scope);
+        return;
       }
-    } catch {
-      this.#retainSessionDeletion(sessionId, scope);
-    }
+      try {
+        const result = await this.#runScopedSessionRequest(
+          'OpenCode cancelled session delete',
+          scope,
+          (signal, requestScope) => deleteThrough.session.delete(
+            withOpenCodeRequestScope({ sessionID: sessionId }, requestScope),
+            { signal },
+          ),
+        );
+        if (!isOpenCodeNotFoundResult(result)) {
+          throwOpenCodeResultError(result, 'OpenCode cancelled session delete failed');
+        }
+      } catch {
+        this.#retainSessionDeletion(sessionId, scope, deleteThrough);
+      }
+    });
   }
 
   // Retained deletions stay keyed by session id so repeated failures for one
   // session cannot accumulate, and the queue stays bounded: a provider that
   // never accepts deletions must not grow Garcon's memory without limit.
-  #retainSessionDeletion(sessionId: string, scope: OpenCodeRequestScope): void {
+  #retainSessionDeletion(sessionId: string, scope: OpenCodeRequestScope, attemptedClient: any = null): void {
     const existing = this.#pendingSessionDeletions.findIndex((entry) => entry.sessionId === sessionId);
     if (existing >= 0) this.#pendingSessionDeletions.splice(existing, 1);
     if (this.#pendingSessionDeletions.length >= RETAINED_SESSION_DELETION_LIMIT) {
@@ -551,6 +547,8 @@ export class OpenCodeRuntime {
       return;
     }
     this.#pendingSessionDeletions.push({ sessionId, scope });
+    const replacement = attemptedClient && this.getClientIfInitialized();
+    if (replacement && replacement !== attemptedClient) this.#drainPendingSessionDeletions();
   }
 
   // Replays retained deletions through the freshly installed instance. Each
@@ -559,21 +557,25 @@ export class OpenCodeRuntime {
     if (this.#pendingSessionDeletions.length === 0) return;
     const pending = this.#pendingSessionDeletions.splice(0);
     for (const { sessionId, scope } of pending) {
-      void this.withClientLease(async (client) => {
-        const result = await this.#runScopedSessionRequest(
-          'OpenCode retained session delete',
-          scope,
-          (signal, requestScope) => client.session.delete(
-            withOpenCodeRequestScope({ sessionID: sessionId }, requestScope),
-            { signal },
-          ),
-        );
-        if (!isOpenCodeNotFoundResult(result)) {
-          throwOpenCodeResultError(result, 'OpenCode retained session delete failed');
-        }
-      }).catch(() => {
-        this.#retainSessionDeletion(sessionId, scope);
-      });
+      let attemptedClient: any;
+      void this.#endpointCoordinator.runProtectedNativeCleanup(() => (
+        this.withClientLease(async (client) => {
+          attemptedClient = client;
+          const result = await this.#runScopedSessionRequest(
+            'OpenCode retained session delete',
+            scope,
+            (signal, requestScope) => client.session.delete(
+              withOpenCodeRequestScope({ sessionID: sessionId }, requestScope),
+              { signal },
+            ),
+          );
+          if (!isOpenCodeNotFoundResult(result)) {
+            throwOpenCodeResultError(result, 'OpenCode retained session delete failed');
+          }
+        }).catch(() => {
+          this.#retainSessionDeletion(sessionId, scope, attemptedClient);
+        })
+      ));
     }
   }
 
@@ -1142,8 +1144,8 @@ export class OpenCodeRuntime {
     const instance = await this.#ensureOpenCodeServer();
     return instance.client;
   }
-  withClientLease<T>(operation: (client: any) => Promise<T>): Promise<T> {
-    return this.#endpointCoordinator.withClientLease(operation);
+  withClientLease<T>(operation: (client: any) => Promise<T>, admissionSignal?: AbortSignal): Promise<T> {
+    return this.#endpointCoordinator.withClientLease(operation, admissionSignal);
   }
   getClientIfInitialized(): any | null {
     return this.#instance?.client ?? null;
@@ -1616,10 +1618,9 @@ export class OpenCodeRuntime {
     }
   }
 
-  async forkSession(
-    sourceSessionId: string,
-    options: { projectPath?: string | null; messageId?: string; permissionMode?: string; signal?: AbortSignal } = {},
-  ): Promise<string> {
+  runProtectedNativeFork<T>(operation: () => Promise<T>): Promise<T> { return this.#endpointCoordinator.runProtectedNativeFork(operation); }
+
+  async forkSession(sourceSessionId: string, options: OpenCodeForkSessionOptions = {}): Promise<string> {
     // OpenCode persists a manual compaction control before its summary runs, so
     // a whole-tip fork mid-compaction would clone a pending control into the
     // child, where the next prompt could be consumed as compaction input.
@@ -1632,11 +1633,15 @@ export class OpenCodeRuntime {
         { nativeForkReason: 'not-settled' },
       );
     }
+    const scope = createOpenCodeRequestScope(options.projectPath);
     const forkedSessionId = await this.#endpointCoordinator.forkSession(
       sourceSessionId,
       options,
       (label, scope, operation, control) => this.#runScopedSessionRequest(label, scope, operation, control),
+      (client, sessionId, requestScope) => this.#deleteSessionBestEffort(sessionId, requestScope, { client }),
     );
+    if (options.signal?.aborted) await this.#deleteSessionBestEffort(forkedSessionId, scope);
+    options.signal?.throwIfAborted();
     // Native fork clones only messages: the forked session carries no permission
     // ruleset, so without this the forked chat prompts for everything the source
     // had allowed. https://github.com/anomalyco/opencode/blob/v1.18.22/packages/opencode/src/session/session.ts#L691-L701
@@ -1654,10 +1659,11 @@ export class OpenCodeRuntime {
               }, requestScope),
               { signal: requestSignal },
             ),
-            { signal: options.signal },
+            { signal: options.signal, timeoutMs: null },
           );
           throwOpenCodeResultError(result, 'Failed to apply OpenCode fork permission mode');
-        });
+        }, options.signal);
+        options.signal?.throwIfAborted();
       } catch (error) {
         // Never leave a forked session behind with a ruleset that does not match the
         // chat record; the fork caller retries the whole operation. Cleanup goes
@@ -1667,6 +1673,7 @@ export class OpenCodeRuntime {
           forkedSessionId,
           createOpenCodeRequestScope(options.projectPath),
         );
+        options.signal?.throwIfAborted();
         throw new AgentIntegrationError(
           'TRANSCRIPT_UNAVAILABLE',
           errorMessage(error),
@@ -1676,26 +1683,17 @@ export class OpenCodeRuntime {
     }
     return forkedSessionId;
   }
+
+  async discardSession(agentSessionId: string, projectPath?: string | null): Promise<void> {
+    await this.#deleteSessionBestEffort(agentSessionId, createOpenCodeRequestScope(projectPath));
+  }
+
   async moveSession(agentSessionId: string, directory: string, signal: AbortSignal): Promise<void> {
     await this.#endpointCoordinator.moveSession(
       agentSessionId, directory, signal, (...args) => this.#runRequest(...args),
     );
     const session = this.#sessions.get(agentSessionId.trim());
     if (session) relocateOpenCodeSession(session, directory.trim());
-  }
-  async deleteSession(agentSessionId: string, signal?: AbortSignal): Promise<void> {
-    await this.withClientLease(async (client) => {
-      const result = await this.#runScopedSessionRequest(
-        'OpenCode forked session delete',
-        {},
-        (requestSignal, requestScope) => client.session.delete(
-          withOpenCodeRequestScope({ sessionID: agentSessionId }, requestScope),
-          { signal: requestSignal },
-        ),
-        { signal },
-      );
-      throwOpenCodeResultError(result, 'OpenCode forked session delete failed');
-    });
   }
 
   abort(agentSessionId: string): Promise<boolean> {

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -1085,7 +1085,7 @@ export class OpenCodeRuntime {
         infoId: typeof info?.id === 'string' ? info.id : null,
         toolMessageId: typeof tool?.messageID === 'string' ? tool.messageID : null,
       };
-      if (shouldWarnForUnroutedOpenCodeEvent(event.type)) {
+      if (shouldWarnForUnroutedOpenCodeEvent(event.type, this.#sessions.has(sessionId))) {
         this.#logger.warn('Ignoring an OpenCode event without an operation identity', details);
       } else {
         this.#logger.debug('Ignoring an OpenCode event without an operation identity', details);
@@ -1148,7 +1148,6 @@ export class OpenCodeRuntime {
   getClientIfInitialized(): any | null {
     return this.#instance?.client ?? null;
   }
-
   async getModels(): Promise<OpenCodeModelOption[]> {
     return this.#models.getModels();
   }
@@ -1163,14 +1162,14 @@ export class OpenCodeRuntime {
   async #runRequest<T>(
     label: string,
     operation: (signal: AbortSignal) => Promise<T>,
-    control: { signal?: AbortSignal; timeoutMs?: number } = {},
+    control: { signal?: AbortSignal; timeoutMs?: number | null } = {},
   ): Promise<T> {
     const generation = this.#instanceGeneration;
     this.#endpointCoordinator.requestStarted();
     try {
       return await withAbortableTimeout(
         operation,
-        control.timeoutMs ?? this.#options.requestTimeoutMs,
+        control.timeoutMs === undefined ? this.#options.requestTimeoutMs : control.timeoutMs,
         label,
         control.signal,
       );
@@ -1191,7 +1190,7 @@ export class OpenCodeRuntime {
     label: string,
     scope: OpenCodeRequestScope,
     operation: (signal: AbortSignal, scope: OpenCodeRequestScope) => Promise<T>,
-    control: { signal?: AbortSignal; timeoutMs?: number } = {},
+    control: { signal?: AbortSignal; timeoutMs?: number | null } = {},
   ): Promise<T> {
     return this.#runRequest<T>(label, (signal) => operation(signal, scope), control);
   }
@@ -1619,7 +1618,7 @@ export class OpenCodeRuntime {
 
   async forkSession(
     sourceSessionId: string,
-    options: { projectPath?: string | null; messageId?: string; permissionMode?: string } = {},
+    options: { projectPath?: string | null; messageId?: string; permissionMode?: string; signal?: AbortSignal } = {},
   ): Promise<string> {
     // OpenCode persists a manual compaction control before its summary runs, so
     // a whole-tip fork mid-compaction would clone a pending control into the
@@ -1636,7 +1635,7 @@ export class OpenCodeRuntime {
     const forkedSessionId = await this.#endpointCoordinator.forkSession(
       sourceSessionId,
       options,
-      (label, scope, operation) => this.#runScopedSessionRequest(label, scope, operation),
+      (label, scope, operation, control) => this.#runScopedSessionRequest(label, scope, operation, control),
     );
     // Native fork clones only messages: the forked session carries no permission
     // ruleset, so without this the forked chat prompts for everything the source
@@ -1655,6 +1654,7 @@ export class OpenCodeRuntime {
               }, requestScope),
               { signal: requestSignal },
             ),
+            { signal: options.signal },
           );
           throwOpenCodeResultError(result, 'Failed to apply OpenCode fork permission mode');
         });

--- a/server-agents/opencode/src/agents/opencode/request-control.ts
+++ b/server-agents/opencode/src/agents/opencode/request-control.ts
@@ -7,7 +7,7 @@ export class OpenCodeTimeoutError extends Error {
 
 export async function withAbortableTimeout<T>(
   operation: (signal: AbortSignal) => Promise<T>,
-  timeoutMs: number,
+  timeoutMs: number | null,
   label: string,
   callerSignal?: AbortSignal,
 ): Promise<T> {
@@ -30,6 +30,7 @@ export async function withAbortableTimeout<T>(
     return await Promise.race([
       operationResult,
       new Promise<never>((_, reject) => {
+        if (timeoutMs === null) return;
         timeoutHandle = setTimeout(() => {
           const error = new OpenCodeTimeoutError(label, timeoutMs);
           controller.abort(error);

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -245,7 +245,16 @@ export function openCodeEventBelongsToTurn(
   return true;
 }
 
-export function shouldWarnForUnroutedOpenCodeEvent(eventType: string): boolean {
+export function shouldWarnForUnroutedOpenCodeEvent(
+  eventType: string,
+  managedSession: boolean,
+): boolean {
+  // Native fork replays are published before OpenCode returns the child session identity.
+  // https://github.com/anomalyco/opencode/blob/47b6b6f5f4f9b42d2bce7af1c4e5bf6efaf22ba7/packages/opencode/src/session/session.ts#L691-L730
+  if (
+    !managedSession
+    && (eventType === 'message.updated' || eventType === 'message.part.updated')
+  ) return false;
   return eventType === 'message.updated'
     || eventType === 'message.part.updated'
     || eventType === 'message.part.delta'

--- a/server-agents/opencode/src/index.ts
+++ b/server-agents/opencode/src/index.ts
@@ -182,7 +182,7 @@ function createSessionIdResolver(nativeSessions: NativeSessionCodec) {
   };
 }
 
-function createOpenCodeNativeEvidence(
+export function createOpenCodeNativeEvidence(
   runtime: OpenCodeRuntime,
   nativeSessions: NativeSessionCodec,
   sessionId: (chat: SessionReference) => string | null,
@@ -198,7 +198,7 @@ function createOpenCodeNativeEvidence(
     return runtime.withClientLease((client) => loadMessages(id, async () => client, {
       directory: chat.projectPath,
       signal,
-    }));
+    }), signal);
   };
   return {
     async resolveNativeSession({ chat, signal }) {

--- a/server/agents/__tests__/runtime-router-fork.test.js
+++ b/server/agents/__tests__/runtime-router-fork.test.js
@@ -90,6 +90,7 @@ function makeRouter(fork) {
 
 describe('AgentRuntimeRouter forks', () => {
   it('binds a point fork to the selected native prefix', async () => {
+    const controller = new AbortController();
     const fork = mock(async () => ({
       kind: 'materialized',
       session: {
@@ -105,10 +106,12 @@ describe('AgentRuntimeRouter forks', () => {
       targetChatId: 'target-chat',
       messageOrdinal: 1,
       providerMeta: { entryId: 'native-entry-1', withinSourceOrdinal: 0 },
+      signal: controller.signal,
     });
 
     expect(fork).toHaveBeenCalledWith(expect.objectContaining({
       providerMeta: { entryId: 'native-entry-1', withinSourceOrdinal: 0 },
+      admission: expect.objectContaining({ signal: controller.signal }),
       source: expect.objectContaining({ chatId: 'source-chat' }),
     }));
     expect(integration.forking).not.toHaveProperty('resolvePoint');

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -95,6 +95,7 @@ export interface AgentRegistryServiceContract {
     sourceChatId: string;
     targetChatId: string;
     messageOrdinal?: number;
+    signal: AbortSignal;
   }): Promise<ForkedAgentSessionOutcome | null>;
   discardForkedAgentSession(agentId: string, session: StartedAgentSession): Promise<void>;
   compactSession(chatId: string, opts?: CompactSessionOptions): Promise<void>;
@@ -298,6 +299,7 @@ export class AgentRegistry implements AgentRegistryServiceContract {
     sourceChatId: string;
     targetChatId: string;
     messageOrdinal?: number;
+    signal: AbortSignal;
   }) {
     return this.#runtime.forkAgentSession(args);
   }

--- a/server/agents/runtime-router.ts
+++ b/server/agents/runtime-router.ts
@@ -502,6 +502,7 @@ export class AgentRuntimeRouter {
     targetChatId: string;
     messageOrdinal?: number;
     providerMeta?: JsonObject | null;
+    signal: AbortSignal;
   }): Promise<ForkedAgentSessionOutcome | null> {
     if (
       args.messageOrdinal !== undefined
@@ -532,7 +533,12 @@ export class AgentRuntimeRouter {
         source,
         selection,
         operation.turnId,
-        {},
+        {
+          executionAdmission: {
+            signal: args.signal,
+            markStarted: async () => {},
+          },
+        },
       );
       const result = await integration.forking.fork({
         chatId: context.chatId,

--- a/server/chats/__tests__/fork-chat.test.js
+++ b/server/chats/__tests__/fork-chat.test.js
@@ -5,6 +5,14 @@ import { transcriptViewId } from '../../ledger/contracts.js';
 
 const envelope = (ownerId, values = {}) => ({ ownerId, schemaVersion: 1, values });
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function sourceSession(overrides = {}) {
   return {
     id: 'source-chat',
@@ -95,6 +103,7 @@ function makeDeps(overrides = {}) {
     },
   }));
   return {
+    signal: new AbortController().signal,
     registry,
     settings,
     metadata,
@@ -147,6 +156,40 @@ describe('forkChatFileCopy', () => {
         ordinal: 3,
       },
     });
+  });
+
+  it('rolls back a standalone fork cancelled while the target registry flushes', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const flushEntered = deferred();
+    const releaseFlush = deferred();
+    const deps = makeDeps({
+      source: sourceSession({ agentSessionId: null, nativeSession: null }),
+    });
+    deps.registry.flush.mockImplementation(async () => {
+      flushEntered.resolve();
+      await releaseFlush.promise;
+    });
+    const outcome = forkChatFileCopy({
+      sourceSession: deps.sessions.get('source-chat'),
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      ...deps,
+      signal: controller.signal,
+    }).then(
+      (value) => ({ status: 'fulfilled', value }),
+      (error) => ({ status: 'rejected', error }),
+    );
+
+    await flushEntered.promise;
+    controller.abort(reason);
+    releaseFlush.resolve();
+
+    await expect(outcome).resolves.toEqual({ status: 'rejected', error: reason });
+    expect(deps.sessions.has('target-chat')).toBe(false);
+    expect(deps.ledger.currentView('target-chat')).toBeNull();
+    expect(deps.settings.removeFromAllOrderLists).toHaveBeenCalledWith('target-chat');
+    expect(deps.settings.removeSessionName).toHaveBeenCalledWith('target-chat');
   });
 
   it('copies only rows through the selected ordinal', async () => {
@@ -271,6 +314,84 @@ describe('forkChatFileCopy', () => {
       expect.objectContaining({ kind: 'session' }),
     ]);
     expect(deps.ledger.initializeChat.mock.calls[0][2]).toBe(3);
+  });
+
+  it('discards a materialized native fork when admission closes before target creation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const forkAgentSession = mock(async ({ signal }) => {
+      expect(signal).toBe(controller.signal);
+      controller.abort(reason);
+      return {
+        kind: 'materialized',
+        session: {
+          agentSessionId: 'cancelled-native',
+          nativeSession: { ownerId: 'test', schemaVersion: 1, value: { id: 'cancelled-native' } },
+          nativeSeedReceipt: null,
+        },
+      };
+    });
+    const discardForkedAgentSession = mock(async () => undefined);
+    const deps = makeDeps({ forkAgentSession, discardForkedAgentSession });
+
+    await expect(forkChatFileCopy({
+      sourceSession: deps.sessions.get('source-chat'),
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      ...deps,
+      signal: controller.signal,
+    })).rejects.toBe(reason);
+
+    expect(discardForkedAgentSession).toHaveBeenCalledWith('test', expect.objectContaining({
+      agentSessionId: 'cancelled-native',
+    }));
+    expect(deps.ledger.initializeChat).not.toHaveBeenCalled();
+    expect(deps.registry.addChat).not.toHaveBeenCalled();
+  });
+
+  it('preserves admission cancellation when the native fork operation rejects', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const deps = makeDeps({
+      forkAgentSession: mock(async () => {
+        controller.abort(reason);
+        throw new Error('provider fork failed');
+      }),
+    });
+
+    await expect(forkChatFileCopy({
+      sourceSession: deps.sessions.get('source-chat'),
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      ...deps,
+      signal: controller.signal,
+    })).rejects.toBe(reason);
+
+    expect(deps.ledger.initializeChat).not.toHaveBeenCalled();
+    expect(deps.registry.addChat).not.toHaveBeenCalled();
+  });
+
+  it('preserves admission cancellation before translating an unmaterialized fork', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const deps = makeDeps({
+      forkAgentSession: mock(async () => {
+        controller.abort(reason);
+        return { kind: 'unmaterialized' };
+      }),
+    });
+
+    await expect(forkChatFileCopy({
+      sourceSession: deps.sessions.get('source-chat'),
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      allowHandoffFork: false,
+      ...deps,
+      signal: controller.signal,
+    })).rejects.toBe(reason);
+
+    expect(deps.ledger.initializeChat).not.toHaveBeenCalled();
+    expect(deps.registry.addChat).not.toHaveBeenCalled();
   });
 
   it('[TLV5-FORK.01-CORE-UNIT-01] hands the facet an uncorrelated provider row rather than an older settled one', async () => {
@@ -421,6 +542,7 @@ describe('forkChatFileCopy', () => {
     expect(deps.readForkedNativeHistory).toHaveBeenCalledWith(expect.objectContaining({
       targetChatId: 'target-chat',
       fork: expect.objectContaining({ agentSessionId: 'target-native' }),
+      signal: deps.signal,
     }));
     // Rows below the source content start are earlier-agent history no provider ever held,
     // so they survive alongside the imported current binding.
@@ -481,6 +603,30 @@ describe('forkChatFileCopy', () => {
     expect(deps.sessions.has('target-chat')).toBe(false);
   });
 
+  it('preserves admission cancellation when native seeding rejects', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const deps = makeDeps({
+      readForkedNativeHistory: mock(async () => {
+        controller.abort(reason);
+        throw new Error('history unreadable');
+      }),
+    });
+
+    await expect(forkChatFileCopy({
+      sourceSession: deps.sessions.get('source-chat'),
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      upToOrdinal: 2,
+      ...deps,
+      signal: controller.signal,
+    })).rejects.toBe(reason);
+
+    expect(deps.discardForkedAgentSession).toHaveBeenCalledOnce();
+    expect(deps.ledger.initializeChat).not.toHaveBeenCalled();
+    expect(deps.registry.addChat).not.toHaveBeenCalled();
+  });
+
   it('rejects a point beyond the ledger watermark before creating artifacts', async () => {
     const deps = makeDeps();
 
@@ -528,6 +674,28 @@ describe('forkChatFileCopy', () => {
     expect(deps.ownership.delete).toHaveBeenCalledOnce();
     expect(deps.settings.removeFromAllOrderLists).toHaveBeenCalledOnce();
     expect(deps.settings.removeSessionName).toHaveBeenCalledOnce();
+    expect(deps.discardForkedAgentSession).toHaveBeenCalledOnce();
+  });
+
+  it('preserves admission cancellation when target finalization rejects', async () => {
+    const controller = new AbortController();
+    const reason = new Error('fork admission cancelled');
+    const deps = makeDeps();
+    deps.registry.flush.mockImplementation(async () => {
+      controller.abort(reason);
+      throw new Error('registry flush failed');
+    });
+
+    await expect(forkChatFileCopy({
+      sourceSession: deps.sessions.get('source-chat'),
+      sourceChatId: 'source-chat',
+      targetChatId: 'target-chat',
+      ...deps,
+      signal: controller.signal,
+    })).rejects.toBe(reason);
+
+    expect(deps.sessions.has('target-chat')).toBe(false);
+    expect(deps.ledger.currentView('target-chat')).toBeNull();
     expect(deps.discardForkedAgentSession).toHaveBeenCalledOnce();
   });
 });

--- a/server/chats/fork-chat.ts
+++ b/server/chats/fork-chat.ts
@@ -56,6 +56,7 @@ interface ForkChatInput {
   sourceSession: ChatRegistryEntry;
   sourceChatId: string;
   targetChatId: string;
+  signal: AbortSignal;
   upToOrdinal?: number;
   // Consent to a handoff fork when the point cannot be forked natively. Without it the
   // integration's refusal reaches the caller, who asks the user before repeating the request.
@@ -74,6 +75,7 @@ interface ForkChatInput {
     targetChatId: string;
     messageOrdinal?: number;
     providerMeta?: JsonObject | null;
+    signal: AbortSignal;
   }) => Promise<ForkedAgentSessionOutcome | null>;
   discardForkedAgentSession: (agentId: string, session: StartedAgentSession) => Promise<void>;
   // Reads the forked session's own history so the target feed matches the session it resumes
@@ -82,6 +84,7 @@ interface ForkChatInput {
     targetChatId: string;
     sourceSession: ChatRegistryEntry;
     fork: StartedAgentSession;
+    signal: AbortSignal;
   }) => Promise<LedgerRowDraft[] | null>;
 }
 
@@ -128,6 +131,7 @@ export async function forkChatFileCopy({
   sourceSession,
   sourceChatId,
   targetChatId,
+  signal,
   upToOrdinal,
   allowHandoffFork = false,
   registry,
@@ -139,6 +143,7 @@ export async function forkChatFileCopy({
   discardForkedAgentSession,
   readForkedNativeHistory,
 }: ForkChatInput): Promise<ForkChatFileCopyResult> {
+  signal.throwIfAborted();
   const startedAt = Date.now();
   const sourceAgentSessionId = sourceSession.agentSessionId;
   const targetEpoch = crypto.randomUUID();
@@ -175,6 +180,7 @@ export async function forkChatFileCopy({
         sourceSession,
         sourceChatId,
         targetChatId,
+        signal,
         ...(upToOrdinal === undefined
           ? {}
           : {
@@ -183,10 +189,18 @@ export async function forkChatFileCopy({
             }),
       });
     } catch (error) {
+      signal.throwIfAborted();
       if (!allowHandoffFork || !isUnsettledForkPoint(error)) throw error;
       forkOutcome = null;
     }
   }
+  const nativeFork = forkOutcome?.kind === 'materialized' ? forkOutcome.session : null;
+  await throwIfForkCancelled(
+    signal,
+    nativeFork,
+    sourceSession.agentId,
+    discardForkedAgentSession,
+  );
   if (forkOutcome?.kind === 'unmaterialized' && !allowHandoffFork) {
     throw new DomainError(
       'TRANSCRIPT_NOT_YET_PERSISTED',
@@ -195,7 +209,6 @@ export async function forkChatFileCopy({
       true,
     );
   }
-  const nativeFork = forkOutcome?.kind === 'materialized' ? forkOutcome.session : null;
   try {
     validateForkedSeedReceipt(sourceSession, nativeFork);
   } catch (error) {
@@ -229,15 +242,16 @@ export async function forkChatFileCopy({
         targetChatId,
         sourceSession,
         fork: nativeFork,
+        signal,
       });
+      signal.throwIfAborted();
     } catch (error) {
       const cleanupErrors = await discardForkResources(
         nativeFork,
         sourceSession.agentId,
         discardForkedAgentSession,
       );
-      if (cleanupErrors.length > 0) throw new AggregateError([error, ...cleanupErrors]);
-      throw error;
+      throwForkFailureAfterCleanup(signal, error, cleanupErrors);
     }
   }
   const sessionRow: LedgerRowDraft[] = nativeFork
@@ -360,21 +374,31 @@ export async function forkChatFileCopy({
 
   try {
     await registry.flush();
+    signal.throwIfAborted();
     await registry.updateChat(sourceChatId, {
       nextForkOrdinal: nextForkOrdinal + 1,
     }, { flush: true });
+    signal.throwIfAborted();
     await settings.ensureInNormal(targetChatId);
+    signal.throwIfAborted();
 
     const sourceMeta = metadata.getChatMetadata(sourceChatId);
     if (sourceMeta?.firstMessage) metadata.addNewChatMetadata(targetChatId, sourceMeta.firstMessage);
     await settings.setSessionName(targetChatId, forkTitle);
+    signal.throwIfAborted();
   } catch (error) {
+    const cleanupErrors: unknown[] = [];
     try {
       await rollback();
     } catch (rollbackError) {
-      throw new AggregateError([error, rollbackError], `Failed to create and roll back fork ${targetChatId}`);
+      cleanupErrors.push(rollbackError);
     }
-    throw error;
+    throwForkFailureAfterCleanup(
+      signal,
+      error,
+      cleanupErrors,
+      `Failed to create and roll back fork ${targetChatId}`,
+    );
   }
 
   logger.info('fork created', {
@@ -407,6 +431,44 @@ async function discardForkResources(
   return (await Promise.allSettled(cleanups)).flatMap((result) => (
     result.status === 'rejected' ? [result.reason] : []
   ));
+}
+
+async function throwIfForkCancelled(
+  signal: AbortSignal,
+  nativeFork: StartedAgentSession | null,
+  agentId: string,
+  discardForkedAgentSession: (agentId: string, session: StartedAgentSession) => Promise<void>,
+): Promise<void> {
+  if (!signal.aborted) return;
+  const cleanupErrors = await discardForkResources(
+    nativeFork,
+    agentId,
+    discardForkedAgentSession,
+  );
+  try {
+    signal.throwIfAborted();
+  } catch (error) {
+    if (cleanupErrors.length > 0) throw new AggregateError([error, ...cleanupErrors]);
+    throw error;
+  }
+}
+
+function throwForkFailureAfterCleanup(
+  signal: AbortSignal,
+  error: unknown,
+  cleanupErrors: readonly unknown[],
+  aggregateMessage?: string,
+): never {
+  let primary = error;
+  try {
+    signal.throwIfAborted();
+  } catch (cancellation) {
+    primary = cancellation;
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError([primary, ...cleanupErrors], aggregateMessage);
+  }
+  throw primary;
 }
 
 function validateForkedSeedReceipt(

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -253,7 +253,10 @@ function makeService(overrides = {}) {
         if (control.entries.length > 0 || control.pause) {
           throw new DomainError('SESSION_BUSY', 'Chat execution is blocked by pending control state', 409, true);
         }
-        await input.preparation?.prepare();
+        await input.preparation?.prepare({
+          signal: reservation.executionAdmission.signal,
+          assertAdmissionActive: () => reservation.executionAdmission.signal.throwIfAborted(),
+        });
         await queue.admitUserInput(input.command.chatId, input.content, input.options);
         await input.settlement.markScheduled(input.command, input.options.turnId);
       } catch (error) {
@@ -284,7 +287,10 @@ function makeService(overrides = {}) {
       let scheduled = false;
       try {
         reservation = queue.reserveDirectTurn(input.command.chatId, input.options);
-        await input.preparation?.prepare();
+        await input.preparation?.prepare({
+          signal: reservation.executionAdmission.signal,
+          assertAdmissionActive: () => reservation.executionAdmission.signal.throwIfAborted(),
+        });
         await queue.admitUserInput(input.command.chatId, input.content, input.options);
         await input.settlement.markScheduled(input.command, input.options.turnId);
         scheduled = true;

--- a/server/commands/chat-command-service.ts
+++ b/server/commands/chat-command-service.ts
@@ -77,8 +77,8 @@ export class ChatCommandService {
     return this.#session.submitRun(input);
   }
 
-  forkChat(input: ForkChatCommandRequest) {
-    return this.#fork.forkChat(input);
+  forkChat(input: ForkChatCommandRequest, signal?: AbortSignal) {
+    return this.#fork.forkChat(input, signal);
   }
 
   deleteChat(input: DeleteChatInput) {

--- a/server/commands/command-support.ts
+++ b/server/commands/command-support.ts
@@ -22,6 +22,7 @@ import {
 import { InvalidChatIdError, parseChatId, type ChatId } from '../../common/chat-id.js';
 import type { PermissionMode, ThinkingMode } from '../../common/chat-modes.js';
 import type { UserMessagePresentation } from '../../common/chat-types.js';
+import type { JsonObject } from '../../common/json.js';
 import type { AgentRegistryServiceContract } from '../agents/registry.js';
 import type {
   AgentExecutionCommandType,
@@ -107,6 +108,7 @@ export type ForkChatFileCopyDep = (args: {
   sourceSession: ChatRegistryEntry;
   sourceChatId: string;
   targetChatId: string;
+  signal: AbortSignal;
   upToOrdinal?: number;
   allowHandoffFork?: boolean;
   registry: IChatRegistry;
@@ -119,12 +121,15 @@ export type ForkChatFileCopyDep = (args: {
     sourceChatId: string;
     targetChatId: string;
     messageOrdinal?: number;
+    providerMeta?: JsonObject | null;
+    signal: AbortSignal;
   }) => Promise<ForkedAgentSessionOutcome | null>;
   discardForkedAgentSession: (agentId: string, session: StartedAgentSession) => Promise<void>;
   readForkedNativeHistory: (args: {
     targetChatId: string;
     sourceSession: ChatRegistryEntry;
     fork: StartedAgentSession;
+    signal: AbortSignal;
   }) => Promise<LedgerRowDraft[] | null>;
 }) => Promise<ForkChatFileCopyResult>;
 
@@ -132,6 +137,7 @@ export type ForkedNativeHistoryReaderDep = (args: {
   targetChatId: string;
   sourceSession: ChatRegistryEntry;
   fork: StartedAgentSession;
+  signal: AbortSignal;
 }) => Promise<LedgerRowDraft[] | null>;
 
 export interface FileMentionResolverDep {

--- a/server/commands/fork-commands.ts
+++ b/server/commands/fork-commands.ts
@@ -32,7 +32,10 @@ export class ForkCommands {
     return this.support.deps;
   }
 
-  async forkChat(input: ForkChatCommandRequest): Promise<ForkChatResponse> {
+  async forkChat(
+    input: ForkChatCommandRequest,
+    signal: AbortSignal = new AbortController().signal,
+  ): Promise<ForkChatResponse> {
     const normalized = {
       ...input,
       sourceChatId: this.support.requireChatId(input.sourceChatId, 'sourceChatId'),
@@ -40,7 +43,7 @@ export class ForkCommands {
     };
     return this.support.withChatMutationLocks([normalized.sourceChatId, normalized.chatId], async () => {
       const context = await this.validateFork(normalized);
-      await this.forkChatFromContext(context);
+      await this.forkChatFromContext(context, signal);
       return { success: true, chat: await this.support.projectCommandChat(context.targetChatId) };
     });
   }
@@ -138,7 +141,7 @@ export class ForkCommands {
         turnId,
       }, 'fork-run', {
         operation: 'fork-run',
-        prepare: async () => {
+        prepare: async ({ signal }) => {
           if (forkAlreadyCreated) return;
           await this.deps.ledger.update(ledger.record.key, {
             forkPreparation: {
@@ -147,7 +150,7 @@ export class ForkCommands {
               sourceNextForkOrdinal: forkContext.sourceNextForkOrdinal,
             },
           });
-          forkResult = await this.forkChatFromContext(forkContext);
+          forkResult = await this.forkChatFromContext(forkContext, signal);
           await this.deps.ledger.update(ledger.record.key, {
             forkPreparation: {
               phase: 'created',
@@ -287,7 +290,10 @@ export class ForkCommands {
     }
   }
 
-  private async forkChatFromContext(context: ForkContext): Promise<ForkChatFileCopyResult> {
+  private async forkChatFromContext(
+    context: ForkContext,
+    signal: AbortSignal,
+  ): Promise<ForkChatFileCopyResult> {
     if (!this.deps.forkChatFileCopy) {
       throw new CommandValidationError('UNSUPPORTED_AGENT', 'Forking is not configured on this server', 503, true);
     }
@@ -296,6 +302,7 @@ export class ForkCommands {
       sourceSession: context.sourceSession,
       sourceChatId: context.sourceChatId,
       targetChatId: context.targetChatId,
+      signal,
       ...(context.upToOrdinal ? { upToOrdinal: context.upToOrdinal } : {}),
       ...(context.allowHandoffFork ? { allowHandoffFork: true } : {}),
       registry: this.deps.chats,

--- a/server/routes/__tests__/chats-command-routes.test.js
+++ b/server/routes/__tests__/chats-command-routes.test.js
@@ -189,7 +189,10 @@ function createRouteAgent(sessionOverrides = {}) {
         if (control.entries.length > 0 || control.pause) {
           throw new DomainError('SESSION_BUSY', 'Chat execution is blocked by pending control state', 409, true);
         }
-        await input.preparation?.prepare();
+        await input.preparation?.prepare({
+          signal: reservation.executionAdmission.signal,
+          assertAdmissionActive: () => reservation.executionAdmission.signal.throwIfAborted(),
+        });
         await queue.registerPendingUserInput(input.command.chatId, input.content, input.options);
         await input.settlement.markScheduled(input.command, input.options.turnId);
       } catch (error) {
@@ -205,7 +208,10 @@ function createRouteAgent(sessionOverrides = {}) {
     }),
     runInitialInput: mock(async (input) => {
       const reservation = queue.reserveDirectTurn(input.command.chatId, input.options);
-      await input.preparation?.prepare();
+      await input.preparation?.prepare({
+        signal: reservation.executionAdmission.signal,
+        assertAdmissionActive: () => reservation.executionAdmission.signal.throwIfAborted(),
+      });
       await queue.registerPendingUserInput(input.command.chatId, input.content, input.options);
       await input.settlement.markScheduled(input.command, input.options.turnId);
       await input.dispatch?.(reservation.executionAdmission);
@@ -854,6 +860,7 @@ describe('REST chat command routes', () => {
       orderGroup: 'normal',
     });
     expect(forkChatFileCopy).toHaveBeenCalledTimes(1);
+    expect(forkChatFileCopy.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
     expect(server.timeout).toHaveBeenCalledWith(request, 0);
     expect(agent.queue.registerPendingUserInput).toHaveBeenCalledWith(
       TARGET_CHAT_ID,
@@ -936,6 +943,7 @@ describe('REST chat command routes', () => {
       errorCode: 'TRANSCRIPT_NOT_YET_PERSISTED',
       retryable: true,
     });
+    expect(forkChatFileCopy.mock.calls.at(-1)[0].signal).toBe(request.signal);
     expect(server.timeout).toHaveBeenCalledWith(request, 0);
   });
 

--- a/server/routes/__tests__/chats-command-routes.test.js
+++ b/server/routes/__tests__/chats-command-routes.test.js
@@ -834,9 +834,10 @@ describe('REST chat command routes', () => {
     );
   });
 
-  it('POST /fork-run forks once and schedules the target turn', async () => {
+  it('POST /fork-run disables the Bun idle timeout, forks once, and schedules the target turn', async () => {
     const agent = createRouteAgent();
-    const { response, body } = await callJson(agent.routes['/api/v1/chats/fork-run'].POST, {
+    const server = { timeout: mock(() => undefined) };
+    const { request, response, body } = await callJson(agent.routes['/api/v1/chats/fork-run'].POST, {
       ...agentRunBody({
         clientRequestId: 'req-fork-run-1',
         clientMessageId: 'msg-fork-run-1',
@@ -844,7 +845,7 @@ describe('REST chat command routes', () => {
         chatId: TARGET_CHAT_ID,
         command: 'continue here',
       }),
-    });
+    }, 'POST', server);
     expect(response.status).toBe(202);
     expect(body.commandType).toBe('fork-run');
     expect(body.chatId).toBe(TARGET_CHAT_ID);
@@ -853,6 +854,7 @@ describe('REST chat command routes', () => {
       orderGroup: 'normal',
     });
     expect(forkChatFileCopy).toHaveBeenCalledTimes(1);
+    expect(server.timeout).toHaveBeenCalledWith(request, 0);
     expect(agent.queue.registerPendingUserInput).toHaveBeenCalledWith(
       TARGET_CHAT_ID,
       'continue here',
@@ -912,8 +914,9 @@ describe('REST chat command routes', () => {
     expect(rejected.body).toMatchObject({ error: 'allowHandoffFork must be a boolean' });
   });
 
-  it('POST /fork preserves retryable transcript-persistence refusals', async () => {
+  it('POST /fork disables the Bun idle timeout and preserves retryable refusals', async () => {
     const agent = createRouteAgent();
+    const server = { timeout: mock(() => undefined) };
     forkChatFileCopy.mockRejectedValueOnce(new CommandValidationError(
       'TRANSCRIPT_NOT_YET_PERSISTED',
       "This chat's transcript hasn't been written yet. Try the fork again in a moment.",
@@ -921,10 +924,10 @@ describe('REST chat command routes', () => {
       true,
     ));
 
-    const { response, body } = await callJson(agent.routes['/api/v1/chats/fork'].POST, {
+    const { request, response, body } = await callJson(agent.routes['/api/v1/chats/fork'].POST, {
       sourceChatId: CHAT_ID,
       chatId: TARGET_CHAT_ID,
-    });
+    }, 'POST', server);
 
     expect(response.status).toBe(409);
     expect(body).toEqual({
@@ -933,6 +936,7 @@ describe('REST chat command routes', () => {
       errorCode: 'TRANSCRIPT_NOT_YET_PERSISTED',
       retryable: true,
     });
+    expect(server.timeout).toHaveBeenCalledWith(request, 0);
   });
 
   it('POST /fork carries handoff-fork consent and rejects a non-boolean', async () => {

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -69,7 +69,6 @@ import {
   archivedLogicalCount,
   carryOverRevision,
 } from '../chats/carryover-segments.js';
-
 import type {
   ExecutionSettingsPatchRequest,
   ModelPatchRequest,
@@ -116,6 +115,8 @@ import {
 } from '../chats/title-generator.js';
 
 const logger = createLogger('routes:chats');
+// Bun interprets zero as an unlimited idle window for provider-native forks.
+const FORK_REQUEST_TIMEOUT_SECONDS = 0;
 
 interface RequestTimeoutServer {
   timeout(request: Request, seconds: number): void;
@@ -741,9 +742,16 @@ export default function createChatRoutes({
     }
   }
 
-  async function postForkChat(body: unknown): Promise<Response> {
+  async function postForkChat(
+    body: unknown,
+    request: Request,
+    _url: URL,
+    server?: unknown,
+  ): Promise<Response> {
     try {
-      const result = await commands.forkChat(parseCommandRequest(parseForkChatCommandRequest, body));
+      const input = parseCommandRequest(parseForkChatCommandRequest, body);
+      if (isRequestTimeoutServer(server)) server.timeout(request, FORK_REQUEST_TIMEOUT_SECONDS);
+      const result = await commands.forkChat(input);
 
       return Response.json(result);
     } catch (error: unknown) {
@@ -823,9 +831,15 @@ export default function createChatRoutes({
     }
   }
 
-  async function postForkRunChat(body: unknown): Promise<Response> {
+  async function postForkRunChat(
+    body: unknown,
+    request: Request,
+    _url: URL,
+    server?: unknown,
+  ): Promise<Response> {
     try {
       const input = parseCommandRequest(parseForkRunCommandRequest, body);
+      if (isRequestTimeoutServer(server)) server.timeout(request, FORK_REQUEST_TIMEOUT_SECONDS);
       const images = validatedCommandAttachments(input.images);
       const result = await commands.submitForkRun({ ...input, images });
 

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -751,7 +751,7 @@ export default function createChatRoutes({
     try {
       const input = parseCommandRequest(parseForkChatCommandRequest, body);
       if (isRequestTimeoutServer(server)) server.timeout(request, FORK_REQUEST_TIMEOUT_SECONDS);
-      const result = await commands.forkChat(input);
+      const result = await commands.forkChat(input, request.signal);
 
       return Response.json(result);
     } catch (error: unknown) {

--- a/server/server.ts
+++ b/server/server.ts
@@ -569,7 +569,7 @@ export async function startServer(): Promise<void> {
       agents: agentRegistry,
       fileMentions: { resolve: resolveFileMentionsInCommand },
       forkChatFileCopy,
-      readForkedNativeHistory: async ({ targetChatId, sourceSession, fork }) => {
+      readForkedNativeHistory: async ({ targetChatId, sourceSession, fork, signal }) => {
         const integration = integrationRegistry.get(sourceSession.agentId);
         if (!integration?.nativeHistoryImport) return null;
         return importNativeHistoryDrafts({
@@ -581,7 +581,7 @@ export async function startServer(): Promise<void> {
           // The fork target starts with no carryover of its own; its history is the
           // session it resumes from.
           carryOverRevision: carryOver.revision([]),
-          signal: new AbortController().signal,
+          signal,
           now: () => new Date().toISOString(),
         });
       },

--- a/web/src/lib/api/__tests__/chats-contract.test.ts
+++ b/web/src/lib/api/__tests__/chats-contract.test.ts
@@ -488,6 +488,7 @@ describe('chats API contract', () => {
 	});
 
 	it('forkRunChat sends POST /api/v1/chats/fork-run', async () => {
+		const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
 		fetchMock.mockResolvedValue(
 			jsonResponse(
 				{
@@ -517,6 +518,7 @@ describe('chats API contract', () => {
 		const [url, opts] = fetchMock.mock.calls[0];
 		expect(url).toBe('/api/v1/chats/fork-run');
 		expect(opts.method).toBe('POST');
+		expect(timeoutSpy).not.toHaveBeenCalled();
 		expect(JSON.parse(opts.body)).toMatchObject({
 			clientRequestId: 'req-1',
 			clientMessageId: 'msg-1',
@@ -1379,6 +1381,7 @@ describe('chats API contract', () => {
 	}
 
 	it('forkChat sends POST with sourceChatId and chatId', async () => {
+		const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
 		fetchMock.mockResolvedValue(
 			jsonResponse({ success: true, sourceChatId: '1', chatId: '2', agentId: 'claude' }),
 		);
@@ -1389,6 +1392,7 @@ describe('chats API contract', () => {
 		const [url, opts] = fetchMock.mock.calls[0];
 		expect(url).toBe('/api/v1/chats/fork');
 		expect(opts.method).toBe('POST');
+		expect(timeoutSpy).not.toHaveBeenCalled();
 		expect(JSON.parse(opts.body)).toEqual({ sourceChatId: '1', chatId: '2' });
 	});
 

--- a/web/src/lib/api/__tests__/client.test.ts
+++ b/web/src/lib/api/__tests__/client.test.ts
@@ -235,6 +235,18 @@ describe('API client helpers', () => {
 		expect(opts.headers).toBeUndefined();
 	});
 
+	it('allows callers to disable the default timeout while preserving their signal', async () => {
+		const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+		const controller = new AbortController();
+		fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+		await apiGet('/api/long-request', { timeoutMs: null, signal: controller.signal });
+
+		const [, opts] = fetchMock.mock.calls[0];
+		expect(timeoutSpy).not.toHaveBeenCalled();
+		expect(opts.signal).toBe(controller.signal);
+	});
+
 	it('omits auth header when no token is set', async () => {
 		clearAuthToken();
 		fetchMock.mockResolvedValue(jsonResponse({ ok: true }));

--- a/web/src/lib/api/chats.ts
+++ b/web/src/lib/api/chats.ts
@@ -213,7 +213,7 @@ export async function generateChatTitle(
 }
 
 export async function forkRunChat(params: ForkRunCommandRequest): Promise<ForkRunCommandResponse> {
-	return apiPost<ForkRunCommandResponse>('/api/v1/chats/fork-run', params);
+	return apiPost<ForkRunCommandResponse>('/api/v1/chats/fork-run', params, { timeoutMs: null });
 }
 
 import type { SelfHandoffRunCommandRequest } from '$shared/self-handoff-contracts';
@@ -642,7 +642,7 @@ export interface ForkChatParams {
 
 /** Forks (clones) an existing chat session into a new chat. */
 export async function forkChat(params: ForkChatParams): Promise<ForkChatResponse> {
-	return apiPost<ForkChatResponse>('/api/v1/chats/fork', params);
+	return apiPost<ForkChatResponse>('/api/v1/chats/fork', params, { timeoutMs: null });
 }
 
 /** Persists a chat placement within its server-resolved section. */

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -23,10 +23,11 @@ export function clearAuthToken(): void {
 	removeLocalStorageItem(LOCAL_STORAGE_KEYS.authToken);
 }
 
-export type ApiFetchOptions = RequestInit & { timeoutMs?: number };
+export type ApiFetchOptions = RequestInit & { timeoutMs?: number | null };
 
-/** Merges a default timeout signal with any caller-provided signal. */
-function withTimeout(options: RequestInit, timeoutMs = DEFAULT_TIMEOUT_MS): RequestInit {
+/** Merges a default timeout signal with any caller-provided signal unless disabled. */
+function withTimeout(options: RequestInit, timeoutMs: number | null = DEFAULT_TIMEOUT_MS): RequestInit {
+	if (timeoutMs === null) return options;
 	const timeoutSignal = AbortSignal.timeout(timeoutMs);
 	const callerSignal = options.signal;
 	return {


### PR DESCRIPTION
OpenCode clones every native message and part before returning a forked session, so large chats can exceed Garcon's normal request deadlines and appear broken while replay continues. This change removes fork-specific provider and client deadlines, propagates admission cancellation through target creation, rolls back local artifacts, cleans up cancelled native children across endpoint replacement and bounded shutdown, lowers expected unknown-session replay events to debug logging, and adds pinned-binary coverage for delayed completion and cancellation.