### PR TITLE
Simplify bash message filter code

### DIFF
--- a/web/src/lib/chat/transcript/hidden-bash-commands.ts
+++ b/web/src/lib/chat/transcript/hidden-bash-commands.ts
@@ -1,12 +1,10 @@
 import { BashToolUseMessage } from '$shared/chat-types';
 import type { ChatMessage } from '$shared/chat-types';
 
-export type HiddenBashCommandPatternMode = 'regex' | 'glob';
+export const HIDDEN_BASH_COMMAND_PATTERN_MODE_VALUES = ['regex', 'glob'] as const;
 
-export const HIDDEN_BASH_COMMAND_PATTERN_MODE_VALUES: readonly HiddenBashCommandPatternMode[] = [
-	'regex',
-	'glob',
-];
+export type HiddenBashCommandPatternMode =
+	(typeof HIDDEN_BASH_COMMAND_PATTERN_MODE_VALUES)[number];
 
 export interface HiddenBashCommandPattern {
 	pattern: string;

--- a/web/src/lib/components/chat/conversation-feed-announcer.ts
+++ b/web/src/lib/components/chat/conversation-feed-announcer.ts
@@ -1,6 +1,5 @@
 import {
 	AssistantMessage,
-	BashToolUseMessage,
 	CliRowMessage,
 	ExternalToolUseMessage,
 	McpToolUseMessage,
@@ -10,7 +9,10 @@ import {
 	isToolUseMessage,
 } from '$shared/chat-types';
 import type { ChatDisplayRow } from '$lib/chat/transcript/active-transcript-state.svelte.js';
-import type { BashCommandMatcher } from '$lib/chat/transcript/hidden-bash-commands.js';
+import {
+	isHiddenBashToolUse,
+	type BashCommandMatcher,
+} from '$lib/chat/transcript/hidden-bash-commands.js';
 import { cliPresentationLabel } from '$lib/chat/transcript/cli-presentation-style';
 import {
 	conversationFeedMutationKindsSince,
@@ -151,11 +153,7 @@ export function announcementForAppendedRow(
 	}
 	if (message instanceof PermissionRequestMessage) return m.chat_permission_permission_required();
 	if (!isToolUseMessage(message)) return null;
-	if (
-		message instanceof BashToolUseMessage &&
-		hiddenBashCommands &&
-		hiddenBashCommands(message.command)
-	) {
+	if (hiddenBashCommands && isHiddenBashToolUse(message, hiddenBashCommands)) {
 		return null;
 	}
 	if (

--- a/web/src/lib/components/settings/HiddenBashCommandsSettingsCard.svelte
+++ b/web/src/lib/components/settings/HiddenBashCommandsSettingsCard.svelte
@@ -1,5 +1,3 @@
-<!-- Persists this Remote Settings exception through the browser-local store,
-     never through remoteSettings.update. -->
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as m from '$lib/paraglide/messages.js';
@@ -10,7 +8,10 @@
 		validateHiddenBashCommandPattern,
 		type HiddenBashCommandPattern,
 		type HiddenBashCommandPatternMode,
+		type HiddenBashCommandPatternValidation,
 	} from '$lib/chat/transcript/hidden-bash-commands.js';
+
+	type PatternValidationError = Exclude<HiddenBashCommandPatternValidation, 'ok'>;
 
 	const localSettings = getLocalSettings();
 
@@ -20,16 +21,20 @@
 
 	const patterns = $derived(localSettings.hiddenBashCommandPatterns);
 
-	function errorText(validation: ReturnType<typeof validateHiddenBashCommandPattern>): string {
-		if (validation === 'empty') return m.settings_hidden_bash_commands_error_empty();
-		return m.settings_hidden_bash_commands_error_invalid_regex();
+	function validationErrorText(validation: PatternValidationError): string {
+		switch (validation) {
+			case 'empty':
+				return m.settings_hidden_bash_commands_error_empty();
+			case 'invalid-regex':
+				return m.settings_hidden_bash_commands_error_invalid_regex();
+		}
 	}
 
 	function addPattern(event: SubmitEvent) {
 		event.preventDefault();
 		const validation = validateHiddenBashCommandPattern(draft, mode);
 		if (validation !== 'ok') {
-			error = errorText(validation);
+			error = validationErrorText(validation);
 			return;
 		}
 		if (patterns.some((entry) => entry.pattern === draft && entry.mode === mode)) {

--- a/web/src/lib/stores/local-settings.svelte.ts
+++ b/web/src/lib/stores/local-settings.svelte.ts
@@ -634,7 +634,12 @@ export class LocalSettingsStore {
 		this.markdownViewerOpenPlacement = snap.markdownViewerOpenPlacement;
 		this.language = snap.language;
 		this.hiddenToolTypes = snap.hiddenToolTypes;
-		if (!hiddenBashCommandPatternsEqual(this.hiddenBashCommandPatterns, snap.hiddenBashCommandPatterns)) {
+		if (
+			!hiddenBashCommandPatternsEqual(
+				this.hiddenBashCommandPatterns,
+				snap.hiddenBashCommandPatterns,
+			)
+		) {
 			this.hiddenBashCommandPatterns = snap.hiddenBashCommandPatterns;
 		}
 		this.globalShortcuts = { ...snap.globalShortcuts };


### PR DESCRIPTION
Keeps the Bash message filter easier to maintain by deriving pattern modes from their runtime values, reusing the shared Bash-match predicate in live announcements, and making validation-error handling exhaustive, with a small local-settings readability cleanup. Runtime behavior, browser-local persistence, and server boundaries remain unchanged.