### PR TITLE
Recognize garcon edge commands padded with trailing whitespace

### DIFF
--- a/common/__tests__/garcon-commands.test.js
+++ b/common/__tests__/garcon-commands.test.js
@@ -37,6 +37,42 @@ describe('Garcon edge commands', () => {
     });
     expect(extractGarconCommands(new AssistantMessage(AT, GARCON_GET_CHAT_ID)))
       .toEqual({ message: null, commands: [{ type: 'get-chat-id' }], issues: [] });
+    expect(extractGarconCommands(new AssistantMessage(
+      AT,
+      `${GARCON_GET_CHAT_ID}\n\n`,
+    ))).toEqual({ message: null, commands: [{ type: 'get-chat-id' }], issues: [] });
+    expect(extractGarconCommands(new AssistantMessage(
+      AT,
+      `answer\n${GARCON_GET_CHAT_ID}\n`,
+    ))).toEqual({
+      message: new AssistantMessage(AT, 'answer'),
+      commands: [{ type: 'get-chat-id' }],
+      issues: [],
+    });
+    expect(extractGarconCommands(new AssistantMessage(
+      AT,
+      `${GARCON_GET_CHAT_ID}\nanswer  `,
+    ))).toEqual({
+      message: new AssistantMessage(AT, 'answer  '),
+      commands: [{ type: 'get-chat-id' }],
+      issues: [],
+    });
+  });
+
+  it('extracts whole-message commands despite trailing whitespace', () => {
+    expect(extractGarconCommands(new AssistantMessage(
+      AT,
+      `${send(FIRST, false)}\n`,
+    ))).toEqual({
+      message: null,
+      commands: [{
+        type: 'send-message',
+        recipients: [FIRST],
+        hideSender: false,
+        body: 'message',
+      }],
+      issues: [],
+    });
   });
 
   it('extracts multiple command kinds in document order from both edges', () => {
@@ -176,6 +212,11 @@ describe('Garcon edge commands', () => {
       expect(result?.commands).toEqual([]);
       expect(result?.issues).toHaveLength(1);
     }
+    const padded = `${send('invalid', false)}\n`;
+    const result = extractGarconCommands(new AssistantMessage(AT, padded));
+    expect(result?.message?.content).toBe(padded);
+    expect(result?.commands).toEqual([]);
+    expect(result?.issues).toHaveLength(1);
   });
 
   it('rejects more than 16 unique recipients but permits duplicates within the cap', () => {
@@ -191,11 +232,10 @@ describe('Garcon edge commands', () => {
     )).commands[0].recipients).toEqual([FIRST]);
   });
 
