### PR TITLE
fix(ws): retry stalled connection attempts

### DIFF
--- a/web/src/lib/ws/__tests__/connection.test.ts
+++ b/web/src/lib/ws/__tests__/connection.test.ts
@@ -875,4 +875,60 @@ describe('WsConnection', () => {
 		expect(mockSockets).toHaveLength(2);
 		connection.disconnect();
 	});
+
+	it('retries when a connection attempt never settles', async () => {
+		vi.setSystemTime(0);
+		const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const connection = new WsConnection();
+		connection.connect('token');
+		mockSockets[0].open();
+		mockSockets[0].closeFromServer();
+		await vi.advanceTimersByTimeAsync(250);
+		const stalled = mockSockets[1];
+
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(stalled.close).toHaveBeenCalledOnce();
+		expect(connection.connectionStatus).toMatchObject({
+			phase: 'reconnecting',
+			reason: 'connect-timeout',
+			episodeId: 1,
+			reconnectAttempt: 2,
+			nextRetryAt: 11_050,
+			lastDisconnectedAt: 0,
+		});
+		expect(mockSockets).toHaveLength(2);
+
+		await vi.advanceTimersByTimeAsync(800);
+		expect(mockSockets).toHaveLength(3);
+		expect(warning).toHaveBeenCalledWith('WebSocket connection attempt timed out');
+		connection.disconnect();
+	});
+
+	it('defers a timed-out connection attempt while hidden until the page is visible', async () => {
+		let visibilityState: DocumentVisibilityState = 'visible';
+		vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState);
+		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const connection = new WsConnection();
+		connection.connect('token');
+		const stalled = mockSockets[0];
+
+		visibilityState = 'hidden';
+		document.dispatchEvent(new Event('visibilitychange'));
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(stalled.close).toHaveBeenCalledOnce();
+		expect(connection.connectionStatus).toMatchObject({
+			phase: 'reconnecting',
+			reason: 'connect-timeout',
+			nextRetryAt: null,
+		});
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(mockSockets).toHaveLength(1);
+
+		visibilityState = 'visible';
+		document.dispatchEvent(new Event('visibilitychange'));
+		expect(mockSockets).toHaveLength(2);
+		connection.disconnect();
+	});
 });

--- a/web/src/lib/ws/connection.svelte.ts
+++ b/web/src/lib/ws/connection.svelte.ts
@@ -22,6 +22,7 @@ const HEARTBEAT_TIMEOUT_MS = 6_000;
 const HEARTBEAT_JITTER_MS = 1_500;
 const CONNECTION_STABILITY_MS = 10_000;
 const CONNECT_ATTEMPT_DEDUPE_MS = 2_000;
