### PR TITLE
Restore persisted scheduled prompts

### DIFF
--- a/integration-tests/tests/server/scheduled-prompt-migration.test.ts
+++ b/integration-tests/tests/server/scheduled-prompt-migration.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+
+const CREATED_AT = '2026-01-01T00:00:00.000Z';
+const INTERVAL_DAYS = [14, 14, 21, 7, 1];
+
+function legacyScheduledPrompt(index: number, intervalDays: number) {
+  return {
+    id: `scheduled-${index}`,
+    schedule: {
+      type: 'recurring',
+      intervalDays,
+      nextRunAt: `2099-0${index + 1}-01T09:00:00.000Z`,
+      endAt: null,
+    },
+    target: {
+      type: 'existing-chat',
+      chatId: '1000000000000000',
+      busyBehavior: 'queue',
+    },
+    prompt: `Run scheduled prompt ${index}`,
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+  };
+}
+
+function legacyScheduledPromptsFile() {
+  return {
+    version: 1,
+    revision: 50,
+    prompts: INTERVAL_DAYS.map((days, index) => legacyScheduledPrompt(index, days)),
+  };
+}
+
+describe('scheduled prompt persistence migration', () => {
+  test('migrates every legacy recurring prompt before serving the snapshot', async () => {
+    await withIntegrationFixture(
+      'scheduled-prompt-migration',
+      async (fixture) => {
+        const scheduledPromptsPath = join(fixture.dirs.workspace, 'scheduled-prompts.json');
+        const snapshot = await fixture.client.getScheduledPrompts();
+
+        expect(snapshot.revision).toBe(50);
+        expect(snapshot.prompts.map((scheduledPrompt) => scheduledPrompt.schedule)).toEqual(
+          INTERVAL_DAYS.map((days, index) => ({
+            type: 'recurring',
+            intervalHours: days * 24,
+            nextRunAt: `2099-0${index + 1}-01T09:00:00.000Z`,
+            endAt: null,
+          })),
+        );
+
+        const migrated = JSON.parse(await readFile(scheduledPromptsPath, 'utf8'));
+        expect(migrated.version).toBe(2);
+        expect(migrated.revision).toBe(50);
+        expect(migrated.prompts).toHaveLength(5);
+        expect(
+          migrated.prompts.every(
+            (scheduledPrompt: { schedule: Record<string, unknown> }) => !('intervalDays' in scheduledPrompt.schedule),
+          ),
+        ).toBe(true);
+        expect((await stat(scheduledPromptsPath)).mode & 0o777).toBe(0o600);
+        const backupNames = (await readdir(fixture.dirs.workspace)).filter((entry) =>
+          entry.startsWith('scheduled-prompts.json.v1-backup-'),
+        );
+        expect(backupNames).toHaveLength(1);
+        const backupPath = join(fixture.dirs.workspace, backupNames[0]);
+        expect(await readFile(backupPath, 'utf8')).toBe(JSON.stringify(legacyScheduledPromptsFile()));
+        expect((await stat(backupPath)).mode & 0o777).toBe(0o600);
+
+        await fixture.restartGarcon();
+        expect(await fixture.client.getScheduledPrompts()).toEqual(snapshot);
+        expect(
+          (await readdir(fixture.dirs.workspace)).filter((entry) =>
+            entry.startsWith('scheduled-prompts.json.v1-backup-'),
+          ),
+        ).toEqual(backupNames);
+      },
+      {
+        prepareWorkspace: async ({ workspace }) => {
+          await writeFile(
+            join(workspace, 'scheduled-prompts.json'),
+            JSON.stringify(legacyScheduledPromptsFile()),
+            { mode: 0o644 },
+          );
+        },
+      },
+    );
+  });
+});

