### PR TITLE
Fix stale recent model resolution

### DIFF
--- a/integration-tests/tests/server/startup-recents.test.ts
+++ b/integration-tests/tests/server/startup-recents.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import type { RecentAgentSetting } from '../../../common/settings.js';
+import { GarconApiError } from '../../support/garcon-client.js';
+import { withIntegrationFixture, type IntegrationFixture } from '../../support/integration-fixture.js';
+
+interface AppSettingsSnapshot {
+  recentAgentSettings: RecentAgentSetting[];
+}
+
+async function recentAgentSettings(fixture: IntegrationFixture): Promise<RecentAgentSetting[]> {
+  const settings = await fixture.client.get<AppSettingsSnapshot>('/api/v1/app/settings');
+  return settings.recentAgentSettings ?? [];
+}
+
+describe('startup recents persistence', () => {
+  test('records interactive startup preferences after a successful start', async () => {
+    await withIntegrationFixture('startup-recents-success', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const started = await fixture.client.startDirectChat({
+        chatId,
+        content: 'records-startup-preferences',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAiResponses,
+      });
+      await fixture.client.waitForTurnTerminal(chatId, started.turnId);
+
+      const recents = await recentAgentSettings(fixture);
+      expect(recents[0]).toMatchObject({
+        agentId: fixture.directAgents.openAiResponses.agentId,
+        model: fixture.directAgents.openAiResponses.provider.model,
+        apiProviderId: fixture.directAgents.openAiResponses.provider.providerId,
+        modelEndpointId: fixture.directAgents.openAiResponses.provider.endpointId,
+      });
+    });
+  });
+
+  test('does not record startup preferences when the start fails dispatch validation', async () => {
+    await withIntegrationFixture('startup-recents-failed-start', async (fixture) => {
+      const provider = await fixture.client.createOpenAiResponsesProvider(
+        fixture.fakeProviders.openAiResponses.baseUrl,
+      );
+      const chatId = fixture.newChatId();
+
+      const failure = await fixture.client.startChat({
+        origin: 'interactive',
+        clientRequestId: crypto.randomUUID(),
+        clientMessageId: crypto.randomUUID(),
+        chatId,
+        agentId: fixture.directAgents.openAiResponses.agentId,
+        projectPath: fixture.dirs.project,
+        model: 'model-not-exposed-by-endpoint',
+        apiProviderId: provider.providerId,
+        modelEndpointId: provider.endpointId,
+        modelProtocol: 'openai-compatible',
+        permissionMode: 'default',
+        thinkingMode: 'none',
+        agentSettings: {
+          ownerId: fixture.directAgents.openAiResponses.agentId,
+          schemaVersion: 1,
+          values: {},
+        },
+        command: 'never dispatched',
+      }).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(failure).toBeInstanceOf(GarconApiError);
+      expect((failure as GarconApiError).status).toBe(422);
+      expect(await recentAgentSettings(fixture)).toEqual([]);
+    });
+  });
+});

--- a/server/commands/command-support.ts
+++ b/server/commands/command-support.ts
@@ -24,6 +24,7 @@ import type { PermissionMode, ThinkingMode } from '../../common/chat-modes.js';
 import type { UserMessagePresentation } from '../../common/chat-types.js';
 import type { JsonObject } from '../../common/json.js';
 import type { AgentRegistryServiceContract } from '../agents/registry.js';
+import type { ChatStartupPreferences } from '../settings/types.js';
 import type {
   AgentExecutionCommandType,
   ForkedAgentSessionOutcome,
@@ -65,7 +66,7 @@ export interface SettingsDep {
   getChatName(chatId: string): string | null | undefined;
   setSessionName(chatId: string, title: string): Promise<unknown>;
   setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;
-  recordChatStartup(defaults: Record<string, unknown>): Promise<void>;
+  recordChatStartup(defaults: ChatStartupPreferences): Promise<void>;
   ensureInNormal(chatId: string): Promise<void>;
   removeFromAllOrderLists(chatId: string): Promise<void>;
   removeSessionName(chatId: string): Promise<void>;

--- a/server/commands/start-commands.ts
+++ b/server/commands/start-commands.ts
@@ -185,8 +185,8 @@ export class StartCommands {
           }
         },
       },
-      dispatch: async (executionAdmission) => {
-        await this.deps.agents.startSession(input.chatId, input.command, {
+      dispatch: (executionAdmission) =>
+        this.deps.agents.startSession(input.chatId, input.command, {
           projectPath: input.projectPath,
           images: input.images.length > 0 ? input.images : undefined,
           clientRequestId: input.clientRequestId,
@@ -194,8 +194,7 @@ export class StartCommands {
           turnId,
           executionAdmission,
           agentSettings: input.agentSettings,
-        });
-      },
+        }),
     });
 
     if (recordsStartupPreferences(input.origin)) {

--- a/server/commands/start-commands.ts
+++ b/server/commands/start-commands.ts
@@ -169,19 +169,6 @@ export class StartCommands {
               : { chatId: input.parentChatId, relation: 'delegation' },
           });
           this.deps.metadata.addNewChatMetadata(input.chatId, input.command);
-          if (recordsStartupPreferences(input.origin)) {
-            await this.deps.settings.recordChatStartup({
-              agentId: input.agentId,
-              projectPath: input.projectPath,
-              model: input.model,
-              apiProviderId: input.apiProviderId,
-              modelEndpointId: input.modelEndpointId,
-              modelProtocol: input.modelProtocol,
-              permissionMode: input.permissionMode,
-              thinkingMode: input.thinkingMode,
-              agentSettingsById: { [input.agentId]: input.agentSettings },
-            });
-          }
           await this.deps.settings.ensureInNormal(input.chatId);
           await this.deps.chats.flush();
         },
@@ -198,16 +185,26 @@ export class StartCommands {
           }
         },
       },
-      dispatch: (executionAdmission) => this.deps.agents.startSession(input.chatId, input.command, {
-        projectPath: input.projectPath,
-        images: input.images.length > 0 ? input.images : undefined,
-        clientRequestId: input.clientRequestId,
-        clientMessageId: input.clientMessageId,
-        turnId,
-        executionAdmission,
-        agentSettings: input.agentSettings,
-      }),
+      dispatch: async (executionAdmission) => {
+        await this.deps.agents.startSession(input.chatId, input.command, {
+          projectPath: input.projectPath,
+          images: input.images.length > 0 ? input.images : undefined,
+          clientRequestId: input.clientRequestId,
+          clientMessageId: input.clientMessageId,
+          turnId,
+          executionAdmission,
+          agentSettings: input.agentSettings,
+        });
+      },
     });
