### PR TITLE
Preserve Codex provider reasoning defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
         "@garcon/common": "workspace:*",
         "@garcon/server-agent-common": "workspace:*",
         "@garcon/server-agent-interface": "workspace:*",
-        "@openai/codex": "0.153.1",
+        "@openai/codex": "0.153.4",
         "acorn": "^8.18.0",
         "bun-pty": "^0.4.10",
         "shell-quote": "^1.10.0",
@@ -601,19 +601,19 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.1", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw=="],
 
-    "@openai/codex": ["@openai/codex@0.153.1", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.1-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.1-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.1-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.1-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.1-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.1-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-d5txIVzNIkZnAmCiqxksAACqm+xUvq83YGKd3YYAF9ISXWkC7hsiPXpSD24ypKOqpvbZiScMSq0e0p4TycczNw=="],
+    "@openai/codex": ["@openai/codex@0.153.4", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.4-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.4-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.4-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.4-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.4-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.4-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.1-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/58i/KvdmqUqcXOaHDTw8tEWEZ6F806QwAPmeSjHKa+9IAhH8VSppQLMD9vQmvcUhmaoIVrF0X90TN4jEFsf+A=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.4-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.153.1-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vocSldmR5nJV0OiqUrALT/qtz9AkRtt8F9oIQUB2kxnBgU2qPP65FiJOBJx8Y4q93vPSp07R9L20YW2yHcF/jg=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.153.4-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.153.1-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-1Y0t2OjCeqR8GaReaeDSrIpf7CDzUmbNGwEQeWPggNQvrwm3zd9R74WHMyalcxr6e4UOlJXXFfZPjpGbPoclWQ=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.153.4-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.153.1-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q+0FqEFRkao0o8mBG1q2wDlREvQFlwPt/SdXCJLGWx2zTL2iuzwgUiGD3zDzrTecpPrtv7uMHo/+jGc+Dk3yLA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.153.4-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.153.1-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SwdiqMTVaduPMmo85uxAfxW7/y8M1RBYP8gsPWKQd9NbdmTFbbfeolG19vr0gA1dQtb3mWy40QfU4y1dxHrTcA=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.153.4-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.153.1-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-A2qiRPjDTOkqaMji+UcakoeJtL3QbGaxz+jjEeCRp7EE9GPxgc9bxATHVC5ACeg6PD6cDvpRTkeAWG1vUXCdwQ=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.153.4-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.22", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-fRZ2r6nqdLBXfs7j531aibrqCC9tpbL2tmz3ThnwtLa3bMNUozEVAOPnZjh86JcTBDhNtACt5CNgKDZ1Pve1NA=="],
 

--- a/integration-tests/bun.lock
+++ b/integration-tests/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-code": "2.1.238",
         "@earendil-works/pi-coding-agent": "0.84.2",
-        "@openai/codex": "0.153.1",
+        "@openai/codex": "0.153.4",
         "@types/bun": "1.4.0",
         "opencode-ai": "1.18.22",
         "playwright": "1.62.1",
@@ -125,19 +125,19 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@openai/codex": ["@openai/codex@0.153.1", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.1-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.1-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.1-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.1-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.1-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.1-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-d5txIVzNIkZnAmCiqxksAACqm+xUvq83YGKd3YYAF9ISXWkC7hsiPXpSD24ypKOqpvbZiScMSq0e0p4TycczNw=="],
+    "@openai/codex": ["@openai/codex@0.153.4", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.4-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.4-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.4-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.153.4-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.4-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.153.4-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.1-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/58i/KvdmqUqcXOaHDTw8tEWEZ6F806QwAPmeSjHKa+9IAhH8VSppQLMD9vQmvcUhmaoIVrF0X90TN4jEFsf+A=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.153.4-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.153.1-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vocSldmR5nJV0OiqUrALT/qtz9AkRtt8F9oIQUB2kxnBgU2qPP65FiJOBJx8Y4q93vPSp07R9L20YW2yHcF/jg=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.153.4-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.153.1-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-1Y0t2OjCeqR8GaReaeDSrIpf7CDzUmbNGwEQeWPggNQvrwm3zd9R74WHMyalcxr6e4UOlJXXFfZPjpGbPoclWQ=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.153.4-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.153.1-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q+0FqEFRkao0o8mBG1q2wDlREvQFlwPt/SdXCJLGWx2zTL2iuzwgUiGD3zDzrTecpPrtv7uMHo/+jGc+Dk3yLA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.153.4-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.153.1-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SwdiqMTVaduPMmo85uxAfxW7/y8M1RBYP8gsPWKQd9NbdmTFbbfeolG19vr0gA1dQtb3mWy40QfU4y1dxHrTcA=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.153.4-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.153.1-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-A2qiRPjDTOkqaMji+UcakoeJtL3QbGaxz+jjEeCRp7EE9GPxgc9bxATHVC5ACeg6PD6cDvpRTkeAWG1vUXCdwQ=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.153.4-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@anthropic-ai/claude-code": "2.1.238",
     "@earendil-works/pi-coding-agent": "0.84.2",
-    "@openai/codex": "0.153.1",
+    "@openai/codex": "0.153.4",
     "@types/bun": "1.4.0",
     "opencode-ai": "1.18.22",
     "playwright": "1.62.1",

--- a/integration-tests/tests/server/codex-scripted-default-switch.test.ts
+++ b/integration-tests/tests/server/codex-scripted-default-switch.test.ts
@@ -13,11 +13,13 @@ import {
   type ScriptedCodexTestEnvironment,
 } from '../../support/scripted-codex.js';
 
-const MODEL_DEFAULTS = {
+const SCRIPTED_MODEL_DEFAULTS = {
   'gpt-6-astra': 'low',
   'gpt-5.6-sol': 'low',
   'gpt-5.6-terra': 'medium',
   'gpt-5.6-luna': 'medium',
+  'gpt-5.5': 'medium',
+  'gpt-5.4': 'medium',
 } as const;
 
 describe('Codex scripted default effort model switching', () => {
@@ -31,7 +33,10 @@ describe('Codex scripted default effort model switching', () => {
     await environment?.dispose();
   });
 
-  test('uses each destination model default after switching from Astra', async () => {
+  test.each([
+    ['catalog', undefined],
+    ['configured high', 'high'],
+  ] as const)('preserves %s provider defaults', async (_label, configuredEffort) => {
     if (!environment) throw new Error('Scripted Codex environment was not initialized.');
     const testEnvironment = environment;
 
@@ -44,9 +49,12 @@ describe('Codex scripted default effort model switching', () => {
         model: 'gpt-6-astra',
         command: 'Start with the Astra default.',
         start: true,
+        expectedEffort: configuredEffort ?? SCRIPTED_MODEL_DEFAULTS['gpt-6-astra'],
       });
 
-      for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'] as const) {
+      for (const model of [
+        'gpt-5.5', 'gpt-5.6-sol', 'gpt-5.4', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-6-astra',
+      ] as const) {
         const response = await fetch(`${fixture.client.baseUrl}/api/v1/chats/model`, {
           method: 'PATCH',
           headers: { 'content-type': 'application/json' },
@@ -64,6 +72,7 @@ describe('Codex scripted default effort model switching', () => {
           chatId,
           model,
           command: `Continue with the ${model} default.`,
+          expectedEffort: configuredEffort ?? SCRIPTED_MODEL_DEFAULTS[model],
         });
       }
 
@@ -72,7 +81,47 @@ describe('Codex scripted default effort model switching', () => {
       serverEnvironment: testEnvironment.serverEnvironment,
       prepareWorkspace: async (directories) => {
         await testEnvironment.prepareWorkspace(directories);
-        await overlayOfficialModelDefaults(directories);
+        await overlayScriptedModelDefaults(directories);
+        if (configuredEffort) {
+          await configureReasoningEffort(directories, configuredEffort);
+        }
+      },
+    });
+  }, 120_000);
+
+  test('restores configured Default after an explicit turn', async () => {
+    if (!environment) throw new Error('Scripted Codex environment was not initialized.');
+    const testEnvironment = environment;
+
+    await withIntegrationFixture('codex-scripted-explicit-default-switch', async (fixture) => {
+      const chatId = fixture.newChatId();
+      await runScriptedTurn({
+        fixture,
+        testEnvironment,
+        chatId,
+        model: 'gpt-6-astra',
+        command: 'Use an explicit effort.',
+        start: true,
+        thinkingMode: 'high',
+        expectedEffort: 'high',
+      });
+      await runScriptedTurn({
+        fixture,
+        testEnvironment,
+        chatId,
+        model: 'gpt-6-astra',
+        command: 'Return to the configured default.',
+        thinkingMode: 'none',
+        expectedEffort: 'low',
+      });
+
+      testEnvironment.model.assertSettled();
+    }, {
+      serverEnvironment: testEnvironment.serverEnvironment,
+      prepareWorkspace: async (directories) => {
+        await testEnvironment.prepareWorkspace(directories);
+        await overlayScriptedModelDefaults(directories);
+        await configureReasoningEffort(directories, 'low');
       },
     });
   }, 120_000);
@@ -82,11 +131,21 @@ async function runScriptedTurn(options: {
   fixture: Parameters<Parameters<typeof withIntegrationFixture>[1]>[0];
   testEnvironment: ScriptedCodexTestEnvironment;
   chatId: string;
-  model: keyof typeof MODEL_DEFAULTS;
+  model: keyof typeof SCRIPTED_MODEL_DEFAULTS;
   command: string;
   start?: boolean;
+  thinkingMode?: 'none' | 'high';
+  expectedEffort: string;
 }): Promise<void> {
-  const { fixture, testEnvironment, chatId, model, command, start = false } = options;
+  const {
+    fixture,
+    testEnvironment,
+    chatId,
+    model,
+    command,
+    start = false,
+    thinkingMode = 'none',
+  } = options;
   const reply = `SCRIPTED_${model}_${crypto.randomUUID()}`;
   const requestIndex = testEnvironment.model.requests().length;
   testEnvironment.model.scriptTurn([codexAssistantMessage(reply)]);
@@ -99,12 +158,12 @@ async function runScriptedTurn(options: {
         command,
       }),
       model,
-      thinkingMode: 'none',
+      thinkingMode,
     })
     : await fixture.client.runChat({
       ...liveCodexRunRequest({ chatId, command }),
       model,
-      thinkingMode: 'none',
+      thinkingMode,
     });
   await waitForVisibleResponse({
     fixture,
@@ -116,18 +175,18 @@ async function runScriptedTurn(options: {
 
   expect(testEnvironment.model.requests()[requestIndex]?.body).toMatchObject({
     model,
-    reasoning: { effort: MODEL_DEFAULTS[model] },
+    reasoning: { effort: options.expectedEffort },
   });
 }
 
-async function overlayOfficialModelDefaults(directories: IntegrationDirectories): Promise<void> {
+async function overlayScriptedModelDefaults(directories: IntegrationDirectories): Promise<void> {
   const catalogPath = join(directories.home, '.codex', 'live-models.json');
   const catalog = JSON.parse(await readFile(catalogPath, 'utf8')) as {
     models: Array<Record<string, unknown>>;
   };
   const template = catalog.models[0];
   if (!template) throw new Error('Scripted Codex model catalog is empty.');
-  catalog.models = Object.entries(MODEL_DEFAULTS).map(([slug, effort], priority) => ({
+  catalog.models = Object.entries(SCRIPTED_MODEL_DEFAULTS).map(([slug, effort], priority) => ({
     ...template,
     slug,
     display_name: slug,
@@ -140,4 +199,13 @@ async function overlayOfficialModelDefaults(directories: IntegrationDirectories)
     priority,
   }));
   await writeFile(catalogPath, JSON.stringify(catalog), { mode: 0o600 });
+}
+
+async function configureReasoningEffort(
+  directories: IntegrationDirectories,
+  effort: string,
+): Promise<void> {
+  const configPath = join(directories.home, '.codex', 'config.toml');
+  const config = await readFile(configPath, 'utf8');
+  await writeFile(configPath, `model_reasoning_effort = "${effort}"\n${config}`);
 }

--- a/server-agents/codex/package.json
+++ b/server-agents/codex/package.json
@@ -9,7 +9,7 @@
     "@garcon/common": "workspace:*",
     "@garcon/server-agent-common": "workspace:*",
     "@garcon/server-agent-interface": "workspace:*",
-    "@openai/codex": "0.153.1",
+    "@openai/codex": "0.153.4",
     "acorn": "^8.18.0",
     "bun-pty": "^0.4.10",
     "shell-quote": "^1.10.0"

--- a/server-agents/codex/src/agents/codex/__tests__/execution.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/execution.test.js
@@ -519,9 +519,10 @@ describe('CodexExecution', () => {
 
   it.each([
     'gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
-  ])('allows %s to restore its concrete provider-default effort', async (model) => {
+  ])('rejects clearing an explicit effort during an active %s turn', async (model) => {
     const runtime = createRuntime();
     runtime.hasSource.mockReturnValue(true);
+    runtime.isRunning.mockReturnValue(true);
     const execution = new CodexExecution(
       createHost(),
       runtime,
@@ -536,16 +537,60 @@ describe('CodexExecution', () => {
       endpoint: null,
     };
 
+    await expect(execution.applySessionConfiguration('thread-1', {
+      ...previous,
+      thinkingMode: 'none',
+    }, previous)).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
+    expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
+  });
+
+  it('defers returning to provider-default effort until the retained source is replaced', async () => {
+    const runtime = createRuntime();
+    runtime.hasSource.mockReturnValue(true);
+    const execution = new CodexExecution(
+      createHost(),
+      runtime,
+      createPathNativeSessionCodec('codex'),
+      createConfig(),
+    );
+    const previous = {
+      model: 'gpt-6-astra',
+      permissionMode: 'default',
+      thinkingMode: 'high',
+      settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      endpoint: null,
+    };
+
     await execution.applySessionConfiguration('thread-1', {
       ...previous,
       thinkingMode: 'none',
     }, previous);
 
-    expect(runtime.updateSessionSettings).toHaveBeenCalledWith('thread-1', {
-      model,
+    expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
+  });
+
+  it('allows returning to provider-default effort after the source is gone', async () => {
+    const runtime = createRuntime();
+    const execution = new CodexExecution(
+      createHost(),
+      runtime,
+      createPathNativeSessionCodec('codex'),
+      createConfig(),
+    );
+    const previous = {
+      model: 'gpt-6-astra',
       permissionMode: 'default',
+      thinkingMode: 'high',
+      settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
+      endpoint: null,
+    };
+
+    await execution.applySessionConfiguration('thread-1', {
+      ...previous,
       thinkingMode: 'none',
-    });
+    }, previous);
+
+    expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
   });
 
   it('switches an established GPT-6 Astra Default session to GPT-5.6 Sol Default', async () => {
@@ -578,8 +623,8 @@ describe('CodexExecution', () => {
   });
 
   it.each([
-    'gpt-5.4', 'gpt-5.6', 'gpt-5.6-sol-custom', 'gpt-5.60-sol',
-  ])('rejects carrying Astra low effort into an unknown %s default', async (model) => {
+    'gpt-5.5', 'gpt-5.4', 'gpt-5.6', 'gpt-5.6-sol-custom', 'gpt-5.60-sol',
+  ])('allows switching from Astra Default to %s Default', async (model) => {
     const runtime = createRuntime();
     runtime.hasSource.mockReturnValue(true);
     const execution = new CodexExecution(
@@ -596,11 +641,15 @@ describe('CodexExecution', () => {
       endpoint: null,
     };
 
-    await expect(execution.applySessionConfiguration('thread-1', {
+    await execution.applySessionConfiguration('thread-1', {
       ...previous,
       model,
-    }, previous)).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
-    expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
+    }, previous);
+    expect(runtime.updateSessionSettings).toHaveBeenCalledWith('thread-1', {
+      model,
+      permissionMode: 'default',
+      thinkingMode: 'none',
+    });
   });
 
   it('rejects live endpoint replacement and concrete reasoning-effort clearing', async () => {

--- a/server-agents/codex/src/agents/codex/__tests__/execution.test.js
+++ b/server-agents/codex/src/agents/codex/__tests__/execution.test.js
@@ -517,9 +517,7 @@ describe('CodexExecution', () => {
     });
   });
 
-  it.each([
-    'gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
-  ])('rejects clearing an explicit effort during an active %s turn', async (model) => {
+  it('rejects clearing an explicit effort during an active turn', async () => {
     const runtime = createRuntime();
     runtime.hasSource.mockReturnValue(true);
     runtime.isRunning.mockReturnValue(true);
@@ -530,7 +528,7 @@ describe('CodexExecution', () => {
       createConfig(),
     );
     const previous = {
-      model,
+      model: 'gpt-6-astra',
       permissionMode: 'default',
       thinkingMode: 'high',
       settings: { ownerId: 'codex', schemaVersion: 1, values: {} },
@@ -566,6 +564,7 @@ describe('CodexExecution', () => {
       thinkingMode: 'none',
     }, previous);
 
+    expect(runtime.isRunning).toHaveBeenCalledWith('thread-1');
     expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
   });
 
@@ -587,9 +586,13 @@ describe('CodexExecution', () => {
 
     await execution.applySessionConfiguration('thread-1', {
       ...previous,
+      model: 'gpt-5.5',
+      permissionMode: 'manualBypass',
       thinkingMode: 'none',
     }, previous);
 
+    expect(runtime.hasSource).toHaveBeenCalledWith('thread-1');
+    expect(runtime.isRunning).not.toHaveBeenCalled();
     expect(runtime.updateSessionSettings).not.toHaveBeenCalled();
   });
 

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -984,11 +984,9 @@ describe('Codex app-server request builders', () => {
   });
 
   it.each([
-    ['gpt-6-astra', 'low'],
-    ['gpt-5.6-sol', 'low'],
-    ['gpt-5.6-terra', 'medium'],
-    ['gpt-5.6-luna', 'medium'],
-  ])('maps provider-default thinking to %s %s effort', (model, effort) => {
+    'gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
+    'gpt-5.5', 'gpt-5.4', 'custom-model',
+  ])('leaves provider-default effort unset for %s', (model) => {
     const params = buildTurnStartParams({
       threadId: 'thread-1',
       command: 'hello',
@@ -998,16 +996,16 @@ describe('Codex app-server request builders', () => {
       thinkingMode: 'none',
     });
 
-    expect(params.effort).toBe(effort);
+    expect(params).not.toHaveProperty('effort');
     const target = codexThreadSettingsTarget({
       model,
       permissionMode: 'default',
       thinkingMode: 'none',
     });
-    expect(target.effort).toBe(effort);
-    expect(buildThreadSettingsUpdateParams('thread-1', target)).toMatchObject({ model, effort });
+    expect(target.effort).toBeNull();
+    expect(buildThreadSettingsUpdateParams('thread-1', target)).not.toHaveProperty('effort');
+    expect(mapThinkingModeToCodexEffort('none', model)).toBeUndefined();
     expect(mapThinkingModeToCodexEffort(undefined, model)).toBeUndefined();
-    expect(mapThinkingModeToCodexEffort('max', model)).toBe('max');
     expect(mapThinkingModeToCodexEffort('ultra', model)).toBe('ultra');
   });
 
@@ -2093,7 +2091,7 @@ describe('CodexAppServerRuntime', () => {
     };
   }
 
-  async function startSettingsSession(runtimeOptions = {}) {
+  async function startSettingsSession(runtimeOptions = {}, requestOverrides = {}) {
     const nativePath = path.join(tmpDir, 'settings-thread.jsonl');
     const fake = new FakeClient({
       startThread: async () => ({
@@ -2123,7 +2121,10 @@ describe('CodexAppServerRuntime', () => {
       ...runtimeOptions,
     });
     const published = collectOperation();
-    const started = await provider.startSession(makeRequest({ operation: published.operation }));
+    const started = await provider.startSession(makeRequest({
+      ...requestOverrides,
+      operation: published.operation,
+    }));
     return { fake, provider, published, started };
   }
 
@@ -7732,6 +7733,141 @@ describe('CodexAppServerRuntime', () => {
     expect(permissionEvents(second.events)).toEqual([]);
   });
 
+  it.each([
+    'turn', 'settings update', 'goal',
+  ])('replaces a retained source after explicit %s effort before Default', async (explicitSource) => {
+    const nativePath = path.join(tmpDir, `default-after-explicit-${explicitSource}.jsonl`);
+    let turnNumber = 0;
+    let firstClient;
+    firstClient = new FakeClient({
+      startThread: async () => ({
+        thread: makeThread({
+          id: 'thread-1',
+          path: nativePath,
+          model: 'gpt-5.4-codex',
+          reasoningEffort: 'medium',
+        }),
+        model: 'gpt-5.4-codex',
+        modelProvider: 'openai',
+        serviceTier: null,
+        cwd: '/repo',
+        reasoningEffort: 'medium',
+      }),
+      startTurn: async () => {
+        turnNumber += 1;
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ id: `turn-${turnNumber}`, status: 'inProgress' }) };
+      },
+      updateThreadSettings: async (params) => {
+        queueMicrotask(() => emitThreadSettings(firstClient, {
+          model: params.model,
+          effort: params.effort,
+          approvalPolicy: params.approvalPolicy,
+          approvalsReviewer: params.approvalsReviewer,
+          sandboxPolicy: params.sandboxPolicy,
+        }));
+        return {};
+      },
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => firstClient.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective, 'active') };
+      },
+    });
+    const replacementClient = new FakeClient({
+      resumeThread: async () => {
+        expect(firstClient.shutdown).toHaveBeenCalledTimes(1);
+        return {
+          thread: makeThread({
+            id: 'thread-1',
+            path: nativePath,
+            model: 'gpt-5.4-codex',
+            reasoningEffort: 'medium',
+          }),
+          model: 'gpt-5.4-codex',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/repo',
+          reasoningEffort: 'medium',
+        };
+      },
+      startTurn: async () => ({
+        turn: makeTurn({ id: 'turn-3', status: 'inProgress' }),
+      }),
+    });
+    const clients = [firstClient, replacementClient];
+    const createClient = mock(() => clients.shift());
+    const provider = createRuntime({ createClient });
+    const started = await provider.startSession(makeRequest({ thinkingMode: 'none' }));
+    firstClient.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-1' }) },
+    });
+
+    if (explicitSource === 'turn') {
+      await provider.runTurn(makeRequest({
+        agentSessionId: started.agentSessionId,
+        nativePath,
+        thinkingMode: 'high',
+      }));
+      firstClient.emit('notification', {
+        method: 'turn/completed',
+        params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-2' }) },
+      });
+    } else if (explicitSource === 'settings update') {
+      await provider.updateSessionSettings(started.agentSessionId, {
+        model: 'gpt-5.4-codex',
+        permissionMode: 'default',
+        thinkingMode: 'high',
+      });
+    } else {
+      await provider.runTurn(makeRequest({
+        agentSessionId: started.agentSessionId,
+        nativePath,
+        thinkingMode: 'high',
+        codexGoalCommand: { kind: 'set', objective: 'Use explicit effort' },
+      }));
+      await expect(provider.submitGoalControl(makeRequest({
+        agentSessionId: started.agentSessionId,
+        nativePath,
+        thinkingMode: 'none',
+        codexGoalCommand: { kind: 'status' },
+      }))).resolves.toBe(true);
+      firstClient.emit('notification', {
+        method: 'thread/goal/updated',
+        params: {
+          threadId: 'thread-1',
+          turnId: 'goal-turn',
+          goal: makeGoal('thread-1', 'Use explicit effort', 'complete'),
+        },
+      });
+      firstClient.emit('notification', {
+        method: 'turn/completed',
+        params: { threadId: 'thread-1', turn: makeTurn({ id: 'goal-turn' }) },
+      });
+    }
+    await provider.runTurn(makeRequest({
+      agentSessionId: started.agentSessionId,
+      nativePath,
+      thinkingMode: 'none',
+    }));
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    if (explicitSource === 'turn') {
+      expect(firstClient.startTurn).toHaveBeenCalledTimes(2);
+      expect(firstClient.startTurn.mock.calls[1][0]).toMatchObject({ effort: 'high' });
+    } else {
+      expect(firstClient.updateThreadSettings).toHaveBeenCalledTimes(1);
+      expect(firstClient.updateThreadSettings.mock.calls[0][0]).toMatchObject({ effort: 'high' });
+    }
+    if (explicitSource === 'goal') expect(firstClient.setThreadGoal).toHaveBeenCalledTimes(1);
+    expect(replacementClient.resumeThread).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn.mock.calls[0][0]).not.toHaveProperty('effort');
+  });
+
   it('waits for interrupt acknowledgement before reusing the writer without awaiting its terminal event', async () => {
     const nativePath = path.join(tmpDir, 'interrupted-writer.jsonl');
     let turnNumber = 0;
@@ -7802,6 +7938,94 @@ describe('CodexAppServerRuntime', () => {
       },
     });
     expect(provider.isRunning('thread-1')).toBe(true);
+  });
+
+  it('rechecks Default reuse after an explicit settings update during interruption', async () => {
+    const nativePath = path.join(tmpDir, 'interrupted-writer-settings-race.jsonl');
+    const interruptAcknowledgement = createDeferred();
+    const settingsResponse = createDeferred();
+    let firstClient;
+    firstClient = new FakeClient({
+      startThread: async () => ({
+        thread: makeThread({ id: 'thread-1', path: nativePath }),
+        model: 'gpt-5.4-codex',
+        modelProvider: 'openai',
+        serviceTier: null,
+        cwd: '/repo',
+      }),
+      startTurn: async () => {
+        await fs.writeFile(nativePath, '{}\n');
+        return { turn: makeTurn({ id: 'turn-1', status: 'inProgress' }) };
+      },
+      interruptTurn: async () => {
+        await interruptAcknowledgement.promise;
+        return {};
+      },
+      updateThreadSettings: async (params) => {
+        queueMicrotask(() => emitThreadSettings(firstClient, { effort: params.effort }));
+        await settingsResponse.promise;
+        return {};
+      },
+    });
+    const replacementClient = new FakeClient({
+      resumeThread: async () => {
+        expect(firstClient.shutdown).toHaveBeenCalledTimes(1);
+        return {
+          thread: makeThread({ id: 'thread-1', path: nativePath }),
+          model: 'gpt-5.4-codex',
+          modelProvider: 'openai',
+          serviceTier: null,
+          cwd: '/repo',
+        };
+      },
+      startTurn: async () => ({
+        turn: makeTurn({ id: 'turn-2', status: 'inProgress' }),
+      }),
+    });
+    const clients = [firstClient, replacementClient];
+    const createClient = mock(() => clients.shift());
+    const provider = createRuntime({ createClient });
+    const started = await provider.startSession(makeRequest({ thinkingMode: 'none' }));
+
+    const aborting = provider.abort(started.agentSessionId);
+    const resumed = provider.runTurn(makeRequest({
+      agentSessionId: started.agentSessionId,
+      nativePath,
+      thinkingMode: 'none',
+    }));
+    await waitForCondition(() => firstClient.interruptTurn.mock.calls.length === 1);
+    const settingsUpdate = provider.updateSessionSettings(started.agentSessionId, {
+      model: 'gpt-5.4-codex',
+      permissionMode: 'default',
+      thinkingMode: 'high',
+    });
+    await waitForCondition(() => firstClient.updateThreadSettings.mock.calls.length === 1);
+    await Bun.sleep(0);
+
+    interruptAcknowledgement.resolve();
+    await expect(aborting).resolves.toBe(true);
+    await Bun.sleep(0);
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(firstClient.shutdown).not.toHaveBeenCalled();
+    expect(firstClient.startTurn).toHaveBeenCalledTimes(1);
+
+    settingsResponse.resolve();
+    await settingsUpdate;
+
+    firstClient.emit('notification', {
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: makeTurn({ id: 'turn-1', status: 'interrupted' }),
+      },
+    });
+    await resumed;
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(firstClient.shutdown).toHaveBeenCalledTimes(1);
+    expect(replacementClient.resumeThread).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn.mock.calls[0][0]).not.toHaveProperty('effort');
   });
 
   it('rejects genuinely concurrent same-thread use without opening a second writer', async () => {
@@ -8395,7 +8619,7 @@ describe('CodexAppServerRuntime', () => {
   });
 
   it('updates a retained idle source while preserving provider-default effort', async () => {
-    const { fake, provider, started } = await startSettingsSession();
+    const { fake, provider, started } = await startSettingsSession({}, { thinkingMode: 'none' });
     fake.emit('notification', {
       method: 'turn/completed',
       params: { threadId: 'thread-1', turn: makeTurn({ id: 'turn-1' }) },

--- a/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
+++ b/server-agents/codex/src/agents/codex/app-server/__tests__/app-server.test.js
@@ -7868,6 +7868,69 @@ describe('CodexAppServerRuntime', () => {
     expect(replacementClient.startTurn.mock.calls[0][0]).not.toHaveProperty('effort');
   });
 
+  it('replaces a retained source after explicit goal-control effort before Default', async () => {
+    let firstClient;
+    firstClient = new FakeClient({
+      setThreadGoal: async (threadId, params) => {
+        queueMicrotask(() => firstClient.emit('notification', {
+          method: 'turn/started',
+          params: { threadId, turn: makeTurn({ id: 'goal-turn', status: 'inProgress' }) },
+        }));
+        return { goal: makeGoal(threadId, params.objective) };
+      },
+      steerTurn: async () => { throw new Error('no active turn to steer'); },
+      startTurn: async () => ({
+        turn: makeTurn({ id: 'priority-turn', status: 'inProgress' }),
+      }),
+    });
+    const replacementClient = new FakeClient({
+      startTurn: async () => ({
+        turn: makeTurn({ id: 'default-turn', status: 'inProgress' }),
+      }),
+    });
+    const clients = [firstClient, replacementClient];
+    const createClient = mock(() => clients.shift());
+    const provider = createRuntime({ createClient });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      nativePath: null,
+      thinkingMode: 'none',
+      codexGoalCommand: { kind: 'set', objective: 'Continue automatically' },
+    }));
+
+    await expect(provider.submitGoalControl(makeRequest({
+      agentSessionId: 'thread-1',
+      nativePath: null,
+      command: 'Prioritize this input',
+      thinkingMode: 'high',
+    }))).resolves.toBe(true);
+    expect(firstClient.startTurn).toHaveBeenCalledWith(expect.objectContaining({ effort: 'high' }));
+
+    firstClient.emit('notification', {
+      method: 'thread/goal/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'priority-turn',
+        goal: makeGoal('thread-1', 'Continue automatically', 'complete'),
+      },
+    });
+    firstClient.emit('notification', {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: makeTurn({ id: 'priority-turn' }) },
+    });
+    await provider.runTurn(makeRequest({
+      agentSessionId: 'thread-1',
+      nativePath: null,
+      thinkingMode: 'none',
+    }));
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(firstClient.shutdown).toHaveBeenCalledTimes(1);
+    expect(replacementClient.resumeThread).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn.mock.calls[0][0]).not.toHaveProperty('effort');
+  });
+
   it('waits for interrupt acknowledgement before reusing the writer without awaiting its terminal event', async () => {
     const nativePath = path.join(tmpDir, 'interrupted-writer.jsonl');
     let turnNumber = 0;
@@ -8023,6 +8086,92 @@ describe('CodexAppServerRuntime', () => {
 
     expect(createClient).toHaveBeenCalledTimes(2);
     expect(firstClient.shutdown).toHaveBeenCalledTimes(1);
+    expect(replacementClient.resumeThread).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn).toHaveBeenCalledTimes(1);
+    expect(replacementClient.startTurn.mock.calls[0][0]).not.toHaveProperty('effort');
+  });
+
+  it('does not wait on a source superseded during interrupt acknowledgement', async () => {
+    const firstPath = path.join(tmpDir, 'superseded-during-interrupt-first.jsonl');
+    const supersedingPath = path.join(tmpDir, 'superseded-during-interrupt-second.jsonl');
+    const interruptAcknowledgement = createDeferred();
+    let firstClient;
+    firstClient = new FakeClient({
+      startThread: async () => ({
+        thread: makeThread({ id: 'thread-1', path: firstPath }),
+        model: 'gpt-5.4-codex',
+        modelProvider: 'openai',
+        serviceTier: null,
+        cwd: '/repo',
+      }),
+      startTurn: async () => {
+        await fs.writeFile(firstPath, '{}\n');
+        return { turn: makeTurn({ id: 'turn-1', status: 'inProgress' }) };
+      },
+      interruptTurn: async () => {
+        await interruptAcknowledgement.promise;
+        return {};
+      },
+      updateThreadSettings: async (params) => {
+        queueMicrotask(() => emitThreadSettings(firstClient, { effort: params.effort }));
+        return {};
+      },
+    });
+    const supersedingClient = new FakeClient({
+      startThread: async () => ({
+        thread: makeThread({ id: 'thread-2', path: supersedingPath }),
+        model: 'gpt-5.4-codex',
+        modelProvider: 'openai',
+        serviceTier: null,
+        cwd: '/repo',
+      }),
+      startTurn: async () => {
+        await fs.writeFile(supersedingPath, '{}\n');
+        return { turn: makeTurn({ id: 'turn-2', status: 'inProgress' }) };
+      },
+    });
+    const replacementClient = new FakeClient({
+      resumeThread: async () => ({
+        thread: makeThread({ id: 'thread-1', path: firstPath }),
+        model: 'gpt-5.4-codex',
+        modelProvider: 'openai',
+        serviceTier: null,
+        cwd: '/repo',
+      }),
+      startTurn: async () => ({
+        turn: makeTurn({ id: 'turn-3', status: 'inProgress' }),
+      }),
+    });
+    const clients = [firstClient, supersedingClient, replacementClient];
+    const createClient = mock(() => clients.shift());
+    const provider = createRuntime({ createClient });
+    const started = await provider.startSession(makeRequest({ thinkingMode: 'none' }));
+
+    const aborting = provider.abort(started.agentSessionId);
+    const resumed = provider.runTurn(makeRequest({
+      agentSessionId: started.agentSessionId,
+      nativePath: firstPath,
+      thinkingMode: 'none',
+    }));
+    await waitForCondition(() => firstClient.interruptTurn.mock.calls.length === 1);
+    await provider.updateSessionSettings(started.agentSessionId, {
+      model: 'gpt-5.4-codex',
+      permissionMode: 'default',
+      thinkingMode: 'high',
+    });
+    await provider.startSession(makeRequest({
+      chatId: 'chat-1',
+      command: 'Supersede the interrupted source',
+      thinkingMode: 'none',
+    }));
+
+    interruptAcknowledgement.resolve();
+    await expect(aborting).resolves.toBe(true);
+    await resumed;
+
+    expect(createClient).toHaveBeenCalledTimes(3);
+    expect(firstClient.shutdown).toHaveBeenCalledTimes(1);
+    expect(supersedingClient.shutdown).toHaveBeenCalledTimes(1);
     expect(replacementClient.resumeThread).toHaveBeenCalledTimes(1);
     expect(replacementClient.startTurn).toHaveBeenCalledTimes(1);
     expect(replacementClient.startTurn.mock.calls[0][0]).not.toHaveProperty('effort');

--- a/server-agents/codex/src/agents/codex/app-server/request-builders.ts
+++ b/server-agents/codex/src/agents/codex/app-server/request-builders.ts
@@ -35,6 +35,7 @@ interface CodexSandboxSettings {
 
 export interface CodexThreadSettingsTarget {
   readonly model: string;
+  // Represents provider-owned Default as null because Codex reports the effective concrete effort.
   readonly effort: string | null;
   readonly approvalPolicy: CodexApprovalPolicy;
   readonly approvalsReviewer: 'user';
@@ -112,7 +113,7 @@ export function buildThreadSettingsUpdateParams(
     approvalPolicy: target.approvalPolicy,
     approvalsReviewer: target.approvalsReviewer,
     sandboxPolicy: target.sandboxPolicy,
-    ...(target.effort ? { effort: target.effort } : {}),
+    ...(target.effort !== null ? { effort: target.effort } : {}),
   };
 }
 
@@ -120,6 +121,7 @@ export function threadSettingsMatch(
   settings: CodexConfirmedThreadSettings,
   target: CodexThreadSettingsTarget,
 ): boolean {
+  // Accepts any confirmed effort when Codex owns the Default omitted from the update.
   return settings.model === target.model
     && (target.effort === null || settings.effort === target.effort)
     && settings.approvalPolicy === target.approvalPolicy
@@ -176,14 +178,6 @@ function sandboxPolicyMatches(
     && (left.excludeSlashTmp ?? false) === (right.excludeSlashTmp ?? false);
 }
 
-// Resolves known defaults explicitly because thread/settings/update cannot clear an effort override.
-// https://github.com/openai/codex/blob/985641272869835d01d025ed2a218fbbce35fa9f/codex-rs/models-manager/models.json#L173-L463
-function codexModelDefaultEffort(model: string | undefined): string | undefined {
-  if (model === GPT_6_ASTRA_MODEL || model === 'gpt-5.6-sol') return 'low';
-  if (model === 'gpt-5.6-terra' || model === 'gpt-5.6-luna') return 'medium';
-  return undefined;
-}
-
 // Preserves xhigh compatibility for older models while allowing models that
 // advertise max reasoning to receive that effort explicitly.
 export function mapThinkingModeToCodexEffort(
@@ -191,7 +185,8 @@ export function mapThinkingModeToCodexEffort(
   model?: string,
 ): string | undefined {
   switch (thinkingMode) {
-    case 'none': return codexModelDefaultEffort(model);
+    // Leaves provider defaults unset so Codex can honor config and model catalog defaults.
+    case 'none': return undefined;
     case 'low': return 'low';
     case 'medium': return 'medium';
     case 'high': return 'high';

--- a/server-agents/codex/src/agents/codex/app-server/runtime-goal.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime-goal.ts
@@ -63,6 +63,7 @@ export interface RuntimeGoalPort {
   flushPendingFinish(session: RunningCodexSession): void;
   canApplyTurnAttempt(session: RunningCodexSession, generation: number): boolean;
   generationAcrossTurnBoundary(session: RunningCodexSession, generation: number): number | null;
+  recordExplicitReasoningEffort(session: RunningCodexSession, request: CodexResumeRequest): void;
 }
 
 // Owns Codex goal lifecycle orchestration: /goal command handling, queued
@@ -305,6 +306,7 @@ export class RuntimeGoalCoordinator {
     request: CodexResumeRequest,
     operation: CodexOperation,
   ): Promise<void> {
+    this.#port.recordExplicitReasoningEffort(session, request);
     if (request.codexGoalCommand) {
       await this.handleCommand(
         session.client,

--- a/server-agents/codex/src/agents/codex/app-server/runtime-session-state.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime-session-state.ts
@@ -1,5 +1,6 @@
 import type { PermissionMode } from '@garcon/common/chat-modes';
 import type { AgentLogger } from '@garcon/server-agent-interface';
+import type { CodexStartRequest } from '../runtime-types.js';
 import type { CodexSkillDiscovery } from '../slash-command-discovery.js';
 import type { cleanupOwnedGoalAttachments } from './goal-files.js';
 import type { GoalAttachmentOperations } from './goal-attachment-operations.js';
@@ -12,9 +13,10 @@ import type {
   JsonRpcServerRequest,
 } from './protocol.js';
 import type { CodexTurnItemLedger } from './turn-item-ledger.js';
-import type {
-  CodexConfirmedThreadSettings,
-  CodexThreadSettingsTarget,
+import {
+  codexThreadSettingsTarget,
+  type CodexConfirmedThreadSettings,
+  type CodexThreadSettingsTarget,
 } from './request-builders.js';
 
 export type RunningStatus = (
@@ -85,6 +87,8 @@ export interface RunningCodexSession {
   turnRoutes: Map<string, CodexOperation>;
   terminalTurnIds: Set<string>;
   superseded: boolean;
+  // Tracks omitted Default intent because Codex snapshots only the effective concrete effort.
+  providerOwnsReasoningEffort: boolean;
   confirmedThreadSettings: CodexConfirmedThreadSettings;
   pendingThreadSettings: ThreadSettingsWaiter | null;
   threadSettingsUpdateChain: Promise<void>;
@@ -92,6 +96,19 @@ export interface RunningCodexSession {
   // Wall-clock stamp taken when the session finishes while its source stays
   // retained; drives the idle reclamation sweep for retained writers.
   idleSince: number | null;
+}
+
+export function providerOwnsReasoningEffort(
+  request: Pick<CodexStartRequest, 'model' | 'permissionMode' | 'thinkingMode'>,
+): boolean {
+  return codexThreadSettingsTarget(request).effort === null;
+}
+
+export function recordExplicitReasoningEffort(
+  session: RunningCodexSession,
+  request: Pick<CodexStartRequest, 'model' | 'permissionMode' | 'thinkingMode'>,
+): void {
+  if (!providerOwnsReasoningEffort(request)) session.providerOwnsReasoningEffort = false;
 }
 
 export interface CodexAppServerRuntimeOptions {

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -903,7 +903,7 @@ export class CodexAppServerRuntime {
   ): Promise<{ session: RunningCodexSession; buffered: boolean }> {
     const runtimeIdentity = codexSourceRuntimeIdentity(request);
     const retained = this.#latestSourceByChat.get(request.chatId);
-    // Omitted effort is reusable only when every prior turn also left the effort provider-owned.
+    // Omitted effort is reusable only when no prior turn, settings update, or goal delivery took ownership.
     const reasoningEffortIsReusable = () => !providerOwnsReasoningEffort(request)
       || retained?.providerOwnsReasoningEffort === true;
     const matchingPath = !retained?.nativePath

--- a/server-agents/codex/src/agents/codex/app-server/runtime.ts
+++ b/server-agents/codex/src/agents/codex/app-server/runtime.ts
@@ -92,6 +92,8 @@ import {
 import {
   adoptTurn,
   cancelTurnStartWaiters,
+  providerOwnsReasoningEffort,
+  recordExplicitReasoningEffort,
   sessionForClientThread,
   sourceForClientThread,
   sourceForClientTurn,
@@ -199,6 +201,7 @@ export class CodexAppServerRuntime {
       flushPendingFinish: (session) => this.#flushPendingFinish(session),
       canApplyTurnAttempt: (session, generation) => this.#canApplyTurnAttempt(session, generation),
       generationAcrossTurnBoundary: (session, generation) => this.#generationAcrossTurnBoundary(session, generation),
+      recordExplicitReasoningEffort,
     });
   }
 
@@ -319,6 +322,7 @@ export class CodexAppServerRuntime {
         codexHome: initialized.codexHome || null,
         client,
         runtimeIdentity: codexSourceRuntimeIdentity(request),
+        providerOwnsReasoningEffort: providerOwnsReasoningEffort(request),
         confirmedThreadSettings: this.#initialThreadSettings(request, started),
         operation,
       });
@@ -378,6 +382,7 @@ export class CodexAppServerRuntime {
           if (this.#sessions.get(session.threadId) !== session || hasTerminalPendingFinish(session)) {
             throw new TurnStartWaitCancelledError('Codex session ended while synchronizing the restored goal');
           }
+          recordExplicitReasoningEffort(session, request);
           await this.#ensureGoalEffort(session, request);
           if (request.executionAdmission) await markCodexExecutionStarted(request);
           if (!request.codexGoalCommand) {
@@ -584,6 +589,8 @@ export class CodexAppServerRuntime {
     const session = this.#sourceForThread(agentSessionId);
     if (!session) return Promise.resolve();
     const target = codexThreadSettingsTarget(configuration);
+    // Records explicit intent before the RPC because its confirmation may precede its response.
+    if (target.effort !== null) session.providerOwnsReasoningEffort = false;
     const update = session.threadSettingsUpdateChain.then(() => (
       this.#applyThreadSettings(session, target)
     ));
@@ -819,6 +826,7 @@ export class CodexAppServerRuntime {
     codexHome: string | null;
     client: CodexAppServerClient;
     runtimeIdentity: string;
+    providerOwnsReasoningEffort: boolean;
     confirmedThreadSettings: CodexConfirmedThreadSettings;
     operation: CodexOperation;
   }): RunningCodexSession {
@@ -870,6 +878,7 @@ export class CodexAppServerRuntime {
       lastTurnOperation: null,
       terminalTurnIds: new Set(),
       superseded: false,
+      providerOwnsReasoningEffort: args.providerOwnsReasoningEffort,
       confirmedThreadSettings: args.confirmedThreadSettings,
       pendingThreadSettings: null,
       threadSettingsUpdateChain: Promise.resolve(),
@@ -894,6 +903,9 @@ export class CodexAppServerRuntime {
   ): Promise<{ session: RunningCodexSession; buffered: boolean }> {
     const runtimeIdentity = codexSourceRuntimeIdentity(request);
     const retained = this.#latestSourceByChat.get(request.chatId);
+    // Omitted effort is reusable only when every prior turn also left the effort provider-owned.
+    const reasoningEffortIsReusable = () => !providerOwnsReasoningEffort(request)
+      || retained?.providerOwnsReasoningEffort === true;
     const matchingPath = !retained?.nativePath
       || !request.nativePath
       || retained.nativePath === request.nativePath;
@@ -902,7 +914,8 @@ export class CodexAppServerRuntime {
       && !retained.configurationFenced
       && !retained.pendingThreadSettings
       && retained.runtimeIdentity === runtimeIdentity
-      && matchingPath,
+      && matchingPath
+      && reasoningEffortIsReusable(),
     );
     let interruptedWriterReady = false;
     if (
@@ -940,6 +953,19 @@ export class CodexAppServerRuntime {
       assertCodexExecutionOpen(request);
     }
     if (
+      retained?.status === 'interrupting'
+      && interruptedWriterReady
+      && !retained.superseded
+      && (
+        retained.configurationFenced
+        || retained.pendingThreadSettings
+        || !reasoningEffortIsReusable()
+      )
+    ) {
+      await this.#waitForSourceTerminal(retained, request);
+      assertCodexExecutionOpen(request);
+    }
+    if (
       retained
       && this.#latestSourceByChat.get(request.chatId) === retained
       && retained.threadId === request.agentSessionId
@@ -951,6 +977,7 @@ export class CodexAppServerRuntime {
       ))
       && retained.runtimeIdentity === runtimeIdentity
       && matchingPath
+      && reasoningEffortIsReusable()
     ) {
       return {
         session: this.#reactivateSession(retained, request, operation),
@@ -979,6 +1006,7 @@ export class CodexAppServerRuntime {
           codexHome: initialized.codexHome || null,
           client,
           runtimeIdentity,
+          providerOwnsReasoningEffort: providerOwnsReasoningEffort(request),
           confirmedThreadSettings: this.#initialThreadSettings(request, resumed),
           operation,
         }),

--- a/server-agents/codex/src/agents/codex/execution.ts
+++ b/server-agents/codex/src/agents/codex/execution.ts
@@ -136,14 +136,16 @@ export class CodexExecution implements AgentRuntimeExecution {
       configuration.thinkingMode,
       configuration.model,
     );
+    if (!this.runtime.hasSource(agentSessionId)) return;
     if (previousEffort !== undefined && nextEffort === undefined) {
+      // Defers the whole update because the runtime replaces explicit-effort sources before Default turns.
+      if (!this.runtime.isRunning(agentSessionId)) return;
       throw new AgentIntegrationError(
         'INVALID_SETTINGS',
-        'Codex cannot clear a concrete reasoning effort on an established session',
+        'Codex cannot clear a concrete reasoning effort during an active turn',
         false,
       );
     }
-    if (!this.runtime.hasSource(agentSessionId)) return;
     if (!sameEndpoint(configuration.endpoint, previousConfiguration.endpoint)) {
       if (!this.runtime.isRunning(agentSessionId)) return;
       throw new AgentIntegrationError(


### PR DESCRIPTION
Codex Default reasoning should honor native configuration and each model's catalog default instead of a partial hard-coded mapping. This change omits provider-owned effort overrides, replaces retained Codex writers after explicit-effort use so defaults can be resolved again, expands regression coverage across model and configuration transitions, and upgrades the pinned Codex CLI to 0.153.4.