+const CONNECT_ATTEMPT_TIMEOUT_MS = 10_000;
 
 export interface WsMessage {
 	data: Record<string, unknown>;
@@ -39,6 +40,7 @@ export type WsConnectionIssue =
 	| 'browser-offline'
 	| 'browser-online'
 	| 'visibility-visible'
+	| 'connect-timeout'
 	| 'connect-threw'
 	| 'missing-auth'
 	| 'manual-disconnect';
@@ -120,6 +122,7 @@ export class WsConnection {
 	#cursors = new Set<DrainCursor>();
 	#trimOffset = 0;
 	#reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+	#connectTimeout: ReturnType<typeof setTimeout> | null = null;
 	#stabilityTimeout: ReturnType<typeof setTimeout> | null = null;
 	#reconnectAttempts = 0;
 	#destroyed = false;
@@ -215,6 +218,7 @@ export class WsConnection {
 
 			websocket.onopen = () => {
 				if (!this.#isCurrentSocket(websocket)) return;
+				this.#clearConnectTimeout();
 				const now = Date.now();
 				this.#lastInboundAt = now;
 				this.#connectStartedAt = null;
@@ -293,6 +297,8 @@ export class WsConnection {
 				});
 				this.#setConnectionStatus({ reason: 'socket-error' });
 			};
+
+			this.#scheduleConnectTimeout(websocket);
 		} catch (error) {
 			console.error('Error creating WebSocket connection:', error);
 			const episodeId = this.#beginOutage();
@@ -375,6 +381,7 @@ export class WsConnection {
 
 	#handleSocketClosed(reason: WsConnectionIssue): void {
 		const episodeId = this.#beginOutage();
+		this.#clearConnectTimeout();
 		this.#clearStabilityTimeout();
 		this.#suspendHeartbeat();
 		this.#setConnected(false);
@@ -507,6 +514,7 @@ export class WsConnection {
 
 	#closeExisting(options: { rejectPending?: boolean } = {}): void {
 		this.#clearReconnectTimeout();
+		this.#clearConnectTimeout();
 		this.#clearStabilityTimeout();
 		this.#suspendHeartbeat();
 		if (options.rejectPending) this.#rejectAllPending();
@@ -694,6 +702,39 @@ export class WsConnection {
 		if (this.#reconnectTimeout !== null) {
 			clearTimeout(this.#reconnectTimeout);
 			this.#reconnectTimeout = null;
+		}
+	}
+
+	#scheduleConnectTimeout(socket: WebSocket): void {
+		this.#clearConnectTimeout();
+		this.#connectTimeout = setTimeout(() => {
+			this.#connectTimeout = null;
+			if (
+				this.#destroyed ||
+				!this.#isCurrentSocket(socket) ||
+				socket.readyState !== WebSocket.CONNECTING
+			)
+				return;
+
+			console.warn('WebSocket connection attempt timed out');
+			const episodeId = this.#beginOutage();
+			this.#rejectAllPending();
+			this.#closeExisting({ rejectPending: false });
+			this.#setConnectionStatus({
+				phase: 'reconnecting',
+				reason: 'connect-timeout',
+				episodeId,
+				nextRetryAt: null,
+				lastDisconnectedAt: this.#lastDisconnectedAt,
+			});
+			this.#scheduleReconnect('connect-timeout', episodeId);
+		}, CONNECT_ATTEMPT_TIMEOUT_MS);
+	}
+
+	#clearConnectTimeout(): void {
+		if (this.#connectTimeout !== null) {
+			clearTimeout(this.#connectTimeout);
+			this.#connectTimeout = null;
 		}
 	}
 


### PR DESCRIPTION
## Before

- A replacement WebSocket could remain in `CONNECTING` without an `open` or `close` event.
- With no further browser lifecycle event, the reconnect loop had no transition that scheduled another attempt.

```mermaid
flowchart LR
  A[Network handoff] --> B[Replacement socket]
  B --> C[CONNECTING indefinitely]
  C --> D[Reconnect banner remains]
```

## After

```mermaid
flowchart LR
  A[Network handoff] --> B[Replacement socket]
  B --> C{Settled in 10 seconds?}
  C -->|Yes| D[Connected]
  C -->|No| E[Close stalled attempt]
  E --> F[Visibility-aware backoff]
  F --> B
```

Adds an ownership-guarded connection-attempt watchdog. A foreground attempt that does not settle within 10 seconds is closed and routed through the existing bounded backoff policy. Hidden pages remain paused until they become visible, and every socket ownership transition clears the watchdog so stale callbacks cannot affect a newer socket.

## Files

- `web/src/lib/ws/connection.svelte.ts` bounds silent connection attempts and records their retry reason.
- `web/src/lib/ws/__tests__/connection.test.ts` covers stalled replacement attempts and hidden-page deferral.

## Tests

- `bun run check` — passed with 0 Svelte errors and 0 warnings.
- `bun run --cwd web test -- connection.test.ts` — 29 passed.
- `timeout 30s bun run start --port 0` — production build and startup passed; stopped by the expected timeout.
- `bun run test` — incomplete: unrelated `reader worker v9` test timed out and left the test process open.
- `bun run --cwd web test` — incomplete: host terminated the broad suite with SIGKILL.

Closes #658.

Prompted by: yk (@chiayong)
