### PR TITLE
Fix rename-chat shortcut from chat surfaces

### DIFF
--- a/web/src/lib/components/shared/__tests__/keyboard-shortcuts.test.ts
+++ b/web/src/lib/components/shared/__tests__/keyboard-shortcuts.test.ts
@@ -413,6 +413,36 @@ describe('KeyboardShortcuts', () => {
 		}
 	});
 
+	it('requests rename on Ctrl-R while Chat owns focus and consumes the browser default', async () => {
+		const appShell = createMockAppShell();
+		const navigation = createMockNavigation();
+
+		render(KeyboardShortcutsHost, {
+			appShell,
+			navigation,
+			onToggleCommandMenu: vi.fn(),
+			focusOwner: 'chat',
+		});
+
+		const input = document.createElement('input');
+		document.body.appendChild(input);
+		input.focus();
+
+		try {
+			const event = new KeyboardEvent('keydown', {
+				key: 'r',
+				ctrlKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			input.dispatchEvent(event);
+			expect(appShell.requestRenameSelectedChat).toHaveBeenCalledOnce();
+			expect(event.defaultPrevented).toBe(true);
+		} finally {
+			input.remove();
+		}
+	});
+
 	it('moves left between tabs on Ctrl-Shift-J while a workspace window owns focus', () => {
 		const appShell = createMockAppShell();
 		const navigation = createMockNavigation();

--- a/web/src/lib/workspace/workspace-shortcuts.ts
+++ b/web/src/lib/workspace/workspace-shortcuts.ts
@@ -218,6 +218,11 @@ export class WorkspaceShortcutDispatcher {
 				this.deps.appShell.openSidebarSearch();
 				return;
 			}
+			if (descriptor?.type === 'chat' && matches('rename-chat')) {
+				event.preventDefault();
+				this.deps.appShell.requestRenameSelectedChat();
+				return;
+			}
 			if (descriptor?.type === 'chat' && matches('delete-chat')) {
 				event.preventDefault();
 				this.deps.appShell.requestDeleteSelectedChat();


### PR DESCRIPTION
Ctrl+R advertised as a global shortcut only renamed when the sidebar chat list owned focus: opening a chat auto-focuses the composer, so the chord hit the chat-surface branch of `WorkspaceShortcutDispatcher`, which handled `delete-chat` but not `rename-chat`, and without `preventDefault` the browser page refresh fired instead. This mirrors the `delete-chat` handling for chat descriptors (preventDefault plus `requestRenameSelectedChat`), keeping terminal surfaces excluded so readline's Ctrl+R still works, and adds a dispatcher test asserting both dispatch and the consumed browser default.