### PR TITLE
Simplify shared chat and Git review flow

### DIFF
--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -91,7 +91,6 @@
 
 		isLoading = true;
 		loadError = null;
-		let loaded = false;
 		try {
 			const resp = await getSharedChat(token);
 			const snapshot = resp.snapshot;
@@ -102,12 +101,12 @@
 			totalMessages = resp.page.totalMessages;
 			nextBefore = resp.page.nextBefore;
 			snapshotVersion = resp.page.snapshotVersion;
-			loaded = true;
 		} catch (error) {
 			loadError = error instanceof ApiError && error.status === 404 ? 'not-found' : 'load-failed';
+			isLoading = false;
+			return;
 		}
 		isLoading = false;
-		if (!loaded) return;
 		// Scrolls after rendering so shared links open at the latest message.
 		await tick();
 		window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });

--- a/web/src/lib/git/review/git-virtual-review-row-source.ts
+++ b/web/src/lib/git/review/git-virtual-review-row-source.ts
@@ -84,6 +84,10 @@ export function arrayGitVirtualReviewRowSource(
 				row.kind === 'file-header' ? ([[row.filePath, index]] as const) : [],
 			),
 		);
+	const estimateHeight = (row: GitVirtualReviewRow, lineHeight: number): number =>
+		row.kind === 'unified-row' || row.kind === 'split-row'
+			? Math.max(row.estimatedHeight, lineHeight)
+			: row.estimatedHeight;
 	return {
 		rowCount: rows.length,
 		measurementRevision: JSON.stringify(rows.map((row) => [row.id, row.kind, row.estimatedHeight])),
@@ -92,17 +96,11 @@ export function arrayGitVirtualReviewRowSource(
 		estimateRowHeight: (index, lineHeight) => {
 			const row = rows[index];
 			if (!row) return lineHeight;
-			return row.kind === 'unified-row' || row.kind === 'split-row'
-				? Math.max(row.estimatedHeight, lineHeight)
-				: row.estimatedHeight;
+			return estimateHeight(row, lineHeight);
 		},
 		buildVirtualMeasurements: (lineHeight) => ({
 			keys: rows.map((row) => virtualMeasurementKey(row.id)),
-			estimates: rows.map((row) =>
-				row.kind === 'unified-row' || row.kind === 'split-row'
-					? Math.max(row.estimatedHeight, lineHeight)
-					: row.estimatedHeight,
-			),
+			estimates: rows.map((row) => estimateHeight(row, lineHeight)),
 		}),
 		fileStart: (filePath) => starts.get(filePath),
 		fileState: (filePath) => {


### PR DESCRIPTION
Simplifies shared-chat loading by replacing success bookkeeping with direct failure control flow, and consolidates duplicated Git virtual-row height estimation so both measurement paths share one explicit rule without changing behavior.