--- a/server/lib/__tests__/json-file-store.test.js
+++ b/server/lib/__tests__/json-file-store.test.js
@@ -6,7 +6,6 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import {
   CorruptStateFileError,
-  JsonFileStore,
   QUARANTINE_INFIX,
   readJsonStateFile,
   writeJsonFileAtomic,
@@ -55,26 +54,6 @@ describe('json file store', () => {
     const source = atomicWriterSource();
     expect(source).toContain('await syncDirectory(dir)');
     expect(source.indexOf('await fs.rename(tempPath')).toBeLessThan(source.lastIndexOf('await syncDirectory(dir)'));
-  });
-
-  it('normalizes parsed values and supplies empty state for missing files', async () => {
-    const dir = await tempDir();
-    const filePath = path.join(dir, 'ledger.json');
-    const store = new JsonFileStore({
-      filePath,
-      empty: () => ({ version: 1, records: [] }),
-      normalize: (value) => {
-        const record = value && typeof value === 'object' ? value : {};
-        return {
-          version: 1,
-          records: Array.isArray(record.records) ? record.records : [],
-        };
-      },
-    });
-
-    await expect(store.read()).resolves.toEqual({ version: 1, records: [] });
-    await fs.writeFile(filePath, JSON.stringify({ records: [{ id: 'a' }] }), 'utf8');
-    await expect(store.read()).resolves.toEqual({ version: 1, records: [{ id: 'a' }] });
   });
 
   it('quarantines malformed state without losing its bytes or mode', async () => {

--- a/server/lib/json-file-store.ts
+++ b/server/lib/json-file-store.ts
@@ -141,30 +141,3 @@ function isUnsupportedDirectorySyncError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code;
   return code === 'EISDIR' || code === 'EINVAL' || code === 'EPERM' || code === 'ENOTSUP';
 }
-
-export class JsonFileStore<T> {
-  constructor(private readonly options: {
-    filePath: string;
-    empty(): T;
-    normalize(value: unknown): T;
-    mode?: number;
-  }) {}
-
-  async read(): Promise<T> {
-    try {
-      const raw = await fs.readFile(this.options.filePath, 'utf8');
-      return this.options.normalize(JSON.parse(raw));
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return this.options.empty();
-      }
-      throw error;
-    }
-  }
-
-  async write(value: T): Promise<void> {
-    await writeJsonFileAtomic(this.options.filePath, value, {
-      mode: this.options.mode,
-    });
-  }
-}

--- a/server/scheduled-prompts/__tests__/store.test.js
+++ b/server/scheduled-prompts/__tests__/store.test.js
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { randomUUID } from 'crypto';
+import crypto, { randomUUID } from 'crypto';
 import { ScheduledPromptRunLog } from '../run-log.ts';
 import { ScheduledPromptStore } from '../store.ts';
 
@@ -24,6 +24,18 @@ function scheduledPrompt(id, schedule) {
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
   };
+}
+
+async function seedScheduledPrompts(dir, file) {
+  const filePath = path.join(dir, 'scheduled-prompts.json');
+  await fs.writeFile(filePath, JSON.stringify(file));
+  return filePath;
+}
+
+async function scheduledPromptBackupPaths(dir) {
+  return (await fs.readdir(dir))
+    .filter((entry) => entry.startsWith('scheduled-prompts.json.v1-backup-'))
+    .map((entry) => path.join(dir, entry));
 }
 
 describe('scheduled prompt persistence', () => {
@@ -100,6 +112,275 @@ describe('scheduled prompt persistence', () => {
     await store.init();
 
     expect(store.list()[0].target.tags).toEqual([]);
+  });
+
+  it('atomically migrates the saved day-based recurring prompts without dropping records', async () => {
+    const dir = await tempDir();
+    const intervalDays = [14, 14, 21, 7, 1];
+    const filePath = await seedScheduledPrompts(dir, {
+      version: 1,
+      revision: 50,
+      prompts: intervalDays.map((days, index) =>
+        scheduledPrompt(`legacy-${index}`, {
+          type: 'recurring',
+          intervalDays: days,
+          nextRunAt: `2030-0${index + 1}-01T09:00:00.000Z`,
+          endAt: null,
+        }),
+      ),
+    });
+    const originalContents = await fs.readFile(filePath, 'utf8');
+
+    const store = new ScheduledPromptStore(dir);
+    await store.init();
+
+    expect(store.revision).toBe(50);
+    const prompts = store.list();
+    expect(prompts).toHaveLength(5);
+    expect(prompts.map((entry) => entry.schedule.intervalHours)).toEqual([14 * 24, 14 * 24, 21 * 24, 7 * 24, 24]);
+    const migrated = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    expect(migrated.version).toBe(2);
+    expect(migrated.revision).toBe(50);
+    expect(migrated.prompts).toHaveLength(5);
+    expect(migrated.prompts.every((entry) => !('intervalDays' in entry.schedule))).toBe(true);
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
+    const backupPaths = await scheduledPromptBackupPaths(dir);
+    expect(backupPaths).toHaveLength(1);
+    expect(await fs.readFile(backupPaths[0], 'utf8')).toBe(originalContents);
+    expect((await fs.stat(backupPaths[0])).mode & 0o777).toBe(0o600);
+
+    const migratedContents = await fs.readFile(filePath, 'utf8');
+    await new ScheduledPromptStore(dir).init();
+    expect(await fs.readFile(filePath, 'utf8')).toBe(migratedContents);
+    expect(await scheduledPromptBackupPaths(dir)).toEqual(backupPaths);
+  });
+
+  it('migrates mixed version-one schedules and prefers valid intervalHours', async () => {
+    const dir = await tempDir();
+    await seedScheduledPrompts(dir, {
+      version: 1,
+      revision: 8,
+      prompts: [
+        scheduledPrompt('legacy', {
+          type: 'recurring',
+          intervalDays: 7,
+          nextRunAt: '2030-01-01T09:00:00.000Z',
+          endAt: null,
+        }),
+        scheduledPrompt('hours', {
+          type: 'recurring',
+          intervalDays: 99,
+          intervalHours: 6,
+          nextRunAt: '2030-01-02T09:00:00.000Z',
+          endAt: null,
+        }),
+        scheduledPrompt('invalid-hours', {
+          type: 'recurring',
+          intervalDays: 2,
+          intervalHours: 0,
+          nextRunAt: '2030-01-03T09:00:00.000Z',
+          endAt: null,
+        }),
+        scheduledPrompt('once', {
+          type: 'once',
+          nextRunAt: '2030-01-04T09:00:00.000Z',
+        }),
+      ],
+    });
+
+    const store = new ScheduledPromptStore(dir);
+    await store.init();
+
+    expect(store.list().map((entry) => entry.schedule)).toEqual([
+      {
+        type: 'recurring',
+        intervalHours: 7 * 24,
+        nextRunAt: '2030-01-01T09:00:00.000Z',
+        endAt: null,
+      },
+      {
+        type: 'recurring',
+        intervalHours: 6,
+        nextRunAt: '2030-01-02T09:00:00.000Z',
+        endAt: null,
+      },
+      {
+        type: 'recurring',
+        intervalHours: 2 * 24,
+        nextRunAt: '2030-01-03T09:00:00.000Z',
+        endAt: null,
+      },
+      { type: 'once', nextRunAt: '2030-01-04T09:00:00.000Z' },
+    ]);
+  });
+
+  it('backs up invalid legacy intervals before excluding them from the migrated file', async () => {
+    const dir = await tempDir();
+    const invalidIntervals = [0, -3, 1.5, 3_651, '7'];
+    const filePath = await seedScheduledPrompts(dir, {
+      version: 1,
+      revision: 4,
+      prompts: [
+        scheduledPrompt('valid', {
+          type: 'recurring',
+          intervalDays: 1,
+          nextRunAt: '2030-01-01T09:00:00.000Z',
+          endAt: null,
+        }),
+        ...invalidIntervals.map((interval, index) =>
+          scheduledPrompt(`invalid-${index}`, {
+            type: 'recurring',
+            intervalDays: interval,
+            nextRunAt: '2030-01-01T09:00:00.000Z',
+            endAt: null,
+          }),
+        ),
+      ],
+    });
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const store = new ScheduledPromptStore(dir);
+      await store.init();
+
+      expect(store.list().map((entry) => entry.id)).toEqual(['valid']);
+      const backupPaths = await scheduledPromptBackupPaths(dir);
+      expect(backupPaths).toHaveLength(1);
+      const backupPath = backupPaths[0];
+      const backup = JSON.parse(await fs.readFile(backupPath, 'utf8'));
+      expect(backup.version).toBe(1);
+      expect(backup.prompts).toHaveLength(6);
+      expect((await fs.stat(backupPath)).mode & 0o777).toBe(0o600);
+      expect(warn).toHaveBeenCalledWith(
+        '[scheduled-prompts]',
+        `Ignored 5 invalid or duplicate scheduled prompt records while loading scheduled-prompts.json. Original file backed up to ${backupPath}.`,
+      );
+      expect(JSON.parse(await fs.readFile(filePath, 'utf8')).prompts).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps version one intact when its migration write fails', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'scheduled-prompts.json');
+    const persisted = JSON.stringify({
+      version: 1,
+      revision: 2,
+      prompts: [
+        scheduledPrompt('legacy', {
+          type: 'recurring',
+          intervalDays: 1,
+          nextRunAt: '2030-01-01T09:00:00.000Z',
+          endAt: null,
+        }),
+      ],
+    });
+    await fs.writeFile(filePath, persisted);
+
+    await fs.mkdir(path.join(dir, `.scheduled-prompts.json.${process.pid}.migration-write-failure.tmp`));
+    const originalRandomUUID = crypto.randomUUID;
+    crypto.randomUUID = () => 'migration-write-failure';
+    try {
+      await expect(new ScheduledPromptStore(dir).init()).rejects.toMatchObject({ code: 'EISDIR' });
+    } finally {
+      crypto.randomUUID = originalRandomUUID;
+    }
+
+    expect(await fs.readFile(filePath, 'utf8')).toBe(persisted);
+  });
+
+  it('uses the migrated interval for occurrence advancement', async () => {
+    const dir = await tempDir();
+    await seedScheduledPrompts(dir, {
+      version: 1,
+      revision: 6,
+      prompts: [
+        scheduledPrompt('weekly', {
+          type: 'recurring',
+          intervalDays: 7,
+          nextRunAt: '2030-01-01T09:00:00.000Z',
+          endAt: null,
+        }),
+      ],
+    });
+    const store = new ScheduledPromptStore(dir);
+    await store.init();
+
+    const result = await store.claimOccurrence('weekly', '2030-01-01T09:00:00.000Z');
+
+    expect(result?.nextScheduledPrompt?.schedule.nextRunAt).toBe('2030-01-08T09:00:00.000Z');
+  });
+
+  it('uses the migrated interval for missed-run reconciliation', async () => {
+    const dir = await tempDir();
+    await seedScheduledPrompts(dir, {
+      version: 1,
+      revision: 50,
+      prompts: [
+        scheduledPrompt('weekly', {
+          type: 'recurring',
+          intervalDays: 7,
+          nextRunAt: '2030-01-01T09:00:00.000Z',
+          endAt: null,
+        }),
+      ],
+    });
+    const store = new ScheduledPromptStore(dir);
+    await store.init();
+
+    const result = await store.reconcileMissed(new Date('2030-01-15T09:00:00.000Z'), {
+      includeCurrentMinute: true,
+    });
+
+    expect(result).toEqual({
+      changed: true,
+      events: [
+        {
+          scheduledPromptId: 'weekly',
+          message: 'Skipped 3 missed occurrences; next run is 2030-01-22T09:00:00.000Z.',
+        },
+      ],
+    });
+    expect(store.revision).toBe(51);
+    expect(store.get('weekly')?.schedule.nextRunAt).toBe('2030-01-22T09:00:00.000Z');
+  });
+
+  it('does not apply the day-based migration to version-two files', async () => {
+    const dir = await tempDir();
+    const filePath = await seedScheduledPrompts(dir, {
+      version: 2,
+      revision: 9,
+      prompts: [
+        scheduledPrompt('days-only', {
+          type: 'recurring',
+          intervalDays: 7,
+          nextRunAt: '2030-01-01T09:00:00.000Z',
+          endAt: null,
+        }),
+      ],
+    });
+    const persisted = await fs.readFile(filePath, 'utf8');
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const store = new ScheduledPromptStore(dir);
+      await store.init();
+
+      expect(store.list()).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        '[scheduled-prompts]',
+        'Ignored 1 invalid or duplicate scheduled prompt record while loading scheduled-prompts.json.',
+      );
+      expect(await fs.readFile(filePath, 'utf8')).toBe(persisted);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('rejects future scheduled prompt file versions', async () => {
+    const dir = await tempDir();
+    await seedScheduledPrompts(dir, { version: 3, revision: 0, prompts: [] });
+
+    await expect(new ScheduledPromptStore(dir).init()).rejects.toThrow('Unsupported scheduled-prompts.json version: 3');
   });
 
   it('claims once and recurring occurrences before dispatch', async () => {

--- a/server/scheduled-prompts/store.ts
+++ b/server/scheduled-prompts/store.ts
@@ -1,16 +1,34 @@
 import path from 'path';
-import { JsonFileStore } from '../lib/json-file-store.js';
+import { promises as fs } from 'fs';
+import { randomUUID } from 'crypto';
 import { KeyedPromiseLock } from '../lib/keyed-lock.js';
 import {
   SCHEDULED_PROMPT_MAX_COUNT,
   normalizeScheduledPrompt,
   type ScheduledPrompt,
 } from '../../common/scheduled-prompts.js';
+import { hasNodeErrorCode } from '../lib/errors.js';
+import { syncDirectory, writeJsonFileAtomic } from '../lib/json-file-store.js';
+import { createLogger } from '../lib/log.js';
+
+const logger = createLogger('scheduled-prompts');
+const SCHEDULED_PROMPTS_FILE_VERSION = 2;
+const HOURS_PER_DAY = 24;
 
 interface ScheduledPromptsFile {
-  version: 1;
+  version: typeof SCHEDULED_PROMPTS_FILE_VERSION;
   revision: number;
   prompts: ScheduledPrompt[];
+}
+
+interface NormalizedScheduledPromptsFile {
+  file: ScheduledPromptsFile;
+  migrated: boolean;
+  ignoredPromptCount: number;
+}
+
+interface LoadedScheduledPromptsFile extends NormalizedScheduledPromptsFile {
+  sourceBytes: Buffer | null;
 }
 
 const HOUR_MS = 3_600_000;
@@ -43,28 +61,90 @@ export class ScheduledPromptDomainError extends Error {
 }
 
 function emptyFile(): ScheduledPromptsFile {
-  return { version: 1, revision: 0, prompts: [] };
+  return { version: SCHEDULED_PROMPTS_FILE_VERSION, revision: 0, prompts: [] };
 }
 
-function normalizeFile(value: unknown): ScheduledPromptsFile {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return emptyFile();
+function normalizeVersionOneScheduledPrompt(value: unknown): ScheduledPrompt | null {
+  const scheduledPrompt = normalizeScheduledPrompt(value);
+  if (scheduledPrompt) return scheduledPrompt;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const raw = value as Record<string, unknown>;
-  if (raw.version !== 1) {
+  const schedule = raw.schedule;
+  if (!schedule || typeof schedule !== 'object' || Array.isArray(schedule)) return null;
+  const legacySchedule = schedule as Record<string, unknown>;
+  if (legacySchedule.type !== 'recurring') return null;
+  const intervalDays = legacySchedule.intervalDays;
+  if (typeof intervalDays !== 'number' || !Number.isSafeInteger(intervalDays)) return null;
+  return normalizeScheduledPrompt({
+    ...raw,
+    schedule: {
+      ...legacySchedule,
+      intervalHours: intervalDays * HOURS_PER_DAY,
+    },
+  });
+}
+
+function normalizeFile(value: unknown): NormalizedScheduledPromptsFile {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { file: emptyFile(), migrated: false, ignoredPromptCount: 0 };
+  }
+  const raw = value as Record<string, unknown>;
+  if (raw.version !== 1 && raw.version !== SCHEDULED_PROMPTS_FILE_VERSION) {
     throw new Error(`Unsupported scheduled-prompts.json version: ${String(raw.version)}`);
   }
   const revision =
     typeof raw.revision === 'number' && Number.isSafeInteger(raw.revision) && raw.revision >= 0 ? raw.revision : 0;
   const prompts: ScheduledPrompt[] = [];
   const seen = new Set<string>();
+  let ignoredPromptCount = 0;
   if (Array.isArray(raw.prompts)) {
     for (const value of raw.prompts) {
-      const scheduledPrompt = normalizeScheduledPrompt(value);
-      if (!scheduledPrompt || seen.has(scheduledPrompt.id)) continue;
+      const scheduledPrompt =
+        raw.version === 1 ? normalizeVersionOneScheduledPrompt(value) : normalizeScheduledPrompt(value);
+      if (!scheduledPrompt || seen.has(scheduledPrompt.id)) {
+        ignoredPromptCount += 1;
+        continue;
+      }
       seen.add(scheduledPrompt.id);
       prompts.push(scheduledPrompt);
     }
   }
-  return { version: 1, revision, prompts };
+  return {
+    file: { version: SCHEDULED_PROMPTS_FILE_VERSION, revision, prompts },
+    migrated: raw.version === 1,
+    ignoredPromptCount,
+  };
+}
+
+async function readFile(filePath: string): Promise<LoadedScheduledPromptsFile> {
+  try {
+    const sourceBytes = await fs.readFile(filePath);
+    return { ...normalizeFile(JSON.parse(sourceBytes.toString('utf8'))), sourceBytes };
+  } catch (error) {
+    if (hasNodeErrorCode(error, 'ENOENT')) {
+      return { file: emptyFile(), migrated: false, ignoredPromptCount: 0, sourceBytes: null };
+    }
+    throw error;
+  }
+}
+
+async function backupVersionOneFile(filePath: string, sourceBytes: Buffer): Promise<string> {
+  const timestamp = new Date().toISOString().replace(/[-:.]/g, '');
+  const backupPath = `${filePath}.v1-backup-${timestamp}-${randomUUID().slice(0, 8)}`;
+  let backupFile: Awaited<ReturnType<typeof fs.open>> | null = null;
+  try {
+    backupFile = await fs.open(backupPath, 'wx', 0o600);
+    await backupFile.writeFile(sourceBytes);
+    await backupFile.sync();
+    await backupFile.close();
+    backupFile = null;
+    await syncDirectory(path.dirname(filePath));
+  } catch (error) {
+    if (backupFile) await backupFile.close().catch(() => {});
+    await fs.unlink(backupPath).catch(() => {});
+    throw error;
+  }
+  return backupPath;
 }
 
 function clonePrompt(scheduledPrompt: ScheduledPrompt): ScheduledPrompt {
@@ -80,21 +160,34 @@ function nextRecurringRun(scheduledPrompt: ScheduledPrompt): string | null {
 }
 
 export class ScheduledPromptStore {
-  readonly #persistence: JsonFileStore<ScheduledPromptsFile>;
+  readonly #filePath: string;
   readonly #lock = new KeyedPromiseLock();
   #file: ScheduledPromptsFile = emptyFile();
 
   constructor(workspaceDir: string) {
-    this.#persistence = new JsonFileStore({
-      filePath: path.join(workspaceDir, 'scheduled-prompts.json'),
-      mode: 0o600,
-      empty: emptyFile,
-      normalize: normalizeFile,
-    });
+    this.#filePath = path.join(workspaceDir, 'scheduled-prompts.json');
   }
 
   async init(): Promise<void> {
-    this.#file = await this.#persistence.read();
+    const loaded = await readFile(this.#filePath);
+    let backupPath: string | null = null;
+    if (loaded.migrated) {
+      if (!loaded.sourceBytes) throw new Error('Version-one scheduled-prompts.json source is unavailable');
+      backupPath = await backupVersionOneFile(this.#filePath, loaded.sourceBytes);
+    }
+    if (loaded.ignoredPromptCount > 0) {
+      const backupMessage = backupPath ? ` Original file backed up to ${backupPath}.` : '';
+      logger.warn(
+        `Ignored ${loaded.ignoredPromptCount} invalid or duplicate scheduled prompt record${loaded.ignoredPromptCount === 1 ? '' : 's'} while loading scheduled-prompts.json.${backupMessage}`,
+      );
+    }
+    if (loaded.migrated) {
+      await this.#write(loaded.file);
+      logger.info(
+        `Migrated scheduled-prompts.json from version 1 to version 2. Original file backed up to ${backupPath}.`,
+      );
+    }
+    this.#file = loaded.file;
   }
 
   get revision(): number {
@@ -267,7 +360,7 @@ export class ScheduledPromptStore {
       const draft = structuredClone(this.#file);
       const result = change(draft);
       draft.revision += 1;
-      await this.#persistence.write(draft);
+      await this.#write(draft);
       this.#file = draft;
       return structuredClone(result);
     });
@@ -279,10 +372,14 @@ export class ScheduledPromptStore {
       const result = change(draft);
       if (result === false) return structuredClone(unchanged);
       draft.revision += 1;
-      await this.#persistence.write(draft);
+      await this.#write(draft);
       this.#file = draft;
       return structuredClone(result);
     });
+  }
+
+  async #write(file: ScheduledPromptsFile): Promise<void> {
+    await writeJsonFileAtomic(this.#filePath, file, { mode: 0o600 });
   }
 
   #notFound(): ScheduledPromptDomainError {


### PR DESCRIPTION
Recurring prompts saved before hourly cadence support still use intervalDays, so the current loader hides them. This change migrates version-one scheduled-prompts.json files to intervalHours without changing recurrence timing, preserves revision and ordering, writes a private byte-exact backup before the atomic version-two rewrite, warns when malformed records are excluded, and adds unit and black-box restart coverage for the production migration shape.