### PR TITLE
Simplify chat reorder preset paths

### DIFF
--- a/common/__tests__/chat-order-sort.test.js
+++ b/common/__tests__/chat-order-sort.test.js
@@ -3,6 +3,7 @@ import {
   chatActivityTimeMs,
   chatCreationTimeMs,
   compareChatOrderNewestFirst,
+  isChatOrderSortKey,
 } from '../chat-order-sort.ts';
 
 const chat = (overrides = {}) => ({
@@ -13,6 +14,13 @@ const chat = (overrides = {}) => ({
 });
 
 describe('chat order sort', () => {
+  it('recognizes supported sort keys', () => {
+    expect(isChatOrderSortKey('created')).toBe(true);
+    expect(isChatOrderSortKey('activity')).toBe(true);
+    expect(isChatOrderSortKey('oldest')).toBe(false);
+    expect(isChatOrderSortKey(null)).toBe(false);
+  });
+
   it('prefers valid metadata creation over the id timestamp', () => {
     expect(chatCreationTimeMs(chat({ createdAt: '2024-01-01T00:00:00.000Z' })))
       .toBe(new Date('2024-01-01T00:00:00.000Z').getTime());

--- a/common/chat-order-contracts.ts
+++ b/common/chat-order-contracts.ts
@@ -2,7 +2,7 @@ import type { ErrorCode } from './error-codes.js';
 import type { HttpErrorResponse } from './http-error.js';
 import { isRecord } from './json.js';
 import {
-  CHAT_ORDER_SORT_KEYS,
+  isChatOrderSortKey,
   type ChatOrderSortKey,
 } from './chat-order-sort.js';
 
@@ -128,17 +128,17 @@ export function parseReorderChatResponse(value: unknown): ReorderChatResponse | 
 
 export function parseSortChatOrderRequest(value: unknown): SortChatOrderRequest | null {
   if (!isRecord(value) || !hasOnlyKeys(value, SORT_REQUEST_KEYS)) return null;
-  if (!CHAT_ORDER_SORT_KEYS.includes(value.sortKey as ChatOrderSortKey)) return null;
-  return { sortKey: value.sortKey as ChatOrderSortKey };
+  if (!isChatOrderSortKey(value.sortKey)) return null;
+  return { sortKey: value.sortKey };
 }
 
 export function parseSortChatOrderResponse(value: unknown): SortChatOrderResponse | null {
   if (!isRecord(value) || !hasOnlyKeys(value, SORT_RESPONSE_KEYS)) return null;
   if (value.success !== true || typeof value.changed !== 'boolean') return null;
-  if (!CHAT_ORDER_SORT_KEYS.includes(value.sortKey as ChatOrderSortKey)) return null;
+  if (!isChatOrderSortKey(value.sortKey)) return null;
   return {
     success: true,
-    sortKey: value.sortKey as ChatOrderSortKey,
+    sortKey: value.sortKey,
     changed: value.changed,
   };
 }

--- a/common/chat-order-sort.ts
+++ b/common/chat-order-sort.ts
@@ -3,6 +3,12 @@ import { CHAT_ID_LENGTH, chatIdCreatedAt } from './chat-id.js';
 export const CHAT_ORDER_SORT_KEYS = ['created', 'activity'] as const;
 export type ChatOrderSortKey = (typeof CHAT_ORDER_SORT_KEYS)[number];
 
+const CHAT_ORDER_SORT_KEY_SET = new Set<string>(CHAT_ORDER_SORT_KEYS);
+
+export function isChatOrderSortKey(value: unknown): value is ChatOrderSortKey {
+  return typeof value === 'string' && CHAT_ORDER_SORT_KEY_SET.has(value);
+}
+
 export interface ChatOrderTimestamps {
   id: string;
   createdAt: string | null;

--- a/integration-tests/tests/chromium/sidebar-chat-reorder.test.ts
+++ b/integration-tests/tests/chromium/sidebar-chat-reorder.test.ts
@@ -23,7 +23,7 @@ import { seedLocalSettings } from '../../support/local-settings-seed.js';
 
 const CHAT_ROW_SELECTOR = '[data-sidebar-virtual-row][data-sidebar-virtual-list-row="normal"]';
 
-interface ReorderExchange {
+interface OrderExchange {
   request: {
     method: string;
     url: string;
@@ -36,8 +36,8 @@ interface ReorderExchange {
 }
 
 interface ChromiumFixture extends BaseChromiumFixture {
-  reorderExchanges: ReorderExchange[];
-  sortExchanges: ReorderExchange[];
+  reorderExchanges: OrderExchange[];
+  sortExchanges: OrderExchange[];
 }
 
 function isReorderRequest(request: Request): boolean {
@@ -300,18 +300,20 @@ async function withSidebarChromiumFixture<T>(
     testName,
     async (baseFixture) => {
       const fixture = Object.assign(baseFixture, {
-        reorderExchanges: [] as ReorderExchange[],
-        sortExchanges: [] as ReorderExchange[],
+        reorderExchanges: [] as OrderExchange[],
+        sortExchanges: [] as OrderExchange[],
       });
-      const exchangesByRequest = new Map<Request, ReorderExchange>();
+      const exchangesByRequest = new Map<Request, OrderExchange>();
       fixture.page.on('request', (request) => {
-        const exchanges = isReorderRequest(request)
-          ? fixture.reorderExchanges
-          : isSortRequest(request)
-            ? fixture.sortExchanges
-            : null;
-        if (!exchanges) return;
-        const exchange: ReorderExchange = {
+        let exchanges: OrderExchange[];
+        if (isReorderRequest(request)) {
+          exchanges = fixture.reorderExchanges;
+        } else if (isSortRequest(request)) {
+          exchanges = fixture.sortExchanges;
+        } else {
+          return;
+        }
+        const exchange: OrderExchange = {
           request: {
             method: request.method(),
             url: request.url(),

--- a/server/settings/__tests__/chat-order-store.test.js
+++ b/server/settings/__tests__/chat-order-store.test.js
@@ -288,11 +288,6 @@ describe('ChatOrderStore.sortChatOrder', () => {
       normalChatIds: ['n-a', 'n-b', 'n-c'],
       archivedChatIds: ['a-a'],
     });
-    const before = {
-      pinned: [...harness.settings.pinnedChatIds].sort(),
-      normal: [...harness.settings.normalChatIds].sort(),
-      archived: [...harness.settings.archivedChatIds].sort(),
-    };
 
     const result = await harness.store.sortChatOrder(() => 0);
 
@@ -300,9 +295,6 @@ describe('ChatOrderStore.sortChatOrder', () => {
     expect(harness.settings.pinnedChatIds).toEqual(['p-a', 'p-b']);
     expect(harness.settings.normalChatIds).toEqual(['n-a', 'n-b', 'n-c']);
     expect(harness.settings.archivedChatIds).toEqual(['a-a']);
-    expect([...harness.settings.pinnedChatIds].sort()).toEqual(before.pinned);
-    expect([...harness.settings.normalChatIds].sort()).toEqual(before.normal);
-    expect([...harness.settings.archivedChatIds].sort()).toEqual(before.archived);
     expect(harness.saveCalls).toEqual([]);
     expect(harness.listChanges).toEqual([]);
   });

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -239,10 +239,9 @@
 	async function handleSortChatOrder(sortKey: ChatOrderSortKey): Promise<void> {
 		try {
 			const response = await controller.sortChatOrder(sortKey);
-			if (response.changed) {
-				notifications.info(m.notifications_reorder_chats_applied());
-				appShell.requestSidebarRecenterToSelected();
-			}
+			if (!response.changed) return;
+			notifications.info(m.notifications_reorder_chats_applied());
+			appShell.requestSidebarRecenterToSelected();
 		} catch (error) {
 			reportActionFailure(
 				'Failed to sort manual chat order:',


### PR DESCRIPTION
This behavior-preserving cleanup centralizes chat-order sort-key validation behind a typed guard, simplifies the sidebar changed-result flow, makes Chromium request capture explicit and accurately named, and removes redundant stable-order assertions. No migrations or protocol changes are required.