### PR TITLE
Harden preamble browser workflows

### DIFF
--- a/integration-tests/tests/chromium/preambles.test.ts
+++ b/integration-tests/tests/chromium/preambles.test.ts
@@ -1,0 +1,556 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { CDPSession, Locator, Page } from 'playwright';
+import type { CompleteChatHistoryResponse } from '../../../common/chat-view.js';
+import type {
+  PreambleDefinitionInput,
+  PreamblesMutationResponse,
+  PreamblesSnapshot,
+} from '../../../common/preambles.js';
+import { type ChromiumFixture, withChromiumFixture } from '../../support/chromium-fixture.js';
+import { Deferred, withTimeout } from '../../support/deferred.js';
+
+interface ViewportScenario {
+  name: string;
+  width: number;
+  height: number;
+  touch: boolean;
+}
+
+type PreambleBrowserScope = typeof globalThis & {
+  __preambleComposer?: HTMLTextAreaElement;
+};
+
+const viewportScenarios: readonly ViewportScenario[] = [
+  { name: 'desktop', width: 1_440, height: 900, touch: false },
+  { name: 'wide mobile', width: 700, height: 800, touch: true },
+  { name: 'mobile portrait', width: 390, height: 844, touch: true },
+  { name: 'mobile keyboard', width: 390, height: 390, touch: true },
+  { name: 'narrow mobile', width: 320, height: 568, touch: true },
+];
+
+const preambles = [
+  {
+    title: 'Repository conventions for narrow workspaces',
+    content: 'SYNTHETIC_CHROMIUM_PREAMBLE_BODY_ONE',
+  },
+  {
+    title: 'Security and privacy constraints',
+    content: 'SYNTHETIC_CHROMIUM_PREAMBLE_BODY_TWO',
+  },
+  {
+    title: 'Verification requirements',
+    content: 'SYNTHETIC_CHROMIUM_PREAMBLE_BODY_THREE',
+  },
+] as const;
+
+async function setViewport(page: Page, cdp: CDPSession, scenario: ViewportScenario): Promise<void> {
+  if (scenario.touch) {
+    await cdp.send('Emulation.setTouchEmulationEnabled', {
+      enabled: true,
+      maxTouchPoints: 1,
+    });
+  }
+  await page.setViewportSize({
+    width: scenario.width,
+    height: scenario.height,
+  });
+  expect(await page.evaluate(() => matchMedia('(pointer: fine)').matches)).toBe(!scenario.touch);
+}
+
+async function waitForDialogAnimations(dialog: Locator): Promise<void> {
+  await dialog.evaluate(async (element) => {
+    await Promise.all(
+      element
+        .getAnimations({ subtree: true })
+        .map((animation) => animation.finished.catch(() => undefined)),
+    );
+  });
+}
+
+async function openPreambles(
+  page: Page,
+  baseUrl: string,
+): Promise<{
+  trigger: Locator;
+  dialog: Locator;
+}> {
+  const response = await page.goto(baseUrl);
+  if (!response?.ok()) throw new Error(`SPA navigation failed with ${String(response?.status())}.`);
+  const trigger = page.getByRole('button', { name: 'More actions' }).first();
+  if (await page.evaluate(() => matchMedia('(max-width: 768px)').matches)) {
+    await page.getByRole('button', { name: 'Menu', exact: true }).click();
+  }
+  await trigger.click();
+  await page.getByRole('menuitem', { name: 'Preambles', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Preambles', exact: true });
+  await dialog.waitFor();
+  await waitForDialogAnimations(dialog);
+  return { trigger, dialog };
+}
+
+async function dialogLayout(dialog: Locator, fieldNames: readonly string[] = []) {
+  return dialog.evaluate((element, names) => {
+    const root = element as HTMLElement;
+    const body = root.querySelector<HTMLElement>('[data-slot="preambles-scroll-body"]');
+    if (!body) throw new Error('Missing scrollable dialog body.');
+    const rect = root.getBoundingClientRect();
+    const fieldFontSizes = Object.fromEntries(
+      names.map((name) => {
+        const field = [
+          ...root.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>('input, textarea'),
+        ].find(
+          (candidate) =>
+            candidate.getAttribute('aria-label') === name ||
+            candidate.labels?.[0]?.textContent?.trim() === name,
+        );
+        if (!field) throw new Error(`Missing dialog field: ${name}`);
+        return [name, getComputedStyle(field).fontSize];
+      }),
+    );
+    return {
+      rect: {
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      },
+      bodyClientHeight: body.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyOverflowY: getComputedStyle(body).overflowY,
+      dialogOverflow: getComputedStyle(root).overflow,
+      documentOverflow: document.documentElement.scrollWidth - innerWidth,
+      fieldFontSizes,
+    };
+  }, fieldNames);
+}
+
+function expectContainedDialog(
+  layout: Awaited<ReturnType<typeof dialogLayout>>,
+  scenario: ViewportScenario,
+): void {
+  expect(layout.rect.top).toBeGreaterThanOrEqual(-1);
+  expect(layout.rect.left).toBeGreaterThanOrEqual(-1);
+  expect(layout.rect.right).toBeLessThanOrEqual(scenario.width + 1);
+  expect(layout.rect.bottom).toBeLessThanOrEqual(scenario.height + 1);
+  expect(layout.bodyOverflowY).toBe('auto');
+  expect(layout.dialogOverflow).toBe('hidden');
+  expect(layout.documentOverflow).toBeLessThanOrEqual(1);
+}
+
+async function expectFocusWithin(page: Page, container: Locator): Promise<void> {
+  const element = await container.elementHandle();
+  if (!element) throw new Error('Missing focus container.');
+  await page.waitForFunction(
+    (target) => target instanceof HTMLElement && target.contains(document.activeElement),
+    element,
+  );
+}
+
+async function expectFocused(page: Page, target: Locator): Promise<void> {
+  const element = await target.elementHandle();
+  if (!element) throw new Error('Missing focus target.');
+  await page.waitForFunction((candidate) => document.activeElement === candidate, element);
+}
+
+async function createGlobalPreambles(fixture: ChromiumFixture): Promise<void> {
+  let snapshot = await fixture.integration.client.get<PreamblesSnapshot>('/api/v1/preambles');
+  for (const preamble of preambles) {
+    const definition: PreambleDefinitionInput = {
+      enabled: true,
+      title: preamble.title,
+      content: preamble.content,
+      scope: { type: 'global' },
+    };
+    const response = await fixture.integration.client.post<PreamblesMutationResponse>(
+      '/api/v1/preambles',
+      { expectedRevision: snapshot.revision, preamble: definition },
+    );
+    snapshot = response.snapshot;
+  }
+}
+
+async function completeChat(
+  fixture: ChromiumFixture,
+  chatId: string,
+  content: string,
+): Promise<void> {
+  const started = await fixture.integration.client.startDirectChat({
+    chatId,
+    content,
+    projectPath: fixture.integration.dirs.project,
+    agent: fixture.integration.directAgents.openAi,
+  });
+  expect((await fixture.integration.client.waitForTurnTerminal(chatId, started.turnId)).type).toBe(
+    'agent-run-finished',
+  );
+}
+
+describe('Chromium preambles', () => {
+  test('keeps nested catalog dialogs usable and restores focus across desktop and touch layouts', async () => {
+    for (const scenario of viewportScenarios) {
+      const fixtureName = `preambles-dialog-layout-focus-${scenario.name.replaceAll(' ', '-')}`;
+      await withChromiumFixture(fixtureName, async (fixture, markPhase) => {
+        await mkdir(join(fixture.integration.dirs.project, 'nested-directory'));
+        const cdp = await fixture.context.newCDPSession(fixture.page);
+        markPhase(`checking ${scenario.name} preamble dialogs`);
+        await setViewport(fixture.page, cdp, scenario);
+        const { trigger, dialog: manager } = await openPreambles(
+          fixture.page,
+          fixture.integration.garcon.baseUrl,
+        );
+        await fixture.page.waitForFunction(
+          (height) =>
+            document.documentElement.style.getPropertyValue('--app-height') ===
+            `${String(height)}px`,
+          scenario.height,
+        );
+
+        const managerLayout = await dialogLayout(manager);
+        expectContainedDialog(managerLayout, scenario);
+        await expectFocusWithin(fixture.page, manager);
+        await fixture.page.keyboard.press('Shift+Tab');
+        await expectFocusWithin(fixture.page, manager);
+        if (scenario.touch) {
+          expect(managerLayout.rect.width).toBeGreaterThanOrEqual(scenario.width - 1);
+          expect(managerLayout.rect.height).toBeGreaterThanOrEqual(scenario.height - 1);
+        } else {
+          expect(managerLayout.rect.width).toBeLessThanOrEqual(768);
+          expect(managerLayout.rect.height).toBeLessThanOrEqual(704);
+        }
+
+        const addPreamble = manager.getByRole('button', {
+          name: 'Add preamble',
+        });
+        await addPreamble.click();
+        const form = fixture.page.getByRole('dialog', {
+          name: 'Add Preamble',
+          exact: true,
+        });
+        await form.waitFor();
+        await waitForDialogAnimations(form);
+        await expectFocusWithin(fixture.page, form);
+
+        const title = form.getByRole('textbox', { name: 'Title', exact: true });
+        const content = form.getByRole('textbox', {
+          name: 'Preamble text',
+          exact: true,
+        });
+        await title.fill('Chromium layout preamble');
+        await content.fill(
+          Array.from({ length: 20 }, (_, index) => `Preamble line ${String(index + 1)}`).join('\n'),
+        );
+        const formLayout = await dialogLayout(form, ['Title', 'Preamble text']);
+        expectContainedDialog(formLayout, scenario);
+        expect(formLayout.fieldFontSizes).toEqual({
+          Title: scenario.touch ? '16px' : '14px',
+          'Preamble text': scenario.touch ? '16px' : '14px',
+        });
+        if (scenario.touch) {
+          expect(formLayout.rect.width).toBeGreaterThanOrEqual(scenario.width - 1);
+          expect(formLayout.rect.height).toBeGreaterThanOrEqual(scenario.height - 1);
+        } else {
+          expect(formLayout.rect.width).toBeLessThanOrEqual(768);
+          expect(formLayout.rect.height).toBeLessThanOrEqual(768);
+        }
+        if (scenario.name === 'mobile keyboard') {
+          expect(formLayout.bodyScrollHeight).toBeGreaterThan(formLayout.bodyClientHeight);
+        }
+
+        await content.evaluate((element) => {
+          const textarea = element as HTMLTextAreaElement;
+          textarea.focus({ preventScroll: true });
+          textarea.setSelectionRange(2, 8);
+        });
+        const formBody = form.locator('[data-slot="preambles-scroll-body"]');
+        const scrollBeforeEditor = await formBody.evaluate((element) => element.scrollTop);
+        await form
+          .getByRole('button', { name: 'Expand preamble editor' })
+          .evaluate((element) => (element as HTMLButtonElement).click());
+        const editor = fixture.page.getByRole('dialog', {
+          name: 'Edit Preamble Text',
+          exact: true,
+        });
+        await editor.waitFor();
+        const editorContent = editor.locator('.cm-content[aria-label="Preamble text"]');
+        await editorContent.waitFor();
+        await fixture.page.waitForFunction(
+          () => document.activeElement?.matches('.cm-content[aria-label="Preamble text"]') === true,
+        );
+        await editor.getByRole('button', { name: 'Close expanded editor' }).click();
+        await editor.waitFor({ state: 'detached' });
+        expect(
+          await content.evaluate((element) => {
+            const textarea = element as HTMLTextAreaElement;
+            return {
+              focused: document.activeElement === textarea,
+              selectionStart: textarea.selectionStart,
+              selectionEnd: textarea.selectionEnd,
+            };
+          }),
+        ).toEqual({ focused: true, selectionStart: 2, selectionEnd: 8 });
+        expect(
+          Math.abs((await formBody.evaluate((element) => element.scrollTop)) - scrollBeforeEditor),
+        ).toBeLessThanOrEqual(1);
+
+        await form.getByRole('radio', { name: /Project paths/ }).click();
+        const addPath = form.getByRole('button', { name: 'Add project path' });
+        await addPath.click();
+        const directoryBrowser = fixture.page.locator('[data-slot="directory-browser"]');
+        await directoryBrowser.waitFor();
+        if (scenario.touch) {
+          await expectFocusWithin(fixture.page, directoryBrowser);
+          const directoryEntry = directoryBrowser.getByRole('listbox').locator('button').first();
+          const directoryEntryElement = await directoryEntry.elementHandle();
+          if (!directoryEntryElement) throw new Error('Missing directory entry.');
+          await directoryEntry.focus();
+          await directoryEntry.click();
+          await fixture.page.waitForFunction(
+            (element) => element instanceof HTMLElement && !element.isConnected,
+            directoryEntryElement,
+          );
+          await expectFocusWithin(fixture.page, directoryBrowser);
+          await fixture.page.keyboard.press('Shift+Tab');
+          await expectFocusWithin(fixture.page, directoryBrowser);
+          await fixture.page.keyboard.press('Tab');
+          await expectFocusWithin(fixture.page, directoryBrowser);
+          const bounds = await directoryBrowser.boundingBox();
+          expect(bounds).not.toBeNull();
+          expect(bounds?.width).toBeGreaterThanOrEqual(scenario.width - 1);
+          expect(bounds?.height).toBeGreaterThanOrEqual(scenario.height - 1);
+          await directoryBrowser.getByRole('button', { name: 'Cancel' }).click();
+        } else {
+          await expectFocused(fixture.page, addPath);
+          expect(
+            await fixture.page.locator('[data-slot="directory-browser-dismiss"]').count(),
+          ).toBe(1);
+          await fixture.page
+            .locator('[data-slot="directory-browser-dismiss"]')
+            .evaluate((element) => (element as HTMLButtonElement).click());
+        }
+        await directoryBrowser.waitFor({ state: 'detached' });
+        await expectFocused(fixture.page, addPath);
+
+        const projectPathLayout = await dialogLayout(form, ['Project path']);
+        expect(projectPathLayout.fieldFontSizes['Project path']).toBe(
+          scenario.touch ? '16px' : '14px',
+        );
+        await form.getByRole('button', { name: 'Cancel', exact: true }).click();
+        await form.waitFor({ state: 'detached' });
+        await expectFocused(fixture.page, addPreamble);
+
+        await manager.getByRole('button', { name: 'Close', exact: true }).click();
+        await manager.waitFor({ state: 'detached' });
+        await expectFocused(fixture.page, trigger);
+        fixture.assertNoBrowserErrors();
+      });
+    }
+  });
+
+  test('preserves the active composer during a background application and wraps the notice narrowly', async () => {
+    await withChromiumFixture('preambles-background-application', async (fixture, markPhase) => {
+      await createGlobalPreambles(fixture);
+      const controlChatId = fixture.integration.newChatId();
+      const controlPrompt = Array.from(
+        { length: 80 },
+        (_, index) => `Chromium control transcript paragraph ${String(index + 1)}.`,
+      ).join('\n\n');
+      await completeChat(fixture, controlChatId, controlPrompt);
+
+      markPhase('opening the control chat');
+      await fixture.page.goto(
+        `${fixture.integration.garcon.baseUrl}/chat/${encodeURIComponent(controlChatId)}`,
+      );
+      const feed = fixture.page.locator('[data-chat-scroll-viewport]');
+      await feed.waitFor();
+      const composer = fixture.page.locator('textarea[placeholder="Reply..."]:visible');
+      await composer.fill('preserved draft');
+      await composer.focus();
+      await composer.evaluate((element) => {
+        (globalThis as PreambleBrowserScope).__preambleComposer = element as HTMLTextAreaElement;
+      });
+      await feed.evaluate(async (element) => {
+        const scrollViewport = element as HTMLElement;
+        const maximum = scrollViewport.scrollHeight - scrollViewport.clientHeight;
+        if (maximum < 100) throw new Error('Control transcript does not produce a scroll range.');
+        scrollViewport.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -1 }));
+        scrollViewport.scrollTop = maximum / 2;
+        scrollViewport.dispatchEvent(new Event('scroll', { bubbles: true }));
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      });
+      const activeLayout = await fixture.page.evaluate(() => {
+        const scope = globalThis as PreambleBrowserScope;
+        const composerElement = scope.__preambleComposer;
+        const activeFeed = document.querySelector<HTMLElement>('[data-chat-scroll-viewport]');
+        if (!composerElement || !activeFeed) throw new Error('Missing active chat elements.');
+        const rect = composerElement.getBoundingClientRect();
+        return {
+          composerRect: {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+          },
+          feedScrollTop: activeFeed.scrollTop,
+        };
+      });
+      expect(activeLayout.feedScrollTop).toBeGreaterThan(0);
+
+      const targetPrompt = 'chromium preamble background prompt';
+      const targetChatId = fixture.integration.newChatId();
+      const held = fixture.integration.fakeProviders.openAi.holdNext({
+        model: fixture.integration.directAgents.openAi.provider.model,
+      });
+      let turnId: string | undefined;
+      let heldReleased = false;
+      try {
+        markPhase('appending the background preamble application');
+        const startedPromise = fixture.integration.client.startDirectChat({
+          chatId: targetChatId,
+          content: targetPrompt,
+          projectPath: fixture.integration.dirs.project,
+          agent: fixture.integration.directAgents.openAi,
+        });
+        await held.received;
+        const started = await startedPromise;
+        turnId = started.turnId;
+        const targetRow = fixture.page.locator(`[data-sidebar-virtual-row="${targetChatId}"]`);
+        await targetRow.waitFor();
+        const processingIndicator = targetRow.locator(
+          '[data-slot="sidebar-chat-processing-indicator"]',
+        );
+        await processingIndicator.waitFor();
+        held.releaseText('chromium preamble background response');
+        heldReleased = true;
+        expect(
+          (await fixture.integration.client.waitForTurnTerminal(targetChatId, turnId)).type,
+        ).toBe('agent-run-finished');
+        await processingIndicator.waitFor({ state: 'detached' });
+
+        expect(
+          await fixture.page.evaluate((expectedLayout) => {
+            const scope = globalThis as PreambleBrowserScope;
+            const composerElement = scope.__preambleComposer;
+            const activeFeed = document.querySelector<HTMLElement>('[data-chat-scroll-viewport]');
+            if (!composerElement || !activeFeed) return false;
+            const rect = composerElement.getBoundingClientRect();
+            return (
+              document.activeElement === composerElement &&
+              composerElement.isConnected &&
+              composerElement.value === 'preserved draft' &&
+              Math.abs(rect.x - expectedLayout.composerRect.x) <= 1 &&
+              Math.abs(rect.y - expectedLayout.composerRect.y) <= 1 &&
+              Math.abs(rect.width - expectedLayout.composerRect.width) <= 1 &&
+              Math.abs(rect.height - expectedLayout.composerRect.height) <= 1 &&
+              Math.abs(activeFeed.scrollTop - expectedLayout.feedScrollTop) <= 1
+            );
+          }, activeLayout),
+        ).toBeTrue();
+
+        markPhase('opening and measuring the applied target');
+        const targetPage = await fixture.integration.client.get<CompleteChatHistoryResponse>(
+          `/api/v1/chats/messages?chatId=${encodeURIComponent(targetChatId)}&limit=50`,
+        );
+        const targetHistoryResponse = new Deferred<void>();
+        let targetHistoryRequestCount = 0;
+        await fixture.page.route('**/api/v1/chats/messages?**', async (route) => {
+          const url = new URL(route.request().url());
+          if (url.searchParams.get('chatId') === targetChatId) {
+            targetHistoryRequestCount += 1;
+            await route.fulfill({
+              json: {
+                ...targetPage,
+                messages: [],
+                pageOldestOrdinal: 0,
+                resendCandidates: [],
+              },
+            });
+            targetHistoryResponse.resolve(undefined);
+            return;
+          }
+          await route.continue();
+        });
+        await targetRow.locator('button').first().click();
+        await fixture.page.waitForURL(new RegExp(`/chat/${targetChatId}$`));
+        await withTimeout(
+          targetHistoryResponse.promise,
+          10_000,
+          () => 'Timed out waiting for the empty target-history response.',
+        );
+        expect(targetHistoryRequestCount).toBeGreaterThan(0);
+        const notice = fixture.page
+          .locator('[data-chat-message-type="transcript-notice"]')
+          .filter({ hasText: 'Preambles applied' });
+        await notice.waitFor();
+        const user = fixture.page.locator('[data-chat-message-type="user-message"]').filter({
+          hasText: targetPrompt,
+        });
+        await user.waitFor();
+        expect(
+          await fixture.page.locator('[data-chat-message-type]').evaluateAll((rows, prompt) => {
+            const noticeIndex = rows.findIndex(
+              (row) =>
+                row.getAttribute('data-chat-message-type') === 'transcript-notice' &&
+                row.textContent?.includes('Preambles applied'),
+            );
+            const userIndex = rows.findIndex(
+              (row) =>
+                row.getAttribute('data-chat-message-type') === 'user-message' &&
+                row.textContent?.trim() === prompt,
+            );
+            return noticeIndex >= 0 && userIndex === noticeIndex + 1;
+          }, targetPrompt),
+        ).toBeTrue();
+        expect(
+          await notice.locator('[data-slot="preamble-application-title"]').allTextContents(),
+        ).toEqual(preambles.map((preamble) => preamble.title));
+        for (const preamble of preambles) {
+          expect(await fixture.page.getByText(preamble.content, { exact: false }).count()).toBe(0);
+        }
+
+        const cdp = await fixture.context.newCDPSession(fixture.page);
+        await setViewport(fixture.page, cdp, {
+          name: 'narrow application',
+          width: 320,
+          height: 568,
+          touch: true,
+        });
+        await fixture.page.waitForFunction(
+          () => document.documentElement.style.getPropertyValue('--app-height') === '568px',
+        );
+        const noticeLayout = await notice.evaluate((element) => {
+          const root = element as HTMLElement;
+          const rootRect = root.getBoundingClientRect();
+          const titleRects = [
+            ...root.querySelectorAll<HTMLElement>('[data-slot="preamble-application-title"]'),
+          ].map((title) => title.getBoundingClientRect());
+          return {
+            overflow: root.scrollWidth - root.clientWidth,
+            titleRows: new Set(titleRects.map((rect) => Math.round(rect.top))).size,
+            titlesContained: titleRects.every(
+              (rect) => rect.left >= rootRect.left - 1 && rect.right <= rootRect.right + 1,
+            ),
+            documentOverflow: document.documentElement.scrollWidth - innerWidth,
+          };
+        });
+        expect(noticeLayout.titlesContained).toBeTrue();
+        expect(noticeLayout.overflow).toBeLessThanOrEqual(1);
+        expect(noticeLayout.titleRows).toBeGreaterThan(1);
+        expect(noticeLayout.documentOverflow).toBeLessThanOrEqual(1);
+      } finally {
+        await fixture.page.unroute('**/api/v1/chats/messages?**').catch(() => undefined);
+        if (!heldReleased) held.releaseText('chromium preamble background response');
+        if (turnId) {
+          await fixture.integration.client
+            .waitForTurnTerminal(targetChatId, turnId)
+            .catch(() => undefined);
+        }
+      }
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});

--- a/integration-tests/tests/chromium/snippet-default-arguments-layout.test.ts
+++ b/integration-tests/tests/chromium/snippet-default-arguments-layout.test.ts
@@ -35,7 +35,7 @@ async function openNewChat(page: Page, projectPath: string): Promise<Locator> {
   const dialog = page.locator('[role="dialog"]').filter({ has: composer });
   await dialog.waitFor();
   await dialog.getByRole('textbox', { name: 'Project Path' }).fill(projectPath);
-  const pathOverlay = page.locator('button.fixed.inset-0[aria-label="Close"]');
+  const pathOverlay = page.locator('[data-slot="directory-browser-dismiss"]');
   if (await pathOverlay.isVisible()) {
     await pathOverlay.click({ position: { x: 4, y: 4 } });
   }
@@ -43,10 +43,16 @@ async function openNewChat(page: Page, projectPath: string): Promise<Locator> {
 }
 
 async function openSnippetPalette(page: Page, newChat: Locator): Promise<Locator> {
-  await page.evaluate(() => {
-    document.querySelector<HTMLButtonElement>('button.fixed.inset-0[aria-label="Close"]')?.click();
-  });
-  await page.locator('button.fixed.inset-0[aria-label="Close"]').waitFor({ state: 'detached' });
+  const directoryBrowser = page.locator('[data-slot="directory-browser"]');
+  if (await directoryBrowser.isVisible()) {
+    const dismiss = page.locator('[data-slot="directory-browser-dismiss"]');
+    if (await dismiss.isVisible()) {
+      await dismiss.evaluate((element) => (element as HTMLButtonElement).click());
+    } else {
+      await directoryBrowser.getByRole('button', { name: 'Cancel', exact: true }).click();
+    }
+    await directoryBrowser.waitFor({ state: 'detached' });
+  }
   await newChat
     .getByRole('button', { name: 'Add to prompt' })
     .evaluate((element) => (element as HTMLButtonElement).click());

--- a/integration-tests/tests/e2e/preambles.test.ts
+++ b/integration-tests/tests/e2e/preambles.test.ts
@@ -15,15 +15,17 @@ async function clickPreambleRowAction(
   action: string,
 ): Promise<void> {
   await fixture.page.waitForFunction(({ title, action }) => {
-    const row = [...document.querySelectorAll<HTMLElement>('article')]
-      .find((element) => element.querySelector('h3')?.textContent?.trim() === title);
+    const row = [...document.querySelectorAll<HTMLElement>('[data-slot="preamble-row"]')]
+      .find((element) => element
+        .querySelector('[data-slot="preamble-row-title"]')?.textContent?.trim() === title);
     const button = [...(row?.querySelectorAll<HTMLButtonElement>('button') ?? [])]
       .find((element) => element.getAttribute('aria-label') === action);
     return Boolean(button && !button.disabled);
   }, { timeout: 20_000 }, { title, action });
   await fixture.page.evaluate(({ title, action }) => {
-    const row = [...document.querySelectorAll<HTMLElement>('article')]
-      .find((element) => element.querySelector('h3')?.textContent?.trim() === title);
+    const row = [...document.querySelectorAll<HTMLElement>('[data-slot="preamble-row"]')]
+      .find((element) => element
+        .querySelector('[data-slot="preamble-row-title"]')?.textContent?.trim() === title);
     const button = [...(row?.querySelectorAll<HTMLButtonElement>('button') ?? [])]
       .find((element) => element.getAttribute('aria-label') === action);
     if (!button) throw new Error(`Missing ${action} action for ${title}.`);
@@ -80,10 +82,11 @@ async function selectDirectory(
     expectedPath,
   );
   await fixture.page.evaluate(() => {
-    const dialog = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Select Directory"]');
-    const close = dialog?.previousElementSibling;
-    if (!(close instanceof HTMLButtonElement)) throw new Error('Missing directory picker backdrop.');
-    close.click();
+    const dismiss = document.querySelector<HTMLButtonElement>(
+      '[data-slot="directory-browser-dismiss"]',
+    );
+    if (!dismiss) throw new Error('Missing directory picker dismiss control.');
+    dismiss.click();
   });
   await fixture.page.waitForFunction(
     () => document.querySelector('[role="dialog"][aria-label="Select Directory"]') === null,
@@ -108,7 +111,7 @@ describe('Lightpanda preambles', () => {
       await app.clickButton('More actions');
       await app.waitForMenuItemEnabled('Preambles');
       await app.clickMenuItem('Preambles');
-      await app.waitForButton('Add preamble');
+      await app.waitForButtonEnabled('Add preamble');
 
       await app.clickButton('Add preamble');
       await app.fill('#preamble-title', 'Global UI rules');
@@ -124,7 +127,7 @@ describe('Lightpanda preambles', () => {
       await app.waitForText('Disabled');
       await clickPreambleRowAction(fixture, 'Global UI rules', 'Enable Global UI rules');
       await fixture.page.waitForFunction(
-        () => ![...document.querySelectorAll<HTMLElement>('article')]
+        () => ![...document.querySelectorAll<HTMLElement>('[data-slot="preamble-row"]')]
           .some((element) => element.textContent?.includes('Disabled')),
         { timeout: 20_000 },
       );
@@ -174,7 +177,7 @@ describe('Lightpanda preambles', () => {
       await app.waitForText('Project UI rules');
       expect(await app.exactTextCount('Global UI rules')).toBe(0);
       expect(await fixture.page.$eval(
-        'article button[aria-label="Move Project UI rules up"]',
+        '[data-slot="preamble-row"] button[aria-label="Move Project UI rules up"]',
         (element) => (element as HTMLButtonElement).disabled,
       )).toBeTrue();
       await app.clickButton('Clear preamble filter');
@@ -182,7 +185,7 @@ describe('Lightpanda preambles', () => {
 
       await clickPreambleRowAction(fixture, 'Project UI rules', 'Move Project UI rules up');
       await fixture.page.waitForFunction(
-        () => [...document.querySelectorAll<HTMLElement>('article h3')]
+        () => [...document.querySelectorAll<HTMLElement>('[data-slot="preamble-row-title"]')]
           .map((element) => element.textContent?.trim())
           .join('|') === 'Project UI rules|Global UI rules',
         { timeout: 20_000 },
@@ -216,7 +219,9 @@ describe('Lightpanda preambles', () => {
         return {
           adjacent: noticeIndex >= 0 && userIndex === noticeIndex + 1,
           titles: notice
-            ? [...notice.querySelectorAll('span')].map((element) => element.textContent?.trim())
+            ? [...notice.querySelectorAll(
+              '[data-slot="preamble-application-label"], [data-slot="preamble-application-title"]',
+            )].map((element) => element.textContent?.trim())
             : [],
         };
       })).toEqual({
@@ -237,8 +242,10 @@ describe('Lightpanda preambles', () => {
       await app.waitForButton('Remove preamble');
       await app.clickButton('Remove preamble', { last: true });
       await fixture.page.waitForFunction(
-        () => ![...document.querySelectorAll<HTMLElement>('article')]
-          .some((element) => element.querySelector('h3')?.textContent?.trim() === 'Project UI rules'),
+        () => ![...document.querySelectorAll<HTMLElement>('[data-slot="preamble-row"]')]
+          .some((element) => element
+            .querySelector('[data-slot="preamble-row-title"]')?.textContent?.trim()
+            === 'Project UI rules'),
         { timeout: 20_000 },
       );
 

--- a/web/src/lib/components/chat/DirectoryBrowser.svelte
+++ b/web/src/lib/components/chat/DirectoryBrowser.svelte
@@ -10,6 +10,7 @@
 	import CircleAlert from '@lucide/svelte/icons/circle-alert';
 	import Search from '@lucide/svelte/icons/search';
 	import * as m from '$lib/paraglide/messages.js';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { getTransientLayers } from '$lib/context';
 	import { transientLayer } from '$lib/workspace/transient-layer-action.js';
 
@@ -105,7 +106,7 @@
 		return () => abortController.abort();
 	});
 
-	function handleEscape(e: KeyboardEvent): void {
+	function handlePopoverKeydown(e: KeyboardEvent): void {
 		if (e.key === 'Escape') {
 			e.preventDefault();
 			e.stopPropagation();
@@ -168,144 +169,138 @@
 
 {#if isMobile}
 	<!-- Fullscreen mobile browser -->
-		<div
-			class="fixed inset-0 z-50 flex flex-col bg-background"
-			role="dialog"
-			tabindex="-1"
-			aria-modal="true"
+	<Dialog.Root open={true} requestClose={onClose}>
+		<Dialog.Content
+			data-slot="directory-browser"
+			showCloseButton={false}
+			class="flex h-dvh w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:max-w-none"
 			aria-label={m.chat_directory_browser_select_directory()}
-			onkeydown={handleEscape}
-			use:transientLayer={{
-				registry: transientLayers,
-				id: 'directory-browser-mobile',
-				kind: 'application-dialog',
-				modality: 'main-inert',
-				onEscape: handleLayerEscape,
-				restoreFocus: () => focusReturnTarget?.focus(),
-			}}
 		>
-		<div class="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
-			<h3 class="text-sm font-medium text-foreground">
-				{m.chat_directory_browser_select_directory()}
-			</h3>
-			<button
-				type="button"
-				onclick={onClose}
-				class="text-sm text-muted-foreground hover:text-foreground"
+			<div class="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
+				<h3 class="text-sm font-medium text-foreground">
+					{m.chat_directory_browser_select_directory()}
+				</h3>
+				<button
+					type="button"
+					onclick={onClose}
+					class="text-sm text-muted-foreground hover:text-foreground"
+				>
+					{m.chat_directory_browser_cancel()}
+				</button>
+			</div>
+
+			<!-- Breadcrumbs -->
+			<div
+				class="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto px-3 py-2 border-b border-border flex-shrink-0"
 			>
-				{m.chat_directory_browser_cancel()}
-			</button>
-		</div>
-
-		<!-- Breadcrumbs -->
-		<div
-			class="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto px-3 py-2 border-b border-border flex-shrink-0"
-		>
-			{#each segments as seg, i (seg.path)}
-				<span class="flex items-center gap-1 whitespace-nowrap">
-					{#if i > 0}
-						<ChevronRight class="w-3 h-3 flex-shrink-0" />
-					{/if}
-					<button
-						type="button"
-						onclick={() => handleNavigate(seg.path)}
-						class="hover:text-foreground hover:underline"
-					>
-						{seg.label}
-					</button>
-				</span>
-			{/each}
-		</div>
-
-		<!-- Filter input for mobile -->
-		<div class="flex items-center gap-2 px-3 py-2 border-b border-border flex-shrink-0">
-			<Search class="w-4 h-4 text-muted-foreground flex-shrink-0" />
-			<input
-				type="text"
-				bind:value={mobileFilter}
-				aria-label={m.chat_directory_browser_filter_placeholder()}
-				placeholder={m.chat_directory_browser_filter_placeholder()}
-				class="flex-1 bg-transparent text-base leading-6 text-foreground outline-none placeholder-muted-foreground/60"
-			/>
-		</div>
-
-		<!-- Directory list -->
-		<div class="overflow-y-auto flex-1" tabindex="0" onkeydown={handleListKeyDown} role="listbox">
-			{#if loading}
-				<div class="flex items-center justify-center py-8">
-					<Loader2 class="w-5 h-5 animate-spin text-muted-foreground" />
-				</div>
-			{:else if error}
-				<div class="flex items-center gap-2 px-3 py-4 text-sm text-status-error-foreground">
-					<CircleAlert class="w-4 h-4 flex-shrink-0" />
-					{error}
-				</div>
-			{:else}
-				{#if parentPath !== null}
-					<button
-						type="button"
-						onclick={() => handleNavigate(parentPath)}
-						class="flex items-center gap-2 w-full px-4 py-3 text-sm hover:bg-muted/50 active:bg-muted/70 transition-colors text-muted-foreground"
-					>
-						<ArrowUp class="w-4 h-4" />
-						..
-					</button>
-				{/if}
-				{#each entries as entry, i (entry.path)}
-					<button
-						type="button"
-						onclick={() => handleNavigate(entry.path)}
-						class="flex items-center gap-2 w-full px-4 py-3 text-sm transition-colors {i ===
-						focusIndex
-							? 'bg-muted/70 text-foreground'
-							: 'hover:bg-muted/50 active:bg-muted/70 text-foreground'}"
-					>
-						<Folder class="w-4 h-4 text-primary flex-shrink-0" />
-						<span class="truncate">{entry.name}</span>
-					</button>
+				{#each segments as seg, i (seg.path)}
+					<span class="flex items-center gap-1 whitespace-nowrap">
+						{#if i > 0}
+							<ChevronRight class="w-3 h-3 flex-shrink-0" />
+						{/if}
+						<button
+							type="button"
+							onclick={() => handleNavigate(seg.path)}
+							class="hover:text-foreground hover:underline"
+						>
+							{seg.label}
+						</button>
+					</span>
 				{/each}
-				{#if entries.length === 0}
-					<div class="px-3 py-4 text-sm text-muted-foreground text-center">
-						{m.chat_directory_browser_no_subdirectories()}
-					</div>
-				{/if}
-			{/if}
-		</div>
+			</div>
 
-		<div class="border-t border-border p-3 flex-shrink-0 space-y-1.5">
-			<p class="text-xs text-muted-foreground truncate px-1">{browsePath}</p>
-			<button
-				type="button"
-				onclick={() => handleConfirm(browsePath)}
-				class="w-full py-3 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 active:bg-primary/80 transition-colors"
-			>
-				{m.chat_directory_browser_select_this()}
-			</button>
-		</div>
-	</div>
+			<!-- Filter input for mobile -->
+			<div class="flex items-center gap-2 px-3 py-2 border-b border-border flex-shrink-0">
+				<Search class="w-4 h-4 text-muted-foreground flex-shrink-0" />
+				<input
+					type="text"
+					bind:value={mobileFilter}
+					aria-label={m.chat_directory_browser_filter_placeholder()}
+					placeholder={m.chat_directory_browser_filter_placeholder()}
+					class="flex-1 bg-transparent text-base leading-6 text-foreground outline-none placeholder-muted-foreground/60"
+				/>
+			</div>
+
+			<!-- Directory list -->
+			<div class="overflow-y-auto flex-1" tabindex="0" onkeydown={handleListKeyDown} role="listbox">
+				{#if loading}
+					<div class="flex items-center justify-center py-8">
+						<Loader2 class="w-5 h-5 animate-spin text-muted-foreground" />
+					</div>
+				{:else if error}
+					<div class="flex items-center gap-2 px-3 py-4 text-sm text-status-error-foreground">
+						<CircleAlert class="w-4 h-4 flex-shrink-0" />
+						{error}
+					</div>
+				{:else}
+					{#if parentPath !== null}
+						<button
+							type="button"
+							onclick={() => handleNavigate(parentPath)}
+							class="flex items-center gap-2 w-full px-4 py-3 text-sm hover:bg-muted/50 active:bg-muted/70 transition-colors text-muted-foreground"
+						>
+							<ArrowUp class="w-4 h-4" />
+							..
+						</button>
+					{/if}
+					{#each entries as entry, i (entry.path)}
+						<button
+							type="button"
+							onclick={() => handleNavigate(entry.path)}
+							class="flex items-center gap-2 w-full px-4 py-3 text-sm transition-colors {i ===
+							focusIndex
+								? 'bg-muted/70 text-foreground'
+								: 'hover:bg-muted/50 active:bg-muted/70 text-foreground'}"
+						>
+							<Folder class="w-4 h-4 text-primary flex-shrink-0" />
+							<span class="truncate">{entry.name}</span>
+						</button>
+					{/each}
+					{#if entries.length === 0}
+						<div class="px-3 py-4 text-sm text-muted-foreground text-center">
+							{m.chat_directory_browser_no_subdirectories()}
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			<div class="border-t border-border p-3 flex-shrink-0 space-y-1.5">
+				<p class="text-xs text-muted-foreground truncate px-1">{browsePath}</p>
+				<button
+					type="button"
+					onclick={() => handleConfirm(browsePath)}
+					class="w-full py-3 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 active:bg-primary/80 transition-colors"
+				>
+					{m.chat_directory_browser_select_this()}
+				</button>
+			</div>
+		</Dialog.Content>
+	</Dialog.Root>
 {:else}
 	<!-- Desktop dropdown browser -->
 	<button
 		type="button"
+		data-slot="directory-browser-dismiss"
 		class="fixed inset-0 z-20 border-0 bg-transparent p-0"
 		onclick={onClose}
 		aria-label={m.editor_actions_close()}
 	></button>
-		<div
-			class="absolute top-full left-0 right-0 z-30 mt-1 border border-border rounded-lg shadow-lg bg-card flex flex-col max-h-72"
-			role="dialog"
-			tabindex="-1"
-			aria-label={m.chat_directory_browser_select_directory()}
-			onkeydown={handleEscape}
-			use:transientLayer={{
-				registry: transientLayers,
-				id: 'directory-browser-popover',
-				kind: 'popover',
-				modality: 'nonmodal',
-				onEscape: handleLayerEscape,
-				restoreFocus: () => focusReturnTarget?.focus(),
-			}}
-		>
+	<div
+		data-slot="directory-browser"
+		class="absolute top-full left-0 right-0 z-30 mt-1 border border-border rounded-lg shadow-lg bg-card flex flex-col max-h-72"
+		role="dialog"
+		tabindex="-1"
+		aria-label={m.chat_directory_browser_select_directory()}
+		onkeydown={handlePopoverKeydown}
+		use:transientLayer={{
+			registry: transientLayers,
+			id: 'directory-browser-popover',
+			kind: 'popover',
+			modality: 'nonmodal',
+			onEscape: handleLayerEscape,
+			restoreFocus: () => focusReturnTarget?.focus(),
+		}}
+	>
 		<!-- Breadcrumbs -->
 		<div
 			class="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto px-3 py-2 border-b border-border flex-shrink-0"

--- a/web/src/lib/components/chat/rows/PreambleApplicationRow.svelte
+++ b/web/src/lib/components/chat/rows/PreambleApplicationRow.svelte
@@ -9,10 +9,13 @@
 <ChatEventCard variant="info">
 	{#snippet body()}
 		<div class="flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
-			<span class="text-muted-foreground">{m.preambles_applied_label()}</span>
+			<span data-slot="preamble-application-label" class="text-muted-foreground">
+				{m.preambles_applied_label()}
+			</span>
 			{#each detail.preambles as preamble (preamble.id)}
 				<svelte:boundary>
 					<span
+						data-slot="preamble-application-title"
 						class="max-w-full break-words rounded-full bg-accent px-2 py-0.5 text-accent-foreground"
 					>
 						{preamble.title}

--- a/web/src/lib/components/preambles/PreambleFormDialog.svelte
+++ b/web/src/lib/components/preambles/PreambleFormDialog.svelte
@@ -36,6 +36,7 @@
 	const appShell = getAppShell();
 	const form = new PreambleFormState();
 	let pickerKey = $state<string | null>(null);
+	let pickerFocusReturnTarget: HTMLElement | null = null;
 	let contentTextarea = $state<HTMLTextAreaElement | null>(null);
 	const contentEditor = new PromptEditorDialogState();
 
@@ -43,6 +44,7 @@
 		if (!open) return;
 		form.reset(preamble);
 		pickerKey = null;
+		pickerFocusReturnTarget = null;
 		contentEditor.close();
 	});
 
@@ -69,14 +71,28 @@
 	function closeForm(): void {
 		if (form.saving) return;
 		pickerKey = null;
+		pickerFocusReturnTarget = null;
 		contentEditor.close();
 		onClose();
+	}
+
+	function openPathPicker(key: string): void {
+		pickerFocusReturnTarget =
+			document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		pickerKey = key;
+	}
+
+	function closePathPicker(): void {
+		pickerKey = null;
+		const focusTarget = pickerFocusReturnTarget;
+		pickerFocusReturnTarget = null;
+		queueMicrotask(() => focusTarget?.focus({ preventScroll: true }));
 	}
 
 	function addPath(): void {
 		form.scopeType = 'project-paths';
 		const key = form.addPath(appShell.projectBasePath);
-		if (key) pickerKey = key;
+		if (key) openPathPicker(key);
 	}
 
 	function openExpandedEditor(): void {
@@ -112,7 +128,7 @@
 
 <Dialog.Root {open} requestClose={closeForm}>
 	<Dialog.Content
-		class="top-[var(--app-viewport-center-y)] flex h-[var(--app-height)] max-h-[var(--app-height)] w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:w-[calc(100vw-2rem)] sm:pointer-fine:top-[50%] sm:pointer-fine:h-[min(48rem,calc(var(--app-height)-2rem))] sm:pointer-fine:max-h-[48rem] sm:pointer-fine:max-w-3xl sm:pointer-fine:rounded-lg sm:pointer-fine:border"
+		class="top-[var(--app-viewport-center-y)] flex h-[var(--app-height)] max-h-[var(--app-height)] w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:w-screen sm:max-w-none sm:pointer-fine:top-[50%] sm:pointer-fine:h-[min(48rem,calc(var(--app-height)-2rem))] sm:pointer-fine:max-h-[48rem] sm:pointer-fine:w-[calc(100vw-2rem)] sm:pointer-fine:max-w-3xl sm:pointer-fine:rounded-lg sm:pointer-fine:border"
 		showCloseButton={false}
 	>
 		<Dialog.Header class="shrink-0 border-b border-border bg-background px-5 py-4 sm:px-6">
@@ -123,6 +139,7 @@
 		</Dialog.Header>
 
 		<div
+			data-slot="preambles-scroll-body"
 			class="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6"
 			inert={form.saving}
 			aria-busy={form.saving}
@@ -197,16 +214,17 @@
 										bind:value={rule.projectPath}
 										aria-label={m.preambles_project_path_label()}
 										aria-invalid={Boolean(pathError)}
-										aria-describedby={pathError
-											? `preamble-path-error-${rule.key}`
-											: undefined}
+										aria-describedby={pathError ? `preamble-path-error-${rule.key}` : undefined}
 										class="h-10 min-w-0 flex-1 rounded-md border border-input bg-background px-3 text-base outline-none focus-visible:ring-2 focus-visible:ring-ring sm:pointer-fine:text-sm"
 									/>
 									<Button
 										type="button"
 										variant="secondary"
 										size="icon"
-										onclick={() => (pickerKey = pickerKey === rule.key ? null : rule.key)}
+										onclick={() => {
+											if (pickerKey === rule.key) closePathPicker();
+											else openPathPicker(rule.key);
+										}}
 										aria-label={m.preambles_browse_path()}
 										title={m.preambles_browse_path()}
 									>
@@ -227,10 +245,7 @@
 									<input type="checkbox" bind:checked={rule.includeNested} />
 									{m.preambles_apply_nested()}
 								</label>
-								<p
-									id={`preamble-path-error-${rule.key}`}
-									class="min-h-4 text-xs text-destructive"
-								>
+								<p id={`preamble-path-error-${rule.key}`} class="min-h-4 text-xs text-destructive">
 									{pathError ?? ''}
 								</p>
 								{#if pickerKey === rule.key}
@@ -238,18 +253,13 @@
 										currentPath={rule.projectPath || appShell.projectBasePath}
 										basePath={appShell.projectBasePath}
 										onSelect={(projectPath) => form.setPath(rule.key, projectPath)}
-										onClose={() => (pickerKey = null)}
+										onClose={closePathPicker}
 										isMobile={appShell.isMobile}
 									/>
 								{/if}
 							</div>
 						{/each}
-						<Button
-							type="button"
-							variant="secondary"
-							onclick={addPath}
-							disabled={!form.canAddPath}
-						>
+						<Button type="button" variant="secondary" onclick={addPath} disabled={!form.canAddPath}>
 							<Plus class="mr-2 h-4 w-4" />
 							{m.preambles_add_path()}
 						</Button>

--- a/web/src/lib/components/preambles/PreambleRow.svelte
+++ b/web/src/lib/components/preambles/PreambleRow.svelte
@@ -41,6 +41,7 @@
 </script>
 
 <article
+	data-slot="preamble-row"
 	class="rounded-md border border-border p-3 transition-colors {preamble.enabled
 		? 'bg-card'
 		: 'bg-muted/30'}"
@@ -48,7 +49,11 @@
 	<div class="flex min-w-0 items-start gap-3">
 		<div class="min-w-0 flex-1 space-y-2">
 			<div class="flex min-w-0 flex-wrap items-center gap-2">
-				<h3 class="min-w-0 truncate text-sm font-medium text-foreground" title={preamble.title}>
+				<h3
+					data-slot="preamble-row-title"
+					class="min-w-0 truncate text-sm font-medium text-foreground"
+					title={preamble.title}
+				>
 					{preamble.title}
 				</h3>
 				{#if preamble.scope.type === 'global'}
@@ -86,7 +91,7 @@
 			<Switch
 				class="col-span-2 mx-auto mb-1 sm:col-span-1 sm:mb-0 sm:mr-1"
 				checked={preamble.enabled}
-				disabled={disabled}
+				{disabled}
 				onCheckedChange={onEnabledChange}
 				aria-label={preamble.enabled
 					? m.preambles_disable_toggle({ title: preamble.title })

--- a/web/src/lib/components/preambles/PreamblesDialog.svelte
+++ b/web/src/lib/components/preambles/PreamblesDialog.svelte
@@ -13,7 +13,7 @@
 
 <Dialog.Root open={appShell.showPreambles} onOpenChange={handleOpenChange}>
 	<Dialog.Content
-		class="top-[var(--app-viewport-center-y)] flex h-[var(--app-height)] max-h-[var(--app-height)] w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:w-[calc(100vw-2rem)] sm:pointer-fine:top-[50%] sm:pointer-fine:h-[min(44rem,calc(var(--app-height)-2rem))] sm:pointer-fine:max-h-[44rem] sm:pointer-fine:max-w-3xl sm:pointer-fine:rounded-lg sm:pointer-fine:border"
+		class="top-[var(--app-viewport-center-y)] flex h-[var(--app-height)] max-h-[var(--app-height)] w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:w-screen sm:max-w-none sm:pointer-fine:top-[50%] sm:pointer-fine:h-[min(44rem,calc(var(--app-height)-2rem))] sm:pointer-fine:max-h-[44rem] sm:pointer-fine:w-[calc(100vw-2rem)] sm:pointer-fine:max-w-3xl sm:pointer-fine:rounded-lg sm:pointer-fine:border"
 		showCloseButton={true}
 	>
 		<Dialog.Header class="shrink-0 border-b border-border px-5 py-4 sm:px-6">
@@ -21,7 +21,7 @@
 			<Dialog.Description>{m.preambles_description()}</Dialog.Description>
 		</Dialog.Header>
 
-		<div class="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6">
+		<div data-slot="preambles-scroll-body" class="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6">
 			<PreamblesSection active={appShell.showPreambles} />
 		</div>
 	</Dialog.Content>

--- a/web/src/lib/components/prompt-editor/PromptEditorDialog.svelte
+++ b/web/src/lib/components/prompt-editor/PromptEditorDialog.svelte
@@ -46,15 +46,23 @@
 	}: Props = $props();
 	const editorRenderer = lazyRenderer(() => import('./PromptEditor.svelte'));
 	let retryKey = $state(0);
+	let dialogElement = $state<HTMLElement | null>(null);
 	let promptRefinementActionLabel = $derived(
 		isPromptRefinementPending ? m.prompt_refinement_cancel() : m.prompt_refinement_refine(),
 	);
+
+	function handleOpenAutoFocus(event: Event): void {
+		event.preventDefault();
+		dialogElement?.focus({ preventScroll: true });
+	}
 </script>
 
 <Dialog.Root open={true} requestClose={onClose}>
 	<Dialog.Content
+		bind:ref={dialogElement}
 		showCloseButton={false}
 		transientKind="application-dialog"
+		onOpenAutoFocus={handleOpenAutoFocus}
 		data-workspace-surface-id={surfaceId}
 		data-prompt-editor-dialog
 		class="flex h-dvh w-screen max-w-none flex-col gap-0 overflow-hidden rounded-none border-0 p-0 sm:h-[min(88dvh,900px)] sm:w-[min(94vw,1100px)] sm:max-w-none sm:rounded-lg sm:border"

--- a/web/src/lib/components/settings/ScheduledNewChatComposer.svelte
+++ b/web/src/lib/components/settings/ScheduledNewChatComposer.svelte
@@ -83,6 +83,11 @@
 		textarea?.focus();
 	}
 
+	function handlePathFocus(event: FocusEvent & { currentTarget: HTMLInputElement }): void {
+		if (isMobile) event.currentTarget.blur();
+		startup.handlePathFocus();
+	}
+
 	function handleModelChange(next: ModelSelectorChange): void {
 		startup.selectAgent(next.agentId);
 		startup.selectModel(next.modelValue, next);
@@ -102,7 +107,7 @@
 						type="text"
 						value={startup.projectPath}
 						readonly={startup.isUpdatingPinnedPath}
-						onfocus={() => startup.handlePathFocus()}
+						onfocus={handlePathFocus}
 						oninput={(event) => {
 							startup.projectPath = event.currentTarget.value;
 							startup.clearError();

--- a/web/src/lib/components/settings/__tests__/ScheduledNewChatComposer.test.ts
+++ b/web/src/lib/components/settings/__tests__/ScheduledNewChatComposer.test.ts
@@ -69,6 +69,7 @@ function renderComposer(
 		promptError?: string | null;
 		modelSelectionError?: string | null;
 		selectableAgentIds?: readonly SessionAgentId[];
+		isMobile?: boolean;
 	} = {},
 ) {
 	const onPromptChange = vi.fn();
@@ -89,7 +90,7 @@ function renderComposer(
 		prompt: overrides.prompt ?? '',
 		promptError: overrides.promptError ?? null,
 		knownTags: ['qa', 'review-needed'],
-		isMobile: false,
+		isMobile: overrides.isMobile ?? false,
 		onPromptChange,
 		onPromptKeydown,
 	});
@@ -138,6 +139,16 @@ describe('ScheduledNewChatComposer', () => {
 
 		expect(onPromptChange).toHaveBeenCalledWith('Review the build');
 		expect(onPromptKeydown).toHaveBeenCalledOnce();
+	});
+
+	it('releases input focus before opening the directory browser on mobile', async () => {
+		const { startup } = renderComposer({ isMobile: true });
+		const projectPath = screen.getByRole('textbox', { name: 'Project Path' });
+
+		projectPath.focus();
+
+		expect(document.activeElement).not.toBe(projectPath);
+		expect(startup.handlePathFocus).toHaveBeenCalledOnce();
 	});
 
 	it('renders unavailable scheduled model feedback', () => {


### PR DESCRIPTION
Preamble management needs to remain reliable across nested dialogs, touch layouts, and background chat activity. This change adopts the shared dialog focus scope for the mobile directory browser, restores focus predictably across picker and editor transitions, hardens responsive sizing and semantic selectors, and adds Chromium and Lightpanda coverage for layout, focus containment, cached background delivery, composer stability, notice adjacency, and private-body exclusion.