+
+    if (recordsStartupPreferences(input.origin)) {
+      try {
+        await this.deps.settings.recordChatStartup(input);
+      } catch (error: unknown) {
+        logger.warn('commands: failed to record startup preferences:', error);
+      }
+    }
 
     void maybeGenerateChatTitle({
       chatId: input.chatId,

--- a/server/routes/__tests__/chats-start.test.js
+++ b/server/routes/__tests__/chats-start.test.js
@@ -185,7 +185,7 @@ describe('POST /api/v1/chats/start', () => {
     await fs.rm(testBasePath, { recursive: true, force: true });
   });
 
-  it('records startup recents before starting the agent session', async () => {
+  it('records startup recents after the agent session starts', async () => {
     const projectPath = path.join(testBasePath, 'project-a');
     await fs.mkdir(projectPath, { recursive: true });
     parseJsonBody.mockImplementation(() => Promise.resolve({
@@ -208,19 +208,19 @@ describe('POST /api/v1/chats/start', () => {
 	    expect(response.status).toBe(202);
 	    expect(body.success).toBe(true);
 	    expect(body.commandType).toBe('chat-start');
-    expect(settings.recordChatStartup).toHaveBeenCalledWith({
+    expect(settings.recordChatStartup).toHaveBeenCalledTimes(1);
+    expect(settings.recordChatStartup).toHaveBeenCalledWith(expect.objectContaining({
       agentId: 'codex',
-      projectPath,
       model: 'gpt-5.4',
       apiProviderId: null,
       modelEndpointId: null,
       modelProtocol: null,
       permissionMode: 'acceptEdits',
       thinkingMode: 'medium',
-      agentSettingsById: {
-        codex: { ownerId: 'codex', schemaVersion: 1, values: {} },
-      },
-    });
+      agentSettings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+    }));
+    expect(settings.recordChatStartup.mock.invocationCallOrder[0])
+      .toBeGreaterThan(agents.startSession.mock.invocationCallOrder[0]);
 	    expect(agents.startSession).toHaveBeenCalledWith(CHAT_ID, 'hello', expect.objectContaining({
 	      projectPath,
 	      clientRequestId: 'req-start-a',
@@ -236,6 +236,37 @@ describe('POST /api/v1/chats/start', () => {
     );
     expect(queue.completeDirectTurn).toHaveBeenCalledTimes(1);
     expect(queue.releaseDirectTurn).not.toHaveBeenCalled();
+  });
+
+  it('keeps a successfully started chat when startup preference recording fails', async () => {
+    const chatId = '1783725900000112';
+    const projectPath = path.join(testBasePath, 'project-preference-failure');
+    await fs.mkdir(projectPath, { recursive: true });
+    parseJsonBody.mockImplementation(() => Promise.resolve({
+      origin: 'interactive',
+      clientRequestId: 'req-start-preference-failure',
+      clientMessageId: 'msg-start-preference-failure',
+      chatId,
+      agentId: 'codex',
+      projectPath,
+      model: 'gpt-5.4',
+      permissionMode: 'acceptEdits',
+      thinkingMode: 'medium',
+      agentSettings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      command: 'hello',
+    }));
+    settings.recordChatStartup.mockImplementationOnce(() => Promise.reject(new Error('settings unavailable')));
+
+    const response = await handler(new Request('http://localhost/api/v1/chats/start', { method: 'POST' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body.success).toBe(true);
+    expect(testChats.has(chatId)).toBe(true);
+    expect(registry.removeChat).not.toHaveBeenCalled();
+    expect(settings.removeFromAllOrderLists).not.toHaveBeenCalled();
+    expect(queue.completeDirectTurn).toHaveBeenCalledTimes(1);
+    expect(queue.failDirectTurn).not.toHaveBeenCalled();
   });
 
   it('accepts a scalar parent ID and records server-authored delegation parentage', async () => {
@@ -300,7 +331,7 @@ describe('POST /api/v1/chats/start', () => {
     expect(agents.startSession).not.toHaveBeenCalled();
   });
 
-  it('keeps the attempted defaults even when agent startup fails', async () => {
+  it('discards the attempted defaults when agent startup fails', async () => {
     const projectPath = path.join(testBasePath, 'project-b');
     await fs.mkdir(projectPath, { recursive: true });
     parseJsonBody.mockImplementation(() => Promise.resolve({
@@ -323,19 +354,7 @@ describe('POST /api/v1/chats/start', () => {
 
     expect(response.status).toBe(500);
     expect(body.error).toBe('Internal server error');
-    expect(settings.recordChatStartup).toHaveBeenCalledWith({
-      agentId: 'claude',
-      projectPath,
-      model: 'opus',
-      apiProviderId: null,
-      modelEndpointId: null,
-      modelProtocol: null,
-      permissionMode: 'default',
-      thinkingMode: 'none',
-      agentSettingsById: {
-        claude: { ownerId: 'claude', schemaVersion: 1, values: {} },
-      },
-    });
+    expect(settings.recordChatStartup).not.toHaveBeenCalled();
     expect(settings.removeFromAllOrderLists).toHaveBeenCalledWith('1783725900000101');
     expect(queue.failDirectTurn).toHaveBeenCalledTimes(1);
   });
@@ -410,12 +429,10 @@ describe('POST /api/v1/chats/start', () => {
     expect(settings.recordChatStartup).toHaveBeenCalledWith(expect.objectContaining({
       permissionMode: 'default',
       thinkingMode: 'none',
-      agentSettingsById: {
-        claude: {
-          ownerId: 'claude',
-          schemaVersion: 1,
-          values: { vendorOption: 'sometimes' },
-        },
+      agentSettings: {
+        ownerId: 'claude',
+        schemaVersion: 1,
+        values: { vendorOption: 'sometimes' },
       },
     }));
   });

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -46,7 +46,7 @@ import {
 } from '../lib/domain-error.js';
 import { AttachmentValidationError, validateCommandAttachments } from '../attachments/validation.js';
 import { TranscriptHistoryUnavailableError } from '../chats/errors.js';
-import type { ChatReorderResult } from '../settings/types.js';
+import type { ChatReorderResult, ChatStartupPreferences } from '../settings/types.js';
 import type { RouteMap } from '../lib/http-route-types.js';
 import { InMemoryLastSelectedChatState, type LastSelectedChatState } from '../chats/last-selected-chat-state.js';
 import {
@@ -144,7 +144,7 @@ interface SettingsDep {
   getChatName(chatId: string): string | null;
   setSessionName(chatId: string, title: string): Promise<unknown>;
   setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;
-  recordChatStartup(defaults: Record<string, unknown>): Promise<void>;
+  recordChatStartup(defaults: ChatStartupPreferences): Promise<void>;
   ensureInNormal(chatId: string): Promise<void>;
   removeFromAllOrderLists(chatId: string): Promise<void>;
   removeSessionName(chatId: string): Promise<void>;

--- a/server/settings/__tests__/store.test.js
+++ b/server/settings/__tests__/store.test.js
@@ -991,6 +991,40 @@ describe('settings store', () => {
       }]);
     });
 
+    it('maps a chat start agentSettings envelope into per-agent execution defaults', async () => {
+      const envelope = { ownerId: 'codex', schemaVersion: 1, values: { effort: 'high' } };
+      await store.recordChatStartup({
+        origin: 'interactive',
+        agentId: 'codex',
+        projectPath: '/workspace/project-a',
+        model: 'gpt-5.4',
+        permissionMode: 'bypassPermissions',
+        thinkingMode: 'medium',
+        agentSettings: envelope,
+      });
+
+      expect(store.getExecutionDefaults().byAgent.codex).toEqual({
+        permissionMode: 'bypassPermissions',
+        thinkingMode: 'medium',
+        agentSettingsById: { codex: envelope },
+      });
+    });
+
+    it('keeps recordChatStartup best-effort when persistence fails', async () => {
+      await fs.mkdir(settingsFile());
+      try {
+        await store.recordChatStartup({
+          agentId: 'codex',
+          projectPath: '/workspace/project-a',
+          model: 'gpt-5.4',
+        });
+      } finally {
+        await fs.rm(settingsFile(), { recursive: true });
+      }
+
+      expect(store.getRecentAgentSettings()).toEqual([]);
+    });
+
     it('moves duplicate recent targets to the front and caps the list', async () => {
       for (let index = 0; index < 21; index += 1) {
         await store.recordChatStartup({

--- a/server/settings/domain-stores.ts
+++ b/server/settings/domain-stores.ts
@@ -1,5 +1,6 @@
 import type { IChatRegistry } from '../chats/store.js';
 import { createLogger } from '../lib/log.js';
+import { isRecord } from '../../common/json.js';
 
 const logger = createLogger('settings:domain-stores');
 import {
@@ -18,6 +19,7 @@ import {
 import type {
   ChatFolder,
   ChatReorderResult,
+  ChatStartupPreferences,
   ExecutionDefaults,
   ProjectSettings,
   ReorderResult,
@@ -361,35 +363,52 @@ export class StartupDefaultsStore {
     return sanitizeExecutionDefaultsSettings(settings.executionDefaults).defaults;
   }
 
-  async recordChatStartup(defaults: Record<string, unknown> | null | undefined): Promise<void> {
-    return this.#context.mutate(async () => {
-      const settings = this.#context.readSettings();
+  // Startup preferences are advisory: recording happens after a chat already
+  // dispatched, so a persistence failure is logged instead of failing the chat.
+  async recordChatStartup(defaults: ChatStartupPreferences | null | undefined): Promise<void> {
+    try {
+      await this.#context.mutate(async () => {
+        const settings = this.#context.readSettings();
 
-      const recent = sanitizeRecentAgentSetting(defaults);
-      if (recent) {
-        settings.recentAgentSettings = dedupeRecentAgentSettings([
-          recent,
-          ...(settings.recentAgentSettings || []),
-        ]);
-      }
+        const recent = sanitizeRecentAgentSetting(defaults);
+        if (recent) {
+          settings.recentAgentSettings = dedupeRecentAgentSettings([
+            recent,
+            ...(settings.recentAgentSettings || []),
+          ]);
+        }
 
-      settings.paths = recordRecentProjectPath(settings.paths || {}, defaults?.projectPath);
+        settings.paths = recordRecentProjectPath(settings.paths || {}, defaults?.projectPath);
 
-      const agentId = typeof defaults?.agentId === 'string' ? defaults.agentId.trim() : recent?.agentId ?? '';
-      if (agentId) {
-        const current = sanitizeExecutionDefaultsSettings(settings.executionDefaults).defaults;
-        settings.executionDefaults = {
-          ...current,
-          byAgent: {
-            ...current.byAgent,
-            [agentId]: sanitizeExecutionDefaults(defaults),
-          },
-        };
-      }
+        const agentId = typeof defaults?.agentId === 'string' ? defaults.agentId.trim() : recent?.agentId ?? '';
+        if (agentId) {
+          const current = sanitizeExecutionDefaultsSettings(settings.executionDefaults).defaults;
+          // Chat starts carry a single agentSettings envelope for the starting
+          // agent rather than a prebuilt agentSettingsById map.
+          const envelope = isRecord(defaults?.agentSettings) ? defaults.agentSettings : null;
+          settings.executionDefaults = {
+            ...current,
+            byAgent: {
+              ...current.byAgent,
+              [agentId]: sanitizeExecutionDefaults({
+                permissionMode: defaults?.permissionMode,
+                thinkingMode: defaults?.thinkingMode,
+                agentSettingsById: defaults?.agentSettingsById
+                  ?? (envelope ? { [agentId]: envelope } : undefined),
+              }),
+            },
+          };
+        }
 
-      bumpRemoteSettingsVersion(settings);
-      await this.#context.saveAndMaybeEmitRemote(settings, true);
-    });
+        bumpRemoteSettingsVersion(settings);
+        await this.#context.saveAndMaybeEmitRemote(settings, true);
+      });
+    } catch (error: unknown) {
+      logger.warn(
+        'settings: failed to record chat startup preferences:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
   async updateExecutionDefaultsForAgent(

--- a/server/settings/store.ts
+++ b/server/settings/store.ts
@@ -44,6 +44,7 @@ import type { ReorderChatRequest } from '../../common/chat-order-contracts.js';
 import type {
   ChatFolder,
   ChatReorderResult,
+  ChatStartupPreferences,
   ProjectSettings,
   ReorderResult,
   SavedChatSearch,
@@ -439,7 +440,7 @@ export class SettingsStore extends EventEmitter<SettingsStoreEvents> {
     return this.#startupDefaults.getExecutionDefaults();
   }
 
-  async recordChatStartup(defaults: Record<string, unknown> | null | undefined): Promise<void> {
+  async recordChatStartup(defaults: ChatStartupPreferences | null | undefined): Promise<void> {
     return this.#startupDefaults.recordChatStartup(defaults);
   }
 

--- a/server/settings/types.ts
+++ b/server/settings/types.ts
@@ -97,6 +97,22 @@ export interface ExecutionDefaultsSettings {
 
 export type SettingsMutation<T> = () => T | Promise<T>;
 
+// Chat-start records carry startup preferences as unsanitized fields; the
+// store reads only these and ignores the rest of the start command.
+export interface ChatStartupPreferences {
+  origin?: unknown;
+  agentId?: unknown;
+  projectPath?: unknown;
+  model?: unknown;
+  apiProviderId?: unknown;
+  modelEndpointId?: unknown;
+  modelProtocol?: unknown;
+  permissionMode?: unknown;
+  thinkingMode?: unknown;
+  agentSettings?: unknown;
+  agentSettingsById?: unknown;
+}
+
 export interface SettingsStoreContext {
   readSettings(): ProjectSettings;
   mutate<T>(fn: SettingsMutation<T>): Promise<T>;

--- a/server/settings/types.ts
+++ b/server/settings/types.ts
@@ -100,7 +100,6 @@ export type SettingsMutation<T> = () => T | Promise<T>;
 // Chat-start records carry startup preferences as unsanitized fields; the
 // store reads only these and ignores the rest of the start command.
 export interface ChatStartupPreferences {
-  origin?: unknown;
   agentId?: unknown;
   projectPath?: unknown;
   model?: unknown;

--- a/web/src/lib/agents/__tests__/model-catalog-store.test.ts
+++ b/web/src/lib/agents/__tests__/model-catalog-store.test.ts
@@ -420,6 +420,42 @@ describe('ModelCatalogStore', () => {
 		});
 	});
 
+	it('treats an explicit endpoint as a hard constraint when resolving selections', () => {
+		localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({
+				agentModels: {
+					sample: [
+						{ value: 'sol', label: 'Sol' },
+						{ value: 'luna', label: 'Luna' },
+						{
+							value: 'acme-openai:sonnet',
+							label: 'Acme: Sonnet',
+							rawModel: 'sonnet',
+							apiProviderId: 'acme',
+							endpointId: 'acme-openai',
+							protocol: 'openai-compatible',
+						},
+					],
+				},
+				agentMetadata: { sample: agentEntry('sample', { defaultModel: 'sol' }) },
+				apiProviderCatalog: [],
+				lastFetchedAt: Date.now(),
+			}),
+		);
+
+		const store = createModelCatalogStore();
+
+		expect(store.getModelForSelection('sample', 'luna')?.value).toBe('luna');
+		expect(store.getModelForSelection('sample', 'sonnet', 'acme-openai')?.value).toBe(
+			'acme-openai:sonnet',
+		);
+		// A model the endpoint no longer exposes stays unresolvable instead of
+		// silently re-targeting the native model sharing its raw name.
+		expect(store.getModelForSelection('sample', 'luna', 'acme-openai')).toBeNull();
+		expect(store.selectionFor('sample', 'luna', 'acme-openai')).toBeNull();
+	});
+
 	it('ignores malformed integration ids from persisted data', () => {
 		localStorage.setItem(
 			STORAGE_KEY,

--- a/web/src/lib/agents/__tests__/model-catalog-store.test.ts
+++ b/web/src/lib/agents/__tests__/model-catalog-store.test.ts
@@ -436,6 +436,14 @@ describe('ModelCatalogStore', () => {
 							endpointId: 'acme-openai',
 							protocol: 'openai-compatible',
 						},
+						{
+							value: 'acme-openai:retired-native',
+							label: 'Acme: Retired Native',
+							rawModel: 'retired-native',
+							apiProviderId: 'acme',
+							endpointId: 'acme-openai',
+							protocol: 'openai-compatible',
+						},
 					],
 				},
 				agentMetadata: { sample: agentEntry('sample', { defaultModel: 'sol' }) },
@@ -454,6 +462,23 @@ describe('ModelCatalogStore', () => {
 		// silently re-targeting the native model sharing its raw name.
 		expect(store.getModelForSelection('sample', 'luna', 'acme-openai')).toBeNull();
 		expect(store.selectionFor('sample', 'luna', 'acme-openai')).toBeNull();
+		// An unscoped persisted name denotes a native model, not an endpoint
+		// that happens to expose the same raw name.
+		expect(store.getModelForSelection('sample', 'retired-native', null)).toBeNull();
+		expect(
+			store.getModelForSelection('sample', 'acme-openai:retired-native', null),
+		).toBeNull();
+		expect(store.selectionFor('sample', 'retired-native', null)).toEqual({
+			model: 'retired-native',
+			apiProviderId: null,
+			modelEndpointId: null,
+			modelProtocol: null,
+		});
+		expect(store.selectionFor('sample', 'acme-openai:retired-native')).toMatchObject({
+			model: 'retired-native',
+			apiProviderId: 'acme',
+			modelEndpointId: 'acme-openai',
+		});
 	});
 
 	it('ignores malformed integration ids from persisted data', () => {

--- a/web/src/lib/agents/model-catalog-store.svelte.ts
+++ b/web/src/lib/agents/model-catalog-store.svelte.ts
@@ -518,13 +518,12 @@ export class ModelCatalogStore {
 		modelEndpointId?: string | null,
 	): ModelOption | null {
 		const models = this.getModels(agentId);
+		if (modelEndpointId === null) {
+			return models.find(
+				(entry) => !entry.endpointId && (entry.value === model || entry.rawModel === model),
+			) ?? null;
+		}
 		if (modelEndpointId !== undefined) {
-			if (modelEndpointId === null) {
-				return models.find(
-					(entry) =>
-						!entry.endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null;
-			}
 			return models.find(
 				(entry) =>
 					entry.endpointId === modelEndpointId &&

--- a/web/src/lib/agents/model-catalog-store.svelte.ts
+++ b/web/src/lib/agents/model-catalog-store.svelte.ts
@@ -7,6 +7,7 @@ import {
 } from '$lib/utils/local-persistence';
 import type { SessionAgentId } from '$lib/types/app';
 import type { ModelCatalogResponse } from '$shared/model-catalog';
+import type { ResolvedModelSelection } from '$shared/start-selection';
 import {
 	isAgentSettingLabelKey,
 	isAgentSettingOptionDescriptionKey,
@@ -509,6 +510,8 @@ export class ModelCatalogStore {
 		);
 	}
 
+	// An explicit endpoint scopes the selection; a model no longer exposed by
+	// that endpoint is unresolvable rather than matched against another source.
 	getModelForSelection(
 		agentId: SessionAgentId,
 		model: string,
@@ -516,12 +519,11 @@ export class ModelCatalogStore {
 	): ModelOption | null {
 		const models = this.getModels(agentId);
 		if (modelEndpointId) {
-			const matchedEndpointModel = models.find(
+			return models.find(
 				(entry) =>
 					entry.endpointId === modelEndpointId &&
 					(entry.value === model || entry.rawModel === model),
-			);
-			if (matchedEndpointModel) return matchedEndpointModel;
+			) ?? null;
 		}
 		return models.find((entry) => entry.value === model || entry.rawModel === model) ?? null;
 	}
@@ -588,14 +590,29 @@ export class ModelCatalogStore {
 	selectionFor(
 		agentId: SessionAgentId,
 		model: string,
+	): ResolvedModelSelection;
+	selectionFor(
+		agentId: SessionAgentId,
+		model: string,
+		modelEndpointId: string,
+	): ResolvedModelSelection | null;
+	selectionFor(
+		agentId: SessionAgentId,
+		model: string,
+		modelEndpointId: null | undefined,
+	): ResolvedModelSelection;
+	selectionFor(
+		agentId: SessionAgentId,
+		model: string,
 		modelEndpointId?: string | null,
-	): {
-		model: string;
-		apiProviderId: string | null;
-		modelEndpointId: string | null;
-		modelProtocol: ApiProtocol | null;
-	} {
+	): ResolvedModelSelection | null;
+	selectionFor(
+		agentId: SessionAgentId,
+		model: string,
+		modelEndpointId?: string | null,
+	): ResolvedModelSelection | null {
 		const selected = this.getModelForSelection(agentId, model, modelEndpointId);
+		if (!selected && modelEndpointId) return null;
 		return {
 			model: selected?.rawModel ?? model,
 			apiProviderId: selected?.apiProviderId ?? null,

--- a/web/src/lib/agents/model-catalog-store.svelte.ts
+++ b/web/src/lib/agents/model-catalog-store.svelte.ts
@@ -510,22 +510,32 @@ export class ModelCatalogStore {
 		);
 	}
 
-	// An explicit endpoint scopes the selection; a model no longer exposed by
-	// that endpoint is unresolvable rather than matched against another source.
+	// Catalog values identify explicit endpoint choices. Raw persisted names
+	// resolve only within their recorded endpoint or the native catalog.
 	getModelForSelection(
 		agentId: SessionAgentId,
 		model: string,
 		modelEndpointId?: string | null,
 	): ModelOption | null {
 		const models = this.getModels(agentId);
-		if (modelEndpointId) {
+		if (modelEndpointId !== undefined) {
+			if (modelEndpointId === null) {
+				return models.find(
+					(entry) =>
+						!entry.endpointId && (entry.value === model || entry.rawModel === model),
+				) ?? null;
+			}
 			return models.find(
 				(entry) =>
 					entry.endpointId === modelEndpointId &&
 					(entry.value === model || entry.rawModel === model),
 			) ?? null;
 		}
-		return models.find((entry) => entry.value === model || entry.rawModel === model) ?? null;
+		return (
+			models.find((entry) => entry.value === model) ??
+			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+			null
+		);
 	}
 
 	supportsCompact(agentId: SessionAgentId): boolean {

--- a/web/src/lib/chat/conversation/__tests__/conversation-slash-command-service.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-slash-command-service.test.ts
@@ -189,12 +189,14 @@ function createDeps(chat = createChat()) {
 			setCurrentChatId: vi.fn(),
 		},
 		modelCatalog: {
-			selectionFor: vi.fn((_agentId, model) => ({
-				model,
-				apiProviderId: null,
-				modelEndpointId: null,
-				modelProtocol: null,
-			})),
+			selectionFor: vi.fn(
+				(_agentId, model): ReturnType<ConversationSlashCommandDeps['modelCatalog']['selectionFor']> => ({
+					model,
+					apiProviderId: null,
+					modelEndpointId: null,
+					modelProtocol: null,
+				}),
+			),
 			supportsFork: vi.fn(() => false),
 			supportsForkWhileRunning: vi.fn(() => false),
 			supportsSteering: vi.fn(() => false),
@@ -949,6 +951,42 @@ describe('ConversationSlashCommandService', () => {
 		expect(deps.sessions.setSelectedChatId).toHaveBeenCalledWith('chat-2');
 		expect(deps.navigation.navigateToChat).toHaveBeenCalledWith('chat-2');
 		expect(deps.lifecycle.beginTurn).toHaveBeenCalledWith('chat-2');
+	});
+
+	it('preserves stale endpoint routing when a fork model is absent from the catalog', async () => {
+		const chat = createChat({
+			model: 'gpt-stale',
+			apiProviderId: 'stale',
+			modelEndpointId: 'stale_openai',
+			modelProtocol: 'openai-compatible',
+		});
+		const { deps } = createDeps(chat);
+		deps.modelCatalog.selectionFor.mockReturnValueOnce(null);
+		mockForkRunChat.mockResolvedValueOnce({
+			success: true,
+			commandType: 'fork-run',
+			clientRequestId: 'request-1',
+			chatId: 'chat-2',
+			turnId: 'turn-1',
+			status: 'accepted',
+			acceptedAt: '2026-07-14T00:00:00.000Z',
+			chat: createServerEntry('chat-2'),
+		});
+
+		await new ConversationSlashCommandService(deps).submitForkCommand(
+			chat.id,
+			chat,
+			'continue here',
+			[],
+			true,
+		);
+
+		expect(mockForkRunChat).toHaveBeenCalledWith(expect.objectContaining({
+			model: 'gpt-stale',
+			apiProviderId: 'stale',
+			modelEndpointId: 'stale_openai',
+			modelProtocol: 'openai-compatible',
+		}));
 	});
 
 	it('asks before a fork run falls back and repeats it with the same command identities', async () => {

--- a/web/src/lib/chat/conversation/conversation-model-selection.ts
+++ b/web/src/lib/chat/conversation/conversation-model-selection.ts
@@ -1,4 +1,3 @@
-import type { ApiProtocol } from '$shared/api-providers';
 import type { ConversationExecutionSelection } from './conversation-execution-draft-state.svelte.js';
 
 export type ConversationModelSelection = Pick<
@@ -16,12 +15,7 @@ interface ConversationModelSelectionCatalog {
 		agentId: string,
 		model: string,
 		modelEndpointId?: string | null,
-	): {
-		model: string;
-		apiProviderId: string | null;
-		modelEndpointId: string | null;
-		modelProtocol: ApiProtocol | null;
-	};
+	): ConversationModelSelection | null;
 }
 
 export function resolveConversationModelSelection(
@@ -29,9 +23,9 @@ export function resolveConversationModelSelection(
 	catalog: ConversationModelSelectionCatalog,
 ): ConversationModelSelection {
 	const resolved = catalog.selectionFor(source.agentId, source.model, source.modelEndpointId);
-	if (resolved.modelEndpointId || !source.modelEndpointId) return resolved;
+	if (resolved && (resolved.modelEndpointId || !source.modelEndpointId)) return resolved;
 	return {
-		model: resolved.model,
+		model: resolved?.model ?? source.model,
 		apiProviderId: source.apiProviderId,
 		modelEndpointId: source.modelEndpointId,
 		modelProtocol: source.modelProtocol,

--- a/web/src/lib/chat/conversation/conversation-slash-command-service.ts
+++ b/web/src/lib/chat/conversation/conversation-slash-command-service.ts
@@ -4,6 +4,7 @@ import { scheduleChatPrompt } from '$lib/api/scheduled-prompts.js';
 import type { ChatImage } from '$shared/chat-types';
 import type { ChatListEntry } from '$shared/chat-list';
 import type { ApiProtocol } from '$shared/api-providers';
+import { resolveConversationModelSelection } from './conversation-model-selection.js';
 import {
 	steerSubmissionRejection,
 	steerSubmissionRejectionNotice,
@@ -113,7 +114,7 @@ interface SlashCommandModelCatalog {
 		apiProviderId: string | null;
 		modelEndpointId: string | null;
 		modelProtocol: ApiProtocol | null;
-	};
+	} | null;
 	supportsFork(agentId: SessionAgentId): boolean;
 	supportsForkWhileRunning(agentId: SessionAgentId): boolean;
 	supportsSteering(agentId: SessionAgentId): boolean;
@@ -682,11 +683,13 @@ export class ConversationSlashCommandService {
 
 		const forkChatId = createClientChatId();
 		const model = sourceChat.model ?? deps.agentState.model;
-		const selection = deps.modelCatalog.selectionFor(
-			sourceChat.agentId,
+		const selection = resolveConversationModelSelection({
+			agentId: sourceChat.agentId,
 			model,
-			sourceChat.modelEndpointId,
-		);
+			apiProviderId: sourceChat.apiProviderId ?? null,
+			modelEndpointId: sourceChat.modelEndpointId ?? null,
+			modelProtocol: sourceChat.modelProtocol ?? null,
+		}, deps.modelCatalog);
 		const submission = this.acceptedInputs.fork({
 			sourceChatId,
 			chatId: forkChatId,

--- a/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
+++ b/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
@@ -6,6 +6,11 @@ import type { GitWorktreeItem } from '$lib/api/git';
 import type { ModelOption } from '$lib/agents/model-catalog-store.svelte';
 import type { SessionAgentId } from '$lib/types/app';
 import type { RemoteSettingsSnapshot } from '$shared/settings';
+import {
+	findModelForSelection,
+	modelValueForSelection,
+	resolveModelSelection,
+} from '../../../../test/model-catalog';
 
 vi.mock('$lib/api/files', () => ({
 	browseDirectory: vi.fn(),
@@ -190,43 +195,12 @@ const mockModelCatalog = {
 			: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
 	),
 	getModels: vi.fn(modelsForAgent),
-	getModelForSelection: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
-		const models = mockModelCatalog.getModels(agentId);
-		if (endpointId !== undefined) {
-			if (endpointId === null) {
-				return (
-					models.find(
-						(entry) =>
-							!entry.endpointId && (entry.value === model || entry.rawModel === model),
-					) ?? null
-				);
-			}
-			return (
-				models.find(
-					(entry) =>
-						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null
-			);
-		}
-		return (
-			models.find((entry) => entry.value === model) ??
-			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
-			null
-		);
-	}),
-	selectionFor: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
-		const selected = mockModelCatalog.getModelForSelection(agentId, model, endpointId);
-		if (!selected && endpointId) return null;
-		return {
-			model: selected?.rawModel ?? model,
-			apiProviderId: selected?.apiProviderId ?? null,
-			modelEndpointId: selected?.endpointId ?? null,
-			modelProtocol: selected?.protocol ?? null,
-		};
-	}),
-	selectionValueFor: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
-		return mockModelCatalog.getModelForSelection(agentId, model, endpointId)?.value ?? model;
-	}),
+	getModelForSelection: vi.fn((agentId: string, model: string, endpointId?: string | null) =>
+		findModelForSelection(mockModelCatalog.getModels(agentId), model, endpointId)),
+	selectionFor: vi.fn((agentId: string, model: string, endpointId?: string | null) =>
+		resolveModelSelection(mockModelCatalog.getModels(agentId), model, endpointId)),
+	selectionValueFor: vi.fn((agentId: string, model: string, endpointId?: string | null) =>
+		modelValueForSelection(mockModelCatalog.getModels(agentId), model, endpointId)),
 	refreshIfStale: vi.fn().mockResolvedValue(undefined),
 };
 

--- a/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
+++ b/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
@@ -192,54 +192,40 @@ const mockModelCatalog = {
 	getModels: vi.fn(modelsForAgent),
 	getModelForSelection: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
 		const models = mockModelCatalog.getModels(agentId);
+		if (endpointId !== undefined) {
+			if (endpointId === null) {
+				return (
+					models.find(
+						(entry) =>
+							!entry.endpointId && (entry.value === model || entry.rawModel === model),
+					) ?? null
+				);
+			}
+			return (
+				models.find(
+					(entry) =>
+						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
+				) ?? null
+			);
+		}
 		return (
-			models.find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			) ?? null
+			models.find((entry) => entry.value === model) ??
+			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+			null
 		);
 	}),
-	selectionFor: vi.fn((agentId: string, model: string) => {
-		if (agentId === 'direct-anthropic-compatible' && model === 'acme_anthropic:acme-sonnet') {
-			return {
-				model: 'acme-sonnet',
-				apiProviderId: 'acme',
-				modelEndpointId: 'acme_anthropic',
-				modelProtocol: 'anthropic-messages',
-			};
-		}
-		if (agentId === 'direct-openai-compatible' && model === 'zai_openai:glm-5.1') {
-			return {
-				model: 'glm-5.1',
-				apiProviderId: 'zai',
-				modelEndpointId: 'zai_openai',
-				modelProtocol: 'openai-compatible',
-			};
-		}
+	selectionFor: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
+		const selected = mockModelCatalog.getModelForSelection(agentId, model, endpointId);
+		if (!selected && endpointId) return null;
 		return {
-			model,
-			apiProviderId: null,
-			modelEndpointId: null,
-			modelProtocol: null,
+			model: selected?.rawModel ?? model,
+			apiProviderId: selected?.apiProviderId ?? null,
+			modelEndpointId: selected?.endpointId ?? null,
+			modelProtocol: selected?.protocol ?? null,
 		};
 	}),
 	selectionValueFor: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
-		if (
-			agentId === 'direct-anthropic-compatible' &&
-			model === 'acme-sonnet' &&
-			endpointId === 'acme_anthropic'
-		) {
-			return 'acme_anthropic:acme-sonnet';
-		}
-		if (
-			agentId === 'direct-openai-compatible' &&
-			model === 'glm-5.1' &&
-			endpointId === 'zai_openai'
-		) {
-			return 'zai_openai:glm-5.1';
-		}
-		return model;
+		return mockModelCatalog.getModelForSelection(agentId, model, endpointId)?.value ?? model;
 	}),
 	refreshIfStale: vi.fn().mockResolvedValue(undefined),
 };
@@ -574,6 +560,61 @@ describe('NewChatFormState', () => {
 		expect(formState.modelValue).toBe('opus');
 	});
 
+	it('skips a stale native recent when refresh leaves only an endpoint with the same model', async () => {
+		const refresh = deferred<void>();
+		let catalogFresh = false;
+		mockModelCatalog.getModels.mockImplementation((agentId: string) => {
+			if (agentId !== 'codex') return modelsForAgent(agentId);
+			if (!catalogFresh) return [{ value: 'shared-model', label: 'Shared Model' }];
+			return [
+				{
+					value: 'live_openai:shared-model',
+					label: 'Live: Shared Model',
+					rawModel: 'shared-model',
+					apiProviderId: 'live-provider',
+					endpointId: 'live_openai',
+					protocol: 'openai-compatible',
+				},
+			];
+		});
+		mockModelCatalog.refreshIfStale.mockImplementationOnce(async () => {
+			await refresh.promise;
+			catalogFresh = true;
+		});
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'codex',
+						model: 'shared-model',
+						apiProviderId: null,
+						modelEndpointId: null,
+						modelProtocol: null,
+					},
+					{
+						agentId: 'claude',
+						model: 'opus',
+						apiProviderId: null,
+						modelEndpointId: null,
+						modelProtocol: null,
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+		expect(formState.agentId).toBe('codex');
+		expect(formState.modelValue).toBe('shared-model');
+
+		refresh.resolve();
+		await refresh.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(formState.agentId).toBe('claude');
+		expect(formState.modelValue).toBe('opus');
+	});
+
 	it('blocks a user-touched endpoint selection that disappears during catalog refresh', async () => {
 		const refresh = deferred<void>();
 		let catalogFresh = false;
@@ -850,6 +891,41 @@ describe('NewChatFormState', () => {
 
 		expect(formState.agentId).toBe('codex');
 		expect(formState.modelValue).toBe('gpt-5.4');
+	});
+
+	it('preserves a user-touched selection when its agent becomes unavailable', async () => {
+		const refresh = deferred<void>();
+		mockModelCatalog.refreshIfStale.mockReturnValueOnce(refresh.promise);
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'direct-openai-compatible',
+						model: 'glm-5.1',
+						apiProviderId: 'zai',
+						modelEndpointId: 'zai_openai',
+						modelProtocol: 'openai-compatible',
+					},
+				],
+			}),
+		);
+		await formState.loadSettingsAndModels();
+		formState.setThinkingMode('low');
+
+		selectableAgentIds = ['claude', 'codex'];
+		formState.reconcileAgentSelection();
+
+		expect(formState.agentId).toBe('direct-openai-compatible');
+		expect(formState.modelSelectionTarget).toMatchObject({
+			model: 'glm-5.1',
+			apiProviderId: 'zai',
+			modelEndpointId: 'zai_openai',
+		});
+		expect(formState.canSubmit).toBe(false);
+		expect(formState.buildConfig()).toBeNull();
+
+		refresh.resolve();
+		await refresh.promise;
 	});
 
 	it('falls back when startup defaults reference a non-agent API provider id', async () => {

--- a/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
+++ b/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
@@ -122,6 +122,36 @@ function deferred<T>() {
 	return { promise, resolve };
 }
 
+function modelsForAgent(agentId: string): ModelOption[] {
+	if (agentId === 'claude') return [{ value: 'opus', label: 'Opus' }];
+	if (agentId === 'codex') return [{ value: 'gpt-5.4', label: 'GPT-5.4' }];
+	if (agentId === 'direct-anthropic-compatible') {
+		return [
+			{
+				value: 'acme_anthropic:acme-sonnet',
+				label: 'Acme: Acme Sonnet',
+				rawModel: 'acme-sonnet',
+				apiProviderId: 'acme',
+				endpointId: 'acme_anthropic',
+				protocol: 'anthropic-messages',
+			},
+		];
+	}
+	if (agentId === 'direct-openai-compatible') {
+		return [
+			{
+				value: 'zai_openai:glm-5.1',
+				label: 'Z.AI: GLM-5.1',
+				rawModel: 'glm-5.1',
+				apiProviderId: 'zai',
+				endpointId: 'zai_openai',
+				protocol: 'openai-compatible',
+			},
+		];
+	}
+	return [];
+}
+
 const mockModelCatalog = {
 	agentMetadata: {
 		claude: { label: 'Claude' },
@@ -159,35 +189,7 @@ const mockModelCatalog = {
 			? ['none', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
 			: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
 	),
-	getModels: vi.fn((agentId: string): ModelOption[] => {
-		if (agentId === 'claude') return [{ value: 'opus', label: 'Opus' }];
-		if (agentId === 'codex') return [{ value: 'gpt-5.4', label: 'GPT-5.4' }];
-		if (agentId === 'direct-anthropic-compatible') {
-			return [
-				{
-					value: 'acme_anthropic:acme-sonnet',
-					label: 'Acme: Acme Sonnet',
-					rawModel: 'acme-sonnet',
-					apiProviderId: 'acme',
-					endpointId: 'acme_anthropic',
-					protocol: 'anthropic-messages',
-				},
-			];
-		}
-		if (agentId === 'direct-openai-compatible') {
-			return [
-				{
-					value: 'zai_openai:glm-5.1',
-					label: 'Z.AI: GLM-5.1',
-					rawModel: 'glm-5.1',
-					apiProviderId: 'zai',
-					endpointId: 'zai_openai',
-					protocol: 'openai-compatible',
-				},
-			];
-		}
-		return [];
-	}),
+	getModels: vi.fn(modelsForAgent),
 	getModelForSelection: vi.fn((agentId: string, model: string, endpointId?: string | null) => {
 		const models = mockModelCatalog.getModels(agentId);
 		return (
@@ -257,6 +259,8 @@ describe('NewChatFormState', () => {
 			'direct-anthropic-compatible',
 			'direct-openai-compatible',
 		]);
+		mockModelCatalog.getModels.mockImplementation(modelsForAgent);
+		mockModelCatalog.refreshIfStale.mockResolvedValue(undefined);
 		selectableAgentIds = [
 			'claude',
 			'codex',
@@ -458,6 +462,116 @@ describe('NewChatFormState', () => {
 
 		expect(formState.agentId).toBe('codex');
 		expect(formState.modelValue).toBe('gpt-5.4');
+	});
+
+	it('skips a startup recent whose endpoint no longer exposes the model', async () => {
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'claude',
+						model: 'opus',
+						apiProviderId: 'acme',
+						modelEndpointId: 'acme_anthropic',
+						modelProtocol: 'anthropic-messages',
+					},
+					{
+						agentId: 'codex',
+						model: 'gpt-5.4',
+						apiProviderId: null,
+						modelEndpointId: null,
+						modelProtocol: null,
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+
+		expect(formState.agentId).toBe('codex');
+		expect(formState.modelValue).toBe('gpt-5.4');
+	});
+
+	it('reselects the next valid recent after a cached endpoint model disappears', async () => {
+		const refresh = deferred<void>();
+		let catalogFresh = false;
+		mockModelCatalog.getModels.mockImplementation((agentId: string) => {
+			if (agentId !== 'codex' || catalogFresh) return modelsForAgent(agentId);
+			return [
+				{
+					value: 'stale_openai:gpt-stale',
+					label: 'Stale: GPT',
+					rawModel: 'gpt-stale',
+					apiProviderId: 'stale',
+					endpointId: 'stale_openai',
+					protocol: 'openai-compatible',
+				},
+			];
+		});
+		mockModelCatalog.refreshIfStale.mockImplementationOnce(async () => {
+			await refresh.promise;
+			catalogFresh = true;
+		});
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'codex',
+						model: 'gpt-stale',
+						apiProviderId: 'stale',
+						modelEndpointId: 'stale_openai',
+						modelProtocol: 'openai-compatible',
+					},
+					{
+						agentId: 'claude',
+						model: 'opus',
+						apiProviderId: null,
+						modelEndpointId: null,
+						modelProtocol: null,
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+		expect(formState.agentId).toBe('codex');
+		expect(formState.modelValue).toBe('stale_openai:gpt-stale');
+
+		refresh.resolve();
+		await refresh.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(formState.agentId).toBe('claude');
+		expect(formState.modelValue).toBe('opus');
+	});
+
+	it('preserves a user model selection while the catalog refreshes', async () => {
+		const refresh = deferred<void>();
+		mockModelCatalog.refreshIfStale.mockReturnValueOnce(refresh.promise);
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'codex',
+						model: 'gpt-5.4',
+						apiProviderId: null,
+						modelEndpointId: null,
+						modelProtocol: null,
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+		formState.selectAgent('claude');
+		formState.handleModelChange('opus');
+		refresh.resolve();
+		await refresh.promise;
+		await Promise.resolve();
+
+		expect(formState.agentId).toBe('claude');
+		expect(formState.modelValue).toBe('opus');
 	});
 
 	it('applies eligible startup recents after background catalog discovery', async () => {

--- a/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
+++ b/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
@@ -565,7 +565,7 @@ describe('NewChatFormState', () => {
 
 		await formState.loadSettingsAndModels();
 		formState.selectAgent('claude');
-		formState.handleModelChange('opus');
+		formState.selectModel('opus');
 		refresh.resolve();
 		await refresh.promise;
 		await Promise.resolve();
@@ -609,7 +609,7 @@ describe('NewChatFormState', () => {
 		);
 
 		await formState.loadSettingsAndModels();
-		formState.handleModelChange('stale_openai:gpt-stale');
+		formState.selectModel('stale_openai:gpt-stale');
 		formState.projectPath = '/valid/path';
 		formState.validationStatus = 'valid';
 		formState.firstMessage = 'Start this task';
@@ -625,10 +625,111 @@ describe('NewChatFormState', () => {
 		expect(formState.canSubmit).toBe(false);
 		expect(formState.buildConfig()).toBeNull();
 
-		formState.handleModelChange('gpt-5.4');
+		formState.selectModel('gpt-5.4');
 		expect(formState.modelSelectionError).toBeNull();
 		expect(formState.canSubmit).toBe(true);
 		expect(formState.buildConfig()?.model).toBe('gpt-5.4');
+	});
+
+	it('blocks a touched direct selection when its sole endpoint disappears', async () => {
+		const refresh = deferred<void>();
+		let catalogFresh = false;
+		selectableAgentIds = ['direct-openai-compatible'];
+		mockModelCatalog.getModels.mockImplementation((agentId: string) => {
+			if (agentId === 'direct-openai-compatible' && catalogFresh) return [];
+			return modelsForAgent(agentId);
+		});
+		mockModelCatalog.refreshIfStale.mockImplementationOnce(async () => {
+			await refresh.promise;
+			catalogFresh = true;
+		});
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'direct-openai-compatible',
+						model: 'glm-5.1',
+						apiProviderId: 'zai',
+						modelEndpointId: 'zai_openai',
+						modelProtocol: 'openai-compatible',
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+		formState.setThinkingMode('low');
+		formState.projectPath = '/valid/path';
+		formState.validationStatus = 'valid';
+		formState.firstMessage = 'Start this task';
+
+		expect(formState.canSubmit).toBe(true);
+		expect(formState.modelSelectionTarget?.modelEndpointId).toBe('zai_openai');
+
+		refresh.resolve();
+		await refresh.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(formState.agentId).toBe('direct-openai-compatible');
+		expect(formState.modelValue).toBe('zai_openai:glm-5.1');
+		expect(formState.modelSelectionTarget).toMatchObject({
+			model: 'glm-5.1',
+			apiProviderId: 'zai',
+			modelEndpointId: 'zai_openai',
+			modelProtocol: 'openai-compatible',
+		});
+		expect(formState.modelSelectionError).toBe('Model unavailable');
+		expect(formState.canSubmit).toBe(false);
+		expect(formState.buildConfig()).toBeNull();
+	});
+
+	it('falls back to the live default when the only automatic recent disappears', async () => {
+		const refresh = deferred<void>();
+		let catalogFresh = false;
+		selectableAgentIds = ['codex'];
+		mockModelCatalog.getModels.mockImplementation((agentId: string) => {
+			if (agentId !== 'codex' || catalogFresh) return modelsForAgent(agentId);
+			return [
+				{
+					value: 'stale_openai:gpt-stale',
+					label: 'Stale: GPT',
+					rawModel: 'gpt-stale',
+					apiProviderId: 'stale',
+					endpointId: 'stale_openai',
+					protocol: 'openai-compatible',
+				},
+			];
+		});
+		mockModelCatalog.refreshIfStale.mockImplementationOnce(async () => {
+			await refresh.promise;
+			catalogFresh = true;
+		});
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'codex',
+						model: 'gpt-stale',
+						apiProviderId: 'stale',
+						modelEndpointId: 'stale_openai',
+						modelProtocol: 'openai-compatible',
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+		expect(formState.modelValue).toBe('stale_openai:gpt-stale');
+
+		refresh.resolve();
+		await refresh.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(formState.agentId).toBe('codex');
+		expect(formState.modelValue).toBe('gpt-5.4');
+		expect(formState.modelSelectionError).toBeNull();
 	});
 
 	it('applies eligible startup recents after background catalog discovery', async () => {
@@ -915,7 +1016,7 @@ describe('NewChatFormState', () => {
 		formState.validationStatus = 'valid';
 		formState.firstMessage = 'Start this task';
 		formState.agentId = 'codex';
-		formState.handleModelChange('gpt-5.4');
+		formState.selectModel('gpt-5.4');
 		formState.permissionMode = 'acceptEdits';
 		formState.thinkingMode = 'medium';
 		formState.agentSettingsById = {

--- a/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
+++ b/web/src/lib/chat/new-chat/__tests__/new-chat-form-state.test.ts
@@ -574,6 +574,63 @@ describe('NewChatFormState', () => {
 		expect(formState.modelValue).toBe('opus');
 	});
 
+	it('blocks a user-touched endpoint selection that disappears during catalog refresh', async () => {
+		const refresh = deferred<void>();
+		let catalogFresh = false;
+		mockModelCatalog.getModels.mockImplementation((agentId: string) => {
+			if (agentId !== 'codex' || catalogFresh) return modelsForAgent(agentId);
+			return [
+				{
+					value: 'stale_openai:gpt-stale',
+					label: 'Stale: GPT',
+					rawModel: 'gpt-stale',
+					apiProviderId: 'stale',
+					endpointId: 'stale_openai',
+					protocol: 'openai-compatible',
+				},
+			];
+		});
+		mockModelCatalog.refreshIfStale.mockImplementationOnce(async () => {
+			await refresh.promise;
+			catalogFresh = true;
+		});
+		mockRemoteSettings.ensureLoaded.mockResolvedValue(
+			makeSnapshot({
+				recentAgentSettings: [
+					{
+						agentId: 'codex',
+						model: 'gpt-stale',
+						apiProviderId: 'stale',
+						modelEndpointId: 'stale_openai',
+						modelProtocol: 'openai-compatible',
+					},
+				],
+			}),
+		);
+
+		await formState.loadSettingsAndModels();
+		formState.handleModelChange('stale_openai:gpt-stale');
+		formState.projectPath = '/valid/path';
+		formState.validationStatus = 'valid';
+		formState.firstMessage = 'Start this task';
+
+		refresh.resolve();
+		await refresh.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(formState.agentId).toBe('codex');
+		expect(formState.modelValue).toBe('stale_openai:gpt-stale');
+		expect(formState.modelSelectionError).toBe('Model unavailable');
+		expect(formState.canSubmit).toBe(false);
+		expect(formState.buildConfig()).toBeNull();
+
+		formState.handleModelChange('gpt-5.4');
+		expect(formState.modelSelectionError).toBeNull();
+		expect(formState.canSubmit).toBe(true);
+		expect(formState.buildConfig()?.model).toBe('gpt-5.4');
+	});
+
 	it('applies eligible startup recents after background catalog discovery', async () => {
 		const refresh = deferred<void>();
 		selectableAgentIds = [];

--- a/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
@@ -143,6 +143,7 @@ export class NewChatFormState {
 		return (
 			this.settingsLoaded &&
 			this.#selectableAgentIds.includes(this.agentId) &&
+			!this.modelSelectionError &&
 			canSubmitNewChat(
 				this.trimmedPath,
 				this.validationStatus,
@@ -173,6 +174,14 @@ export class NewChatFormState {
 		return (
 			this.selectedModelsByAgent[this.agentId] ?? this.#modelCatalog.getDefaultModel(this.agentId)
 		);
+	}
+
+	get modelSelectionError(): string | null {
+		const liveModels = this.#modelCatalog.getModels(this.agentId);
+		if (!liveModels.length || liveModels.some((entry) => entry.value === this.modelValue)) {
+			return null;
+		}
+		return m.model_selector_unavailable();
 	}
 
 	get agentSettings(): AgentSettingsEnvelope {
@@ -258,12 +267,15 @@ export class NewChatFormState {
 		};
 	}
 
-	/** Validates the selected model against the live model list for an agent. */
+	/** Replaces only untouched startup selections that are absent from the live catalog. */
 	validateModelAgainstLive(agentId: SessionAgentId): void {
 		const liveModels = this.#modelCatalog.getModels(agentId);
 		if (!liveModels?.length) return;
 		const current = this.selectedModelsByAgent[agentId];
-		if (!current || !liveModels.some((entry) => entry.value === current)) {
+		if (!current || (
+			this.#startupSelectionAutomatic &&
+			!liveModels.some((entry) => entry.value === current)
+		)) {
 			this.selectedModelsByAgent = {
 				...this.selectedModelsByAgent,
 				[agentId]: liveModels[0].value,
@@ -557,6 +569,7 @@ export class NewChatFormState {
 			this.error = m.chat_new_chat_errors_agent_unavailable();
 			return null;
 		}
+		if (this.modelSelectionError) return null;
 		if (!this.trimmedPath) {
 			this.error = m.chat_new_chat_errors_project_path_required();
 			return null;

--- a/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
@@ -722,10 +722,8 @@ export class NewChatFormState {
 					this.applyResolvedModel(this.agentId, this.#modelCatalog.getDefaultModel(this.agentId));
 				}
 				this.#applyExecutionDefaultsForAgent(this.agentId);
-				this.validateAllModelsAgainstLive();
-			} else {
-				this.validateAllModelsAgainstLive();
 			}
+			this.validateAllModelsAgainstLive();
 		} catch (err) {
 			console.warn('[NewChatFormState] Failed to refresh models', err);
 		}
@@ -772,15 +770,9 @@ export class NewChatFormState {
 		for (const recent of recents) {
 			const agentId = recent.agentId as SessionAgentId;
 			if (!selectable.has(agentId)) continue;
-			const modelValue = this.#modelCatalog.selectionValueFor(
-				agentId,
-				recent.model,
-				recent.modelEndpointId,
-			);
-			if (!modelValue) continue;
 			const model = this.#modelCatalog.getModelForSelection(
 				agentId,
-				modelValue,
+				recent.model,
 				recent.modelEndpointId,
 			);
 			if (model) return recent;

--- a/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
@@ -75,7 +75,7 @@ export class NewChatFormState {
 	#modesTouched = false;
 	#executionDefaults: RemoteExecutionDefaults | null = null;
 	#startupRecents: RecentAgentSetting[] = [];
-	#awaitingCatalogStartupSelection = false;
+	#startupSelectionAutomatic = false;
 
 	// Tags
 	chatTags = $state<string[]>([]);
@@ -191,7 +191,7 @@ export class NewChatFormState {
 
 	selectAgent(next: SessionAgentId): void {
 		if (!this.#selectableAgentIds.includes(next)) return;
-		this.#awaitingCatalogStartupSelection = false;
+		this.#startupSelectionAutomatic = false;
 		const changed = this.agentId !== next;
 		this.agentId = next;
 		if (changed && !this.#modesTouched) {
@@ -210,16 +210,19 @@ export class NewChatFormState {
 	}
 
 	setPermissionMode(mode: PermissionMode): void {
+		this.#startupSelectionAutomatic = false;
 		this.permissionMode = normalizeSupportedPermissionMode(mode, this.permissionModes);
 		this.#modesTouched = true;
 	}
 
 	setThinkingMode(mode: ThinkingMode): void {
+		this.#startupSelectionAutomatic = false;
 		this.thinkingMode = normalizeSupportedThinkingMode(mode, this.thinkingModes);
 		this.#modesTouched = true;
 	}
 
 	setAgentSetting(descriptor: AgentSettingDescriptor, value: JsonValue): void {
+		this.#startupSelectionAutomatic = false;
 		this.#configuredAgentSettings.add(this.agentId);
 		this.agentSettingsById = {
 			...this.agentSettingsById,
@@ -248,6 +251,7 @@ export class NewChatFormState {
 	// Model
 
 	handleModelChange(value: string): void {
+		this.#startupSelectionAutomatic = false;
 		this.selectedModelsByAgent = {
 			...this.selectedModelsByAgent,
 			[this.agentId]: value,
@@ -610,7 +614,7 @@ export class NewChatFormState {
 
 	/** Loads server settings without blocking the form on live model discovery. */
 	async loadSettingsAndModels(): Promise<void> {
-		this.#awaitingCatalogStartupSelection = this.#selectableAgentIds.length === 0;
+		this.#startupSelectionAutomatic = true;
 		try {
 			const settingsData = await this.#remoteSettings.ensureLoaded();
 			this.#applySettings(settingsData);
@@ -633,7 +637,7 @@ export class NewChatFormState {
 		try {
 			await this.#modelCatalog.refreshIfStale();
 			this.#reconcileAgentSettingsWithCatalog();
-			if (this.#awaitingCatalogStartupSelection) {
+			if (this.#startupSelectionAutomatic) {
 				const recent = this.#firstSelectableRecent(this.#startupRecents);
 				this.agentId = recent
 					? (recent.agentId as SessionAgentId)
@@ -642,7 +646,7 @@ export class NewChatFormState {
 					this.applyResolvedModel(this.agentId, recent.model, recent.modelEndpointId);
 				}
 				this.#applyExecutionDefaultsForAgent(this.agentId);
-				this.#awaitingCatalogStartupSelection = false;
+				this.#startupSelectionAutomatic = false;
 			}
 			this.validateAllModelsAgainstLive();
 		} catch (err) {

--- a/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
@@ -221,6 +221,10 @@ export class NewChatFormState {
 	selectAgent(next: SessionAgentId): void {
 		if (!this.#selectableAgentIds.includes(next)) return;
 		this.#startupSelectionAutomatic = false;
+		this.#applyAgent(next);
+	}
+
+	#applyAgent(next: SessionAgentId): void {
 		const changed = this.agentId !== next;
 		this.agentId = next;
 		if (changed && !this.#modesTouched) {
@@ -288,7 +292,9 @@ export class NewChatFormState {
 		);
 	}
 
-	restoreModelSelection(agentId: SessionAgentId, selection: ResolvedModelSelection): void {
+	restoreSelection(agentId: SessionAgentId, selection: ResolvedModelSelection): void {
+		this.#startupSelectionAutomatic = false;
+		this.agentId = agentId;
 		this.#setModelSelection(
 			agentId,
 			this.#modelCatalog.selectionValueFor(
@@ -322,6 +328,7 @@ export class NewChatFormState {
 		selectableAgentIds: readonly SessionAgentId[] = this.#selectableAgentIds,
 	): void {
 		if (selectableAgentIds.includes(this.agentId)) return;
+		if (!this.#startupSelectionAutomatic) return;
 
 		const recent = this.#firstSelectableRecent(this.#startupRecents, selectableAgentIds);
 		const nextAgentId = recent
@@ -329,7 +336,7 @@ export class NewChatFormState {
 			: this.#resolveStartupAgent(DEFAULT_AGENT_ID, selectableAgentIds);
 		if (!selectableAgentIds.includes(nextAgentId)) return;
 
-		this.selectAgent(nextAgentId);
+		this.#applyAgent(nextAgentId);
 		if (recent) {
 			this.applyResolvedModel(nextAgentId, recent.model, recent.modelEndpointId);
 		} else {
@@ -716,7 +723,6 @@ export class NewChatFormState {
 				}
 				this.#applyExecutionDefaultsForAgent(this.agentId);
 				this.validateAllModelsAgainstLive();
-				this.#startupSelectionAutomatic = false;
 			} else {
 				this.validateAllModelsAgainstLive();
 			}

--- a/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
+++ b/web/src/lib/chat/new-chat/new-chat-form-state.svelte.ts
@@ -25,8 +25,9 @@ import {
 	normalizeAgentSettings,
 	withAgentSetting,
 } from '$shared/agent-settings';
-import type { ModelCatalogStore } from '$lib/agents/model-catalog-store.svelte.js';
+import type { ModelCatalogStore, ModelOption } from '$lib/agents/model-catalog-store.svelte.js';
 import type { RemoteSettingsStore } from '$lib/stores/remote-settings.svelte.js';
+import type { ResolvedModelSelection } from '$shared/start-selection';
 import {
 	executionDefaultsForAgent,
 	normalizeSupportedPermissionMode,
@@ -52,6 +53,8 @@ export class NewChatFormState {
 	// Agent and model
 	agentId = $state<SessionAgentId>(DEFAULT_AGENT_ID);
 	selectedModelsByAgent = $state<Record<string, string>>({});
+	#selectedModelTargetsByAgent = $state<Record<string, ResolvedModelSelection>>({});
+	#catalogRefreshCompleted = $state(false);
 
 	// Path
 	projectPath = $state('');
@@ -143,6 +146,7 @@ export class NewChatFormState {
 		return (
 			this.settingsLoaded &&
 			this.#selectableAgentIds.includes(this.agentId) &&
+			!this.modelSelectionPending &&
 			!this.modelSelectionError &&
 			canSubmitNewChat(
 				this.trimmedPath,
@@ -176,11 +180,27 @@ export class NewChatFormState {
 		);
 	}
 
+	get modelSelectionTarget(): ResolvedModelSelection | null {
+		return this.#selectedModelTargetsByAgent[this.agentId] ?? null;
+	}
+
+	get resolvedModelSelection(): ResolvedModelSelection | null {
+		const modelValue = this.modelValue;
+		const endpointId = this.modelSelectionTarget?.modelEndpointId;
+		if (!this.#modelCatalog.getModelForSelection(this.agentId, modelValue, endpointId)) return null;
+		return this.#modelCatalog.selectionFor(this.agentId, modelValue, endpointId);
+	}
+
+	get modelSelectionPending(): boolean {
+		return (
+			!this.resolvedModelSelection &&
+			!this.#catalogRefreshCompleted &&
+			this.#modelCatalog.getModels(this.agentId).length === 0
+		);
+	}
+
 	get modelSelectionError(): string | null {
-		const liveModels = this.#modelCatalog.getModels(this.agentId);
-		if (!liveModels.length || liveModels.some((entry) => entry.value === this.modelValue)) {
-			return null;
-		}
+		if (this.resolvedModelSelection || this.modelSelectionPending) return null;
 		return m.model_selector_unavailable();
 	}
 
@@ -259,28 +279,37 @@ export class NewChatFormState {
 
 	// Model
 
-	handleModelChange(value: string): void {
+	selectModel(value: string, selection?: ResolvedModelSelection): void {
 		this.#startupSelectionAutomatic = false;
-		this.selectedModelsByAgent = {
-			...this.selectedModelsByAgent,
-			[this.agentId]: value,
-		};
+		this.#setModelSelection(
+			this.agentId,
+			value,
+			selection ?? this.#modelCatalog.selectionFor(this.agentId, value),
+		);
+	}
+
+	restoreModelSelection(agentId: SessionAgentId, selection: ResolvedModelSelection): void {
+		this.#setModelSelection(
+			agentId,
+			this.#modelCatalog.selectionValueFor(
+				agentId,
+				selection.model,
+				selection.modelEndpointId,
+			),
+			selection,
+		);
 	}
 
 	/** Replaces only untouched startup selections that are absent from the live catalog. */
 	validateModelAgainstLive(agentId: SessionAgentId): void {
 		const liveModels = this.#modelCatalog.getModels(agentId);
-		if (!liveModels?.length) return;
 		const current = this.selectedModelsByAgent[agentId];
-		if (!current || (
+		const endpointId = this.#selectedModelTargetsByAgent[agentId]?.modelEndpointId;
+		if (
 			this.#startupSelectionAutomatic &&
-			!liveModels.some((entry) => entry.value === current)
-		)) {
-			this.selectedModelsByAgent = {
-				...this.selectedModelsByAgent,
-				[agentId]: liveModels[0].value,
-			};
-		}
+			(!current || !this.#modelCatalog.getModelForSelection(agentId, current, endpointId)) &&
+			liveModels[0]
+		) this.#selectCatalogModel(agentId, liveModels[0]);
 	}
 
 	validateAllModelsAgainstLive(): void {
@@ -323,14 +352,36 @@ export class NewChatFormState {
 		modelEndpointId?: string | null,
 	): void {
 		const liveModels = this.#modelCatalog.getModels(agentId);
-		const selectionValue = this.#modelCatalog.selectionValueFor(agentId, model, modelEndpointId);
-		const resolvedModel = liveModels.some((entry) => entry.value === selectionValue)
-			? selectionValue
-			: (liveModels[0]?.value ?? model);
+		const selected = this.#modelCatalog.getModelForSelection(agentId, model, modelEndpointId);
+		const resolvedModel = selected ?? liveModels[0];
+		if (resolvedModel) {
+			this.#selectCatalogModel(agentId, resolvedModel);
+			return;
+		}
+		this.#setModelSelection(agentId, model, null);
+	}
+
+	#selectCatalogModel(agentId: SessionAgentId, model: ModelOption): void {
+		this.#setModelSelection(
+			agentId,
+			model.value,
+			this.#modelCatalog.selectionFor(agentId, model.value, model.endpointId),
+		);
+	}
+
+	#setModelSelection(
+		agentId: SessionAgentId,
+		modelValue: string,
+		selection: ResolvedModelSelection | null,
+	): void {
 		this.selectedModelsByAgent = {
 			...this.selectedModelsByAgent,
-			[agentId]: resolvedModel,
+			[agentId]: modelValue,
 		};
+		const targets = { ...this.#selectedModelTargetsByAgent };
+		if (selection) targets[agentId] = selection;
+		else delete targets[agentId];
+		this.#selectedModelTargetsByAgent = targets;
 	}
 
 	// Images (delegated to ImageAttachmentState)
@@ -587,7 +638,8 @@ export class NewChatFormState {
 			return null;
 		}
 		this.error = null;
-		const selection = this.#modelCatalog.selectionFor(this.agentId, this.modelValue);
+		const selection = this.resolvedModelSelection;
+		if (!selection) return null;
 
 		return {
 			agentId: this.agentId,
@@ -628,6 +680,7 @@ export class NewChatFormState {
 	/** Loads server settings without blocking the form on live model discovery. */
 	async loadSettingsAndModels(): Promise<void> {
 		this.#startupSelectionAutomatic = true;
+		this.#catalogRefreshCompleted = false;
 		try {
 			const settingsData = await this.#remoteSettings.ensureLoaded();
 			this.#applySettings(settingsData);
@@ -649,6 +702,7 @@ export class NewChatFormState {
 	async #refreshModelsInBackground(): Promise<void> {
 		try {
 			await this.#modelCatalog.refreshIfStale();
+			this.#catalogRefreshCompleted = true;
 			this.#reconcileAgentSettingsWithCatalog();
 			if (this.#startupSelectionAutomatic) {
 				const recent = this.#firstSelectableRecent(this.#startupRecents);
@@ -657,11 +711,15 @@ export class NewChatFormState {
 					: this.#resolveStartupAgent(DEFAULT_AGENT_ID);
 				if (recent) {
 					this.applyResolvedModel(this.agentId, recent.model, recent.modelEndpointId);
+				} else {
+					this.applyResolvedModel(this.agentId, this.#modelCatalog.getDefaultModel(this.agentId));
 				}
 				this.#applyExecutionDefaultsForAgent(this.agentId);
+				this.validateAllModelsAgainstLive();
 				this.#startupSelectionAutomatic = false;
+			} else {
+				this.validateAllModelsAgainstLive();
 			}
-			this.validateAllModelsAgainstLive();
 		} catch (err) {
 			console.warn('[NewChatFormState] Failed to refresh models', err);
 		}

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -537,6 +537,7 @@
 	const modelSelectorValue = $derived({
 		agentId: form.agentId,
 		model: form.modelValue,
+		...(form.modelSelectionTarget ?? {}),
 	});
 	const recentSelectorOptions = $derived.by(() =>
 		buildModelSelectorRecents(modelCatalog, remoteSettings.snapshot?.recentAgentSettings ?? []),
@@ -549,7 +550,7 @@
 	function handleModelSelectorChange(next: ModelSelectorChange): void {
 		if (!newChatAgentIds.includes(next.agentId)) return;
 		form.selectAgent(next.agentId);
-		form.handleModelChange(next.modelValue);
+		form.selectModel(next.modelValue, next);
 	}
 </script>
 

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -542,6 +542,7 @@
 		buildModelSelectorRecents(modelCatalog, remoteSettings.snapshot?.recentAgentSettings ?? []),
 	);
 	const preferRecentsOnOpen = $derived(recentSelectorOptions.length > 1);
+	const displayedFormError = $derived(form.modelSelectionError ?? form.error);
 	const sendButtonClass =
 		'bg-primary text-primary-foreground border-primary/30 hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:border-border disabled:cursor-not-allowed';
 
@@ -694,8 +695,8 @@
 					onClose={() => (form.showTagInput = false)}
 				/>
 
-				{#if form.error}
-					<p class="text-sm text-destructive">{form.error}</p>
+				{#if displayedFormError}
+					<p class="text-sm text-destructive">{displayedFormError}</p>
 				{/if}
 			</div>
 

--- a/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
+++ b/web/src/lib/components/chat/__tests__/NewChatForm.test.ts
@@ -7,6 +7,7 @@ import type { RemoteSettingsSnapshot } from '$shared/settings';
 import * as snippetsApi from '$lib/api/snippets';
 import * as clientChatId from '$shared/client-chat-id';
 import { parseChatId } from '$shared/chat-id';
+import { DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID } from '$shared/agents';
 
 const PROSPECTIVE_CHAT_ID = parseChatId('1787471053739199');
 const RESEEDED_CHAT_ID = parseChatId('1787471053739200');
@@ -215,6 +216,57 @@ describe('NewChatForm', () => {
 
 		expect(onStartChat).toHaveBeenCalledTimes(1);
 		expect(onStartChat.mock.calls[0]?.[1]).toBe(PROSPECTIVE_CHAT_ID);
+	});
+
+	it('blocks click and Enter after the selected endpoint disappears', async () => {
+		stubMatchMedia(false);
+		const chatsApi = await import('$lib/api/chats');
+		vi.mocked(chatsApi.validateStart).mockResolvedValue({ valid: true, isGitRepo: false });
+		vi.mocked(settingsApi.getRemoteSettings).mockResolvedValueOnce(
+			makeSnapshot({
+				paths: { recentProjectPaths: ['/workspace/project'] },
+				recentAgentSettings: [
+					{
+						agentId: DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
+						model: 'chat-model',
+						apiProviderId: 'test-provider',
+						modelEndpointId: 'test_openai',
+						modelProtocol: 'openai-compatible',
+					},
+				],
+			}),
+		);
+		const onStartChat = vi.fn();
+		const view = render(NewChatFormTestHost, {
+			props: {
+				allowDirectChats: true,
+				endpointBackedDirectModel: true,
+				modelsAvailable: true,
+				onStartChat,
+			},
+		});
+
+		await waitFor(() => {
+			expect(screen.queryByRole('status', { name: 'Loading chat defaults...' })).toBeNull();
+		});
+		const messageInput = screen.getByPlaceholderText('How can I help you today?');
+		await fireEvent.input(messageInput, { target: { value: 'first line' } });
+		await waitFor(() => {
+			expect((screen.getByRole('button', { name: 'Start session' }) as HTMLButtonElement).disabled).toBe(
+				false,
+			);
+		});
+
+		await view.rerender({ catalogVersion: 1, modelsAvailable: false });
+
+		const submit = screen.getByRole('button', { name: 'Start session' }) as HTMLButtonElement;
+		await waitFor(() => {
+			expect(screen.getByText('Model unavailable')).toBeTruthy();
+			expect(submit.disabled).toBe(true);
+		});
+		await fireEvent.click(submit);
+		await fireEvent.keyDown(messageInput, { key: 'Enter' });
+		expect(onStartChat).not.toHaveBeenCalled();
 	});
 
 	it('shows a centered spinner and hides the composer until settings load', async () => {

--- a/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
@@ -24,9 +24,13 @@
 		DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID,
 		DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
 	} from '$shared/agents';
+	import type { ModelOption } from '$lib/agents/model-catalog-store.svelte.js';
 
 	interface Props {
 		allowDirectChats?: boolean;
+		catalogVersion?: number;
+		endpointBackedDirectModel?: boolean;
+		modelsAvailable?: boolean;
 		supportsImages?: boolean;
 		snippetTrigger?: string;
 		snippetTemplate?: string;
@@ -36,6 +40,9 @@
 
 	let {
 		allowDirectChats = false,
+		catalogVersion = 0,
+		endpointBackedDirectModel = false,
+		modelsAvailable = true,
 		supportsImages = true,
 		snippetTrigger = ';;',
 		snippetTemplate = 'Review {{arguments}} in {{project_path}}',
@@ -87,10 +94,20 @@
 		'codex',
 	];
 
-	function modelForAgent(agentId: string): { value: string; label: string } {
+	function modelForAgent(agentId: string): ModelOption {
 		if (agentId === 'claude') return { value: 'opus', label: 'Opus' };
 		if (agentId === 'codex') return { value: 'gpt-5.4', label: 'GPT-5.4' };
 		if (agentId === DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID) {
+			if (endpointBackedDirectModel) {
+				return {
+					value: 'test_openai:chat-model',
+					label: 'Test: Chat Model',
+					rawModel: 'chat-model',
+					apiProviderId: 'test-provider',
+					endpointId: 'test_openai',
+					protocol: 'openai-compatible',
+				};
+			}
 			return { value: 'chat-model', label: 'Chat Model' };
 		}
 		if (agentId === DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID) {
@@ -121,7 +138,9 @@
 	);
 
 	setModelCatalog({
-		version: 0,
+		get version() {
+			return catalogVersion;
+		},
 		agentMetadata: {
 			claude: { label: 'Claude' },
 			codex: { label: 'Codex' },
@@ -196,25 +215,36 @@
 			return { ownerId: agentId, schemaVersion: 1, values: { thinking: 'auto' } };
 		},
 		getModels(agentId: string) {
+			if (
+				agentId === DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID &&
+				endpointBackedDirectModel &&
+				!modelsAvailable
+			) return [];
 			return [modelForAgent(agentId)];
 		},
 		supportsImages() {
 			return supportsImages;
 		},
-		getModelForSelection(agentId: string, model: string) {
-			const models = [modelForAgent(agentId)];
-			return models.find((entry) => entry.value === model) ?? null;
+		getModelForSelection(agentId: string, model: string, endpointId?: string | null) {
+			const models = this.getModels(agentId);
+			return models.find(
+				(entry) =>
+					(endpointId ? entry.endpointId === endpointId : true) &&
+					(entry.value === model || entry.rawModel === model),
+			) ?? null;
 		},
-		selectionFor(_provider: string, model: string) {
+		selectionFor(agentId: string, model: string, endpointId?: string | null) {
+			const selected = this.getModelForSelection(agentId, model, endpointId);
+			if (!selected && endpointId) return null;
 			return {
-				model,
-				apiProviderId: null,
-				modelEndpointId: null,
-				modelProtocol: null,
+				model: selected?.rawModel ?? model,
+				apiProviderId: selected?.apiProviderId ?? null,
+				modelEndpointId: selected?.endpointId ?? null,
+				modelProtocol: selected?.protocol ?? null,
 			};
 		},
-		selectionValueFor(_provider: string, model: string) {
-			return model;
+		selectionValueFor(agentId: string, model: string, endpointId?: string | null) {
+			return this.getModelForSelection(agentId, model, endpointId)?.value ?? model;
 		},
 		refreshIfStale() {
 			return Promise.resolve();

--- a/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
@@ -116,6 +116,27 @@
 		return { value: 'anthropic-model', label: 'Anthropic Model' };
 	}
 
+	function modelsForAgent(agentId: string): ModelOption[] {
+		if (
+			agentId === DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID &&
+			endpointBackedDirectModel &&
+			!modelsAvailable
+		) return [];
+		return [modelForAgent(agentId)];
+	}
+
+	function modelForSelection(
+		agentId: string,
+		model: string,
+		endpointId?: string | null,
+	): ModelOption | null {
+		return modelsForAgent(agentId).find(
+			(entry) =>
+				(endpointId ? entry.endpointId === endpointId : true) &&
+				(entry.value === model || entry.rawModel === model),
+		) ?? null;
+	}
+
 	setSnippets(
 		createSnippetsStore({
 			get: async () => {
@@ -215,26 +236,16 @@
 			return { ownerId: agentId, schemaVersion: 1, values: { thinking: 'auto' } };
 		},
 		getModels(agentId: string) {
-			if (
-				agentId === DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID &&
-				endpointBackedDirectModel &&
-				!modelsAvailable
-			) return [];
-			return [modelForAgent(agentId)];
+			return modelsForAgent(agentId);
 		},
 		supportsImages() {
 			return supportsImages;
 		},
 		getModelForSelection(agentId: string, model: string, endpointId?: string | null) {
-			const models = this.getModels(agentId);
-			return models.find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			) ?? null;
+			return modelForSelection(agentId, model, endpointId);
 		},
 		selectionFor(agentId: string, model: string, endpointId?: string | null) {
-			const selected = this.getModelForSelection(agentId, model, endpointId);
+			const selected = modelForSelection(agentId, model, endpointId);
 			if (!selected && endpointId) return null;
 			return {
 				model: selected?.rawModel ?? model,
@@ -244,7 +255,7 @@
 			};
 		},
 		selectionValueFor(agentId: string, model: string, endpointId?: string | null) {
-			return this.getModelForSelection(agentId, model, endpointId)?.value ?? model;
+			return modelForSelection(agentId, model, endpointId)?.value ?? model;
 		},
 		refreshIfStale() {
 			return Promise.resolve();

--- a/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
@@ -25,6 +25,11 @@
 		DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID,
 	} from '$shared/agents';
 	import type { ModelOption } from '$lib/agents/model-catalog-store.svelte.js';
+	import {
+		findModelForSelection,
+		modelValueForSelection,
+		resolveModelSelection,
+	} from '../../../../test/model-catalog';
 
 	interface Props {
 		allowDirectChats?: boolean;
@@ -130,28 +135,7 @@
 		model: string,
 		endpointId?: string | null,
 	): ModelOption | null {
-		const models = modelsForAgent(agentId);
-		if (endpointId !== undefined) {
-			if (endpointId === null) {
-				return (
-					models.find(
-						(entry) =>
-							!entry.endpointId && (entry.value === model || entry.rawModel === model),
-					) ?? null
-				);
-			}
-			return (
-				models.find(
-					(entry) =>
-						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null
-			);
-		}
-		return (
-			models.find((entry) => entry.value === model) ??
-			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
-			null
-		);
+		return findModelForSelection(modelsForAgent(agentId), model, endpointId);
 	}
 
 	setSnippets(
@@ -262,17 +246,10 @@
 			return modelForSelection(agentId, model, endpointId);
 		},
 		selectionFor(agentId: string, model: string, endpointId?: string | null) {
-			const selected = modelForSelection(agentId, model, endpointId);
-			if (!selected && endpointId) return null;
-			return {
-				model: selected?.rawModel ?? model,
-				apiProviderId: selected?.apiProviderId ?? null,
-				modelEndpointId: selected?.endpointId ?? null,
-				modelProtocol: selected?.protocol ?? null,
-			};
+			return resolveModelSelection(modelsForAgent(agentId), model, endpointId);
 		},
 		selectionValueFor(agentId: string, model: string, endpointId?: string | null) {
-			return modelForSelection(agentId, model, endpointId)?.value ?? model;
+			return modelValueForSelection(modelsForAgent(agentId), model, endpointId);
 		},
 		refreshIfStale() {
 			return Promise.resolve();

--- a/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/NewChatFormTestHost.svelte
@@ -119,9 +119,9 @@
 	function modelsForAgent(agentId: string): ModelOption[] {
 		if (
 			agentId === DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID &&
-			endpointBackedDirectModel &&
-			!modelsAvailable
-		) return [];
+				endpointBackedDirectModel &&
+				!modelsAvailable
+			) return [];
 		return [modelForAgent(agentId)];
 	}
 
@@ -130,11 +130,28 @@
 		model: string,
 		endpointId?: string | null,
 	): ModelOption | null {
-		return modelsForAgent(agentId).find(
-			(entry) =>
-				(endpointId ? entry.endpointId === endpointId : true) &&
-				(entry.value === model || entry.rawModel === model),
-		) ?? null;
+		const models = modelsForAgent(agentId);
+		if (endpointId !== undefined) {
+			if (endpointId === null) {
+				return (
+					models.find(
+						(entry) =>
+							!entry.endpointId && (entry.value === model || entry.rawModel === model),
+					) ?? null
+				);
+			}
+			return (
+				models.find(
+					(entry) =>
+						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
+				) ?? null
+			);
+		}
+		return (
+			models.find((entry) => entry.value === model) ??
+			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+			null
+		);
 	}
 
 	setSnippets(

--- a/web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts
@@ -273,6 +273,41 @@ describe('ModelSelectorPopover', () => {
 		});
 	});
 
+	it('preserves a stale native source when an endpoint exposes the same model', async () => {
+		const onChange = vi.fn();
+
+		render(ModelSelectorPopoverHost, {
+			value: {
+				agentId: 'claude',
+				model: 'endpoint-model',
+				apiProviderId: null,
+				modelEndpointId: null,
+				modelProtocol: null,
+				thinkingMode: 'none',
+			},
+			mode: { agent: 'select', source: 'select', surface: 'settings', effort: 'select' },
+			includeEndpointModel: true,
+			onChange,
+		});
+
+		await fireEvent.click(
+			screen.getByRole('button', { name: /Claude .* endpoint-model .* Default/ }),
+		);
+		await fireEvent.click(screen.getByRole('button', { name: /High Thorough reasoning/ }));
+
+		await waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith({
+				agentId: 'claude',
+				modelValue: 'endpoint-model',
+				model: 'endpoint-model',
+				apiProviderId: null,
+				modelEndpointId: null,
+				modelProtocol: null,
+				thinkingMode: 'high',
+			});
+		});
+	});
+
 	it('allows explicitly selecting the live endpoint for a stale model name', async () => {
 		const onChange = vi.fn();
 

--- a/web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts
@@ -238,34 +238,73 @@ describe('ModelSelectorPopover', () => {
 		expect(screen.queryByRole('button', { name: /Default Provider default effort/ })).toBeNull();
 	});
 
-	it('preserves saved endpoint routing when only effort changes outside the catalog', async () => {
+	it('preserves a stale endpoint when another endpoint exposes the same model', async () => {
 		const onChange = vi.fn();
 
 		render(ModelSelectorPopoverHost, {
 			value: {
 				agentId: 'claude',
-				model: 'removed-from-catalog',
+				model: 'endpoint-model',
 				apiProviderId: 'custom-provider',
 				modelEndpointId: 'custom-endpoint',
 				modelProtocol: 'anthropic-messages',
 				thinkingMode: 'none',
 			},
 			mode: { agent: 'select', source: 'select', surface: 'settings', effort: 'select' },
+			includeEndpointModel: true,
 			onChange,
 		});
 
 		await fireEvent.click(
-			screen.getByRole('button', { name: /Claude .* removed-from-catalog .* Default/ }),
+			screen.getByRole('button', { name: /Claude .* endpoint-model .* Default/ }),
 		);
 		await fireEvent.click(screen.getByRole('button', { name: /High Thorough reasoning/ }));
 
 		await waitFor(() => {
 			expect(onChange).toHaveBeenCalledWith({
 				agentId: 'claude',
-				modelValue: 'removed-from-catalog',
-				model: 'removed-from-catalog',
+				modelValue: 'endpoint-model',
+				model: 'endpoint-model',
 				apiProviderId: 'custom-provider',
 				modelEndpointId: 'custom-endpoint',
+				modelProtocol: 'anthropic-messages',
+				thinkingMode: 'high',
+			});
+		});
+	});
+
+	it('allows explicitly selecting the live endpoint for a stale model name', async () => {
+		const onChange = vi.fn();
+
+		render(ModelSelectorPopoverHost, {
+			value: {
+				agentId: 'claude',
+				model: 'endpoint-model',
+				apiProviderId: 'custom-provider',
+				modelEndpointId: 'custom-endpoint',
+				modelProtocol: 'anthropic-messages',
+				thinkingMode: 'none',
+			},
+			mode: { agent: 'select', source: 'select', surface: 'settings', effort: 'select' },
+			includeEndpointModel: true,
+			onChange,
+		});
+
+		await fireEvent.click(
+			screen.getByRole('button', { name: /Claude .* endpoint-model .* Default/ }),
+		);
+		await fireEvent.click(await screen.findByRole('button', { name: 'Acme' }));
+		const listbox = await screen.findByRole('listbox', { name: 'Model' });
+		await fireEvent.click(within(listbox).getByText('Endpoint Model'));
+		await fireEvent.click(screen.getByRole('button', { name: /High Thorough reasoning/ }));
+
+		await waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith({
+				agentId: 'claude',
+				modelValue: 'acme-claude:endpoint-model',
+				model: 'endpoint-model',
+				apiProviderId: 'acme',
+				modelEndpointId: 'acme-claude',
 				modelProtocol: 'anthropic-messages',
 				thinkingMode: 'high',
 			});

--- a/web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte
+++ b/web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte
@@ -16,6 +16,11 @@
 		ModelSelectorValue,
 	} from '../model-selector-types';
 	import { THINKING_MODE_VALUES } from '$shared/chat-modes';
+	import {
+		findModelForSelection,
+		modelValueForSelection,
+		resolveModelSelection,
+	} from '../../../../test/model-catalog';
 
 	interface Props {
 		value: ModelSelectorValue;
@@ -107,28 +112,7 @@
 		model: string,
 		endpointId?: string | null,
 	): ModelOption | null {
-		const models = modelsFor(agentId);
-		if (endpointId !== undefined) {
-			if (endpointId === null) {
-				return (
-					models.find(
-						(entry) =>
-							!entry.endpointId && (entry.value === model || entry.rawModel === model),
-					) ?? null
-				);
-			}
-			return (
-				models.find(
-					(entry) =>
-						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null
-			);
-		}
-		return (
-			models.find((entry) => entry.value === model) ??
-			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
-			null
-		);
+		return findModelForSelection(modelsFor(agentId), model, endpointId);
 	}
 
 	setModelCatalog({
@@ -156,20 +140,10 @@
 		getThinkingModes: (agentId: string) => (agentId === 'amp' ? [] : [...THINKING_MODE_VALUES]),
 		getDefaultModel: (agentId: string) => modelsFor(agentId)[0]?.value ?? '',
 		getModelForSelection: modelForSelection,
-		selectionFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const selected = modelForSelection(agentId, model, endpointId);
-			if (!selected && endpointId) return null;
-			return {
-				model: selected?.rawModel ?? model,
-				apiProviderId: selected?.apiProviderId ?? null,
-				modelEndpointId: selected?.endpointId ?? null,
-				modelProtocol: selected?.protocol ?? null,
-			};
-		},
-		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const selected = modelForSelection(agentId, model, endpointId);
-			return selected?.value ?? model;
-		},
+		selectionFor: (agentId: string, model: string, endpointId?: string | null) =>
+			resolveModelSelection(modelsFor(agentId), model, endpointId),
+		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) =>
+			modelValueForSelection(modelsFor(agentId), model, endpointId),
 		findEndpoint: (endpointId: string) => {
 			if (endpointId !== 'acme-claude') return null;
 			const endpoint = {

--- a/web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte
+++ b/web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte
@@ -102,6 +102,35 @@
 		return directModelsByAgent[agentId] ?? claudeModels;
 	}
 
+	function modelForSelection(
+		agentId: string,
+		model: string,
+		endpointId?: string | null,
+	): ModelOption | null {
+		const models = modelsFor(agentId);
+		if (endpointId !== undefined) {
+			if (endpointId === null) {
+				return (
+					models.find(
+						(entry) =>
+							!entry.endpointId && (entry.value === model || entry.rawModel === model),
+					) ?? null
+				);
+			}
+			return (
+				models.find(
+					(entry) =>
+						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
+				) ?? null
+			);
+		}
+		return (
+			models.find((entry) => entry.value === model) ??
+			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+			null
+		);
+	}
+
 	setModelCatalog({
 		getSelectableAgents: () => selectableAgents,
 		getAgent: (agentId: string) => ({
@@ -126,16 +155,10 @@
 		getModels: (agentId: string) => modelsFor(agentId),
 		getThinkingModes: (agentId: string) => (agentId === 'amp' ? [] : [...THINKING_MODE_VALUES]),
 		getDefaultModel: (agentId: string) => modelsFor(agentId)[0]?.value ?? '',
-		getModelForSelection: (agentId: string, model: string, endpointId?: string | null) =>
-			modelsFor(agentId).find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			) ?? null,
-		selectionFor: (agentId: string, model: string) => {
-			const selected = modelsFor(agentId).find(
-				(entry) => entry.value === model || entry.rawModel === model,
-			);
+		getModelForSelection: modelForSelection,
+		selectionFor: (agentId: string, model: string, endpointId?: string | null) => {
+			const selected = modelForSelection(agentId, model, endpointId);
+			if (!selected && endpointId) return null;
 			return {
 				model: selected?.rawModel ?? model,
 				apiProviderId: selected?.apiProviderId ?? null,
@@ -144,11 +167,7 @@
 			};
 		},
 		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const selected = modelsFor(agentId).find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			);
+			const selected = modelForSelection(agentId, model, endpointId);
 			return selected?.value ?? model;
 		},
 		findEndpoint: (endpointId: string) => {

--- a/web/src/lib/components/model-selector/__tests__/model-selector-options.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/model-selector-options.test.ts
@@ -101,18 +101,34 @@ function makeCatalog(options: { multiEndpointProvider?: boolean } = {}): ModelCa
 		getDefaultModel: (agentId: string) => modelsByAgent[agentId]?.[0]?.value ?? '',
 		getModelForSelection: (agentId: string, model: string, endpointId?: string | null) => {
 			const models = modelsByAgent[agentId] ?? [];
-			if (endpointId) {
-				return models.find(
-					(entry) =>
-						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null;
+			if (endpointId !== undefined) {
+				if (endpointId === null) {
+					return (
+						models.find(
+							(entry) =>
+								!entry.endpointId && (entry.value === model || entry.rawModel === model),
+						) ?? null
+					);
+				}
+				return (
+					models.find(
+						(entry) =>
+							entry.endpointId === endpointId &&
+							(entry.value === model || entry.rawModel === model),
+					) ?? null
+				);
 			}
-			return models.find((entry) => entry.value === model || entry.rawModel === model) ?? null;
+			return (
+				models.find((entry) => entry.value === model) ??
+				models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+				null
+			);
 		},
 		selectionFor: (agentId: string, model: string) => {
-			const selected = (modelsByAgent[agentId] ?? []).find(
-				(entry) => entry.value === model || entry.rawModel === model,
-			);
+			const models = modelsByAgent[agentId] ?? [];
+			const selected =
+				models.find((entry) => entry.value === model) ??
+				models.find((entry) => !entry.endpointId && entry.rawModel === model);
 			return {
 				model: selected?.rawModel ?? model,
 				apiProviderId: selected?.apiProviderId ?? null,
@@ -121,11 +137,20 @@ function makeCatalog(options: { multiEndpointProvider?: boolean } = {}): ModelCa
 			};
 		},
 		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const selected = (modelsByAgent[agentId] ?? []).find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			);
+			const models = modelsByAgent[agentId] ?? [];
+			const selected = endpointId !== undefined
+				? endpointId === null
+					? models.find(
+							(entry) =>
+								!entry.endpointId && (entry.value === model || entry.rawModel === model),
+							)
+						: models.find(
+								(entry) =>
+									entry.endpointId === endpointId &&
+									(entry.value === model || entry.rawModel === model),
+							)
+				: (models.find((entry) => entry.value === model) ??
+					models.find((entry) => !entry.endpointId && entry.rawModel === model));
 			return selected?.value ?? model;
 		},
 		findEndpoint: (endpointId: string) => {

--- a/web/src/lib/components/model-selector/__tests__/model-selector-options.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/model-selector-options.test.ts
@@ -102,11 +102,10 @@ function makeCatalog(options: { multiEndpointProvider?: boolean } = {}): ModelCa
 		getModelForSelection: (agentId: string, model: string, endpointId?: string | null) => {
 			const models = modelsByAgent[agentId] ?? [];
 			if (endpointId) {
-				const selected = models.find(
+				return models.find(
 					(entry) =>
 						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				);
-				if (selected) return selected;
+				) ?? null;
 			}
 			return models.find((entry) => entry.value === model || entry.rawModel === model) ?? null;
 		},

--- a/web/src/lib/components/model-selector/__tests__/model-selector-options.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/model-selector-options.test.ts
@@ -18,6 +18,11 @@ import {
 	shouldShowSourceLabelForAgent,
 	shouldShowSourcePickerForAgent,
 } from '../model-selector-options';
+import {
+	findModelForSelection,
+	modelValueForSelection,
+	resolveModelSelection,
+} from '../../../../test/model-catalog';
 
 const claudeModels: ModelOption[] = [
 	{ value: 'opus', label: 'Opus', supportsImages: true },
@@ -99,60 +104,12 @@ function makeCatalog(options: { multiEndpointProvider?: boolean } = {}): ModelCa
 		getAgentLabel: (id: string) => (id === 'codex' ? 'Codex' : 'Claude'),
 		getModels: (agentId: string) => modelsByAgent[agentId] ?? [],
 		getDefaultModel: (agentId: string) => modelsByAgent[agentId]?.[0]?.value ?? '',
-		getModelForSelection: (agentId: string, model: string, endpointId?: string | null) => {
-			const models = modelsByAgent[agentId] ?? [];
-			if (endpointId !== undefined) {
-				if (endpointId === null) {
-					return (
-						models.find(
-							(entry) =>
-								!entry.endpointId && (entry.value === model || entry.rawModel === model),
-						) ?? null
-					);
-				}
-				return (
-					models.find(
-						(entry) =>
-							entry.endpointId === endpointId &&
-							(entry.value === model || entry.rawModel === model),
-					) ?? null
-				);
-			}
-			return (
-				models.find((entry) => entry.value === model) ??
-				models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
-				null
-			);
-		},
-		selectionFor: (agentId: string, model: string) => {
-			const models = modelsByAgent[agentId] ?? [];
-			const selected =
-				models.find((entry) => entry.value === model) ??
-				models.find((entry) => !entry.endpointId && entry.rawModel === model);
-			return {
-				model: selected?.rawModel ?? model,
-				apiProviderId: selected?.apiProviderId ?? null,
-				modelEndpointId: selected?.endpointId ?? null,
-				modelProtocol: selected?.protocol ?? null,
-			};
-		},
-		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const models = modelsByAgent[agentId] ?? [];
-			const selected = endpointId !== undefined
-				? endpointId === null
-					? models.find(
-							(entry) =>
-								!entry.endpointId && (entry.value === model || entry.rawModel === model),
-							)
-						: models.find(
-								(entry) =>
-									entry.endpointId === endpointId &&
-									(entry.value === model || entry.rawModel === model),
-							)
-				: (models.find((entry) => entry.value === model) ??
-					models.find((entry) => !entry.endpointId && entry.rawModel === model));
-			return selected?.value ?? model;
-		},
+		getModelForSelection: (agentId: string, model: string, endpointId?: string | null) =>
+			findModelForSelection(modelsByAgent[agentId] ?? [], model, endpointId),
+		selectionFor: (agentId: string, model: string) =>
+			resolveModelSelection(modelsByAgent[agentId] ?? [], model),
+		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) =>
+			modelValueForSelection(modelsByAgent[agentId] ?? [], model, endpointId),
 		findEndpoint: (endpointId: string) => {
 			if (endpointId === 'acme-anthropic') {
 				return {

--- a/web/src/lib/components/model-selector/__tests__/model-selector-recents.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/model-selector-recents.test.ts
@@ -136,6 +136,33 @@ describe('model selector recents', () => {
 		});
 	});
 
+	it('omits endpoint recents whose endpoint no longer exposes the model', () => {
+		const rows = buildModelSelectorRecents(makeCatalog(), [
+			{
+				agentId: 'codex',
+				model: 'gpt-5',
+				apiProviderId: null,
+				modelEndpointId: null,
+				modelProtocol: null,
+			},
+			{
+				agentId: 'codex',
+				model: 'gpt-5',
+				apiProviderId: 'acme',
+				modelEndpointId: 'acme-anthropic',
+				modelProtocol: 'anthropic-messages',
+			},
+		]);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			agentId: 'codex',
+			modelValue: 'gpt-5',
+			apiProviderId: null,
+			modelEndpointId: null,
+		});
+	});
+
 	it('omits stale recents and caps the list at twenty rows', () => {
 		const recents: RecentAgentSetting[] = [
 			{

--- a/web/src/lib/components/model-selector/__tests__/model-selector-recents.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/model-selector-recents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ModelCatalogStore, ModelOption } from '$lib/agents/model-catalog-store.svelte';
 import type { RecentAgentSetting } from '$shared/settings';
 import { buildModelSelectorRecents } from '../model-selector-recents';
+import { findModelForSelection, modelValueForSelection } from '../../../../test/model-catalog';
 
 const codexModel: ModelOption = { value: 'gpt-5', label: 'gpt-5' };
 const codexEndpointCollision: ModelOption = {
@@ -42,30 +43,7 @@ function makeCatalog(): ModelCatalogStore {
 		agentId: string,
 		model: string,
 		endpointId?: string | null,
-	): ModelOption | null => {
-		const models = modelsByAgent[agentId] ?? [];
-		if (endpointId !== undefined) {
-			if (endpointId === null) {
-				return (
-					models.find(
-						(entry) =>
-							!entry.endpointId && (entry.value === model || entry.rawModel === model),
-					) ?? null
-				);
-			}
-			return (
-				models.find(
-					(entry) =>
-						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null
-			);
-		}
-		return (
-			models.find((entry) => entry.value === model) ??
-			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
-			null
-		);
-	};
+	): ModelOption | null => findModelForSelection(modelsByAgent[agentId] ?? [], model, endpointId);
 
 	return {
 		getSelectableAgents: () => ['codex', 'claude', 'amp'],
@@ -76,10 +54,8 @@ function makeCatalog(): ModelCatalogStore {
 		},
 		getModels: (agentId: string) => modelsByAgent[agentId] ?? [],
 		getModelForSelection,
-		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const selected = getModelForSelection(agentId, model, endpointId);
-			return selected?.value ?? model;
-		},
+		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) =>
+			modelValueForSelection(modelsByAgent[agentId] ?? [], model, endpointId),
 		findEndpoint: (endpointId: string) => {
 			if (endpointId !== endpoint.id) return null;
 			return {

--- a/web/src/lib/components/model-selector/__tests__/model-selector-recents.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/model-selector-recents.test.ts
@@ -4,6 +4,14 @@ import type { RecentAgentSetting } from '$shared/settings';
 import { buildModelSelectorRecents } from '../model-selector-recents';
 
 const codexModel: ModelOption = { value: 'gpt-5', label: 'gpt-5' };
+const codexEndpointCollision: ModelOption = {
+	value: 'acme-openai:retired-native',
+	label: 'Acme: Retired Native',
+	rawModel: 'retired-native',
+	apiProviderId: 'acme',
+	endpointId: 'acme-openai',
+	protocol: 'openai-compatible',
+};
 const ampModel: ModelOption = { value: 'medium', label: 'Amp Medium' };
 const claudeEndpointModel: ModelOption = {
 	value: 'acme-anthropic:sonnet',
@@ -16,7 +24,7 @@ const claudeEndpointModel: ModelOption = {
 
 function makeCatalog(): ModelCatalogStore {
 	const modelsByAgent: Record<string, ModelOption[]> = {
-		codex: [codexModel],
+		codex: [codexModel, codexEndpointCollision],
 		claude: [claudeEndpointModel],
 		amp: [ampModel],
 	};
@@ -30,6 +38,35 @@ function makeCatalog(): ModelCatalogStore {
 		hasApiKey: true,
 	};
 
+	const getModelForSelection = (
+		agentId: string,
+		model: string,
+		endpointId?: string | null,
+	): ModelOption | null => {
+		const models = modelsByAgent[agentId] ?? [];
+		if (endpointId !== undefined) {
+			if (endpointId === null) {
+				return (
+					models.find(
+						(entry) =>
+							!entry.endpointId && (entry.value === model || entry.rawModel === model),
+					) ?? null
+				);
+			}
+			return (
+				models.find(
+					(entry) =>
+						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
+				) ?? null
+			);
+		}
+		return (
+			models.find((entry) => entry.value === model) ??
+			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+			null
+		);
+	};
+
 	return {
 		getSelectableAgents: () => ['codex', 'claude', 'amp'],
 		getAgentLabel: (agentId: string) => {
@@ -38,18 +75,9 @@ function makeCatalog(): ModelCatalogStore {
 			return 'Claude';
 		},
 		getModels: (agentId: string) => modelsByAgent[agentId] ?? [],
-		getModelForSelection: (agentId: string, model: string, endpointId?: string | null) =>
-			(modelsByAgent[agentId] ?? []).find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			) ?? null,
+		getModelForSelection,
 		selectionValueFor: (agentId: string, model: string, endpointId?: string | null) => {
-			const selected = (modelsByAgent[agentId] ?? []).find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			);
+			const selected = getModelForSelection(agentId, model, endpointId);
 			return selected?.value ?? model;
 		},
 		findEndpoint: (endpointId: string) => {
@@ -89,6 +117,20 @@ describe('model selector recents', () => {
 			modelProtocol: null,
 			displayLabel: 'Codex · OpenAI OAuth · gpt-5',
 		});
+	});
+
+	it('omits a stale native recent when only an endpoint exposes the raw model', () => {
+		const rows = buildModelSelectorRecents(makeCatalog(), [
+			{
+				agentId: 'codex',
+				model: 'retired-native',
+				apiProviderId: null,
+				modelEndpointId: null,
+				modelProtocol: null,
+			},
+		]);
+
+		expect(rows).toEqual([]);
 	});
 
 	it('projects endpoint-backed recents without duplicating provider prefixes', () => {

--- a/web/src/lib/components/model-selector/model-selector-recents.ts
+++ b/web/src/lib/components/model-selector/model-selector-recents.ts
@@ -32,6 +32,7 @@ export function buildModelSelectorRecents(
 		const agentId = recent.agentId as SessionAgentId;
 		if (!selectable.has(agentId)) continue;
 
+		// Canonicalizes persisted raw names before resolving the displayed model.
 		const modelValue = modelCatalog.selectionValueFor(
 			agentId,
 			recent.model,

--- a/web/src/lib/components/model-selector/model-selector-state.svelte.ts
+++ b/web/src/lib/components/model-selector/model-selector-state.svelte.ts
@@ -71,6 +71,7 @@ export class ModelSelectorState {
 	draftModelValue = $state<string | null>(null);
 	draftThinkingMode = $state<ThinkingMode | null>(null);
 	contentPane = $state<ModelSelectorContentPane>('browse');
+	#draftTargetChanged = false;
 
 	readonly #options: ModelSelectorStateOptions;
 	#sourcesCache = new Map<SessionAgentId, ModelSourceOption[]>();
@@ -470,6 +471,7 @@ export class ModelSelectorState {
 		if (!this.isAgentSelectable(agentId)) return;
 		this.showBrowsePane();
 		if (agentId === this.agentId) return;
+		this.#draftTargetChanged = true;
 		const sources = this.sourcesFor(agentId);
 		const currentSourceKey = this.sourceKey;
 		const source = sources.find((entry) => entry.key === currentSourceKey) ?? sources[0] ?? null;
@@ -482,6 +484,7 @@ export class ModelSelectorState {
 	selectSource(sourceKey: string): void {
 		this.showBrowsePane();
 		if (sourceKey === this.sourceKey) return;
+		this.#draftTargetChanged = true;
 		const source = this.sources.find((entry) => entry.key === sourceKey) ?? null;
 		const modelValue = this.#committedModelValueFor(this.agentId, source?.key ?? null);
 		this.query = '';
@@ -491,6 +494,7 @@ export class ModelSelectorState {
 
 	selectModel(modelValue: string): void {
 		this.showBrowsePane();
+		this.#draftTargetChanged = true;
 		this.#setDraftSelection(this.agentId, modelValue, this.sourceKey);
 		this.resetActiveModelIndex();
 		if (!this.effortSelectionEnabled) {
@@ -509,6 +513,7 @@ export class ModelSelectorState {
 	selectRecent(recent: ModelSelectorRecentOption): void {
 		if (!this.isAgentSelectable(recent.agentId)) return;
 		if (this.effortSelectionEnabled) {
+			this.#draftTargetChanged = true;
 			this.#setDraftSelection(
 				recent.agentId,
 				recent.modelValue,
@@ -535,7 +540,7 @@ export class ModelSelectorState {
 		const effortOnlyChange =
 			agentId === this.value.agentId &&
 			modelValue === currentModelValue(this.modelCatalog, this.value);
-		if (effortOnlyChange && this.value.modelEndpointId && !next.modelEndpointId) {
+		if (effortOnlyChange && this.value.modelEndpointId && !this.#draftTargetChanged) {
 			next = {
 				...next,
 				model: this.value.model,
@@ -570,6 +575,7 @@ export class ModelSelectorState {
 	}
 
 	#startDraftFromValue(): void {
+		this.#draftTargetChanged = false;
 		const agentId = this.value.agentId;
 		const modelValue = currentModelValue(this.modelCatalog, this.value);
 		this.#setDraftSelection(
@@ -606,6 +612,7 @@ export class ModelSelectorState {
 	}
 
 	#clearDraft(): void {
+		this.#draftTargetChanged = false;
 		this.draftAgentId = null;
 		this.draftModelValue = null;
 		this.activeSourceKey = null;

--- a/web/src/lib/components/settings/ScheduledNewChatComposer.svelte
+++ b/web/src/lib/components/settings/ScheduledNewChatComposer.svelte
@@ -64,6 +64,7 @@
 	const modelSelectorValue = $derived({
 		agentId: startup.agentId,
 		model: startup.modelValue,
+		...(startup.modelSelectionTarget ?? {}),
 	});
 	const recentSelectorOptions = $derived.by(() =>
 		buildModelSelectorRecents(modelCatalog, remoteSettings.snapshot?.recentAgentSettings ?? []),
@@ -84,7 +85,7 @@
 
 	function handleModelChange(next: ModelSelectorChange): void {
 		startup.selectAgent(next.agentId);
-		startup.handleModelChange(next.modelValue);
+		startup.selectModel(next.modelValue, next);
 	}
 </script>
 

--- a/web/src/lib/components/settings/ScheduledNewChatComposer.svelte
+++ b/web/src/lib/components/settings/ScheduledNewChatComposer.svelte
@@ -182,6 +182,10 @@
 			onRemove={(tag) => startup.removeTag(tag)}
 			onClose={() => (startup.showTagInput = false)}
 		/>
+
+		{#if startup.modelSelectionError}
+			<p class="text-sm text-destructive">{startup.modelSelectionError}</p>
+		{/if}
 	</div>
 
 	<ScheduledPromptField

--- a/web/src/lib/components/settings/__tests__/ScheduledNewChatComposer.test.ts
+++ b/web/src/lib/components/settings/__tests__/ScheduledNewChatComposer.test.ts
@@ -12,10 +12,12 @@ vi.mock(
 
 const ScheduledNewChatComposer = (await import('../ScheduledNewChatComposer.svelte')).default;
 
-function makeStartup(): NewChatFormState {
+function makeStartup(modelSelectionError: string | null = null): NewChatFormState {
 	return {
 		agentId: 'claude',
 		modelValue: 'opus',
+		modelSelectionTarget: null,
+		modelSelectionError,
 		projectPath: '/workspace/project',
 		projectBasePath: '/workspace',
 		browseStartPath: '/workspace',
@@ -65,12 +67,13 @@ function renderComposer(
 	overrides: {
 		prompt?: string;
 		promptError?: string | null;
+		modelSelectionError?: string | null;
 		selectableAgentIds?: readonly SessionAgentId[];
 	} = {},
 ) {
 	const onPromptChange = vi.fn();
 	const onPromptKeydown = vi.fn();
-	const startup = makeStartup();
+	const startup = makeStartup(overrides.modelSelectionError);
 	const modelCatalog = {
 		getSelectableAgents: () => [],
 	} as unknown as ModelCatalogStore;
@@ -135,5 +138,11 @@ describe('ScheduledNewChatComposer', () => {
 
 		expect(onPromptChange).toHaveBeenCalledWith('Review the build');
 		expect(onPromptKeydown).toHaveBeenCalledOnce();
+	});
+
+	it('renders unavailable scheduled model feedback', () => {
+		renderComposer({ modelSelectionError: 'Model unavailable' });
+
+		expect(screen.getByText('Model unavailable')).toBeTruthy();
 	});
 });

--- a/web/src/lib/components/settings/__tests__/ScheduledNewChatComposer.test.ts
+++ b/web/src/lib/components/settings/__tests__/ScheduledNewChatComposer.test.ts
@@ -57,7 +57,7 @@ function makeStartup(): NewChatFormState {
 		setThinkingMode: vi.fn(),
 		setAgentSetting: vi.fn(),
 		selectAgent: vi.fn(),
-		handleModelChange: vi.fn(),
+		selectModel: vi.fn(),
 	} as unknown as NewChatFormState;
 }
 

--- a/web/src/lib/components/settings/__tests__/remote-generation-settings-card-state.test.ts
+++ b/web/src/lib/components/settings/__tests__/remote-generation-settings-card-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	RemoteGenerationSettingsCardState,
+	type RemoteGenerationSettingsModelCatalog,
+	type RemoteGenerationSettingsStore,
+} from '../remote-generation-settings-card-state.svelte';
+import type { RemoteSettingsSnapshot } from '$shared/settings';
+
+function snapshot(): RemoteSettingsSnapshot {
+	const selection = {
+		agentId: 'codex',
+		model: 'gpt-stale',
+		apiProviderId: 'stale',
+		modelEndpointId: 'stale_openai',
+		modelProtocol: 'openai-compatible' as const,
+		thinkingMode: 'medium' as const,
+	};
+	return {
+		version: 1,
+		features: {
+			transcriptSearch: { enabled: false },
+			agentCommands: { enabled: true, chatIdDiscovery: true, sendMessage: true },
+		},
+		ui: { promptRefinement: { ...selection, customPrompt: 'Original' } },
+		uiEffective: { promptRefinement: selection },
+		paths: { pinnedProjectPaths: [], browseStartPath: '', recentProjectPaths: [] },
+		pinnedChatIds: [],
+		recentAgentSettings: [],
+		executionDefaults: {
+			global: { permissionMode: 'default', thinkingMode: 'none', agentSettingsById: {} },
+			byAgent: {},
+		},
+		projectBasePath: '/workspace',
+		telegram: {
+			botTokenAvailable: false,
+			botUsername: null,
+			botFirstName: null,
+			recipientUsername: null,
+			recipientDisplayName: null,
+			recipientLinked: false,
+			pendingLink: false,
+			linkUrl: null,
+		},
+	};
+}
+
+describe('RemoteGenerationSettingsCardState', () => {
+	it('preserves stale endpoint routing when saving unrelated settings', async () => {
+		const current = snapshot();
+		const update = vi.fn().mockResolvedValue(current);
+		const remoteSettings = { snapshot: current, update } satisfies RemoteGenerationSettingsStore;
+		const modelCatalog = {
+			selectionValueFor: vi.fn((_agentId: string, model: string) => model),
+			selectionFor: vi.fn(() => null),
+		} satisfies RemoteGenerationSettingsModelCatalog;
+		const state = new RemoteGenerationSettingsCardState({
+			remoteSettings,
+			modelCatalog,
+			get settingsKey() {
+				return 'promptRefinement' as const;
+			},
+			get enabledLabel() {
+				return undefined;
+			},
+		});
+
+		await expect(state.persistPrompt('Updated')).resolves.toEqual({ ok: true });
+		expect(update).toHaveBeenCalledWith({
+			ui: {
+				promptRefinement: {
+					agentId: 'codex',
+					model: 'gpt-stale',
+					apiProviderId: 'stale',
+					modelEndpointId: 'stale_openai',
+					modelProtocol: 'openai-compatible',
+					thinkingMode: 'medium',
+					customPrompt: 'Updated',
+				},
+			},
+		});
+	});
+});

--- a/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
+++ b/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
@@ -8,6 +8,11 @@ import {
 } from '$shared/scheduled-prompts';
 import type { SessionAgentId } from '$lib/types/app';
 import type { ModelOption } from '$lib/agents/model-catalog-store.svelte';
+import {
+	findModelForSelection,
+	modelValueForSelection,
+	resolveModelSelection,
+} from '../../../../test/model-catalog';
 
 interface CatalogOverrides {
 	getModels?(agentId: string): ModelOption[];
@@ -28,30 +33,7 @@ function createForm(
 		agentId: string,
 		model: string,
 		endpointId?: string | null,
-	): ModelOption | null => {
-		const models = getModels(agentId);
-		if (endpointId !== undefined) {
-			if (endpointId === null) {
-				return (
-					models.find(
-						(entry) =>
-							!entry.endpointId && (entry.value === model || entry.rawModel === model),
-					) ?? null
-				);
-			}
-			return (
-				models.find(
-					(entry) =>
-						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
-				) ?? null
-			);
-		}
-		return (
-			models.find((entry) => entry.value === model) ??
-			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
-			null
-		);
-	};
+	): ModelOption | null => findModelForSelection(getModels(agentId), model, endpointId);
 	const modelCatalog = {
 		getSelectableAgents: () => selectableAgentIds(),
 		getModels,
@@ -66,17 +48,10 @@ function createForm(
 		}),
 		getModelForSelection,
 		selectionValueFor(agentId: string, model: string, endpointId?: string | null) {
-			return getModelForSelection(agentId, model, endpointId)?.value ?? model;
+			return modelValueForSelection(getModels(agentId), model, endpointId);
 		},
 		selectionFor(agentId: string, model: string, endpointId?: string | null) {
-			const selected = getModelForSelection(agentId, model, endpointId);
-			if (!selected && endpointId) return null;
-			return {
-				model: selected?.rawModel ?? model,
-				apiProviderId: selected?.apiProviderId ?? null,
-				modelEndpointId: selected?.endpointId ?? null,
-				modelProtocol: selected?.protocol ?? null,
-			};
+			return resolveModelSelection(getModels(agentId), model, endpointId);
 		},
 	};
 	const form = new ScheduledPromptFormState(modelCatalog as never, {} as never, sessions as never, {

--- a/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
+++ b/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
@@ -22,9 +22,20 @@ function createForm(
 		hasChat: (chatId: string) => existingIds.has(chatId),
 		isDraft: () => false,
 	};
+	const getModels: (agentId: string) => ModelOption[] =
+		catalogOverrides.getModels ?? (() => [{ value: 'gpt-5', label: 'GPT-5' }]);
+	const getModelForSelection = (
+		agentId: string,
+		model: string,
+		endpointId?: string | null,
+	): ModelOption | null => getModels(agentId).find(
+		(entry) =>
+			(endpointId ? entry.endpointId === endpointId : true) &&
+			(entry.value === model || entry.rawModel === model),
+	) ?? null;
 	const modelCatalog = {
 		getSelectableAgents: () => selectableAgentIds(),
-		getModels: () => [{ value: 'gpt-5', label: 'GPT-5' }],
+		getModels,
 		getDefaultModel: () => 'gpt-5',
 		getPermissionModes: () => ['default', 'acceptEdits'],
 		getThinkingModes: () => ['none', 'high'],
@@ -34,18 +45,12 @@ function createForm(
 			schemaVersion: 1,
 			values: {},
 		}),
-		getModelForSelection(agentId: string, model: string, endpointId?: string | null) {
-			return this.getModels(agentId).find(
-				(entry) =>
-					(endpointId ? entry.endpointId === endpointId : true) &&
-					(entry.value === model || entry.rawModel === model),
-			) ?? null;
-		},
+		getModelForSelection,
 		selectionValueFor(agentId: string, model: string, endpointId?: string | null) {
-			return this.getModelForSelection(agentId, model, endpointId)?.value ?? model;
+			return getModelForSelection(agentId, model, endpointId)?.value ?? model;
 		},
 		selectionFor(agentId: string, model: string, endpointId?: string | null) {
-			const selected = this.getModelForSelection(agentId, model, endpointId);
+			const selected = getModelForSelection(agentId, model, endpointId);
 			if (!selected && endpointId) return null;
 			return {
 				model: selected?.rawModel ?? model,
@@ -54,7 +59,6 @@ function createForm(
 				modelProtocol: selected?.protocol ?? null,
 			};
 		},
-		...catalogOverrides,
 	};
 	const form = new ScheduledPromptFormState(modelCatalog as never, {} as never, sessions as never, {
 		get selectableAgentIds() {

--- a/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
+++ b/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
@@ -7,10 +7,16 @@ import {
 	type ScheduledPrompt,
 } from '$shared/scheduled-prompts';
 import type { SessionAgentId } from '$lib/types/app';
+import type { ModelOption } from '$lib/agents/model-catalog-store.svelte';
+
+interface CatalogOverrides {
+	getModels?(agentId: string): ModelOption[];
+}
 
 function createForm(
 	existingIds = new Set(['123']),
 	selectableAgentIds: () => readonly SessionAgentId[] = () => ['claude', 'codex'],
+	catalogOverrides: CatalogOverrides = {},
 ): ScheduledPromptFormState {
 	const sessions = {
 		hasChat: (chatId: string) => existingIds.has(chatId),
@@ -20,13 +26,35 @@ function createForm(
 		getSelectableAgents: () => selectableAgentIds(),
 		getModels: () => [{ value: 'gpt-5', label: 'GPT-5' }],
 		getDefaultModel: () => 'gpt-5',
-		selectionValueFor: (_agentId: string, model: string) => model,
-		selectionFor: () => ({
-			model: 'gpt-5',
-			apiProviderId: null,
-			modelEndpointId: null,
-			modelProtocol: null,
+		getPermissionModes: () => ['default', 'acceptEdits'],
+		getThinkingModes: () => ['none', 'high'],
+		getAgentSettingsDescriptors: () => [],
+		getDefaultAgentSettings: (agentId: string) => ({
+			ownerId: agentId,
+			schemaVersion: 1,
+			values: {},
 		}),
+		getModelForSelection(agentId: string, model: string, endpointId?: string | null) {
+			return this.getModels(agentId).find(
+				(entry) =>
+					(endpointId ? entry.endpointId === endpointId : true) &&
+					(entry.value === model || entry.rawModel === model),
+			) ?? null;
+		},
+		selectionValueFor(agentId: string, model: string, endpointId?: string | null) {
+			return this.getModelForSelection(agentId, model, endpointId)?.value ?? model;
+		},
+		selectionFor(agentId: string, model: string, endpointId?: string | null) {
+			const selected = this.getModelForSelection(agentId, model, endpointId);
+			if (!selected && endpointId) return null;
+			return {
+				model: selected?.rawModel ?? model,
+				apiProviderId: selected?.apiProviderId ?? null,
+				modelEndpointId: selected?.endpointId ?? null,
+				modelProtocol: selected?.protocol ?? null,
+			};
+		},
+		...catalogOverrides,
 	};
 	const form = new ScheduledPromptFormState(modelCatalog as never, {} as never, sessions as never, {
 		get selectableAgentIds() {
@@ -42,6 +70,19 @@ function existingPrompt(schedule: ScheduledPrompt['schedule']): ScheduledPrompt 
 		id: 'prompt-a',
 		schedule,
 		target: { type: 'existing-chat', chatId: '123', busyBehavior: 'queue' },
+		prompt: 'Continue the work',
+		createdAt: '2029-01-01T00:00:00.000Z',
+		updatedAt: '2029-01-01T00:00:00.000Z',
+	};
+}
+
+function newChatPrompt(
+	target: Extract<ScheduledPrompt['target'], { type: 'new-chat' }>,
+): ScheduledPrompt {
+	return {
+		id: 'prompt-new-chat',
+		schedule: { type: 'once', nextRunAt: '2030-01-02T09:00:00.000Z' },
+		target,
 		prompt: 'Continue the work',
 		createdAt: '2029-01-01T00:00:00.000Z',
 		updatedAt: '2029-01-01T00:00:00.000Z',
@@ -130,6 +171,119 @@ describe('ScheduledPromptFormState', () => {
 		expect(definition?.schedule.type).toBe('recurring');
 		if (definition?.schedule.type !== 'recurring') throw new Error('Expected recurring schedule');
 		expect(definition.schedule.endAtUtc).toBe(endAt);
+	});
+
+	it('blocks a stale endpoint target until another model is explicitly selected', async () => {
+		const form = createForm(new Set(['123']), () => ['claude', 'codex'], {
+			getModels: () => [
+				{ value: 'native-model', label: 'Native Model' },
+				{
+					value: 'live_openai:shared-model',
+					label: 'Live: Shared Model',
+					rawModel: 'shared-model',
+					apiProviderId: 'live-provider',
+					endpointId: 'live_openai',
+					protocol: 'openai-compatible',
+				},
+			],
+		});
+		form.startup.validatePath = vi.fn();
+		const scheduledPrompt = newChatPrompt({
+			type: 'new-chat',
+			agentId: 'codex',
+			projectPath: '/workspace/project',
+			model: 'shared-model',
+			apiProviderId: 'stale-provider',
+			modelEndpointId: 'stale_openai',
+			modelProtocol: 'openai-compatible',
+			permissionMode: 'acceptEdits',
+			thinkingMode: 'high',
+			agentSettingsById: {},
+			tags: [],
+		});
+
+		await form.initialize(scheduledPrompt);
+		form.startup.settingsLoaded = true;
+		form.startup.validationStatus = 'valid';
+
+		expect(form.startup.modelSelectionTarget).toMatchObject({
+			model: 'shared-model',
+			apiProviderId: 'stale-provider',
+			modelEndpointId: 'stale_openai',
+		});
+		expect(form.startup.modelSelectionError).toBe('Model unavailable');
+		expect(form.targetValid).toBe(false);
+		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))).toBeNull();
+
+		form.startup.selectModel('live_openai:shared-model', {
+			model: 'shared-model',
+			apiProviderId: 'live-provider',
+			modelEndpointId: 'live_openai',
+			modelProtocol: 'openai-compatible',
+		});
+
+		expect(form.startup.modelSelectionError).toBeNull();
+		expect(form.targetValid).toBe(true);
+		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))?.target).toMatchObject({
+			type: 'new-chat',
+			model: 'shared-model',
+			apiProviderId: 'live-provider',
+			modelEndpointId: 'live_openai',
+		});
+	});
+
+	it('preserves a scheduled endpoint target when refresh removes it after initialization', async () => {
+		let catalogFresh = false;
+		let finishRefresh!: () => void;
+		const refresh = new Promise<void>((resolve) => {
+			finishRefresh = resolve;
+		});
+		const form = createForm(new Set(['123']), () => ['claude', 'codex'], {
+			getModels: () => catalogFresh
+				? [{ value: 'native-model', label: 'Native Model' }]
+				: [{
+						value: 'stale_openai:scheduled-model',
+						label: 'Stale: Scheduled Model',
+						rawModel: 'scheduled-model',
+						apiProviderId: 'stale-provider',
+						endpointId: 'stale_openai',
+						protocol: 'openai-compatible',
+					}],
+		});
+		form.startup.loadSettingsAndModels = vi.fn(async () => {
+			form.startup.settingsLoaded = true;
+			void refresh.then(() => {
+				catalogFresh = true;
+				form.startup.validateAllModelsAgainstLive();
+			});
+		});
+		form.startup.validatePath = vi.fn();
+		const scheduledPrompt = newChatPrompt({
+			type: 'new-chat',
+			agentId: 'codex',
+			projectPath: '/workspace/project',
+			model: 'scheduled-model',
+			apiProviderId: 'stale-provider',
+			modelEndpointId: 'stale_openai',
+			modelProtocol: 'openai-compatible',
+			permissionMode: 'acceptEdits',
+			thinkingMode: 'high',
+			agentSettingsById: {},
+			tags: [],
+		});
+
+		await form.initialize(scheduledPrompt);
+		form.startup.validationStatus = 'valid';
+		expect(form.targetValid).toBe(true);
+
+		finishRefresh();
+		await refresh;
+		await Promise.resolve();
+
+		expect(form.startup.modelSelectionTarget?.modelEndpointId).toBe('stale_openai');
+		expect(form.startup.modelSelectionError).toBe('Model unavailable');
+		expect(form.targetValid).toBe(false);
+		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))).toBeNull();
 	});
 
 	it('hydrates and rebuilds new-chat tags when editing a scheduled prompt', async () => {

--- a/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
+++ b/web/src/lib/components/settings/__tests__/scheduled-prompt-form-state.test.ts
@@ -28,11 +28,30 @@ function createForm(
 		agentId: string,
 		model: string,
 		endpointId?: string | null,
-	): ModelOption | null => getModels(agentId).find(
-		(entry) =>
-			(endpointId ? entry.endpointId === endpointId : true) &&
-			(entry.value === model || entry.rawModel === model),
-	) ?? null;
+	): ModelOption | null => {
+		const models = getModels(agentId);
+		if (endpointId !== undefined) {
+			if (endpointId === null) {
+				return (
+					models.find(
+						(entry) =>
+							!entry.endpointId && (entry.value === model || entry.rawModel === model),
+					) ?? null
+				);
+			}
+			return (
+				models.find(
+					(entry) =>
+						entry.endpointId === endpointId && (entry.value === model || entry.rawModel === model),
+				) ?? null
+			);
+		}
+		return (
+			models.find((entry) => entry.value === model) ??
+			models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+			null
+		);
+	};
 	const modelCatalog = {
 		getSelectableAgents: () => selectableAgentIds(),
 		getModels,
@@ -243,16 +262,19 @@ describe('ScheduledPromptFormState', () => {
 			finishRefresh = resolve;
 		});
 		const form = createForm(new Set(['123']), () => ['claude', 'codex'], {
-			getModels: () => catalogFresh
-				? [{ value: 'native-model', label: 'Native Model' }]
-				: [{
-						value: 'stale_openai:scheduled-model',
-						label: 'Stale: Scheduled Model',
-						rawModel: 'scheduled-model',
-						apiProviderId: 'stale-provider',
-						endpointId: 'stale_openai',
-						protocol: 'openai-compatible',
-					}],
+			getModels: () =>
+				catalogFresh
+					? [{ value: 'native-model', label: 'Native Model' }]
+					: [
+							{
+								value: 'stale_openai:scheduled-model',
+								label: 'Stale: Scheduled Model',
+								rawModel: 'scheduled-model',
+								apiProviderId: 'stale-provider',
+								endpointId: 'stale_openai',
+								protocol: 'openai-compatible',
+							},
+						],
 		});
 		form.startup.loadSettingsAndModels = vi.fn(async () => {
 			form.startup.settingsLoaded = true;
@@ -288,6 +310,105 @@ describe('ScheduledPromptFormState', () => {
 		expect(form.startup.modelSelectionError).toBe('Model unavailable');
 		expect(form.targetValid).toBe(false);
 		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))).toBeNull();
+	});
+
+	it('blocks a stale native target when only an endpoint exposes the same raw model', async () => {
+		const form = createForm(new Set(['123']), () => ['claude', 'codex'], {
+			getModels: () => [
+				{
+					value: 'live_openai:shared-model',
+					label: 'Live: Shared Model',
+					rawModel: 'shared-model',
+					apiProviderId: 'live-provider',
+					endpointId: 'live_openai',
+					protocol: 'openai-compatible',
+				},
+			],
+		});
+		form.startup.validatePath = vi.fn();
+		const scheduledPrompt = newChatPrompt({
+			type: 'new-chat',
+			agentId: 'codex',
+			projectPath: '/workspace/project',
+			model: 'shared-model',
+			apiProviderId: null,
+			modelEndpointId: null,
+			modelProtocol: null,
+			permissionMode: 'acceptEdits',
+			thinkingMode: 'high',
+			agentSettingsById: {},
+			tags: [],
+		});
+
+		await form.initialize(scheduledPrompt);
+		form.startup.settingsLoaded = true;
+		form.startup.validationStatus = 'valid';
+
+		expect(form.startup.agentId).toBe('codex');
+		expect(form.startup.modelSelectionError).toBe('Model unavailable');
+		expect(form.targetValid).toBe(false);
+		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))).toBeNull();
+	});
+
+	it('preserves an unavailable scheduled agent until explicit reselection', async () => {
+		const selectableAgentIds = ['claude', 'codex'] as const;
+		const form = createForm(new Set(['123']), () => selectableAgentIds, {
+			getModels: (agentId) => {
+				if (agentId === 'direct-openai-compatible') {
+					return [
+						{
+							value: 'zai_openai:glm-5.1',
+							label: 'Z.AI: GLM-5.1',
+							rawModel: 'glm-5.1',
+							apiProviderId: 'zai',
+							endpointId: 'zai_openai',
+							protocol: 'openai-compatible',
+						},
+					];
+				}
+				return [{ value: 'gpt-5', label: 'GPT-5' }];
+			},
+		});
+		form.startup.validatePath = vi.fn();
+		const scheduledPrompt = newChatPrompt({
+			type: 'new-chat',
+			agentId: 'direct-openai-compatible',
+			projectPath: '/workspace/project',
+			model: 'glm-5.1',
+			apiProviderId: 'zai',
+			modelEndpointId: 'zai_openai',
+			modelProtocol: 'openai-compatible',
+			permissionMode: 'default',
+			thinkingMode: 'none',
+			agentSettingsById: {},
+			tags: [],
+		});
+
+		await form.initialize(scheduledPrompt);
+		form.startup.settingsLoaded = true;
+		form.startup.validationStatus = 'valid';
+		form.startup.reconcileAgentSelection(selectableAgentIds);
+
+		expect(form.startup.agentId).toBe('direct-openai-compatible');
+		expect(form.startup.modelSelectionTarget).toMatchObject({
+			model: 'glm-5.1',
+			apiProviderId: 'zai',
+			modelEndpointId: 'zai_openai',
+		});
+		expect(form.targetValid).toBe(false);
+		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))).toBeNull();
+
+		form.startup.selectAgent('codex');
+		form.startup.selectModel('gpt-5');
+
+		expect(form.targetValid).toBe(true);
+		expect(form.buildDefinition(new Date('2029-12-01T00:00:00.000Z'))?.target).toMatchObject({
+			type: 'new-chat',
+			agentId: 'codex',
+			model: 'gpt-5',
+			apiProviderId: null,
+			modelEndpointId: null,
+		});
 	});
 
 	it('hydrates and rebuilds new-chat tags when editing a scheduled prompt', async () => {

--- a/web/src/lib/components/settings/remote-generation-settings-card-state.svelte.ts
+++ b/web/src/lib/components/settings/remote-generation-settings-card-state.svelte.ts
@@ -5,7 +5,6 @@ import type {
 	ModelSelectorValue,
 } from '$lib/components/model-selector/model-selector-types';
 import * as m from '$lib/paraglide/messages.js';
-import type { ModelCatalogStore } from '$lib/agents/model-catalog-store.svelte';
 import type { RemoteSettingsStore } from '$lib/stores/remote-settings.svelte';
 import type { SessionAgentId } from '$lib/types/app';
 import type { ApiProtocol } from '$shared/api-providers';
@@ -23,6 +22,7 @@ import type {
 	PromptRefinementUiSettings,
 	RemoteUiSettings,
 } from '$shared/settings';
+import type { ResolvedModelSelection } from '$shared/start-selection';
 
 export type GenerationSettingsKey =
 	| 'chatTitle'
@@ -33,9 +33,23 @@ export type GenerationSettingsKey =
 // Keys whose card owns an on/off switch above the model selector.
 const TOGGLEABLE_KEYS = new Set<GenerationSettingsKey>(['chatTitle', 'agentSwitchCompaction']);
 
+export interface RemoteGenerationSettingsStore {
+	snapshot: RemoteSettingsStore['snapshot'];
+	update: RemoteSettingsStore['update'];
+}
+
+export interface RemoteGenerationSettingsModelCatalog {
+	selectionFor(
+		agentId: SessionAgentId,
+		model: string,
+		modelEndpointId?: string | null,
+	): ResolvedModelSelection | null;
+	selectionValueFor(agentId: SessionAgentId, model: string, modelEndpointId?: string | null): string;
+}
+
 interface RemoteGenerationSettingsCardOptions {
-	remoteSettings: RemoteSettingsStore;
-	modelCatalog: ModelCatalogStore;
+	remoteSettings: RemoteGenerationSettingsStore;
+	modelCatalog: RemoteGenerationSettingsModelCatalog;
 	get settingsKey(): GenerationSettingsKey;
 	get enabledLabel(): string | undefined;
 }
@@ -167,12 +181,18 @@ export class RemoteGenerationSettingsCardState {
 	}
 
 	get configurationKey(): string {
-		const configuration = this.selectionOverride
-			? this.options.modelCatalog.selectionFor(
-					this.provider,
-					this.modelValue,
-					this.modelEndpointId,
-				)
+		const override = this.selectionOverride;
+		const configuration = override
+			? (this.options.modelCatalog.selectionFor(
+					override.agentId,
+					override.model,
+					override.modelEndpointId,
+				) ?? {
+					model: override.model,
+					apiProviderId: override.apiProviderId ?? null,
+					modelEndpointId: override.modelEndpointId ?? null,
+					modelProtocol: override.modelProtocol ?? null,
+				})
 			: {
 					model: this.rawModel,
 					apiProviderId: this.apiProviderId,
@@ -227,7 +247,14 @@ export class RemoteGenerationSettingsCardState {
 			nextProvider,
 			nextModelValue,
 			nextEndpointId,
-		);
+		) ?? {
+			model: typeof overrides.model === 'string' ? overrides.model : (this.rawModel || nextModelValue),
+			apiProviderId:
+				overrides.apiProviderId !== undefined ? overrides.apiProviderId : this.apiProviderId,
+			modelEndpointId: nextEndpointId,
+			modelProtocol:
+				overrides.modelProtocol !== undefined ? overrides.modelProtocol : this.modelProtocol,
+		};
 		return {
 			agentId: nextProvider,
 			model: selection.model,

--- a/web/src/lib/components/settings/scheduled-prompt-form-state.svelte.ts
+++ b/web/src/lib/components/settings/scheduled-prompt-form-state.svelte.ts
@@ -92,7 +92,7 @@ export class ScheduledPromptFormState {
 			this.startup.settingsLoaded &&
 			this.options.selectableAgentIds.includes(this.startup.agentId) &&
 			this.startup.validationStatus === 'valid' &&
-			Boolean(this.startup.modelValue)
+			this.startup.resolvedModelSelection !== null
 		);
 	}
 
@@ -131,11 +131,12 @@ export class ScheduledPromptFormState {
 			return;
 		}
 		this.startup.selectAgent(scheduledPrompt.target.agentId);
-		this.startup.applyResolvedModel(
-			scheduledPrompt.target.agentId,
-			scheduledPrompt.target.model,
-			scheduledPrompt.target.modelEndpointId,
-		);
+		this.startup.restoreModelSelection(scheduledPrompt.target.agentId, {
+			model: scheduledPrompt.target.model,
+			apiProviderId: scheduledPrompt.target.apiProviderId,
+			modelEndpointId: scheduledPrompt.target.modelEndpointId,
+			modelProtocol: scheduledPrompt.target.modelProtocol,
+		});
 		this.startup.projectPath = scheduledPrompt.target.projectPath;
 		this.startup.setPermissionMode(scheduledPrompt.target.permissionMode);
 		this.startup.setThinkingMode(scheduledPrompt.target.thinkingMode);
@@ -160,7 +161,8 @@ export class ScheduledPromptFormState {
 				prompt: this.prompt.trim(),
 			};
 		}
-		const selection = this.modelCatalog.selectionFor(this.startup.agentId, this.startup.modelValue);
+		const selection = this.startup.resolvedModelSelection;
+		if (!selection) return null;
 		return {
 			schedule,
 			target: {

--- a/web/src/lib/components/settings/scheduled-prompt-form-state.svelte.ts
+++ b/web/src/lib/components/settings/scheduled-prompt-form-state.svelte.ts
@@ -130,8 +130,7 @@ export class ScheduledPromptFormState {
 			this.busyBehavior = scheduledPrompt.target.busyBehavior;
 			return;
 		}
-		this.startup.selectAgent(scheduledPrompt.target.agentId);
-		this.startup.restoreModelSelection(scheduledPrompt.target.agentId, {
+		this.startup.restoreSelection(scheduledPrompt.target.agentId, {
 			model: scheduledPrompt.target.model,
 			apiProviderId: scheduledPrompt.target.apiProviderId,
 			modelEndpointId: scheduledPrompt.target.modelEndpointId,

--- a/web/src/test/model-catalog.ts
+++ b/web/src/test/model-catalog.ts
@@ -1,0 +1,49 @@
+import type { ModelOption } from '$lib/agents/model-catalog-store.svelte';
+import type { ResolvedModelSelection } from '$shared/start-selection';
+
+function matchesModel(entry: ModelOption, model: string): boolean {
+	return entry.value === model || entry.rawModel === model;
+}
+
+export function findModelForSelection(
+	models: readonly ModelOption[],
+	model: string,
+	modelEndpointId?: string | null,
+): ModelOption | null {
+	if (modelEndpointId === null) {
+		return models.find((entry) => !entry.endpointId && matchesModel(entry, model)) ?? null;
+	}
+	if (modelEndpointId !== undefined) {
+		return models.find(
+			(entry) => entry.endpointId === modelEndpointId && matchesModel(entry, model),
+		) ?? null;
+	}
+	return (
+		models.find((entry) => entry.value === model) ??
+		models.find((entry) => !entry.endpointId && entry.rawModel === model) ??
+		null
+	);
+}
+
+export function resolveModelSelection(
+	models: readonly ModelOption[],
+	model: string,
+	modelEndpointId?: string | null,
+): ResolvedModelSelection | null {
+	const selected = findModelForSelection(models, model, modelEndpointId);
+	if (!selected && modelEndpointId) return null;
+	return {
+		model: selected?.rawModel ?? model,
+		apiProviderId: selected?.apiProviderId ?? null,
+		modelEndpointId: selected?.endpointId ?? null,
+		modelProtocol: selected?.protocol ?? null,
+	};
+}
+
+export function modelValueForSelection(
+	models: readonly ModelOption[],
+	model: string,
+	modelEndpointId?: string | null,
+): string {
+	return findModelForSelection(models, model, modelEndpointId)?.value ?? model;
+}


### PR DESCRIPTION
Treats endpoint-scoped model selections as strict source bindings, preserves stale routed selections without silently retargeting them, reconciles automatic new-chat defaults safely after catalog refresh, and records interactive startup preferences only after successful dispatch so failed starts cannot poison recent models.