### PR TITLE
Fix OpenCode glob and grep tool result counts

### DIFF
--- a/integration-tests/tests/server/opencode-scripted-model.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-model.test.ts
@@ -514,17 +514,17 @@ describeOnLinux('OpenCode against a scripted model', () => {
         expect(messagesOfType(transcript.messages, 'external-tool-use')).toEqual([
           expect.objectContaining({ name: 'skill', namespace: 'opencode' }),
         ]);
-        const globResult = transcript.messages.find(
-          (entry) => entry.message.type === 'tool-result' && entry.message.toolId === 'call_builtin_glob',
+        const globResult = messagesOfType(transcript.messages, 'tool-result').find(
+          (message) => message.toolId === 'call_builtin_glob',
         );
-        expect(globResult?.message.content).toEqual({
+        expect(globResult?.content).toEqual({
           filenames: [filePath],
           numFiles: 1,
         });
-        const grepResult = transcript.messages.find(
-          (entry) => entry.message.type === 'tool-result' && entry.message.toolId === 'call_builtin_grep',
+        const grepResult = messagesOfType(transcript.messages, 'tool-result').find(
+          (message) => message.toolId === 'call_builtin_grep',
         );
-        expect(grepResult?.message.content).toEqual({
+        expect(grepResult?.content).toEqual({
           filenames: [filePath],
           numFiles: 1,
           totalMatches: 1,

--- a/integration-tests/tests/server/opencode-scripted-model.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-model.test.ts
@@ -514,6 +514,21 @@ describeOnLinux('OpenCode against a scripted model', () => {
         expect(messagesOfType(transcript.messages, 'external-tool-use')).toEqual([
           expect.objectContaining({ name: 'skill', namespace: 'opencode' }),
         ]);
+        const globResult = transcript.messages.find(
+          (entry) => entry.message.type === 'tool-result' && entry.message.toolId === 'call_builtin_glob',
+        );
+        expect(globResult?.message.content).toEqual({
+          filenames: [filePath],
+          numFiles: 1,
+        });
+        const grepResult = transcript.messages.find(
+          (entry) => entry.message.type === 'tool-result' && entry.message.toolId === 'call_builtin_grep',
+        );
+        expect(grepResult?.message.content).toEqual({
+          filenames: [filePath],
+          numFiles: 1,
+          totalMatches: 1,
+        });
         expect(JSON.stringify(messagesOfType(transcript.messages, 'tool-result')))
           .toContain(webMarker);
         expect(await readFile(filePath, 'utf8')).toBe('updated\n');

--- a/server-agents/opencode/src/agents/opencode/__tests__/history-loader.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/history-loader.test.js
@@ -850,4 +850,66 @@ describe('OpenCode history loader', () => {
 
     expect(messages).toHaveBeenCalledWith({ sessionID: 'session-1', directory: '/repo' });
   });
+
+  it('normalizes stored glob and grep results to structured counts', async () => {
+    const getClient = mock(() => Promise.resolve({
+      session: {
+        messages: mock(() => Promise.resolve({
+          data: [
+            {
+              info: { role: 'assistant', time: { created: '2026-07-04T00:00:00.000Z' } },
+              parts: [
+                {
+                  type: 'tool',
+                  tool: 'glob',
+                  callID: 'tool-glob',
+                  state: {
+                    status: 'completed',
+                    input: { pattern: '**/*.ts' },
+                    output: '/repo/src/a.ts\n/repo/src/b.ts',
+                    metadata: { count: 2, truncated: false },
+                  },
+                },
+                {
+                  type: 'tool',
+                  tool: 'grep',
+                  callID: 'tool-grep',
+                  state: {
+                    status: 'completed',
+                    input: { pattern: 'updated' },
+                    output: [
+                      'Found 2 matches',
+                      '/repo/src/a.ts:',
+                      '  Line 1: updated',
+                      '/repo/src/b.ts:',
+                      '  Line 4: updated',
+                    ].join('\n'),
+                    metadata: { matches: 2, truncated: false },
+                  },
+                },
+              ],
+            },
+          ],
+        })),
+      },
+    }));
+
+    const messages = await loadOpenCodeChatMessages('session-1', getClient);
+
+    const globResult = messages.find(
+      (message) => message instanceof ToolResultMessage && message.toolId === 'tool-glob',
+    );
+    expect(globResult?.content).toEqual({
+      filenames: ['/repo/src/a.ts', '/repo/src/b.ts'],
+      numFiles: 2,
+    });
+    const grepResult = messages.find(
+      (message) => message instanceof ToolResultMessage && message.toolId === 'tool-grep',
+    );
+    expect(grepResult?.content).toEqual({
+      filenames: ['/repo/src/a.ts', '/repo/src/b.ts'],
+      numFiles: 2,
+      totalMatches: 2,
+    });
+  });
 });

--- a/server-agents/opencode/src/agents/opencode/__tests__/tool-result-converter.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/tool-result-converter.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'bun:test';
+import { normalizeOpenCodeToolResultContent } from '../tool-result-converter.js';
+
+describe('normalizeOpenCodeToolResultContent', () => {
+  it('maps glob output paths and metadata count', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', {
+      status: 'completed',
+      output: '/repo/src/a.ts\n/repo/src/b.ts',
+      metadata: { count: 2, truncated: false },
+    });
+    expect(content).toEqual({
+      filenames: ['/repo/src/a.ts', '/repo/src/b.ts'],
+      numFiles: 2,
+    });
+  });
+
+  it('maps empty glob results without inventing filenames', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', {
+      status: 'completed',
+      output: 'No files found',
+      metadata: { count: 0, truncated: false },
+    });
+    expect(content).toEqual({ filenames: [], numFiles: 0 });
+  });
+
+  it('drops the glob truncation note and trusts metadata count', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', {
+      status: 'completed',
+      output: '/repo/a.ts\n(Results are truncated: showing first 100 results. Consider using a more specific path or pattern.)',
+      metadata: { count: 100, truncated: true },
+    });
+    expect(content).toEqual({ filenames: ['/repo/a.ts'], numFiles: 100 });
+  });
+
+  it('maps grep path headings and metadata matches', () => {
+    const content = normalizeOpenCodeToolResultContent('grep', {
+      status: 'completed',
+      output: [
+        'Found 3 matches',
+        '/repo/src/a.ts:',
+        '  Line 10: export const a',
+        '  Line 12: export const b',
+        '',
+        '/repo/src/b.ts:',
+        '  Line 2: export const c',
+      ].join('\n'),
+      metadata: { matches: 3, truncated: false },
+    });
+    expect(content).toEqual({
+      filenames: ['/repo/src/a.ts', '/repo/src/b.ts'],
+      numFiles: 2,
+      totalMatches: 3,
+    });
+  });
+
+  it('falls back to parsed paths when glob metadata is absent', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', {
+      status: 'completed',
+      output: '/repo/a.ts\n/repo/b.ts',
+    });
+    expect(content).toEqual({ filenames: ['/repo/a.ts', '/repo/b.ts'], numFiles: 2 });
+  });
+
+  it('passes through non-search outputs as raw text', () => {
+    const content = normalizeOpenCodeToolResultContent('read', {
+      status: 'completed',
+      output: '     1\tconst a = 1',
+    });
+    expect(content).toEqual({ raw: '     1\tconst a = 1' });
+  });
+
+  it('normalizes tool names case-insensitively', () => {
+    const content = normalizeOpenCodeToolResultContent('Glob', {
+      status: 'completed',
+      output: '/repo/a.ts',
+      metadata: { count: 1 },
+    });
+    expect(content.numFiles).toBe(1);
+  });
+
+  it('accepts raw string state without object wrapper', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', '/repo/a.ts\n/repo/b.ts');
+    expect(content).toEqual({ filenames: ['/repo/a.ts', '/repo/b.ts'], numFiles: 2 });
+  });
+
+  it('accepts glob-tool-use canonical tool type', () => {
+    const content = normalizeOpenCodeToolResultContent('glob-tool-use', {
+      output: '/repo/a.ts',
+      metadata: { count: 1 },
+    });
+    expect(content).toEqual({ filenames: ['/repo/a.ts'], numFiles: 1 });
+  });
+
+  it('accepts grep-tool-use and falls back to parsed match count from header', () => {
+    const content = normalizeOpenCodeToolResultContent('grep-tool-use', {
+      output: [
+        'Found 2 matches',
+        '/repo/src/a.ts:',
+        '  Line 1: first',
+        '  Line 2: second',
+      ].join('\n'),
+    });
+    expect(content).toEqual({
+      filenames: ['/repo/src/a.ts'],
+      numFiles: 1,
+      totalMatches: 2,
+    });
+  });
+
+  it('preserves paths with parentheses that are not truncation notes', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', {
+      output: '/repo/src/(auth)/login.ts\n(Results are truncated: showing first 1 results. Consider using a more specific path or pattern.)',
+      metadata: { count: 1, truncated: true },
+    });
+    expect(content).toEqual({
+      filenames: ['/repo/src/(auth)/login.ts'],
+      numFiles: 1,
+    });
+  });
+
+  it('does not parse paths out of error-state search output', () => {
+    const content = normalizeOpenCodeToolResultContent('grep', {
+      status: 'error',
+      output: '/repo/src/a.ts:',
+      error: 'pattern is required',
+    });
+    expect(content).toEqual({ raw: '/repo/src/a.ts:' });
+  });
+
+  it('maps glob filenames array fast-path with top-level count', () => {
+    const content = normalizeOpenCodeToolResultContent('glob', {
+      filenames: ['/repo/a.ts', '/repo/b.ts'],
+      numFiles: 2,
+      metadata: { count: 99 },
+    });
+    expect(content).toEqual({ filenames: ['/repo/a.ts', '/repo/b.ts'], numFiles: 2 });
+  });
+
+  it('handles CRLF and array-valued outputs', () => {
+    const crlf = normalizeOpenCodeToolResultContent('glob', {
+      output: '/repo/a.ts\r\n/repo/b.ts',
+      metadata: { count: 2 },
+    });
+    expect(crlf).toEqual({ filenames: ['/repo/a.ts', '/repo/b.ts'], numFiles: 2 });
+
+    const arrayed = normalizeOpenCodeToolResultContent('grep', {
+      output: ['Found 1 matches', '/repo/a.ts:', '  Line 1: x'],
+      metadata: { matches: 1 },
+    });
+    expect(arrayed).toEqual({ filenames: ['/repo/a.ts'], numFiles: 1, totalMatches: 1 });
+  });
+
+  it('dedupes repeated grep headings while preserving metadata count', () => {
+    const content = normalizeOpenCodeToolResultContent('grep', {
+      output: [
+        'Found 3 matches',
+        '/repo/src/a.ts:',
+        '  Line 10: first',
+        '/repo/src/a.ts:',
+        '  Line 12: second',
+        '/repo/src/b.ts:',
+        '  Line 2: third',
+      ].join('\n'),
+      metadata: { matches: 3 },
+    });
+    expect(content).toEqual({
+      filenames: ['/repo/src/a.ts', '/repo/src/b.ts'],
+      numFiles: 2,
+      totalMatches: 3,
+    });
+  });
+});

