### PR TITLE
Align collapsed tool disclosure height with inline rows

### DIFF
--- a/web/src/lib/components/chat/rows/ChatEventCard.svelte
+++ b/web/src/lib/components/chat/rows/ChatEventCard.svelte
@@ -13,7 +13,9 @@
 		variant?: ChatEventCardVariant;
 		compact?: boolean;
 		header?: Snippet;
-		body: Snippet;
+		// Omitted while a disclosure body is hidden so the card does not
+		// reserve the header gap for content it is not showing.
+		body?: Snippet;
 		footer?: Snippet;
 		class?: string;
 	}
@@ -34,14 +36,16 @@
 
 <article class={cn('rounded-xl border shadow-sm', variantClass, paddingClass, className)}>
 	{#if header}
-		<div class="mb-2 flex items-start justify-between gap-2">
+		<div class={cn('flex items-start justify-between gap-2', body && 'mb-2')}>
 			{@render header()}
 		</div>
 	{/if}
 
-	<div class="min-w-0">
-		{@render body()}
-	</div>
+	{#if body}
+		<div class="min-w-0">
+			{@render body()}
+		</div>
+	{/if}
 
 	{#if footer}
 		<div class="mt-3">

--- a/web/src/lib/components/chat/tools/ChatToolExpandableEvent.svelte
+++ b/web/src/lib/components/chat/tools/ChatToolExpandableEvent.svelte
@@ -57,65 +57,66 @@
 	</svg>
 {/snippet}
 
-<div class="my-1 {className}">
-	<ChatEventCard variant="default" compact>
-		{#snippet header()}
-			{#if onTitleClick}
-				<div class="flex w-full items-center gap-1.5">
-					{#if toolName}
-						<span class="text-[11px] font-medium text-muted-foreground tracking-wide flex-shrink-0">
-							{toolName}
-						</span>
-					{/if}
-					<button
-						type="button"
-						class="text-primary hover:text-primary/80 font-mono hover:underline truncate text-left transition-colors text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
-						onclick={(e) => {
-							e.stopPropagation();
-							onTitleClick?.();
-						}}
-					>
-						{title}
-					</button>
-					<span class="flex-1"></span>
-					<button
-						type="button"
-						class="flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-						onclick={handleToggle}
-						aria-expanded={isOpen}
-						aria-controls={toolId ? `tool-body-${toolId}` : undefined}
-						aria-label={isOpen ? m.editor_actions_collapse() : m.editor_actions_expand()}
-					>
-						{@render chevronSvg()}
-					</button>
-				</div>
-			{:else}
-				<button
-					type="button"
-					class="flex w-full items-center gap-1.5 text-left"
-					onclick={handleToggle}
-					aria-expanded={isOpen}
-					aria-controls={toolId ? `tool-body-${toolId}` : undefined}
-				>
-					{#if toolName}
-						<span class="text-[11px] font-medium text-muted-foreground tracking-wide flex-shrink-0">
-							{toolName}
-						</span>
-					{/if}
-					<span class="text-foreground/85 truncate flex-1 text-xs">
-						{title}
-					</span>
-					{@render chevronSvg()}
-				</button>
+{#snippet rowHeader()}
+	{#if onTitleClick}
+		<!-- The overlay button spans the header so the whole row toggles while the file-title
+		button above it keeps its own action; nested buttons forbid wrapping the row in one. -->
+		<div class="relative flex w-full items-center gap-1.5">
+			<button
+				type="button"
+				class="absolute inset-0 z-0 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+				onclick={handleToggle}
+				aria-expanded={isOpen}
+				aria-controls={toolId ? `tool-body-${toolId}` : undefined}
+				aria-label={isOpen ? m.editor_actions_collapse() : m.editor_actions_expand()}
+			></button>
+			{#if toolName}
+				<span class="pointer-events-none z-10 text-[11px] font-medium text-muted-foreground tracking-wide flex-shrink-0">
+					{toolName}
+				</span>
 			{/if}
-		{/snippet}
+			<button
+				type="button"
+				class="relative z-10 text-primary hover:text-primary/80 font-mono hover:underline truncate text-left transition-colors text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
+				onclick={(e) => {
+					e.stopPropagation();
+					onTitleClick?.();
+				}}
+			>
+				{title}
+			</button>
+			<span class="pointer-events-none z-10 flex-1"></span>
+			<span class="pointer-events-none z-10 flex size-4 shrink-0 items-center justify-center">
+				{@render chevronSvg()}
+			</span>
+		</div>
+	{:else}
+		<button
+			type="button"
+			class="flex w-full items-center gap-1.5 text-left"
+			onclick={handleToggle}
+			aria-expanded={isOpen}
+			aria-controls={toolId ? `tool-body-${toolId}` : undefined}
+		>
+			{#if toolName}
+				<span class="text-[11px] font-medium text-muted-foreground tracking-wide flex-shrink-0">
+					{toolName}
+				</span>
+			{/if}
+			<span class="text-foreground/85 truncate flex-1 text-xs">
+				{title}
+			</span>
+			{@render chevronSvg()}
+		</button>
+	{/if}
+{/snippet}
 
-		{#snippet body()}
-			{#if isOpen}
-				<div id={toolId ? `tool-body-${toolId}` : undefined} class="pt-1.5">
-					{@render children()}
-				</div>
-			{/if}
-		{/snippet}
-	</ChatEventCard>
+{#snippet rowBody()}
+	<div id={toolId ? `tool-body-${toolId}` : undefined} class="pt-1.5">
+		{@render children()}
+	</div>
+{/snippet}
+
+<div class="my-0.5 {className}">
+	<ChatEventCard variant="default" compact header={rowHeader} body={isOpen ? rowBody : undefined} />
 </div>

--- a/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
+++ b/web/src/lib/components/chat/tools/__tests__/ChatToolEventRenderer.test.ts
@@ -167,6 +167,51 @@ describe('ChatToolEventRenderer', () => {
 		expect(disclosureButton.getAttribute('aria-expanded')).toBe('true');
 	});
 
+	it('reserves no header gap or body slot while an Edit row is collapsed', async () => {
+		render(ChatToolEventRenderer, {
+			toolMessage: new EditToolUseMessage(
+				'',
+				'tool-collapsed-gap',
+				'/tmp/example.ts',
+				'const a = 1;',
+				'const a = 2;',
+			),
+			mode: 'input',
+			onFileOpen: () => {},
+		});
+
+		const disclosureButton = screen.getByRole('button', { name: 'Expand' });
+		const card = disclosureButton.closest('article');
+		expect(card).toBeTruthy();
+		expect(disclosureButton.closest('div.mb-2')).toBeNull();
+		expect(card!.querySelector('#tool-body-tool-collapsed-gap')).toBeNull();
+
+		await fireEvent.click(disclosureButton);
+		expect(disclosureButton.closest('div.mb-2')).toBeTruthy();
+		expect(screen.getByText('const a = 2;')).toBeTruthy();
+	});
+
+	it('spans the whole header row with the disclosure toggle while the title keeps its own action', () => {
+		render(ChatToolEventRenderer, {
+			toolMessage: new EditToolUseMessage(
+				'',
+				'tool-row-click',
+				'/tmp/example.ts',
+				'const a = 1;',
+				'const a = 2;',
+			),
+			mode: 'input',
+			onFileOpen: () => {},
+		});
+
+		const rowToggle = screen.getByRole('button', { name: 'Expand' });
+		expect(rowToggle.className).toContain('absolute inset-0');
+		expect(screen.getByText('Edit').className).toContain('pointer-events-none');
+		expect(screen.getByRole('button', { name: 'example.ts' }).className).not.toContain(
+			'absolute inset-0',
+		);
+	});
+
 	it('renders streaming Edit without diff as non-expandable single row', () => {
 		const onFileOpen = () => {};
 		render(ChatToolEventRenderer, {


### PR DESCRIPTION
Collapsed Edit and Write rows were visibly taller than the inline tool rows around them: the disclosure card reserved a header-to-body gap even though the collapsed card renders no body, its chevron hit target forced a 24px header line, and its wrapper carried twice the inline rows' vertical margin. The card now applies the header gap only when a body snippet is passed, the expandable tool row passes its body only while open, the chevron target shrinks to the header line height, and the wrapper margin matches inline rows, so a collapsed disclosure row renders at the same height as an inline row while expanded layout stays unchanged. Rows with a clickable file title also gain a full-row disclosure surface: an overlay button spans the header so clicking anywhere on the row toggles it, while the file-title button keeps its open-file action and keyboard focus order remains intact. Regression tests pin the no-gap collapsed state, the restored gap on expand, and the overlay toggle structure.