### PR TITLE
test(chromium): stabilize reorder submenu interaction

### DIFF
--- a/integration-tests/tests/chromium/sidebar-chat-reorder.test.ts
+++ b/integration-tests/tests/chromium/sidebar-chat-reorder.test.ts
@@ -116,8 +116,10 @@ async function sortFromChatMenu(
   await row.hover();
   await row.locator('[data-slot="dropdown-menu-trigger"][aria-label="Chat actions"]').click();
   const reorderChats = fixture.page.getByRole('menuitem', { name: 'Reorder chats', exact: true });
-  await reorderChats.focus();
-  await reorderChats.press('ArrowRight');
+  await reorderChats.click();
+  await fixture.page
+    .getByRole('menuitem', { name: 'Reorder chats', exact: true, expanded: true })
+    .waitFor();
   const preset = fixture.page.getByRole('menuitem', { name: label, exact: true });
   await preset.waitFor();
   const responsePromise = fixture.page.waitForResponse(


### PR DESCRIPTION
## Summary

- open the reorder submenu through the pointer interaction used by this end-to-end flow
- wait for the exact submenu trigger to expose its expanded state before selecting a sort preset
- retain focused keyboard submenu coverage in the sidebar component tests

## Before

Chromium intermittently left the reorder submenu closed after a mixed programmatic focus and keyboard sequence. The parent menu remained healthy, but the sort preset never became visible and the test timed out.

Failed run: https://github.com/cfal/garcon/actions/runs/33940743661/job/101237551489

## After

The end-to-end scenario uses one pointer interaction mode and waits on the semantic expanded state before continuing.

## Validation

- Chromium reorder scenario: 10/10 isolated runs passed, 510 assertions
- focused sidebar component tests: 30 passed
- integration typecheck passed
- `bun run check` passed with zero Svelte errors or warnings
- production build and isolated startup passed
- repository-wide tests reached the pre-existing reader-worker timeout