--- a/server-agents/opencode/src/agents/opencode/event-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/event-converter.ts
@@ -8,6 +8,7 @@ import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/na
 import { normalizeToolResultContent } from '@garcon/server-agent-common/shared/normalize-util';
 import type { AgentLogger } from '@garcon/server-agent-interface';
 import type { SSEEvent } from './sse-events.js';
+import { normalizeOpenCodeToolResultContent } from './tool-result-converter.js';
 import { convertOpenCodeToolUse } from './tool-use-converter.js';
 import type { OpenCodeTurnContext } from './turn-events.js';
 
@@ -66,7 +67,7 @@ export function convertOpenCodeEventToChatMessages(
           chatMessages.push(new ToolResultMessage(
             now,
             toolUse.toolId,
-            normalizeToolResultContent(part.state.output),
+            normalizeOpenCodeToolResultContent(part.tool, part.state),
             false,
           ));
         } else if (part.state?.status === 'error') {

--- a/server-agents/opencode/src/agents/opencode/history-loader.ts
+++ b/server-agents/opencode/src/agents/opencode/history-loader.ts
@@ -10,6 +10,7 @@ import {
 } from '@garcon/common/chat-types';
 import path from 'node:path';
 import { convertOpenCodeToolUse } from './tool-use-converter.js';
+import { normalizeOpenCodeToolResultContent } from './tool-result-converter.js';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { stripResolvedFileMentionContext } from '@garcon/server-agent-common/shared/file-mention-context';
 import { normalizeToolResultContent } from '@garcon/server-agent-common/shared/normalize-util';
@@ -382,7 +383,7 @@ export function convertOpenCodeStoredMessages(rawMessages: readonly OpenCodeMess
             push(new ToolResultMessage(
               ts,
               toolUse.toolId,
-              normalizeToolResultContent(state.output),
+              normalizeOpenCodeToolResultContent(part.tool, state),
               false,
             ), part.id, 1);
           } else if (state.status === 'error') {

--- a/server-agents/opencode/src/agents/opencode/tool-result-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/tool-result-converter.ts
@@ -1,0 +1,112 @@
+// Normalizes OpenCode tool results into the shared result-content shape the
+// frontend display registry consumes. OpenCode tool state carries a plain-text
+// output plus a tool-specific metadata record; glob and grep counts live only
+// in that metadata, so without this pass every result renders as zero files.
+
+import { normalizeToolResultContent } from '@garcon/server-agent-common/shared/normalize-util';
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function canonicalize(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s_-]+/g, '');
+}
+
+function outputLines(state: Record<string, unknown>): string[] {
+  if (Array.isArray(state.output)) {
+    return state.output.map((line) => String(line).trim()).filter(Boolean);
+  }
+  const output = asString(state.output);
+  if (!output) return [];
+  return output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+// Glob emits one resolved path per line; the only non-path lines are the
+// "No files found" sentinel and parenthesized truncation / limit notes.
+function isGlobPathLine(line: string): boolean {
+  return (
+    line !== 'No files found'
+    && !line.startsWith('(Results are truncated')
+    && !line.startsWith('(Output capped')
+    && !(line.startsWith('(') && line.endsWith(')'))
+  );
+}
+
+// Grep groups matches under a non-indented "<path>:" heading; the remaining
+// non-indented lines are the "Found N matches" header and truncation note.
+function isGrepPathLine(line: string): boolean {
+  return /^[^ \t].*:$/.test(line) && !(line.startsWith('(') && line.endsWith(')'));
+}
+
+function grepPathLine(line: string): string {
+  return line.slice(0, -1);
+}
+
+function normalizeGlobResult(state: Record<string, unknown>): Record<string, unknown> {
+  if (Array.isArray(state.filenames)) {
+    const filenames = state.filenames.filter((f): f is string => typeof f === 'string');
+    return {
+      filenames,
+      numFiles: asNumber(state.numFiles ?? state.count) ?? filenames.length,
+    };
+  }
+  const metadata = asObject(state.metadata);
+  const filenames = outputLines(state).filter(isGlobPathLine);
+  return {
+    filenames,
+    numFiles: asNumber(metadata.count) ?? filenames.length,
+  };
+}
+
+function normalizeGrepResult(state: Record<string, unknown>): Record<string, unknown> {
+  const metadata = asObject(state.metadata);
+  const lines = outputLines(state);
+  const filenames = Array.from(new Set(lines.filter(isGrepPathLine).map(grepPathLine)));
+  let totalMatches = asNumber(metadata.matches);
+  if (totalMatches === undefined) {
+    const firstLine = lines[0] ?? '';
+    const match = firstLine.match(/^Found\s+(\d+)\s+matches/i);
+    totalMatches = match ? Number(match[1]) : undefined;
+  }
+  return {
+    filenames,
+    numFiles: filenames.length,
+    totalMatches: totalMatches ?? 0,
+  };
+}
+
+// Error results keep their raw text payload; only completed glob and grep
+// outputs carry the count metadata this converter exists for.
+export function normalizeOpenCodeToolResultContent(
+  toolName: unknown,
+  state: unknown,
+): Record<string, unknown> {
+  const rawState = typeof state === 'string'
+    ? { output: state }
+    : Array.isArray(state)
+      ? { output: state.join('\n') }
+      : asObject(state);
+  const key = canonicalize(asString(toolName) ?? '');
+
+  if (rawState.status !== 'error') {
+    if (key === 'glob' || key === 'globtooluse') return normalizeGlobResult(rawState);
+    if (key === 'grep' || key === 'greptooluse') return normalizeGrepResult(rawState);
+  }
+  return normalizeToolResultContent(rawState.output);
+}


### PR DESCRIPTION
OpenCode glob and grep results always displayed "0 files found" because the integration passed the provider's plain-text tool output through unchanged, while the display registry derives counts from the structured `filenames`/`numFiles`/`totalMatches` fields that other agents emit; OpenCode keeps those counts only in tool-specific metadata that was being dropped. This adds an OpenCode tool-result converter (mirroring the existing Cursor one) that normalizes completed glob results to `filenames`/`numFiles` and grep results to `filenames`/`numFiles`/`totalMatches`, wired into both live event publication and stored-history replay so live and reloaded transcripts stay consistent, with unit coverage for both paths plus scripted-model integration assertions against the pinned binary. Migration note: previously persisted transcript rows keep their original raw shape until their chat's history is re-derived on reload.