-  it('does not consume commands in prose, outer whitespace, or non-assistant rows', () => {
+  it('does not consume commands in prose, leading whitespace, or non-assistant rows', () => {
     for (const content of [
       `Explanation ${GARCON_GET_CHAT_ID}`,
       ` ${GARCON_GET_CHAT_ID}`,
-      `${GARCON_GET_CHAT_ID} `,
       '<garcon-get-chat-id/>',
       '<GARCON-GET-CHAT-ID />',
       `Example: ${send(FIRST, false)}`,

--- a/common/garcon-commands.ts
+++ b/common/garcon-commands.ts
@@ -65,13 +65,17 @@ export function extractGarconCommands(
   const content = message.content;
   let start = 0;
   let end = content.length;
+  // Providers append trailing whitespace to standalone command messages, so
+  // commands are recognized against the trimmed trailing edge while the
+  // retained remainder keeps its original bytes.
+  let parseEnd = trimEndIndex(content, start, end);
   const leading: GarconEdgeCommand[] = [];
   const trailing: GarconEdgeCommand[] = [];
   const issues: GarconCommandIssue[] = [];
   const malformedStarts = new Set<number>();
 
   while (start < end) {
-    const parsed = parseLeadingCommand(content, start, end);
+    const parsed = parseLeadingCommand(content, start, parseEnd);
     if (parsed.kind === 'none') break;
     if (parsed.kind === 'malformed') {
       recordIssue(
@@ -84,11 +88,11 @@ export function extractGarconCommands(
       break;
     }
     leading.push(parsed.command);
-    start = trimStartIndex(content, parsed.end, end);
+    start = trimStartIndex(content, parsed.end, parseEnd);
   }
 
   while (start < end) {
-    const parsed = parseTrailingCommand(content, start, end);
+    const parsed = parseTrailingCommand(content, start, parseEnd);
     if (parsed.kind === 'none') break;
     if (parsed.kind === 'malformed') {
       recordIssue(
@@ -102,6 +106,7 @@ export function extractGarconCommands(
     }
     trailing.push(parsed.command);
     end = trimEndIndex(content, start, parsed.start);
+    parseEnd = end;
   }
 
   if (leading.length === 0 && trailing.length === 0 && issues.length === 0) {
@@ -157,7 +162,6 @@ function parseLeadingCommand(content: string, start: number, end: number): Parse
     && content.startsWith(GARCON_GET_CHAT_ID, start)
   ) {
     const commandEnd = start + GARCON_GET_CHAT_ID.length;
-    if (hasOnlyTrailingWhitespace(content, commandEnd, end)) return { kind: 'none' };
     return {
       kind: 'valid',
       command: { type: 'get-chat-id' },
@@ -183,17 +187,12 @@ function parseLeadingCommand(content: string, start: number, end: number): Parse
     return { kind: 'malformed', command: 'send-message', candidateStart: start };
   }
   const commandEnd = closerStart + GARCON_SEND_MESSAGE_CLOSE.length;
-  if (hasOnlyTrailingWhitespace(content, commandEnd, end)) return { kind: 'none' };
   return {
     kind: 'valid',
     command,
     start,
     end: commandEnd,
   };
-}
-
-function hasOnlyTrailingWhitespace(content: string, commandEnd: number, end: number): boolean {
-  return commandEnd < end && content.slice(commandEnd, end).trim().length === 0;
 }
 
 function parseTrailingCommand(content: string, start: number, end: number): ParsedEdge {

--- a/server/ledger/__tests__/imported-drafts.test.js
+++ b/server/ledger/__tests__/imported-drafts.test.js
@@ -20,7 +20,7 @@ describe('imported transcript drafts', () => {
       {
         message: new AssistantMessage(
           AT,
-          '<garcon-get-chat-id />\nContinuing the response.',
+          '<garcon-get-chat-id />\n\nContinuing the response.',
         ),
         providerMeta: { nativeIdentity: { id: 'assistant-1' } },
       },
@@ -57,7 +57,7 @@ describe('imported transcript drafts', () => {
 
   it('retains a hidden marker-only request without synthesizing an outcome', () => {
     expect(importedDrafts([
-      { message: new AssistantMessage(AT, '<garcon-get-chat-id />'), providerMeta: null },
+      { message: new AssistantMessage(AT, '<garcon-get-chat-id />\n\n'), providerMeta: null },
     ], () => AT)).toEqual([{
       kind: 'notice',
       at: AT,

--- a/server/ledger/__tests__/service.test.js
+++ b/server/ledger/__tests__/service.test.js
@@ -37,7 +37,7 @@ describe('TranscriptLedgerService', () => {
           rows: [{
             message: new AssistantMessage(
               TS,
-              '<garcon-get-chat-id />\nContinuing the response.',
+              '<garcon-get-chat-id />\n\nContinuing the response.',
             ),
           }],
         });
@@ -70,7 +70,7 @@ describe('TranscriptLedgerService', () => {
 
         lease.sink.publish({
           type: 'rows',
-          rows: [{ message: new AssistantMessage(TS, '<garcon-get-chat-id />') }],
+          rows: [{ message: new AssistantMessage(TS, '<garcon-get-chat-id />\n\n') }],
         });
 
         expect(requests).toHaveBeenCalledWith({


### PR DESCRIPTION
A standalone assistant message containing only `<garcon-get-chat-id />` plus trailing newlines was stored raw with no chat-ID request row and no disclosure, because the edge-command parser treated whitespace-only remainder after a leading marker as inert prose and required trailing-edge markers to be the absolute final bytes — yet providers naturally append trailing newlines to standalone messages, so first-attempt discovery silently failed. Edge commands now parse against a whitespace-trimmed trailing edge while the retained remainder keeps its original bytes, so padded standalone markers are recognized with a null remainder at both edges, matching the transcript ledger design's contract of stripping the marker plus remainder whitespace and omitting the provider row when nothing substantive remains; leading-whitespace messages remain inert per the "beginning exactly with" rule. Behavior change: padded standalone `<garcon-get-chat-id />` and whole-message `<garcon-send-message>` envelopes are now consumed as commands instead of remaining visible assistant text; no protocol payload shape changes. TLV5-tagged ledger publication and native-import cases are strengthened with padded inputs, including the incident form.