### PR TITLE
feat(codex): add GPT-6 Astra support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
         "@garcon/common": "workspace:*",
         "@garcon/server-agent-common": "workspace:*",
         "@garcon/server-agent-interface": "workspace:*",
-        "@openai/codex": "0.153.0",
+        "@openai/codex": "0.153.1",
         "acorn": "^8.18.0",
         "bun-pty": "^0.4.10",
         "shell-quote": "^1.10.0",
@@ -601,19 +601,19 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.1", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw=="],
 
-    "@openai/codex": ["@openai/codex@0.153.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-k55kUZaclNi5ceUStSVuyW834ruA6AEdzTK7Xi3M1mOyXokUmq1sJLXm1RJ3XD2S7bRPeF1EXNsYB5Qxwus0mw=="],
+    "@openai/codex": ["@openai/codex@0.153.1", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.1-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.1-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.1-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.1-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.1-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.1-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-d5txIVzNIkZnAmCiqxksAACqm+xUvq83YGKd3YYAF9ISXWkC7hsiPXpSD24ypKOqpvbZiScMSq0e0p4TycczNw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C9F3HVEYekVJC3WhiGSztcxItWBwd7Y6hTWoDqa9Z9aLWsYywzqChABB59n7G5F5jCil9wxW3+u2L6uiVUydmw=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.1-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/58i/KvdmqUqcXOaHDTw8tEWEZ6F806QwAPmeSjHKa+9IAhH8VSppQLMD9vQmvcUhmaoIVrF0X90TN4jEFsf+A=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.153.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-DO5u+X/eL8pObrV0WDErOjS9DeuDvVuOL5oHR5y5Yklp0NGoGj3oOHsmaSXjGesiIiu3IX8l4pzS6dbeQXJAvQ=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.153.1-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vocSldmR5nJV0OiqUrALT/qtz9AkRtt8F9oIQUB2kxnBgU2qPP65FiJOBJx8Y4q93vPSp07R9L20YW2yHcF/jg=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.153.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-N2zLgmuslhMoC2RFC2aDkcCWk3iapZmBlSiESpjXFF+UMNxIpNxWJ5qQtQrCp5Md7kYbF4/EFy8RqJ8tL8UTeA=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.153.1-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-1Y0t2OjCeqR8GaReaeDSrIpf7CDzUmbNGwEQeWPggNQvrwm3zd9R74WHMyalcxr6e4UOlJXXFfZPjpGbPoclWQ=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.153.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-sFF+g7p1o6sZVL6PHd9JTYrP2j3xao3Qeu5AngcrD5brWrCc+w9ifBJCJuRSM728WfgjXML9PQPdHPaZSeHAEA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.153.1-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q+0FqEFRkao0o8mBG1q2wDlREvQFlwPt/SdXCJLGWx2zTL2iuzwgUiGD3zDzrTecpPrtv7uMHo/+jGc+Dk3yLA=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.153.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ro+/2oAQnOObxuw3hpr+anv+j9hFmql/2iDxd7v0m46ctZy8x6ygW/Ud4f9CB1UXlRRsDhW+Tu9UAd5X9vTL1g=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.153.1-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SwdiqMTVaduPMmo85uxAfxW7/y8M1RBYP8gsPWKQd9NbdmTFbbfeolG19vr0gA1dQtb3mWy40QfU4y1dxHrTcA=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.153.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-eXvmitT1Hmr6d8n9r5HVjTuSgdHtxFSyXh0c3rRnaTcJA0ef8JnI5LY0TJci/QHYLNJGaEMBZ5R4dEdB2d87Lw=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.153.1-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-A2qiRPjDTOkqaMji+UcakoeJtL3QbGaxz+jjEeCRp7EE9GPxgc9bxATHVC5ACeg6PD6cDvpRTkeAWG1vUXCdwQ=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.22", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-fRZ2r6nqdLBXfs7j531aibrqCC9tpbL2tmz3ThnwtLa3bMNUozEVAOPnZjh86JcTBDhNtACt5CNgKDZ1Pve1NA=="],
 

