### PR TITLE
fix(codex): preserve destination model defaults

### DIFF
--- a/integration-tests/tests/server/codex-scripted-default-switch.test.ts
+++ b/integration-tests/tests/server/codex-scripted-default-switch.test.ts
@@ -1,0 +1,143 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { codexAssistantMessage } from '../../support/fake-codex-model.js';
+import {
+  type IntegrationDirectories,
+  withIntegrationFixture,
+} from '../../support/integration-fixture.js';
+import { waitForVisibleResponse } from '../../support/live-agent.js';
+import { liveCodexRunRequest, liveCodexStartRequest } from '../../support/live-codex.js';
+import {
+  startScriptedCodexTestEnvironment,
+  type ScriptedCodexTestEnvironment,
+} from '../../support/scripted-codex.js';
+
+const MODEL_DEFAULTS = {
+  'gpt-6-astra': 'low',
+  'gpt-5.6-sol': 'low',
+  'gpt-5.6-terra': 'medium',
+  'gpt-5.6-luna': 'medium',
+} as const;
+
+describe('Codex scripted default effort model switching', () => {
+  let environment: ScriptedCodexTestEnvironment | undefined;
+
+  beforeAll(async () => {
+    environment = await startScriptedCodexTestEnvironment();
+  });
+
+  afterAll(async () => {
+    await environment?.dispose();
+  });
+
+  test('uses each destination model default after switching from Astra', async () => {
+    if (!environment) throw new Error('Scripted Codex environment was not initialized.');
+    const testEnvironment = environment;
+
+    await withIntegrationFixture('codex-scripted-default-switch', async (fixture) => {
+      const chatId = fixture.newChatId();
+      await runScriptedTurn({
+        fixture,
+        testEnvironment,
+        chatId,
+        model: 'gpt-6-astra',
+        command: 'Start with the Astra default.',
+        start: true,
+      });
+
+      for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'] as const) {
+        const response = await fetch(`${fixture.client.baseUrl}/api/v1/chats/model`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ chatId, model }),
+        });
+        const body = await response.json();
+        expect({ status: response.status, body }).toMatchObject({
+          status: 200,
+          body: { success: true, chatId, model },
+        });
+
+        await runScriptedTurn({
+          fixture,
+          testEnvironment,
+          chatId,
+          model,
+          command: `Continue with the ${model} default.`,
+        });
+      }
+
+      testEnvironment.model.assertSettled();
+    }, {
+      serverEnvironment: testEnvironment.serverEnvironment,
+      prepareWorkspace: async (directories) => {
+        await testEnvironment.prepareWorkspace(directories);
+        await overlayOfficialModelDefaults(directories);
+      },
+    });
+  }, 120_000);
+});
+
+async function runScriptedTurn(options: {
+  fixture: Parameters<Parameters<typeof withIntegrationFixture>[1]>[0];
+  testEnvironment: ScriptedCodexTestEnvironment;
+  chatId: string;
+  model: keyof typeof MODEL_DEFAULTS;
+  command: string;
+  start?: boolean;
+}): Promise<void> {
+  const { fixture, testEnvironment, chatId, model, command, start = false } = options;
+  const reply = `SCRIPTED_${model}_${crypto.randomUUID()}`;
+  const requestIndex = testEnvironment.model.requests().length;
+  testEnvironment.model.scriptTurn([codexAssistantMessage(reply)]);
+  const cursor = fixture.client.markEvents();
+  const turn = start
+    ? await fixture.client.startChat({
+      ...liveCodexStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command,
+      }),
+      model,
+      thinkingMode: 'none',
+    })
+    : await fixture.client.runChat({
+      ...liveCodexRunRequest({ chatId, command }),
+      model,
+      thinkingMode: 'none',
+    });
+  await waitForVisibleResponse({
+    fixture,
+    chatId,
+    turnId: turn.turnId,
+    marker: reply,
+    afterIndex: cursor,
+  });
+
+  expect(testEnvironment.model.requests()[requestIndex]?.body).toMatchObject({
+    model,
+    reasoning: { effort: MODEL_DEFAULTS[model] },
+  });
+}
+
+async function overlayOfficialModelDefaults(directories: IntegrationDirectories): Promise<void> {
+  const catalogPath = join(directories.home, '.codex', 'live-models.json');
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8')) as {
+    models: Array<Record<string, unknown>>;
+  };
+  const template = catalog.models[0];
+  if (!template) throw new Error('Scripted Codex model catalog is empty.');
+  catalog.models = Object.entries(MODEL_DEFAULTS).map(([slug, effort], priority) => ({
+    ...template,
+    slug,
+    display_name: slug,
+    description: `Scripted ${slug} model.`,
+    default_reasoning_level: effort,
+    supported_reasoning_levels: ['low', 'medium', 'high', 'xhigh'].map((supportedEffort) => ({
+      effort: supportedEffort,
+      description: `${supportedEffort} effort`,
+    })),
+    priority,
+  }));
+  await writeFile(catalogPath, JSON.stringify(catalog), { mode: 0o600 });
+}

