### PR TITLE
Collapse long user messages automatically

### DIFF
--- a/web/src/lib/chat/transcript/__tests__/user-message-body-disclosure.logic.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/user-message-body-disclosure.logic.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import type { UserMessagePresentation } from '$shared/chat-types';
+import { userMessageBodyDisclosure } from '../user-message-body-disclosure.js';
+
+describe('userMessageBodyDisclosure', () => {
+	it('collapses ordinary user messages by default', () => {
+		expect(userMessageBodyDisclosure(undefined)).toBe('collapsed');
+		expect(userMessageBodyDisclosure(null)).toBe('collapsed');
+	});
+
+	it('preserves CLI-authored disclosure intent', () => {
+		const expanded = {
+			origin: 'cli',
+			style: 'info',
+		} satisfies UserMessagePresentation;
+		const collapsed = {
+			origin: 'cli',
+			style: 'notice',
+			disclosure: 'collapsed',
+		} satisfies UserMessagePresentation;
+
+		expect(userMessageBodyDisclosure(expanded)).toBeUndefined();
+		expect(userMessageBodyDisclosure(collapsed)).toBe('collapsed');
+	});
+});

--- a/web/src/lib/chat/transcript/user-message-body-disclosure.ts
+++ b/web/src/lib/chat/transcript/user-message-body-disclosure.ts
@@ -1,0 +1,7 @@
+import type { UserMessagePresentation } from '$shared/chat-types';
+
+export function userMessageBodyDisclosure(
+	presentation: UserMessagePresentation | null | undefined,
+): 'collapsed' | undefined {
+	return presentation ? presentation.disclosure : 'collapsed';
+}

--- a/web/src/lib/components/chat/ConversationFeedItemState.svelte.ts
+++ b/web/src/lib/components/chat/ConversationFeedItemState.svelte.ts
@@ -1,5 +1,11 @@
 export type ConversationDisclosureKind =
