### PR TITLE
Select pre-filled snippet default arguments on insert

### DIFF
--- a/integration-tests/tests/chromium/snippet-default-arguments-layout.test.ts
+++ b/integration-tests/tests/chromium/snippet-default-arguments-layout.test.ts
@@ -221,7 +221,7 @@ describe('snippet default argument layouts', () => {
           return (
             field?.value === expected &&
             document.activeElement === field &&
-            field.selectionStart === expected.length &&
+            field.selectionStart === 0 &&
             field.selectionEnd === expected.length
           );
         }, savedDefault);

--- a/integration-tests/tests/e2e/snippet-palette-focus.test.ts
+++ b/integration-tests/tests/e2e/snippet-palette-focus.test.ts
@@ -92,7 +92,7 @@ describe('snippet palette focus', () => {
             Boolean(dialog) &&
             document.activeElement === textarea &&
             textarea?.value === expected &&
-            textarea.selectionStart === expected.length &&
+            textarea.selectionStart === 0 &&
             textarea.selectionEnd === expected.length
           );
         },
@@ -114,7 +114,7 @@ describe('snippet palette focus', () => {
       expect(argumentsField).toEqual({
         focused: true,
         value: 'staged changes',
-        selectionStart: 'staged changes'.length,
+        selectionStart: 0,
         selectionEnd: 'staged changes'.length,
       });
       await fixture.page.evaluate(() => {

--- a/web/src/lib/components/chat/ComposerSnippetArgumentsDialog.svelte
+++ b/web/src/lib/components/chat/ComposerSnippetArgumentsDialog.svelte
@@ -84,7 +84,10 @@
 		if (!open || !argumentsRef) return false;
 		argumentsRef.focus({ preventScroll: true });
 		const end = argumentsRef.value.length;
-		argumentsRef.setSelectionRange(end, end);
+		// Selects a pre-filled default so typing replaces it; an edited retry draft keeps the caret at the end.
+		const isDefaultPrefill =
+			snippet !== null && end > 0 && argumentsRef.value === snippet.defaultArguments;
+		argumentsRef.setSelectionRange(isDefaultPrefill ? 0 : end, end);
 		return true;
 	}
 

--- a/web/src/lib/components/chat/ComposerSnippetArgumentsDialog.svelte
+++ b/web/src/lib/components/chat/ComposerSnippetArgumentsDialog.svelte
@@ -13,6 +13,7 @@
 		open: boolean;
 		snippet: Snippet | null;
 		initialArguments?: string;
+		selectInitialArguments?: boolean;
 		onClose: () => void;
 		onSubmit: (snippet: Snippet, argumentsText: string) => void;
 		onCancelled: () => void;
@@ -23,6 +24,7 @@
 		open,
 		snippet,
 		initialArguments = '',
+		selectInitialArguments = false,
 		onClose,
 		onSubmit,
 		onCancelled,
@@ -85,9 +87,8 @@
 		argumentsRef.focus({ preventScroll: true });
 		const end = argumentsRef.value.length;
 		// Selects a pre-filled default so typing replaces it; an edited retry draft keeps the caret at the end.
-		const isDefaultPrefill =
-			snippet !== null && end > 0 && argumentsRef.value === snippet.defaultArguments;
-		argumentsRef.setSelectionRange(isDefaultPrefill ? 0 : end, end);
+		const selectAll = selectInitialArguments && end > 0;
+		argumentsRef.setSelectionRange(selectAll ? 0 : end, end);
 		return true;
 	}
 

--- a/web/src/lib/components/chat/ComposerSnippetPalette.svelte
+++ b/web/src/lib/components/chat/ComposerSnippetPalette.svelte
@@ -254,6 +254,7 @@
 	open={palette.argumentsDialogOpen}
 	snippet={palette.argumentsSnippet}
 	initialArguments={palette.argumentsDraft}
+	selectInitialArguments={palette.argumentsDraftIsFreshDefault}
 	onClose={() => palette.closeArguments()}
 	onSubmit={(snippet, argumentsText) => palette.submitArguments(snippet, argumentsText)}
 	onCancelled={() => palette.settleArgumentsCancel()}

--- a/web/src/lib/components/chat/__tests__/ComposerSnippetPalette.test.ts
+++ b/web/src/lib/components/chat/__tests__/ComposerSnippetPalette.test.ts
@@ -195,7 +195,7 @@ describe('ComposerSnippetPalette', () => {
 		expect(screen.getByTestId('selected-arguments').textContent).toBe(rawArguments);
 	});
 
-	it('prefills saved defaults and places the collapsed caret at the end', async () => {
+	it('prefills saved defaults and selects them for replacement', async () => {
 		render(ComposerSnippetPaletteTestHost, {
 			count: 1,
 			firstTemplate: 'Review {{arguments}}',
@@ -214,7 +214,7 @@ describe('ComposerSnippetPalette', () => {
 		await waitFor(() => expect(document.activeElement).toBe(input));
 		expect(screen.getByTestId('main-inert').textContent).toBe('true');
 		expect(input.value).toBe('staged changes');
-		expect(input.selectionStart).toBe(input.value.length);
+		expect(input.selectionStart).toBe(0);
 		expect(input.selectionEnd).toBe(input.value.length);
 
 		const insert = screen.getByRole('button', { name: 'Insert snippet' });
@@ -318,6 +318,9 @@ describe('ComposerSnippetPalette', () => {
 			name: 'Arguments',
 		})) as HTMLTextAreaElement;
 		expect(reopened.value).toBe(rawArguments);
+		await waitFor(() => expect(document.activeElement).toBe(reopened));
+		expect(reopened.selectionStart).toBe(rawArguments.length);
+		expect(reopened.selectionEnd).toBe(rawArguments.length);
 	});
 
 	it('reopens a failed cleared insertion without restoring the saved default', async () => {

--- a/web/src/lib/components/chat/__tests__/ComposerSnippetPalette.test.ts
+++ b/web/src/lib/components/chat/__tests__/ComposerSnippetPalette.test.ts
@@ -323,6 +323,31 @@ describe('ComposerSnippetPalette', () => {
 		expect(reopened.selectionEnd).toBe(rawArguments.length);
 	});
 
+	it('keeps the caret at the end when a failed reopen draft equals the default', async () => {
+		render(ComposerSnippetPaletteTestHost, {
+			count: 1,
+			firstTemplate: 'Review {{arguments}}',
+			firstDefaultArguments: 'staged changes',
+			insertionResult: 'failed',
+		});
+		await fireEvent.click(await screen.findByRole('option', { name: /item-0/ }));
+		const input = (await screen.findByRole('textbox', {
+			name: 'Arguments',
+		})) as HTMLTextAreaElement;
+		await waitFor(() => expect(document.activeElement).toBe(input));
+		expect(input.selectionStart).toBe(0);
+		expect(input.selectionEnd).toBe('staged changes'.length);
+		await fireEvent.keyDown(input, { key: 'Enter' });
+
+		const reopened = (await screen.findByRole('textbox', {
+			name: 'Arguments',
+		})) as HTMLTextAreaElement;
+		expect(reopened.value).toBe('staged changes');
+		await waitFor(() => expect(document.activeElement).toBe(reopened));
+		expect(reopened.selectionStart).toBe('staged changes'.length);
+		expect(reopened.selectionEnd).toBe('staged changes'.length);
+	});
+
 	it('reopens a failed cleared insertion without restoring the saved default', async () => {
 		render(ComposerSnippetPaletteTestHost, {
 			count: 1,

--- a/web/src/lib/components/chat/composer-snippet-palette-state.svelte.ts
+++ b/web/src/lib/components/chat/composer-snippet-palette-state.svelte.ts
@@ -27,6 +27,7 @@ export class ComposerSnippetPaletteState {
 	highlightedSnippetId = $state<string | null>(null);
 	argumentsSnippet = $state<Snippet | null>(null);
 	argumentsDraft = $state('');
+	argumentsDraftIsFreshDefault = $state(false);
 	argumentsDialogOpen = $state(false);
 
 	#filteredSnippets = $derived.by(() => {
@@ -97,6 +98,7 @@ export class ComposerSnippetPaletteState {
 		this.argumentsDialogOpen = false;
 		this.argumentsSnippet = null;
 		this.argumentsDraft = '';
+		this.argumentsDraftIsFreshDefault = false;
 		if (open) this.#options.onOpenChange(false);
 	}
 
@@ -140,6 +142,7 @@ export class ComposerSnippetPaletteState {
 			queueMicrotask(() => {
 				this.argumentsSnippet = snippet;
 				this.argumentsDraft = snippet.defaultArguments;
+				this.argumentsDraftIsFreshDefault = true;
 				this.argumentsDialogOpen = true;
 			});
 			return;
@@ -159,6 +162,7 @@ export class ComposerSnippetPaletteState {
 		this.argumentsDialogOpen = false;
 		this.argumentsSnippet = null;
 		this.argumentsDraft = '';
+		this.argumentsDraftIsFreshDefault = false;
 		this.#options.onCancelled?.();
 	}
 
@@ -197,10 +201,12 @@ export class ComposerSnippetPaletteState {
 		if (result === 'failed' && snippetTemplateUsesArguments(snippet.template)) {
 			this.argumentsSnippet = snippet;
 			this.argumentsDraft = argumentsText;
+			this.argumentsDraftIsFreshDefault = false;
 			this.argumentsDialogOpen = true;
 			return;
 		}
 		this.argumentsSnippet = null;
 		this.argumentsDraft = '';
+		this.argumentsDraftIsFreshDefault = false;
 	}
 }


### PR DESCRIPTION
Editor snippet systems (VS Code/TextMate/LSP placeholders, IntelliJ live templates) select a placeholder's default text on insertion so that keeping it and replacing it each cost a single keystroke. The snippet arguments dialog previously placed the caret at the end of the pre-filled default, forcing select-all plus delete before typing a replacement. The dialog now selects the full text when the pre-fill matches the snippet's saved default arguments, while an edited draft reopened after a failed expansion keeps the caret at the end so user-entered text is never pre-selected for accidental overwrite.