--- a/server-agents/codex/src/agents/codex/__tests__/execution.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/execution.test.js
@@ -517,7 +517,9 @@ describe('CodexExecution', () => {
     });
   });
 
-  it('allows GPT-6 Astra to restore its low provider-default effort', async () => {
+  it.each([
+    'gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
+  ])('allows %s to restore its concrete provider-default effort', async (model) => {
     const runtime = createRuntime();
     runtime.hasSource.mockReturnValue(true);
     const execution = new CodexExecution(
@@ -527,7 +529,7 @@ describe('CodexExecution', () => {
       createConfig(),
     );
     const previous = {
-      model: 'gpt-6-astra',
+      model,
       permissionMode: 'default',
       thinkingMode: 'high',
       settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
@@ -540,13 +542,44 @@ describe('CodexExecution', () => {
     }, previous);
 
     expect(runtime.updateSessionSettings).toHaveBeenCalledWith('thread-1', {
-      model: 'gpt-6-astra',
+      model,
       permissionMode: 'default',
       thinkingMode: 'none',
     });
   });
 
-  it('rejects carrying Astra low effort into a non-Astra provider-default transition', async () => {
+  it('switches an established GPT-6 Astra Default session to GPT-5.6 Sol Default', async () => {
+    const runtime = createRuntime();
+    runtime.hasSource.mockReturnValue(true);
+    const execution = new CodexExecution(
+      createHost(),
+      runtime,
+      createPathNativeSessionCodec('codex'),
+      createConfig(),
+    );
+    const previous = {
+      model: 'gpt-6-astra',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      endpoint: null,
+    };
+
+    await execution.applySessionConfiguration('thread-1', {
+      ...previous,
+      model: 'gpt-5.6-sol',
+    }, previous);
+
+    expect(runtime.updateSessionSettings).toHaveBeenCalledWith('thread-1', {
+      model: 'gpt-5.6-sol',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+    });
+  });
+
+  it.each([
+    'gpt-5.4', 'gpt-5.6', 'gpt-5.6-sol-custom', 'gpt-5.60-sol',
+  ])('rejects carrying Astra low effort into an unknown %s default', async (model) => {
     const runtime = createRuntime();
     runtime.hasSource.mockReturnValue(true);
     const execution = new CodexExecution(
@@ -565,7 +598,7 @@ describe('CodexExecution', () => {
 
     await expect(execution.applySessionConfiguration('thread-1', {
       ...previous,
-      model: 'gpt-5.4',
+      model,
     }, previous)).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
     expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
   });

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -983,22 +983,32 @@ describe('Codex app-server request builders', () => {
     expect(mapThinkingModeToCodexEffort('ultra')).toBe('ultra');
   });
 
-  it('maps provider-default thinking to GPT-6 Astra low effort', () => {
+  it.each([
+    ['gpt-6-astra', 'low'],
+    ['gpt-5.6-sol', 'low'],
+    ['gpt-5.6-terra', 'medium'],
+    ['gpt-5.6-luna', 'medium'],
+  ])('maps provider-default thinking to %s %s effort', (model, effort) => {
     const params = buildTurnStartParams({
       threadId: 'thread-1',
       command: 'hello',
-      model: 'gpt-6-astra',
+      model,
       projectPath: '/repo',
       permissionMode: 'default',
       thinkingMode: 'none',
     });
 
-    expect(params.effort).toBe('low');
-    expect(codexThreadSettingsTarget({
-      model: 'gpt-6-astra',
+    expect(params.effort).toBe(effort);
+    const target = codexThreadSettingsTarget({
+      model,
       permissionMode: 'default',
       thinkingMode: 'none',
-    }).effort).toBe('low');
+    });
+    expect(target.effort).toBe(effort);
+    expect(buildThreadSettingsUpdateParams('thread-1', target)).toMatchObject({ model, effort });
+    expect(mapThinkingModeToCodexEffort(undefined, model)).toBeUndefined();
+    expect(mapThinkingModeToCodexEffort('max', model)).toBe('max');
+    expect(mapThinkingModeToCodexEffort('ultra', model)).toBe('ultra');
   });
 
   it('builds one complete subsequent-turn settings update', () => {

--- a/server-agents/codex/src/agents/codex/app-server/request-builders.ts
+++ b/server-agents/codex/src/agents/codex/app-server/request-builders.ts
@@ -176,6 +176,14 @@ function sandboxPolicyMatches(
     && (left.excludeSlashTmp ?? false) === (right.excludeSlashTmp ?? false);
 }
 
+// Resolves known defaults explicitly because thread/settings/update cannot clear an effort override.
+// https://github.com/openai/codex/blob/985641272869835d01d025ed2a218fbbce35fa9f/codex-rs/models-manager/models.json#L173-L463
+function codexModelDefaultEffort(model: string | undefined): string | undefined {
+  if (model === GPT_6_ASTRA_MODEL || model === 'gpt-5.6-sol') return 'low';
+  if (model === 'gpt-5.6-terra' || model === 'gpt-5.6-luna') return 'medium';
+  return undefined;
+}
+
 // Preserves xhigh compatibility for older models while allowing models that
 // advertise max reasoning to receive that effort explicitly.
 export function mapThinkingModeToCodexEffort(
@@ -183,7 +191,7 @@ export function mapThinkingModeToCodexEffort(
   model?: string,
 ): string | undefined {
   switch (thinkingMode) {
-    case 'none': return model === GPT_6_ASTRA_MODEL ? 'low' : undefined;
+    case 'none': return codexModelDefaultEffort(model);
     case 'low': return 'low';
     case 'medium': return 'medium';
     case 'high': return 'high';


### PR DESCRIPTION
## Before

Switching an established GPT-6 Astra chat on Default effort to GPT-5.6 Sol on Default failed with HTTP 500. The public Codex settings endpoint cannot clear a retained effort, so Garcon rejected the model update instead of applying Sol's effective default.

```mermaid
flowchart LR
  A[Astra Default low] --> B[Select Sol Default]
  B --> C[Unset destination effort]
  C --> D[HTTP 500]
```

## After

```mermaid
flowchart LR
  A[Astra Default low] --> B[Select destination Default]
  B --> C[Resolve pinned model default]
  C --> D[Atomic model and effort update]
```

Provider-default selections now resolve to the bundled Codex defaults for Astra, Sol, Terra, and Luna. Unknown model defaults retain the existing safety rejection because the app-server contract cannot express clearing an effort override.

## Files

- `request-builders.ts` resolves known provider defaults at the shared request boundary.
- Codex unit tests cover allowed known-default changes and rejected unknown defaults.
- Scripted Codex integration coverage verifies HTTP model changes and subsequent provider efforts.

## Tests

- Focused Codex tests: 247 passed, 942 assertions.
- Scripted real-Codex model-switch test: passed, 27 assertions.
- Codex and integration typechecks: passed.
- `bun run check`: passed with zero errors or warnings.

Prompted by: yk (@chiayong)