-	'thinking' | 'tool-input' | 'tool-result' | 'compaction' | 'cli-body' | 'notice-body';
+	| 'thinking'
+	| 'tool-input'
+	| 'tool-result'
+	| 'compaction'
+	| 'user-body'
+	| 'cli-body'
+	| 'notice-body';
 
 export interface ConversationDisclosureStatePort {
 	open(kind: ConversationDisclosureKind, localId: string, defaultOpen: boolean): boolean;

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -41,6 +41,7 @@
 	import CollapsibleBody from './rows/CollapsibleBody.svelte';
 	import TranscriptNoticeRow from './rows/TranscriptNoticeRow.svelte';
 	import { cliPresentationSurfaceClass } from '$lib/chat/transcript/cli-presentation-style';
+	import { userMessageBodyDisclosure } from '$lib/chat/transcript/user-message-body-disclosure.js';
 	import ChatToolEventRenderer from './tools/ChatToolEventRenderer.svelte';
 	import {
 		ContextMenu,
@@ -155,6 +156,10 @@
 
 	const asUser = $derived(message instanceof UserMessage ? message : null);
 	const userMessagePresentation = $derived(asUser?.presentation ?? null);
+	const userMessageDisclosure = $derived(userMessageBodyDisclosure(userMessagePresentation));
+	const userMessageDisclosureKind = $derived<'user-body' | 'cli-body'>(
+		userMessagePresentation ? 'cli-body' : 'user-body',
+	);
 	const userMessageSurfaceClass = $derived(
 		userMessagePresentation?.style
 			? cliPresentationSurfaceClass(userMessagePresentation.style)
@@ -505,11 +510,13 @@
 								/>
 							{/if}
 							<CollapsibleBody
-								disclosure={userMessagePresentation?.disclosure}
-								alwaysExpanded={localSettings.alwaysExpandCliMessages}
-								expanded={disclosureState?.open('cli-body', 'body', false)}
+								disclosure={userMessageDisclosure}
+								alwaysExpanded={Boolean(userMessagePresentation) &&
+									localSettings.alwaysExpandCliMessages}
+								expanded={disclosureState?.open(userMessageDisclosureKind, 'body', false)}
 								onExpandedChange={disclosureState
-									? (expanded) => disclosureState.setOpen('cli-body', 'body', expanded, false)
+									? (expanded) =>
+											disclosureState.setOpen(userMessageDisclosureKind, 'body', expanded, false)
 									: undefined}
 							>
 								<div class={userMessagePresentation?.style ? 'mt-1 text-sm' : 'text-sm'}>

--- a/web/src/lib/components/chat/SharedChatPage.svelte
+++ b/web/src/lib/components/chat/SharedChatPage.svelte
@@ -22,6 +22,7 @@
 	import CollapsibleBody from '$lib/components/chat/rows/CollapsibleBody.svelte';
 	import TranscriptNoticeRow from '$lib/components/chat/rows/TranscriptNoticeRow.svelte';
 	import { cliPresentationSurfaceClass } from '$lib/chat/transcript/cli-presentation-style';
+	import { userMessageBodyDisclosure } from '$lib/chat/transcript/user-message-body-disclosure.js';
 	import { cn } from '$lib/utils/cn';
 	import { getAppTitle } from '$lib/context';
 	import ChevronRight from '@lucide/svelte/icons/chevron-right';
@@ -299,7 +300,7 @@
 												title={userPresentation.title}
 											/>
 										{/if}
-										<CollapsibleBody disclosure={userPresentation?.disclosure}>
+										<CollapsibleBody disclosure={userMessageBodyDisclosure(userPresentation)}>
 											<div class={userPresentation?.style ? 'mt-1 text-sm' : 'text-sm'}>
 												<Markdown
 													source={message.content}

--- a/web/src/lib/components/chat/__tests__/ConversationFeedItemState.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationFeedItemState.test.ts
@@ -16,7 +16,7 @@ describe('ConversationFeedItemState', () => {
 		expect(disclosure.open('thinking', 'thinking', false)).toBe(false);
 	});
 
-	it('keeps input and result disclosures independent', () => {
+	it('keeps tool and message-body disclosures independent', () => {
 		const items = new ConversationFeedItemState();
 		items.reconcile('chat-1:generation-1', new Set(['row-1']), new Set());
 		const disclosure = items.disclosurePort('row-1');
@@ -25,6 +25,7 @@ describe('ConversationFeedItemState', () => {
 
 		expect(disclosure.open('tool-input', 'tool-1', false)).toBe(true);
 		expect(disclosure.open('tool-result', 'tool-1', false)).toBe(false);
+		expect(disclosure.open('user-body', 'body', false)).toBe(false);
 		expect(disclosure.open('cli-body', 'body', false)).toBe(true);
 	});
 

--- a/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
+++ b/web/src/lib/components/chat/__tests__/ConversationMessage.chat-row.test.ts
@@ -511,6 +511,76 @@ describe('ConversationMessage chat rows', () => {
 		expect(screen.getByText('Long CLI content').closest('.collapsible-body-collapsed')).toBeNull();
 	});
 
+	it('collapses overflowing ordinary user messages automatically', async () => {
+		const { container } = render(ConversationMessageHost, {
+			message: new UserMessage(AT, '## Long user prompt\n\nPreserve **all details**.'),
+		});
+
+		const button = screen.getByRole('button', { name: 'Show more' });
+		expect(button.getAttribute('aria-expanded')).toBe('false');
+		expect(document.getElementById(button.getAttribute('aria-controls')!)?.classList).toContain(
+			'collapsible-body-collapsed',
+		);
+		expect(container.querySelector('[data-user-message-presentation]')).toBeNull();
+		expect(screen.getByText('Long user prompt').tagName).toBe('H2');
+		expect(screen.getByText('all details').tagName).toBe('STRONG');
+
+		await fireEvent.click(button);
+		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
+			'true',
+		);
+	});
+
+	it('leaves short ordinary user messages without a disclosure', async () => {
+		collapsibleLayout.contentHeight = 80;
+		const { container } = render(ConversationMessageHost, {
+			message: new UserMessage(AT, 'Short user prompt'),
+		});
+
+		await waitFor(() => {
+			expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull();
+			expect(container.querySelector('.collapsible-body-truncated')).toBeNull();
+		});
+	});
+
+	it('keeps ordinary user messages collapsed when CLI messages are always expanded', () => {
+		render(ConversationMessageHost, {
+			message: new UserMessage(AT, 'Long ordinary user prompt'),
+			alwaysExpandCliMessages: true,
+		});
+
+		expect(screen.getByRole('button', { name: 'Show more' }).getAttribute('aria-expanded')).toBe(
+			'false',
+		);
+	});
+
+	it('preserves ordinary user expansion across remounts', async () => {
+		const itemState = new ConversationFeedItemState();
+		const disclosureState = itemState.disclosurePort('user-row-1');
+		const message = new UserMessage(AT, 'Long ordinary user prompt');
+		const first = render(ConversationMessageHost, { message, disclosureState });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+		first.unmount();
+
+		render(ConversationMessageHost, { message, disclosureState });
+		expect(screen.getByRole('button', { name: 'Show less' }).getAttribute('aria-expanded')).toBe(
+			'true',
+		);
+	});
+
+	it('keeps styled CLI user messages expanded unless they opt into collapse', () => {
+		const { container } = render(ConversationMessageHost, {
+			message: new UserMessage(AT, 'Long presented user prompt', undefined, undefined, {
+				origin: 'cli',
+				style: 'info',
+			}),
+		});
+
+		expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull();
+		expect(container.querySelector('.collapsible-body-collapsed')).toBeNull();
+	});
+
 	it('collapses styleless CLI user messages without changing the bubble style', async () => {
 		const { container } = render(ConversationMessageHost, {
 			message: new UserMessage(AT, 'Long user content', undefined, undefined, {

--- a/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
+++ b/web/src/lib/components/chat/__tests__/SharedChatPage.test.ts
@@ -379,6 +379,30 @@ describe('SharedChatPage', () => {
 		expect(screen.getByText('Deployment context')).toBeTruthy();
 	});
 
+	it('collapses long ordinary user messages and preserves expansion when prepending history', async () => {
+		const newest = response([], 50, 51);
+		newest.snapshot.messages = [
+			{
+				type: 'user-message',
+				timestamp: '2025-01-02T03:05:00.000Z',
+				content: '**Long shared prompt**\n\nKeep every detail available.',
+			},
+		];
+		newest.page.end = 51;
+		vi.mocked(sharesApi.getSharedChat)
+			.mockResolvedValueOnce(newest)
+			.mockResolvedValueOnce(response(['Earlier response'], 0, 51, { nextBefore: null }));
+
+		render(SharedChatPageTestHost);
+		await screen.findByText('Long shared prompt');
+		await fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+		expect(screen.getByRole('button', { name: 'Show less' })).toBeTruthy();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Load earlier messages' }));
+		await screen.findByText('Earlier response');
+		expect(screen.getByRole('button', { name: 'Show less' })).toBeTruthy();
+	});
+
 	it('renders attachments with duplicate filenames', async () => {
 		const chatRows = response([], 0, 1, { nextBefore: null });
 		chatRows.snapshot.messages = [


### PR DESCRIPTION
Long user prompts can crowd the transcript, so ordinary user-message bodies now collapse only when they exceed the existing measured height limit in both live and shared views. The change preserves Markdown rendering, keeps attachments visible, retains expansion across live remounts and shared-history prepends, and leaves explicit CLI disclosure and CLI expansion settings unchanged.