--- a/common/models.ts
+++ b/common/models.ts
@@ -20,6 +20,7 @@ export const CLAUDE_MODELS = {
 export const CODEX_MODELS = {
   OPTIONS: [
     { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
+    { value: 'gpt-6-astra', label: 'GPT-6-Astra', supportsImages: true },
     { value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol', supportsImages: true },
     { value: 'gpt-5.6-terra', label: 'GPT-5.6-Terra', supportsImages: true },
     { value: 'gpt-5.6-luna', label: 'GPT-5.6-Luna', supportsImages: true },

--- a/common/models.ts
+++ b/common/models.ts
@@ -17,10 +17,12 @@ export const CLAUDE_MODELS = {
   DEFAULT: 'opus',
 };
 
+export const GPT_6_ASTRA_MODEL = 'gpt-6-astra';
+
 export const CODEX_MODELS = {
   OPTIONS: [
     { value: 'gpt-5.5', label: 'GPT-5.5', supportsImages: true },
-    { value: 'gpt-6-astra', label: 'GPT-6-Astra', supportsImages: true },
+    { value: GPT_6_ASTRA_MODEL, label: 'GPT-6-Astra', supportsImages: true },
     { value: 'gpt-5.6-sol', label: 'GPT-5.6-Sol', supportsImages: true },
     { value: 'gpt-5.6-terra', label: 'GPT-5.6-Terra', supportsImages: true },
     { value: 'gpt-5.6-luna', label: 'GPT-5.6-Luna', supportsImages: true },

--- a/integration-tests/bun.lock
+++ b/integration-tests/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-code": "2.1.238",
         "@earendil-works/pi-coding-agent": "0.84.2",
-        "@openai/codex": "0.153.0",
+        "@openai/codex": "0.153.1",
         "@types/bun": "1.4.0",
         "opencode-ai": "1.18.22",
         "playwright": "1.62.1",
@@ -125,19 +125,19 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@openai/codex": ["@openai/codex@0.153.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-k55kUZaclNi5ceUStSVuyW834ruA6AEdzTK7Xi3M1mOyXokUmq1sJLXm1RJ3XD2S7bRPeF1EXNsYB5Qxwus0mw=="],
+    "@openai/codex": ["@openai/codex@0.153.1", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.1-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.1-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.1-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.1-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.1-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.1-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-d5txIVzNIkZnAmCiqxksAACqm+xUvq83YGKd3YYAF9ISXWkC7hsiPXpSD24ypKOqpvbZiScMSq0e0p4TycczNw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C9F3HVEYekVJC3WhiGSztcxItWBwd7Y6hTWoDqa9Z9aLWsYywzqChABB59n7G5F5jCil9wxW3+u2L6uiVUydmw=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.1-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/58i/KvdmqUqcXOaHDTw8tEWEZ6F806QwAPmeSjHKa+9IAhH8VSppQLMD9vQmvcUhmaoIVrF0X90TN4jEFsf+A=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.153.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-DO5u+X/eL8pObrV0WDErOjS9DeuDvVuOL5oHR5y5Yklp0NGoGj3oOHsmaSXjGesiIiu3IX8l4pzS6dbeQXJAvQ=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.153.1-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vocSldmR5nJV0OiqUrALT/qtz9AkRtt8F9oIQUB2kxnBgU2qPP65FiJOBJx8Y4q93vPSp07R9L20YW2yHcF/jg=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.153.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-N2zLgmuslhMoC2RFC2aDkcCWk3iapZmBlSiESpjXFF+UMNxIpNxWJ5qQtQrCp5Md7kYbF4/EFy8RqJ8tL8UTeA=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.153.1-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-1Y0t2OjCeqR8GaReaeDSrIpf7CDzUmbNGwEQeWPggNQvrwm3zd9R74WHMyalcxr6e4UOlJXXFfZPjpGbPoclWQ=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.153.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-sFF+g7p1o6sZVL6PHd9JTYrP2j3xao3Qeu5AngcrD5brWrCc+w9ifBJCJuRSM728WfgjXML9PQPdHPaZSeHAEA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.153.1-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q+0FqEFRkao0o8mBG1q2wDlREvQFlwPt/SdXCJLGWx2zTL2iuzwgUiGD3zDzrTecpPrtv7uMHo/+jGc+Dk3yLA=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.153.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ro+/2oAQnOObxuw3hpr+anv+j9hFmql/2iDxd7v0m46ctZy8x6ygW/Ud4f9CB1UXlRRsDhW+Tu9UAd5X9vTL1g=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.153.1-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SwdiqMTVaduPMmo85uxAfxW7/y8M1RBYP8gsPWKQd9NbdmTFbbfeolG19vr0gA1dQtb3mWy40QfU4y1dxHrTcA=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.153.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-eXvmitT1Hmr6d8n9r5HVjTuSgdHtxFSyXh0c3rRnaTcJA0ef8JnI5LY0TJci/QHYLNJGaEMBZ5R4dEdB2d87Lw=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.153.1-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-A2qiRPjDTOkqaMji+UcakoeJtL3QbGaxz+jjEeCRp7EE9GPxgc9bxATHVC5ACeg6PD6cDvpRTkeAWG1vUXCdwQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@anthropic-ai/claude-code": "2.1.238",
     "@earendil-works/pi-coding-agent": "0.84.2",
-    "@openai/codex": "0.153.0",
+    "@openai/codex": "0.153.1",
     "@types/bun": "1.4.0",
     "opencode-ai": "1.18.22",
     "playwright": "1.62.1",

--- a/server-agents/codex/package.json
+++ b/server-agents/codex/package.json
@@ -9,7 +9,7 @@
     "@garcon/common": "workspace:*",
     "@garcon/server-agent-common": "workspace:*",
     "@garcon/server-agent-interface": "workspace:*",
-    "@openai/codex": "0.153.0",
+    "@openai/codex": "0.153.1",
     "acorn": "^8.18.0",
     "bun-pty": "^0.4.10",
     "shell-quote": "^1.10.0"

--- a/server-agents/codex/src/agents/codex/__tests__/execution.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/execution.test.js
@@ -546,6 +546,30 @@ describe('CodexExecution', () => {
     });
   });
 
+  it('rejects carrying Astra low effort into a non-Astra provider-default transition', async () => {
+    const runtime = createRuntime();
+    runtime.hasSource.mockReturnValue(true);
+    const execution = new CodexExecution(
+      createHost(),
+      runtime,
+      createPathNativeSessionCodec('codex'),
+      createConfig(),
+    );
+    const previous = {
+      model: 'gpt-6-astra',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      endpoint: null,
+    };
+
+    await expect(execution.applySessionConfiguration('thread-1', {
+      ...previous,
+      model: 'gpt-5.4',
+    }, previous)).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
+    expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
+  });
+
   it('rejects live endpoint replacement and concrete reasoning-effort clearing', async () => {
     const runtime = createRuntime();
     runtime.isRunning.mockReturnValue(true);

--- a/server-agents/codex/src/agents/codex/__tests__/execution.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/execution.test.js
@@ -517,6 +517,35 @@ describe('CodexExecution', () => {
     });
   });
 
+  it('allows GPT-6 Astra to restore its low provider-default effort', async () => {
+    const runtime = createRuntime();
+    runtime.hasSource.mockReturnValue(true);
+    const execution = new CodexExecution(
+      createHost(),
+      runtime,
+      createPathNativeSessionCodec('codex'),
+      createConfig(),
+    );
+    const previous = {
+      model: 'gpt-6-astra',
+      permissionMode: 'default',
+      thinkingMode: 'high',
+      settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      endpoint: null,
+    };
+
+    await execution.applySessionConfiguration('thread-1', {
+      ...previous,
+      thinkingMode: 'none',
+    }, previous);
+
+    expect(runtime.updateSessionSettings).toHaveBeenCalledWith('thread-1', {
+      model: 'gpt-6-astra',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+    });
+  });
+
   it('rejects live endpoint replacement and concrete reasoning-effort clearing', async () => {
     const runtime = createRuntime();
     runtime.isRunning.mockReturnValue(true);

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -983,7 +983,7 @@ describe('Codex app-server request builders', () => {
     expect(mapThinkingModeToCodexEffort('ultra')).toBe('ultra');
   });
 
-  it('omits the unsupported none effort for GPT-6 Astra', () => {
+  it('maps provider-default thinking to GPT-6 Astra low effort', () => {
     const params = buildTurnStartParams({
       threadId: 'thread-1',
       command: 'hello',
@@ -993,7 +993,12 @@ describe('Codex app-server request builders', () => {
       thinkingMode: 'none',
     });
 
-    expect(params).not.toHaveProperty('effort');
+    expect(params.effort).toBe('low');
+    expect(codexThreadSettingsTarget({
+      model: 'gpt-6-astra',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+    }).effort).toBe('low');
   });
 
   it('builds one complete subsequent-turn settings update', () => {

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -977,10 +977,23 @@ describe('Codex app-server request builders', () => {
     expect(mapThinkingModeToCodexEffort('high')).toBe('high');
     expect(mapThinkingModeToCodexEffort('xhigh')).toBe('xhigh');
     expect(mapThinkingModeToCodexEffort('max', 'gpt-5.5')).toBe('xhigh');
-    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-6-astra']) {
       expect(mapThinkingModeToCodexEffort('max', model)).toBe('max');
     }
     expect(mapThinkingModeToCodexEffort('ultra')).toBe('ultra');
+  });
+
+  it('omits the unsupported none effort for GPT-6 Astra', () => {
+    const params = buildTurnStartParams({
+      threadId: 'thread-1',
+      command: 'hello',
+      model: 'gpt-6-astra',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+    });
+
+    expect(params).not.toHaveProperty('effort');
   });
 
   it('builds one complete subsequent-turn settings update', () => {

--- a/server-agents/codex/src/agents/codex/app-server/request-builders.ts
+++ b/server-agents/codex/src/agents/codex/app-server/request-builders.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import type { AgentAttachment } from '@garcon/common/agent-execution';
 import type { PermissionMode, ThinkingMode } from '@garcon/common/chat-modes';
+import { GPT_6_ASTRA_MODEL } from '@garcon/common/models';
 import type { CodexProviderConfig, CodexStartRequest } from '../runtime-types.js';
 import type { CodexSkillRef } from '../slash-command-discovery.js';
 import type { ThreadInjectItemsParams } from './protocol.js';
@@ -182,11 +183,12 @@ export function mapThinkingModeToCodexEffort(
   model?: string,
 ): string | undefined {
   switch (thinkingMode) {
+    case 'none': return model === GPT_6_ASTRA_MODEL ? 'low' : undefined;
     case 'low': return 'low';
     case 'medium': return 'medium';
     case 'high': return 'high';
     case 'xhigh': return 'xhigh';
-    case 'max': return model === 'gpt-6-astra'
+    case 'max': return model === GPT_6_ASTRA_MODEL
       || model === 'gpt-5.6'
       || model?.startsWith('gpt-5.6-')
       ? 'max'

--- a/server-agents/codex/src/agents/codex/app-server/request-builders.ts
+++ b/server-agents/codex/src/agents/codex/app-server/request-builders.ts
@@ -175,8 +175,8 @@ function sandboxPolicyMatches(
     && (left.excludeSlashTmp ?? false) === (right.excludeSlashTmp ?? false);
 }
 
-// Preserves xhigh compatibility for older models while allowing GPT-5.6 to use
-// the max effort introduced for that model family.
+// Preserves xhigh compatibility for older models while allowing models that
+// advertise max reasoning to receive that effort explicitly.
 export function mapThinkingModeToCodexEffort(
   thinkingMode: ThinkingMode | undefined,
   model?: string,
@@ -186,7 +186,11 @@ export function mapThinkingModeToCodexEffort(
     case 'medium': return 'medium';
     case 'high': return 'high';
     case 'xhigh': return 'xhigh';
-    case 'max': return model === 'gpt-5.6' || model?.startsWith('gpt-5.6-') ? 'max' : 'xhigh';
+    case 'max': return model === 'gpt-6-astra'
+      || model === 'gpt-5.6'
+      || model?.startsWith('gpt-5.6-')
+      ? 'max'
+      : 'xhigh';
     case 'ultra': return 'ultra';
     default: return undefined;
   }

--- a/server-agents/codex/src/agents/codex/execution.ts
+++ b/server-agents/codex/src/agents/codex/execution.ts
@@ -1,4 +1,5 @@
 import { receiptForCarriedContext } from '@garcon/common/transcript-seed';
+import { GPT_6_ASTRA_MODEL } from '@garcon/common/models';
 import {
   AgentIntegrationError,
   type AgentEstablishedSession,
@@ -127,7 +128,11 @@ export class CodexExecution implements AgentRuntimeExecution {
     configuration: Parameters<import('@garcon/server-agent-interface').AgentSessionConfigurationUpdates['apply']>[1],
     previousConfiguration: Parameters<import('@garcon/server-agent-interface').AgentSessionConfigurationUpdates['apply']>[2],
   ): Promise<void> {
-    if (previousConfiguration.thinkingMode !== 'none' && configuration.thinkingMode === 'none') {
+    if (
+      previousConfiguration.thinkingMode !== 'none'
+      && configuration.thinkingMode === 'none'
+      && configuration.model !== GPT_6_ASTRA_MODEL
+    ) {
       throw new AgentIntegrationError(
         'INVALID_SETTINGS',
         'Codex cannot clear a concrete reasoning effort on an established session',

--- a/server-agents/codex/src/agents/codex/execution.ts
+++ b/server-agents/codex/src/agents/codex/execution.ts
@@ -1,5 +1,4 @@
 import { receiptForCarriedContext } from '@garcon/common/transcript-seed';
-import { GPT_6_ASTRA_MODEL } from '@garcon/common/models';
 import {
   AgentIntegrationError,
   type AgentEstablishedSession,
@@ -21,6 +20,7 @@ import {
   buildCodexHostEnvironment,
 } from './app-server/endpoint-runtime.js';
 import { codexOperation } from './app-server/operation-routes.js';
+import { mapThinkingModeToCodexEffort } from './app-server/request-builders.js';
 import type { CodexAppServerRuntime } from './app-server/runtime.js';
 import { parseCodexGoalCommand, type CodexGoalCommand } from './goal-command.js';
 import type {
@@ -128,11 +128,15 @@ export class CodexExecution implements AgentRuntimeExecution {
     configuration: Parameters<import('@garcon/server-agent-interface').AgentSessionConfigurationUpdates['apply']>[1],
     previousConfiguration: Parameters<import('@garcon/server-agent-interface').AgentSessionConfigurationUpdates['apply']>[2],
   ): Promise<void> {
-    if (
-      previousConfiguration.thinkingMode !== 'none'
-      && configuration.thinkingMode === 'none'
-      && configuration.model !== GPT_6_ASTRA_MODEL
-    ) {
+    const previousEffort = mapThinkingModeToCodexEffort(
+      previousConfiguration.thinkingMode,
+      previousConfiguration.model,
+    );
+    const nextEffort = mapThinkingModeToCodexEffort(
+      configuration.thinkingMode,
+      configuration.model,
+    );
+    if (previousEffort !== undefined && nextEffort === undefined) {
       throw new AgentIntegrationError(
         'INVALID_SETTINGS',
         'Codex cannot clear a concrete reasoning effort on an established session',

--- a/server/routes/__tests__/models.test.js
+++ b/server/routes/__tests__/models.test.js
@@ -34,6 +34,7 @@ const agentCatalogEntries = [
     defaultModel: "gpt-5.5",
     models: [
       { value: "gpt-5.5", label: "GPT-5.5", supportsImages: true },
+      { value: "gpt-6-astra", label: "GPT-6-Astra", supportsImages: true },
       { value: "gpt-5.6-sol", label: "GPT-5.6-Sol", supportsImages: true },
       { value: "gpt-5.6-terra", label: "GPT-5.6-Terra", supportsImages: true },
       { value: "gpt-5.6-luna", label: "GPT-5.6-Luna", supportsImages: true },
@@ -345,6 +346,7 @@ describe("GET /api/v1/models", () => {
     const codexModelValues = codex.models.map((model) => model.value);
     expect(codexModelValues).toEqual([
       "gpt-5.5",
+      "gpt-6-astra",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
       "gpt-5.6-luna",
@@ -354,6 +356,9 @@ describe("GET /api/v1/models", () => {
     ]);
     expect(
       codex.models.find((model) => model.value === "gpt-5.5"),
+    ).toMatchObject({ supportsImages: true });
+    expect(
+      codex.models.find((model) => model.value === "gpt-6-astra"),
     ).toMatchObject({ supportsImages: true });
     expect(
       codex.models.find((model) => model.value === "gpt-5.6-sol"),


### PR DESCRIPTION
## Before

Garcon's Codex fallback catalog did not expose GPT-6 Astra. The bundled Codex version also lacked Astra's model metadata, and provider-default reasoning could send or retain an unsupported effort.

```mermaid
flowchart LR
  A[Garcon selects GPT-6 Astra] --> B[Generic fallback metadata]
  C[Provider-default effort] --> D[Unsupported or stale effort]
```

## After

```mermaid
flowchart LR
  A[Garcon selects GPT-6 Astra] --> B[Codex 0.153.1 Astra metadata]
  C[Provider-default effort] --> D[Low effort]
  E[Established session changes model] --> F[Effective-effort validation]
```

The Codex catalog now exposes GPT-6 Astra with image support and installs Codex 0.153.1, the first release containing Astra's model configuration. Garcon maps provider-default reasoning to Astra's supported `low` effort, preserves its Codex-specific `ultra` mode, forwards `max`, and rejects established-session transitions that would silently retain an incompatible effort.

## Files

- `common/models.ts` and model route coverage add the Astra fallback entry.
- `server-agents/codex` adds Astra-aware request and established-session handling with regression tests.
- Root and integration dependency manifests and lockfiles install Codex 0.153.1 consistently.

## Tests

- Focused Astra request and established-session regressions: passed.
- Codex typecheck: passed.
- `bun run check`: passed with zero errors or warnings.
- Production build and isolated random-port startup: passed.
- Full `bun run test` remains blocked by the existing `reader-worker.test.ts` timeout, which also reproduces in isolation and is outside this diff.

Prompted by: yk (@chiayong)
