### PR TITLE
Fix New Chat dialog clipping its content on mobile

### DIFF
--- a/integration-tests/tests/chromium/new-chat-composer-layout.test.ts
+++ b/integration-tests/tests/chromium/new-chat-composer-layout.test.ts
@@ -83,6 +83,21 @@ describe("Chromium New Chat composer layout", () => {
         expect(
           dialogBoxAtPhoneWidth.x + dialogBoxAtPhoneWidth.width,
         ).toBeLessThanOrEqual(362);
+        // The dialog clips horizontal overflow; the form must fit inside the
+        // dialog instead of relying on the clip to hide it.
+        expect(
+          await dialog.evaluate((node) => node.scrollWidth <= node.clientWidth),
+        ).toBe(true);
+
+        markPhase("checking content containment at 360px width");
+        await fixture.page.setViewportSize({ width: 360, height: 844 });
+        const dialogBoxAt360 = await bounds(dialog);
+        expect(dialogBoxAt360.x).toBeGreaterThanOrEqual(16);
+        expect(dialogBoxAt360.x + dialogBoxAt360.width).toBeLessThanOrEqual(344);
+        expect(
+          await dialog.evaluate((node) => node.scrollWidth <= node.clientWidth),
+        ).toBe(true);
+        await fixture.page.setViewportSize({ width: 390, height: 844 });
 
         markPhase("checking responsive composer actions");
         await bottomBar

--- a/web/src/lib/components/chat/NewChatForm.svelte
+++ b/web/src/lib/components/chat/NewChatForm.svelte
@@ -555,7 +555,7 @@
 </script>
 
 <div
-	class="p-2 sm:p-4"
+	class="min-w-0 p-2 sm:p-4"
 	{@attach snippetExpansion.pending && snippetExpansionLayer}
 	{@attach promptRefinement.pending && !composerEditor.open && promptRefinement.layerAttachment}
 >
@@ -569,7 +569,7 @@
 			<div class="space-y-2">
 				<div class="relative">
 					<div class="flex gap-2">
-						<div class="relative flex-1">
+						<div class="relative min-w-0 flex-1">
 							<input
 								id="project-path-input"
 								type="text"


### PR DESCRIPTION
On phone-width viewports the New Chat dialog stayed within the screen, but its content did not: the form is a grid item whose automatic minimum size pinned the dialog's grid track to the top controls row's min-content width (~342px, dominated by the project-path input's intrinsic width plus the pin/tag/close buttons). The row could not shrink, so the form extended past the dialog's right edge and the dialog's own overflow-x-hidden clipped the buttons on the right while the card itself looked correctly inset. The fix adds min-w-0 to the form root and to the path-input flex wrapper so both can shrink below their min-content width, and extends the Chromium layout suite to assert the dialog's content actually fits inside it (scrollWidth <= clientWidth) at 390px with safe-area insets and at 360px, a case the existing box-bounds checks could not catch.