### PR TITLE
Clear stuck fork and handoff progress notices

### DIFF
--- a/web/src/lib/chat/conversation/__tests__/conversation-panel-registry.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-panel-registry.test.ts
@@ -484,6 +484,28 @@ describe('ConversationPanelRegistry', () => {
 		cache.flush();
 	});
 
+	it('exposes revision-scoped notice clearing for the selected chat', () => {
+		const { registry, overlays } = fixture({ getSelectedChatId: () => 'chat-1' });
+		const selected = new CurrentConversationPanelTranscript({
+			panels: registry,
+			getSelectedChatId: () => 'chat-1',
+		});
+
+		selected.appendLocalNotice('progress', 'Forking chat...');
+		expect(selected.noticeRevisionForChat('chat-1')).toBe(1);
+		selected.appendLocalNotice('error', 'Failed to fork chat: unavailable');
+
+		selected.clearLocalNoticesForChat('chat-1', 1);
+
+		expect(overlays.forChat('chat-1').notices.map((notice) => notice.content)).toEqual([
+			'Failed to fork chat: unavailable',
+		]);
+
+		selected.clearLocalNoticesForChat('chat-1');
+
+		expect(overlays.forChat('chat-1').notices).toEqual([]);
+	});
+
 	it('retains rendered rows until a replacement snapshot installs atomically', async () => {
 		const replacement = deferred<void>();
 		const loadTranscriptSnapshot = vi.fn(async (transcript, chatId: string) => {

--- a/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-session-controller.test.ts
@@ -326,8 +326,9 @@ function createDeps(chat = createRunningChat()) {
 		activeChatId: chat.id,
 		entries: [] as TranscriptMessage[],
 		chatMessages: [] as ChatMessage[],
-		localNotices: [] as LocalNoticeRow[],
-		localNoticesByChatId: {} as Record<string, LocalNoticeRow[]>,
+		localNotices: [] as (LocalNoticeRow & { revision: number })[],
+		localNoticesByChatId: {} as Record<string, (LocalNoticeRow & { revision: number })[]>,
+		noticeRevisionsByChatId: {} as Record<string, number>,
 		optimisticUserInputs: [] as OptimisticUserInput[],
 		excludedResendOrdinals: [] as number[],
 		clearResendExclusions: vi.fn(() => {
@@ -354,19 +355,33 @@ function createDeps(chat = createRunningChat()) {
 			() => new Promise<ChatMessage[]>(() => {}),
 		),
 		appendLocalNotice: vi.fn((noticeType: LocalNoticeType, content: string) => {
-			chatState.localNotices = [
+			const chatId = chatState.activeChatId ?? '';
+			const revision = (chatState.noticeRevisionsByChatId[chatId] ?? 0) + 1;
+			chatState.noticeRevisionsByChatId = {
+				...chatState.noticeRevisionsByChatId,
+				[chatId]: revision,
+			};
+			const notices = [
 				...chatState.localNotices,
 				{
-					kind: 'local-notice',
+					kind: 'local-notice' as const,
 					id: `local-${chatState.localNotices.length + 1}`,
 					noticeType,
 					content,
 					timestamp: new Date().toISOString(),
+					revision,
 				},
 			];
+			chatState.localNotices = notices;
+			chatState.localNoticesByChatId = { ...chatState.localNoticesByChatId, [chatId]: notices };
 		}),
 		appendLocalNoticeForChat: vi.fn(
 			(chatId: string, noticeType: LocalNoticeType, content: string) => {
+				const revision = (chatState.noticeRevisionsByChatId[chatId] ?? 0) + 1;
+				chatState.noticeRevisionsByChatId = {
+					...chatState.noticeRevisionsByChatId,
+					[chatId]: revision,
+				};
 				const notices = [
 					...(chatState.localNoticesByChatId[chatId] ?? []),
 					{
@@ -375,6 +390,7 @@ function createDeps(chat = createRunningChat()) {
 						noticeType,
 						content,
 						timestamp: new Date().toISOString(),
+						revision,
 					},
 				];
 				chatState.localNoticesByChatId = {
@@ -385,9 +401,18 @@ function createDeps(chat = createRunningChat()) {
 			},
 		),
 		clearLocalNotices: vi.fn(),
-		clearLocalNoticesForChat: vi.fn((chatId: string) => {
-			chatState.localNoticesByChatId = { ...chatState.localNoticesByChatId, [chatId]: [] };
-			if (chatState.activeChatId === chatId) chatState.localNotices = [];
+		noticeRevisionForChat: vi.fn(
+			(chatId: string) => chatState.noticeRevisionsByChatId[chatId] ?? 0,
+		),
+		clearLocalNoticesForChat: vi.fn((chatId: string, throughRevision?: number) => {
+			const retained = (chatState.localNoticesByChatId[chatId] ?? []).filter(
+				(notice) => throughRevision === undefined || notice.revision > throughRevision,
+			);
+			chatState.localNoticesByChatId = {
+				...chatState.localNoticesByChatId,
+				[chatId]: retained,
+			};
+			if (chatState.activeChatId === chatId) chatState.localNotices = retained;
 		}),
 		upsertOptimisticUserInput: vi.fn((input: OptimisticUserInput) => {
 			const index = chatState.optimisticUserInputs.findIndex(
@@ -1519,7 +1544,7 @@ describe('ConversationSessionController', () => {
 		]);
 	});
 
-	it('submits /fork with a message as a fork-run request after appending the status message', async () => {
+	it('submits /fork with a message as a fork-run request and clears the status notice on settle', async () => {
 		const chat = createRunningChat({ id: '123' });
 		const { deps } = createDeps(chat);
 		deps.composerState.inputText = '/fork continue from here';
@@ -1538,11 +1563,12 @@ describe('ConversationSessionController', () => {
 
 		await controller.submitForChat('123');
 
-		expect(deps.chatState.localNotices).toHaveLength(1);
-		expect(deps.chatState.localNotices[0]).toMatchObject({
-			noticeType: 'progress',
-			content: 'Forking chat...',
-		});
+		expect(deps.chatState.appendLocalNotice).toHaveBeenCalledWith(
+			'progress',
+			'Forking chat...',
+		);
+		expect(deps.chatState.clearLocalNoticesForChat).toHaveBeenCalledWith('123', 1);
+		expect(deps.chatState.localNotices).toEqual([]);
 		expect(deps.chatState.isUserScrolledUp).toBe(false);
 		expect(deps.composerState.clearAfterSubmit).toHaveBeenCalledWith('123');
 
@@ -1579,15 +1605,36 @@ describe('ConversationSessionController', () => {
 			sourceChatId: '123',
 			chatId: expect.stringMatching(/^\d+$/),
 		});
-		expect(deps.chatState.localNotices).toHaveLength(1);
-		expect(deps.chatState.localNotices[0]).toMatchObject({
-			noticeType: 'progress',
-			content: 'Forking chat...',
-		});
+		expect(deps.chatState.appendLocalNotice).toHaveBeenCalledWith(
+			'progress',
+			'Forking chat...',
+		);
+		expect(deps.chatState.clearLocalNoticesForChat).toHaveBeenCalledWith('123', 1);
+		expect(deps.chatState.localNotices).toEqual([]);
 		expect(deps.sessions.upsertServerChat).toHaveBeenCalledWith(createServerEntry('456'));
 		expect(deps.lifecycle.setCurrentChatId).toHaveBeenCalledWith('456');
 		expect(deps.sessions.setSelectedChatId).toHaveBeenCalledWith('456');
 		expect(deps.navigation.navigateToChat).toHaveBeenCalledWith('456');
+	});
+
+	it('keeps the fork failure notice while clearing the progress notice', async () => {
+		const chat = createRunningChat({ id: '123' });
+		const { deps } = createDeps(chat);
+		deps.composerState.inputText = '/fork continue from here';
+		mockForkRunChat.mockRejectedValueOnce(
+			new ApiError(409, 'Chat is running', 'CHAT_RUNNING', undefined, true),
+		);
+		const controller = new ConversationSessionController(deps);
+
+		await controller.submitForChat('123');
+
+		expect(deps.chatState.localNotices).toEqual([
+			expect.objectContaining({
+				noticeType: 'error',
+				content: 'Failed to fork chat: Chat is running',
+			}),
+		]);
+		expect(deps.chatState.clearLocalNoticesForChat).toHaveBeenCalledWith('123', 1);
 	});
 
 	it('rejects /fork when agent does not support fork', async () => {

--- a/web/src/lib/chat/conversation/__tests__/conversation-slash-command-service.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/conversation-slash-command-service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { compactChat, forkChat, forkRunChat } from '$lib/api/chats.js';
+import { compactChat, forkChat, forkRunChat, selfHandoffRunChat } from '$lib/api/chats.js';
 import { scheduleChatPrompt } from '$lib/api/scheduled-prompts.js';
 import { ApiError } from '$lib/api/client.js';
 import { AssistantMessage } from '$shared/chat-types';
@@ -31,6 +31,7 @@ vi.mock('$lib/api/scheduled-prompts.js', () => ({
 const mockCompactChat = vi.mocked(compactChat);
 const mockForkChat = vi.mocked(forkChat);
 const mockForkRunChat = vi.mocked(forkRunChat);
+const mockSelfHandoffRunChat = vi.mocked(selfHandoffRunChat);
 const mockScheduleChatPrompt = vi.mocked(scheduleChatPrompt);
 
 function deferred<T>() {
@@ -143,11 +144,16 @@ function createDeps(chat = createChat()) {
 		}),
 		restoreDraftIfRevision,
 	};
-	const appendLocalNotice = vi.fn();
+	let noticeRevision = 0;
+	const appendLocalNotice = vi.fn((_noticeType: LocalNoticeType, _content: string) => {
+		noticeRevision += 1;
+	});
 	const appendLocalNoticeForChat = vi.fn(
 		(_chatId: string, noticeType: LocalNoticeType, content: string) =>
 			appendLocalNotice(noticeType, content),
 	);
+	const noticeRevisionForChat = vi.fn(() => noticeRevision);
+	const clearLocalNoticesForChat = vi.fn();
 	const sessions = {
 		selectedChatId: chat.id,
 		byId: { [chat.id]: chat },
@@ -181,6 +187,8 @@ function createDeps(chat = createChat()) {
 			getCursor: vi.fn(() => cursor),
 			appendLocalNotice,
 			appendLocalNoticeForChat,
+			noticeRevisionForChat,
+			clearLocalNoticesForChat,
 		},
 		composerState,
 		agentState: { model: 'sonnet' },
@@ -207,7 +215,15 @@ function createDeps(chat = createChat()) {
 		confirmHandoffFork: vi.fn().mockResolvedValue(true),
 		scrollToBottom: vi.fn(),
 	} satisfies ConversationSlashCommandDeps;
-	return { deps, composerState, appendLocalNotice, appendLocalNoticeForChat, cursor };
+	return {
+		deps,
+		composerState,
+		appendLocalNotice,
+		appendLocalNoticeForChat,
+		noticeRevisionForChat,
+		clearLocalNoticesForChat,
+		cursor,
+	};
 }
 
 describe('ConversationSlashCommandService', () => {
@@ -1085,6 +1101,150 @@ describe('ConversationSlashCommandService', () => {
 			'error',
 			'Could not confirm whether the fork was created. Check the chat list before trying again.',
 		);
+	});
+
+	it('clears the forking progress notice through its captured revision on success', async () => {
+		const { deps, appendLocalNotice, noticeRevisionForChat, clearLocalNoticesForChat } =
+			createDeps();
+		mockForkRunChat.mockResolvedValueOnce({
+			success: true,
+			commandType: 'fork-run',
+			clientRequestId: 'request-1',
+			chatId: 'chat-2',
+			turnId: 'turn-1',
+			status: 'accepted',
+			acceptedAt: '2026-07-14T00:00:00.000Z',
+			chat: createServerEntry('chat-2'),
+		});
+
+		await new ConversationSlashCommandService(deps).submitForkCommand(
+			'chat-1',
+			deps.sessions.byId['chat-1'],
+			'continue here',
+			[],
+			true,
+		);
+
+		expect(appendLocalNotice).toHaveBeenCalledWith('progress', 'Forking chat...');
+		expect(noticeRevisionForChat).toHaveBeenCalledWith('chat-1');
+		expect(clearLocalNoticesForChat).toHaveBeenCalledWith('chat-1', 1);
+	});
+
+	it('keeps the failure notice appended after the forking progress notice', async () => {
+		const { deps, appendLocalNotice, clearLocalNoticesForChat } = createDeps();
+		mockForkRunChat.mockRejectedValueOnce(
+			new ApiError(409, 'Chat is running', 'CHAT_RUNNING', undefined, true),
+		);
+
+		const outcome = await new ConversationSlashCommandService(deps).submitForkCommand(
+			'chat-1',
+			deps.sessions.byId['chat-1'],
+			'continue here',
+			[],
+			true,
+		);
+
+		expect(outcome).toBe('rejected');
+		expect(appendLocalNotice).toHaveBeenCalledTimes(2);
+		expect(appendLocalNotice).toHaveBeenLastCalledWith(
+			'error',
+			'Failed to fork chat: Chat is running',
+		);
+		expect(clearLocalNoticesForChat).toHaveBeenCalledWith('chat-1', 1);
+	});
+
+	it('clears the forking progress notice when the handoff fork confirmation is declined', async () => {
+		const { deps, appendLocalNotice, clearLocalNoticesForChat } = createDeps();
+		mockForkRunChat.mockRejectedValueOnce(
+			new ApiError(
+				409,
+				'The transcript is not written yet',
+				'TRANSCRIPT_NOT_YET_PERSISTED',
+				undefined,
+				true,
+			),
+		);
+		deps.confirmHandoffFork.mockResolvedValueOnce(false);
+
+		const outcome = await new ConversationSlashCommandService(deps).submitForkCommand(
+			'chat-1',
+			deps.sessions.byId['chat-1'],
+			'continue here',
+			[],
+			true,
+		);
+
+		expect(outcome).toBe('rejected');
+		expect(appendLocalNotice).toHaveBeenCalledTimes(1);
+		expect(clearLocalNoticesForChat).toHaveBeenCalledWith('chat-1', 1);
+	});
+
+	it('clears the forking progress notice after a bare fork settles', async () => {
+		const { deps, clearLocalNoticesForChat } = createDeps();
+		mockForkChat.mockResolvedValueOnce({ success: true, chat: createServerEntry('chat-2') });
+
+		const outcome = await new ConversationSlashCommandService(deps).submitForkCommand(
+			'chat-1',
+			deps.sessions.byId['chat-1'],
+			'',
+			[],
+			true,
+		);
+
+		expect(outcome).toBe('accepted');
+		expect(mockForkChat).toHaveBeenCalledWith({
+			sourceChatId: 'chat-1',
+			chatId: expect.stringMatching(/^\d+$/),
+		});
+		expect(clearLocalNoticesForChat).toHaveBeenCalledWith('chat-1', 1);
+	});
+
+	it('clears the handoff progress notice through its captured revision on success', async () => {
+		const { deps, appendLocalNotice, clearLocalNoticesForChat } = createDeps();
+		mockSelfHandoffRunChat.mockResolvedValueOnce({
+			success: true,
+			commandType: 'fork-run',
+			clientRequestId: 'request-1',
+			chatId: 'chat-2',
+			turnId: 'turn-1',
+			status: 'accepted',
+			acceptedAt: '2026-07-14T00:00:00.000Z',
+			chat: createServerEntry('chat-2'),
+		});
+
+		await new ConversationSlashCommandService(deps).submitHandoffCommand(
+			'chat-1',
+			deps.sessions.byId['chat-1'],
+			'take over here',
+			[],
+			true,
+		);
+
+		expect(appendLocalNotice).toHaveBeenCalledWith('progress', 'Continuing in a new chat...');
+		expect(clearLocalNoticesForChat).toHaveBeenCalledWith('chat-1', 1);
+		expect(deps.navigation.navigateToChat).toHaveBeenCalledWith('chat-2');
+	});
+
+	it('keeps the handoff failure notice appended after the progress notice', async () => {
+		const { deps, appendLocalNotice, clearLocalNoticesForChat } = createDeps();
+		mockSelfHandoffRunChat.mockRejectedValueOnce(
+			new ApiError(409, 'Chat is running', 'CHAT_RUNNING', undefined, true),
+		);
+
+		const outcome = await new ConversationSlashCommandService(deps).submitHandoffCommand(
+			'chat-1',
+			deps.sessions.byId['chat-1'],
+			'take over here',
+			[],
+			true,
+		);
+
+		expect(outcome).toBe('rejected');
+		expect(appendLocalNotice).toHaveBeenLastCalledWith(
+			'error',
+			'Failed to hand off chat: Chat is running',
+		);
+		expect(clearLocalNoticesForChat).toHaveBeenCalledWith('chat-1', 1);
 	});
 
 	it('forks without a message and preserves the requested ordinal', async () => {

--- a/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
+++ b/web/src/lib/chat/conversation/conversation-session-controller.svelte.ts
@@ -88,7 +88,8 @@ type SessionTranscriptState = Pick<
 		noticeType: Parameters<ActiveTranscriptPort['appendLocalNotice']>[0],
 		content: string,
 	): void;
-	clearLocalNoticesForChat(chatId: string): void;
+	clearLocalNoticesForChat(chatId: string, throughRevision?: number): void;
+	noticeRevisionForChat(chatId: string): number;
 };
 
 type SessionTranscriptLoadTarget = Pick<

--- a/web/src/lib/chat/conversation/conversation-slash-command-service.ts
+++ b/web/src/lib/chat/conversation/conversation-slash-command-service.ts
@@ -76,6 +76,8 @@ interface SlashCommandChatState {
 		noticeType: LocalNoticeType,
 		content: string,
 	): void;
+	noticeRevisionForChat(chatId: string): number;
+	clearLocalNoticesForChat(chatId: string, throughRevision?: number): void;
 }
 
 export interface ConversationForkSource {
@@ -573,55 +575,62 @@ export class ConversationSlashCommandService {
 		const previousText = deps.composerState.inputText;
 		const previousImages = [...deps.composerState.images];
 		deps.chatState.appendLocalNotice('progress', m.chat_notice_handing_off_chat());
+		// Clearing through this revision on settle removes the progress notice while
+		// keeping any error notice the failure paths append after it.
+		const progressNoticeRevision = deps.chatState.noticeRevisionForChat(sourceChatId);
 		deps.chatState.isUserScrolledUp = false;
 		const clearedRevision = clearComposer
 			? deps.composerState.clearAfterSubmit(sourceChatId)
 			: null;
 
-		let imagePayload: ChatImage[] = [];
-		if (images.length > 0) {
+		try {
+			let imagePayload: ChatImage[] = [];
+			if (images.length > 0) {
+				try {
+					imagePayload = await prepareChatImages(images);
+				} catch (error) {
+					this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+					deps.chatState.appendLocalNotice(
+						'error',
+						m.chat_notice_failed_prepare_attachments({ detail: errorDetail(error) }),
+					);
+					return 'rejected';
+				}
+			}
+
+			const submission = this.acceptedInputs.selfHandoff({
+				sourceChatId,
+				chatId: createClientChatId(),
+				command: message.trim(),
+				...(imagePayload.length > 0 ? { images: imagePayload } : {}),
+			});
 			try {
-				imagePayload = await prepareChatImages(images);
+				const response = await submission.submit();
+				deps.sessions.upsertServerChat(response.chat);
+				deps.sessions.setSelectedChatId(response.chat.id);
+				deps.navigation.navigateToChat?.(response.chat.id);
+				if (response.status === 'accepted') {
+					deps.lifecycle.beginTurn(response.chat.id);
+				}
+				return 'accepted';
 			} catch (error) {
-				this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+				// An ambiguous transport outcome may have already created the target and
+				// started its turn. Restoring the composer and calling it a failure
+				// invites a resubmission that would produce a second continuation.
+				const outcomeUnknown = error instanceof CommandOutcomeUnknownError;
+				if (!outcomeUnknown) {
+					this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+				}
 				deps.chatState.appendLocalNotice(
 					'error',
-					m.chat_notice_failed_prepare_attachments({ detail: errorDetail(error) }),
+					outcomeUnknown
+						? m.chat_notice_handoff_outcome_unconfirmed()
+						: m.chat_notice_failed_handoff({ detail: errorDetail(error) }),
 				);
-				return 'rejected';
+				return outcomeUnknown ? 'unknown' : 'rejected';
 			}
-		}
-
-		const submission = this.acceptedInputs.selfHandoff({
-			sourceChatId,
-			chatId: createClientChatId(),
-			command: message.trim(),
-			...(imagePayload.length > 0 ? { images: imagePayload } : {}),
-		});
-		try {
-			const response = await submission.submit();
-			deps.sessions.upsertServerChat(response.chat);
-			deps.sessions.setSelectedChatId(response.chat.id);
-			deps.navigation.navigateToChat?.(response.chat.id);
-			if (response.status === 'accepted') {
-				deps.lifecycle.beginTurn(response.chat.id);
-			}
-			return 'accepted';
-		} catch (error) {
-			// An ambiguous transport outcome may have already created the target and
-			// started its turn. Restoring the composer and calling it a failure
-			// invites a resubmission that would produce a second continuation.
-			const outcomeUnknown = error instanceof CommandOutcomeUnknownError;
-			if (!outcomeUnknown) {
-				this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
-			}
-			deps.chatState.appendLocalNotice(
-				'error',
-				outcomeUnknown
-					? m.chat_notice_handoff_outcome_unconfirmed()
-					: m.chat_notice_failed_handoff({ detail: errorDetail(error) }),
-			);
-			return outcomeUnknown ? 'unknown' : 'rejected';
+		} finally {
+			deps.chatState.clearLocalNoticesForChat(sourceChatId, progressNoticeRevision);
 		}
 	}
 
@@ -653,81 +662,88 @@ export class ConversationSlashCommandService {
 		const previousText = deps.composerState.inputText;
 		const previousImages = [...deps.composerState.images];
 		deps.chatState.appendLocalNotice('progress', m.chat_notice_forking_chat());
+		// Clearing through this revision on settle removes the progress notice while
+		// keeping any error notice the failure paths append after it.
+		const progressNoticeRevision = deps.chatState.noticeRevisionForChat(sourceChatId);
 		deps.chatState.isUserScrolledUp = false;
 		const clearedRevision = clearComposer
 			? deps.composerState.clearAfterSubmit(sourceChatId)
 			: null;
 
-		if (!message.trim()) {
-			return this.#submitForkOnlyCommand(
-				sourceChatId,
-				previousText,
-				previousImages,
-				clearedRevision,
-			);
-		}
+		try {
+			if (!message.trim()) {
+				return await this.#submitForkOnlyCommand(
+					sourceChatId,
+					previousText,
+					previousImages,
+					clearedRevision,
+				);
+			}
 
-		let imagePayload: ChatImage[] = [];
-		if (images.length > 0) {
+			let imagePayload: ChatImage[] = [];
+			if (images.length > 0) {
+				try {
+					imagePayload = await prepareChatImages(images);
+				} catch (error) {
+					this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+					deps.chatState.appendLocalNotice(
+						'error',
+						m.chat_notice_failed_prepare_attachments({ detail: errorDetail(error) }),
+					);
+					return 'rejected';
+				}
+			}
+
+			const forkChatId = createClientChatId();
+			const model = sourceChat.model ?? deps.agentState.model;
+			const selection = resolveConversationModelSelection({
+				agentId: sourceChat.agentId,
+				model,
+				apiProviderId: sourceChat.apiProviderId ?? null,
+				modelEndpointId: sourceChat.modelEndpointId ?? null,
+				modelProtocol: sourceChat.modelProtocol ?? null,
+			}, deps.modelCatalog);
+			const submission = this.acceptedInputs.fork({
+				sourceChatId,
+				chatId: forkChatId,
+				command: message.trim(),
+				permissionMode: sourceChat.permissionMode,
+				thinkingMode: sourceChat.thinkingMode,
+				agentSettings: sourceChat.agentSettings,
+				images: imagePayload.length > 0 ? imagePayload : undefined,
+				model: selection.model,
+				apiProviderId: selection.apiProviderId,
+				modelEndpointId: selection.modelEndpointId,
+				modelProtocol: selection.modelProtocol,
+			});
 			try {
-				imagePayload = await prepareChatImages(images);
+				const response = await this.#submitForkRunWithConfirmation(submission);
+				if (!response) {
+					this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+					return 'rejected';
+				}
+				deps.sessions.upsertServerChat(response.chat);
+				deps.sessions.setSelectedChatId(response.chat.id);
+				deps.navigation.navigateToChat?.(response.chat.id);
+				if (response.status === 'accepted') {
+					deps.lifecycle.beginTurn(response.chat.id);
+				}
+				return 'accepted';
 			} catch (error) {
-				this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+				const outcomeUnknown = error instanceof CommandOutcomeUnknownError;
+				if (!outcomeUnknown) {
+					this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
+				}
 				deps.chatState.appendLocalNotice(
 					'error',
-					m.chat_notice_failed_prepare_attachments({ detail: errorDetail(error) }),
+					outcomeUnknown
+						? m.chat_notice_fork_outcome_unconfirmed()
+						: m.chat_notice_failed_fork_chat({ detail: errorDetail(error) }),
 				);
-				return 'rejected';
+				return outcomeUnknown ? 'unknown' : 'rejected';
 			}
-		}
-
-		const forkChatId = createClientChatId();
-		const model = sourceChat.model ?? deps.agentState.model;
-		const selection = resolveConversationModelSelection({
-			agentId: sourceChat.agentId,
-			model,
-			apiProviderId: sourceChat.apiProviderId ?? null,
-			modelEndpointId: sourceChat.modelEndpointId ?? null,
-			modelProtocol: sourceChat.modelProtocol ?? null,
-		}, deps.modelCatalog);
-		const submission = this.acceptedInputs.fork({
-			sourceChatId,
-			chatId: forkChatId,
-			command: message.trim(),
-			permissionMode: sourceChat.permissionMode,
-			thinkingMode: sourceChat.thinkingMode,
-			agentSettings: sourceChat.agentSettings,
-			images: imagePayload.length > 0 ? imagePayload : undefined,
-			model: selection.model,
-			apiProviderId: selection.apiProviderId,
-			modelEndpointId: selection.modelEndpointId,
-			modelProtocol: selection.modelProtocol,
-		});
-		try {
-			const response = await this.#submitForkRunWithConfirmation(submission);
-			if (!response) {
-				this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
-				return 'rejected';
-			}
-			deps.sessions.upsertServerChat(response.chat);
-			deps.sessions.setSelectedChatId(response.chat.id);
-			deps.navigation.navigateToChat?.(response.chat.id);
-			if (response.status === 'accepted') {
-				deps.lifecycle.beginTurn(response.chat.id);
-			}
-			return 'accepted';
-		} catch (error) {
-			const outcomeUnknown = error instanceof CommandOutcomeUnknownError;
-			if (!outcomeUnknown) {
-				this.#restoreComposer(sourceChatId, previousText, previousImages, clearedRevision);
-			}
-			deps.chatState.appendLocalNotice(
-				'error',
-				outcomeUnknown
-					? m.chat_notice_fork_outcome_unconfirmed()
-					: m.chat_notice_failed_fork_chat({ detail: errorDetail(error) }),
-			);
-			return outcomeUnknown ? 'unknown' : 'rejected';
+		} finally {
+			deps.chatState.clearLocalNoticesForChat(sourceChatId, progressNoticeRevision);
 		}
 	}
 

--- a/web/src/lib/chat/conversation/current-conversation-panel-transcript.ts
+++ b/web/src/lib/chat/conversation/current-conversation-panel-transcript.ts
@@ -183,8 +183,12 @@ export class CurrentConversationPanelTranscript implements ActiveTranscriptPort 
 		if (chatId) this.options.panels.clearNotices(chatId);
 	}
 
-	clearLocalNoticesForChat(chatId: string): void {
-		this.options.panels.clearNotices(chatId);
+	clearLocalNoticesForChat(chatId: string, throughRevision?: number): void {
+		this.options.panels.clearNotices(chatId, throughRevision);
+	}
+
+	noticeRevisionForChat(chatId: string): number {
+		return this.options.panels.noticeRevisionFor(chatId);
 	}
 
 	upsertOptimisticUserInput(input: OptimisticUserInput): void {

--- a/web/src/lib/chat/transcript/__tests__/conversation-transcript-overlay-store.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-transcript-overlay-store.test.ts
@@ -77,6 +77,38 @@ describe('ConversationTranscriptOverlayStore', () => {
 		expect(view.resendCandidates).toEqual([candidate(3)]);
 	});
 
+	it('clears notices through a captured revision while keeping later ones', () => {
+		const overlays = new ConversationTranscriptOverlayStore();
+		overlays.appendLocalNotice('chat-1', 'progress', 'forking');
+		const capturedRevision = overlays.noticeRevisionFor('chat-1');
+		overlays.appendLocalNotice('chat-1', 'error', 'failed');
+
+		const mutation = overlays.clearNoticesThrough('chat-1', capturedRevision);
+
+		expect(mutation.feedStructureChanged).toBe(true);
+		expect(overlays.forChat('chat-1').notices.map((notice) => notice.content)).toEqual([
+			'failed',
+		]);
+
+		overlays.clearNoticesThrough('chat-1');
+
+		expect(overlays.forChat('chat-1').notices).toEqual([]);
+	});
+
+	it('keeps notice revisions monotonic across transcript replacement', () => {
+		const overlays = new ConversationTranscriptOverlayStore();
+		overlays.appendLocalNotice('chat-1', 'progress', 'forking');
+		const capturedRevision = overlays.noticeRevisionFor('chat-1');
+		overlays.resetForTranscriptReplacement('chat-1');
+		overlays.appendLocalNotice('chat-1', 'error', 'failed');
+
+		overlays.clearNoticesThrough('chat-1', capturedRevision);
+
+		expect(overlays.forChat('chat-1').notices.map((notice) => notice.content)).toEqual([
+			'failed',
+		]);
+	});
+
 	it('preserves stable resend exclusions until their candidate departs', () => {
 		const overlays = new ConversationTranscriptOverlayStore();
 		overlays.replaceResendCandidates('chat-1', [candidate(1), candidate(2)]);

--- a/web/src/lib/chat/transcript/conversation-transcript-overlay-store.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-transcript-overlay-store.svelte.ts
@@ -228,7 +228,8 @@ class ConversationTranscriptOverlayEntry implements ConversationTranscriptOverla
 	resetForTranscriptReplacement(): ConversationTranscriptOverlayMutation {
 		const feedStructureChanged = this.#notices.length > 0 || this.#optimisticInputs.length > 0;
 		this.#notices = [];
-		this.#noticeRevision = 0;
+		// The revision counter stays monotonic across replacements so a revision
+		// captured before the reset cannot clear notices appended after it.
 		this.#optimisticInputs = [];
 		this.#optimisticAfterOrdinals = new Map();
 		this.#resendCandidates = [];


### PR DESCRIPTION
Since local transcript notices moved into the persistent per-chat overlay store, the "Forking chat..." and "Continuing in a new chat..." progress notices appended to the source chat never disappeared: a fork or handoff commits its messages only to the new chat, and slash commands bypass the queue controller's notice reset, so nothing ever cleared the source chat's overlay entry. Each command now captures the source chat's notice revision right after appending the progress notice and clears through that revision when the operation settles on any path (success, definitive failure, unknown outcome, declined handoff-fork confirmation, attachment failure, bare /fork), which removes the progress notice while preserving any failure notice appended after it. The overlay store's notice revision counter also stays monotonic across transcript view replacements so a revision captured before a reset can never clear notices appended after it.