### PR TITLE
Upgrade OpenCode to 1.18.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ FROM base AS runtime
 
 ARG GARCON_UID=1000
 ARG GARCON_GID=1000
-ARG OPENCODE_VERSION=1.18.22
+ARG OPENCODE_VERSION=1.18.29
 
 RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" && npm cache clean --force
 RUN set -eu; \

--- a/bun.lock
+++ b/bun.lock
@@ -193,7 +193,7 @@
         "@garcon/common": "workspace:*",
         "@garcon/server-agent-common": "workspace:*",
         "@garcon/server-agent-interface": "workspace:*",
-        "@opencode-ai/sdk": "1.18.22",
+        "@opencode-ai/sdk": "1.18.29",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
@@ -615,7 +615,7 @@
 
     "@openai/codex-win32-x64": ["@openai/codex@0.153.4-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.22", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-fRZ2r6nqdLBXfs7j531aibrqCC9tpbL2tmz3ThnwtLa3bMNUozEVAOPnZjh86JcTBDhNtACt5CNgKDZ1Pve1NA=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.29", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-4CS+FoLPkymTlcga8jxivGDDb2AbWMIIl3b8+myoe2wtv/1ANYCErslgz1xy5hTVHymWE6CtVNKzRuPU0ED57A=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/integration-tests/bun.lock
+++ b/integration-tests/bun.lock
@@ -9,7 +9,7 @@
         "@earendil-works/pi-coding-agent": "0.84.2",
         "@openai/codex": "0.153.4",
         "@types/bun": "1.4.0",
-        "opencode-ai": "1.18.22",
+        "opencode-ai": "1.18.29",
         "playwright": "1.62.1",
         "puppeteer-core": "25.8.0",
         "typescript": "7.0.2",
@@ -339,31 +339,31 @@
 
     "openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
-    "opencode-ai": ["opencode-ai@1.18.22", "", { "optionalDependencies": { "opencode-darwin-arm64": "1.18.22", "opencode-darwin-x64": "1.18.22", "opencode-darwin-x64-baseline": "1.18.22", "opencode-linux-arm64": "1.18.22", "opencode-linux-arm64-musl": "1.18.22", "opencode-linux-x64": "1.18.22", "opencode-linux-x64-baseline": "1.18.22", "opencode-linux-x64-baseline-musl": "1.18.22", "opencode-linux-x64-musl": "1.18.22", "opencode-windows-arm64": "1.18.22", "opencode-windows-x64": "1.18.22", "opencode-windows-x64-baseline": "1.18.22" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "opencode": "bin/opencode.exe" } }, "sha512-cSIGgB6tX3P+8k4X2ZzuJ9ojClfo01ou0ck2ocRDNXLfhVJy4XVLk/WCsK/m+Venbz3p2qCNxpAFNb47Gj4tLQ=="],
+    "opencode-ai": ["opencode-ai@1.18.29", "", { "optionalDependencies": { "opencode-darwin-arm64": "1.18.29", "opencode-darwin-x64": "1.18.29", "opencode-darwin-x64-baseline": "1.18.29", "opencode-linux-arm64": "1.18.29", "opencode-linux-arm64-musl": "1.18.29", "opencode-linux-x64": "1.18.29", "opencode-linux-x64-baseline": "1.18.29", "opencode-linux-x64-baseline-musl": "1.18.29", "opencode-linux-x64-musl": "1.18.29", "opencode-windows-arm64": "1.18.29", "opencode-windows-x64": "1.18.29", "opencode-windows-x64-baseline": "1.18.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "opencode": "bin/opencode.exe" } }, "sha512-syIDVwlrYTgTOXzZe9SkInJWethbq6l3SNC762UeXyO0a9V0wGfd+U4yACvppwNBnhIsl0j2QPYYCyLpNaSomg=="],
 
-    "opencode-darwin-arm64": ["opencode-darwin-arm64@1.18.22", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fLqcO85WofzjnEw4FuuC4dUk09F9Ebj8iP26QhM00k1sum2ND7lYhTVfkgYDZweXgaMiceyPFjgxoOLFA/sfBQ=="],
+    "opencode-darwin-arm64": ["opencode-darwin-arm64@1.18.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EU0qma5GPJXcDp5rENvedSfqJjqxatQW/Qzjs71pR2YdbrSh7YmBwtvnIb2/KIvfQr0DErX4ST14sbBQI2mQdg=="],
 
-    "opencode-darwin-x64": ["opencode-darwin-x64@1.18.22", "", { "os": "darwin", "cpu": "x64" }, "sha512-FTbkagn7rLv5yXsdYs1LrBzkf8zsVoyvB6JnjONQ88UtmHcJmcymzZlbmM46RdG5ap8x50zDt+v7mieL3+57NA=="],
+    "opencode-darwin-x64": ["opencode-darwin-x64@1.18.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-Soyw5WI5kRI3Wbk5eeuSkMw4x+ScXi3SqzITMsi6rnVX0hsAbFCOmKOieYcd8BKJ1aUTrrG0Vv556CFzekk5Bw=="],
 
-    "opencode-darwin-x64-baseline": ["opencode-darwin-x64-baseline@1.18.22", "", { "os": "darwin", "cpu": "x64" }, "sha512-OuAaZdn55iz44YufSy5jzq4BtYESHImzcYj9nyS5ePYP3J57DoB/QE5RynQNGJXkpN/7enYlhvhuGiGlLWfPaA=="],
+    "opencode-darwin-x64-baseline": ["opencode-darwin-x64-baseline@1.18.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-LJAQWZd4Tixo/IYCM3qYDk+h+OydkcZY6ywL99K67acJzfiAmfzqDKUi7WuQkMrlTCSPoOxkyz3yTPd0GzVeXw=="],
 
-    "opencode-linux-arm64": ["opencode-linux-arm64@1.18.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-eYKPWDlGhIIxtUdRZMlp73UGbk6snBYAmemYvPcvg2OCs4nanvpRPPZGPfUUDShsgwUBUpWt+i2GOGTJBTVYdg=="],
+    "opencode-linux-arm64": ["opencode-linux-arm64@1.18.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-Lr7XXik5wPJZBV5RW+aR6Uogf1n5GogpB565m+D/jiO/vRXr9LhvCpixgAr1tiwuH1ZfMsqOOlbFQz5jgH3Tqg=="],
 
-    "opencode-linux-arm64-musl": ["opencode-linux-arm64-musl@1.18.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-jwayT6RPEFjahMQPg/xaoTwFdAKmfZeeE7pk5GcftHrBALdNfnVulOnYEFgsPCeIReHlT9eqdKLMPXMsP6YQpw=="],
+    "opencode-linux-arm64-musl": ["opencode-linux-arm64-musl@1.18.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-9lNhNvW3FdwbI+BDy/y+0bwIQkbz36u/RVQoZH2tYvWjHkOaf8D+mSuDKbKcFqpLFIbbQona01oYSQZzncZIcQ=="],
 
-    "opencode-linux-x64": ["opencode-linux-x64@1.18.22", "", { "os": "linux", "cpu": "x64" }, "sha512-TFjSVEgEaT0G4bda6x3T/yBjI3tu0o7N6TSBkFZbMeFlTCR6FYvS4QUkPbS9uZlR6PSi/KvyJau83s80PFNIGA=="],
+    "opencode-linux-x64": ["opencode-linux-x64@1.18.29", "", { "os": "linux", "cpu": "x64" }, "sha512-X8/wS/8mzL7Ko0zYYF6RzKax39KkxXDRoimhmzXuo0gPrZX4DQjqBNpPAByBwUjFapk73ZGSVsjDGvoNapBa1Q=="],
 
-    "opencode-linux-x64-baseline": ["opencode-linux-x64-baseline@1.18.22", "", { "os": "linux", "cpu": "x64" }, "sha512-gceBJKo7JvrqNPWnGM3SrbZcsNMZtzAWx3ONrWWwYi4cQ7hInaSzxc5E2G+qPY5vfp64ojedp+RtvZ1DzIVp5g=="],
+    "opencode-linux-x64-baseline": ["opencode-linux-x64-baseline@1.18.29", "", { "os": "linux", "cpu": "x64" }, "sha512-AnPvoVjeLC6qBYSeDwmj8fIVeJxspkrh1xAPow5NMSdH7IZZd0auiI2PHIW+0/3B+xfar1Zx1a6yvDd4Wd74Wg=="],
 
-    "opencode-linux-x64-baseline-musl": ["opencode-linux-x64-baseline-musl@1.18.22", "", { "os": "linux", "cpu": "x64" }, "sha512-Mfqi3gAJFzt/1Qc9/j7uYaEmW8Fc3ppPcz4F5USX15c4ShMhfAO4X84CM9zdYUiZV8mFaxwxPq3l6mpxoG8O7g=="],
+    "opencode-linux-x64-baseline-musl": ["opencode-linux-x64-baseline-musl@1.18.29", "", { "os": "linux", "cpu": "x64" }, "sha512-A60ew2Xu0gXPwjPYbXoYtkzpUYaLKpgp8dVU5RJpGhT2NBMWBaEyY8O/pcZJFvhPOoEFP9IYmcF2k8Pj4mjDfA=="],
 
-    "opencode-linux-x64-musl": ["opencode-linux-x64-musl@1.18.22", "", { "os": "linux", "cpu": "x64" }, "sha512-2ZkR8xsapxYEGxhDqxta/vhcaLsT0oB2U3P7tzznVvG/TX/IlhrAb8LuM2dc98uUaUxlWtG1yiyIclsb781mpg=="],
+    "opencode-linux-x64-musl": ["opencode-linux-x64-musl@1.18.29", "", { "os": "linux", "cpu": "x64" }, "sha512-bGAZ9NFzNOzrXVN9oczd1H+vzLH1aGyYg1ZZNtuZiszxKr8+vTjLnNcjzGJIuc6jtjvlWbfp8l+S5fxCVuQo2A=="],
 
-    "opencode-windows-arm64": ["opencode-windows-arm64@1.18.22", "", { "os": "win32", "cpu": "arm64" }, "sha512-7319aUnoV3U3n2GZqmdJ0HwrcrM/NMmxEtVJb/Ivm3B0PEoXMCNn/F8+GPVUnq6Ec8XY+24kqfRt8YOoMT4xlQ=="],
+    "opencode-windows-arm64": ["opencode-windows-arm64@1.18.29", "", { "os": "win32", "cpu": "arm64" }, "sha512-LwDli4EeZIGNnq8vJ9/uLIvsxAY0zLi6+54KsmOk8E1w7121axXpJ/5TpCg4LvmsNXwRKenKJgWzqoDBhy/2mw=="],
 
-    "opencode-windows-x64": ["opencode-windows-x64@1.18.22", "", { "os": "win32", "cpu": "x64" }, "sha512-7mf1furLXOosiLjNCtnmZO3Qsw9rsmniYP/SQwbrVK+N/RmgnWCBk8NIVlLYKPNhgzhF1MMtSfmeFDTpvSnHbw=="],
+    "opencode-windows-x64": ["opencode-windows-x64@1.18.29", "", { "os": "win32", "cpu": "x64" }, "sha512-xtWiZNMiwFtBl7q9yMG+XK/BTYGfgFoHLDx4ruWVYCoxjV0NYwjJi6rB9B3xIVbTclzu81YLKNFcT3kNBEG9Yw=="],
 
-    "opencode-windows-x64-baseline": ["opencode-windows-x64-baseline@1.18.22", "", { "os": "win32", "cpu": "x64" }, "sha512-xtmRw530O8o+rat8d6p1KPQWK63WjFjPzFZ8ZJvEoUaEnaQC1xpFMr+Tc8CN9Cr/Mjx/fZcO/vQ8BiIZCUmgBQ=="],
+    "opencode-windows-x64-baseline": ["opencode-windows-x64-baseline@1.18.29", "", { "os": "win32", "cpu": "x64" }, "sha512-rUqqp8zbHq5bc3yWPymQxCHgS2Fax07GoEq/KX1R+FE4XNDgL6R+Q1PFqqVDneLd3l0h5qPb+qqsiiWGGEORlA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -21,7 +21,7 @@
     "@earendil-works/pi-coding-agent": "0.84.2",
     "@openai/codex": "0.153.4",
     "@types/bun": "1.4.0",
-    "opencode-ai": "1.18.22",
+    "opencode-ai": "1.18.29",
     "playwright": "1.62.1",
     "puppeteer-core": "25.8.0",
     "typescript": "7.0.2"

--- a/integration-tests/support/opencode-process-supervisor.ts
+++ b/integration-tests/support/opencode-process-supervisor.ts
@@ -11,7 +11,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { access, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-export const PINNED_OPENCODE_VERSION = '1.18.22';
+export const PINNED_OPENCODE_VERSION = '1.18.29';
 const PROVIDER_OWNER_ENV = 'GARCON_TEST_OPENCODE_OWNER_GENERATION';
 
 export interface OpenCodeProcessIdentity {

--- a/integration-tests/support/scripted-opencode.ts
+++ b/integration-tests/support/scripted-opencode.ts
@@ -52,7 +52,7 @@ export const OPENCODE_TEST_THINKING_MODE = 'none';
 export const OPENCODE_TEST_REASONING_MODEL_ID = 'fake-reasoning';
 export const OPENCODE_TEST_REASONING_MODEL = `${OPENCODE_TEST_PROVIDER}/${OPENCODE_TEST_REASONING_MODEL_ID}`;
 
-// OpenCode 1.18.22 makes one initial request plus five retries for retryable failures.
+// OpenCode 1.18.29 makes one initial request plus five retries for retryable failures.
 // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/session/retry.ts#L31-L31
 export const OPENCODE_RETRY_EXHAUSTION_REQUEST_COUNT = 6;
 
@@ -75,7 +75,7 @@ const OPENCODE_AGENT_SETTINGS: AgentSettingsEnvelope = {
   values: {},
 };
 
-// OpenCode 1.18.22 schedules an @opencode-ai/plugin install for every config directory and
+// OpenCode 1.18.29 schedules an @opencode-ai/plugin install for every config directory and
 // skips reification only when node_modules exists and package.json plus package-lock.json
 // already declare the pinned plugin. Seeding these bytes keeps provider runtime offline; the
 // loopback npm registry trap turns any future attempt into an otherRequests() violation.
@@ -218,7 +218,7 @@ function assertFixtureOwnedPaths(paths: OpenCodePaths, fixtureRoot: string): voi
   }
 }
 
-// OpenCode 1.18.22 has no hermetic override for macOS managed-preference plist reads, so the
+// OpenCode 1.18.29 has no hermetic override for macOS managed-preference plist reads, so the
 // real-binary tier runs on Linux only; unit coverage remains cross-platform.
 export function assertScriptedOpenCodePlatform(platform: NodeJS.Platform = process.platform): void {
   if (platform !== 'linux') {

--- a/integration-tests/tests/server/opencode-provider-failures.test.ts
+++ b/integration-tests/tests/server/opencode-provider-failures.test.ts
@@ -244,7 +244,7 @@ describeOnLinux('scripted OpenCode provider failures', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
-  // OpenCode 1.18.22 continues the prompt loop after an unknown stream finish, so a
+  // OpenCode 1.18.29 continues the prompt loop after an unknown stream finish, so a
   // clean-close truncated Chat Completions stream is recovered by the next response
   // instead of ending the turn as an empty success.
   // https://github.com/anomalyco/opencode/commit/57fa34f23599f65dd1027f9caac31e6c576ce644

--- a/scripts/__tests__/docker-contract.test.js
+++ b/scripts/__tests__/docker-contract.test.js
@@ -33,16 +33,21 @@ let dockerGuide;
 let dockerignore;
 let rootPackage;
 let integrationPackage;
+let opencodeAgentPackage;
+let opencodeSupervisor;
 
 beforeAll(async () => {
-  [dockerfile, composeFile, dockerGuide, dockerignore, rootPackage, integrationPackage] = await Promise.all([
-    readFile(path.join(repositoryRoot, 'Dockerfile'), 'utf8'),
-    readFile(path.join(repositoryRoot, 'docker-compose.yml'), 'utf8'),
-    readFile(path.join(repositoryRoot, 'docs/docker.md'), 'utf8'),
-    readFile(path.join(repositoryRoot, '.dockerignore'), 'utf8'),
-    readFile(path.join(repositoryRoot, 'package.json'), 'utf8').then(JSON.parse),
-    readFile(path.join(repositoryRoot, 'integration-tests/package.json'), 'utf8').then(JSON.parse),
-  ]);
+  [dockerfile, composeFile, dockerGuide, dockerignore, rootPackage, integrationPackage, opencodeAgentPackage, opencodeSupervisor] =
+    await Promise.all([
+      readFile(path.join(repositoryRoot, 'Dockerfile'), 'utf8'),
+      readFile(path.join(repositoryRoot, 'docker-compose.yml'), 'utf8'),
+      readFile(path.join(repositoryRoot, 'docs/docker.md'), 'utf8'),
+      readFile(path.join(repositoryRoot, '.dockerignore'), 'utf8'),
+      readFile(path.join(repositoryRoot, 'package.json'), 'utf8').then(JSON.parse),
+      readFile(path.join(repositoryRoot, 'integration-tests/package.json'), 'utf8').then(JSON.parse),
+      readFile(path.join(repositoryRoot, 'server-agents/opencode/package.json'), 'utf8').then(JSON.parse),
+      readFile(path.join(repositoryRoot, 'integration-tests/support/opencode-process-supervisor.ts'), 'utf8'),
+    ]);
 });
 
 describe('Docker contract', () => {
@@ -63,6 +68,8 @@ describe('Docker contract', () => {
   test('keeps coupled CLI versions aligned with the integration tier', () => {
     const openCodeVersion = integrationPackage.devDependencies['opencode-ai'];
     expect(dockerfile).toContain(`ARG OPENCODE_VERSION=${openCodeVersion}`);
+    expect(opencodeAgentPackage.dependencies['@opencode-ai/sdk']).toBe(openCodeVersion);
+    expect(opencodeSupervisor).toContain(`export const PINNED_OPENCODE_VERSION = '${openCodeVersion}';`);
     expect(dockerfile).not.toContain('@openai/codex');
     expect(dockerfile).not.toContain('pi-coding-agent');
     expect(dockerfile).not.toContain('opencode-ai@latest');

--- a/server-agents/opencode/package.json
+++ b/server-agents/opencode/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "exports": { ".": "./src/index.ts" },
   "scripts": { "typecheck": "bunx tsc -p tsconfig.json" },
-  "dependencies": { "@garcon/common": "workspace:*", "@garcon/server-agent-common": "workspace:*", "@garcon/server-agent-interface": "workspace:*", "@opencode-ai/sdk": "1.18.22" },
+  "dependencies": { "@garcon/common": "workspace:*", "@garcon/server-agent-common": "workspace:*", "@garcon/server-agent-interface": "workspace:*", "@opencode-ai/sdk": "1.18.29" },
   "devDependencies": { "@types/bun": "^1.4.0", "typescript": "^6.0.3" },
   "garconBuild": {
     "apiVersion": 2,

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -1644,7 +1644,7 @@ export class OpenCodeRuntime {
     options.signal?.throwIfAborted();
     // Native fork clones only messages: the forked session carries no permission
     // ruleset, so without this the forked chat prompts for everything the source
-    // had allowed. https://github.com/anomalyco/opencode/blob/v1.18.22/packages/opencode/src/session/session.ts#L691-L701
+    // had allowed. https://github.com/anomalyco/opencode/blob/v1.18.29/packages/opencode/src/session/session.ts#L691-L701
     const permissionMode = options.permissionMode;
     if (permissionMode) {
       try {

--- a/server-agents/opencode/src/agents/opencode/project-path.ts
+++ b/server-agents/opencode/src/agents/opencode/project-path.ts
@@ -7,7 +7,7 @@ import {
 import { OpenCodeTimeoutError } from './request-control.js';
 import { OpenCodeSdkResultError } from './sdk-result.js';
 
-// OpenCode 1.18.22 flattens mismatch and missing-session errors into fixed messages.
+// OpenCode 1.18.29 flattens mismatch and missing-session errors into fixed messages.
 // https://github.com/anomalyco/opencode/blob/47b6b6f5f4f9b42d2bce7af1c4e5bf6efaf22ba7/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts#L30-L36
 const DESTINATION_PROJECT_MISMATCH = 'Destination directory belongs to another project';
 const SESSION_NOT_FOUND_PREFIX = 'Session not found:';

--- a/server-agents/opencode/src/agents/opencode/server-instance.ts
+++ b/server-agents/opencode/src/agents/opencode/server-instance.ts
@@ -7,6 +7,10 @@ export function buildOpenCodeServerEnv(
   const { OPENCODE_PURE: _pureMode, ...serverEnv } = baseEnv;
   return {
     ...serverEnv,
+    // Empty content keeps OpenCode's built-in provider defaults active, including
+    // the five-minute header and inter-chunk stream timeouts adopted in 1.18.29;
+    // Garcon sets no turn deadline of its own, and chunk stalls stay retryable
+    // inside OpenCode.
     OPENCODE_CONFIG_CONTENT: '{}',
     OPENCODE_DISABLE_AUTOUPDATE: '1',
   };

--- a/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
+++ b/server-agents/opencode/src/agents/opencode/tool-use-converter.ts
@@ -75,7 +75,7 @@ function canonicalize(raw: unknown): string {
   return raw.trim().toLowerCase().replace(/[\s_\-]+/g, '');
 }
 
-// Pins the built-in tool inventory shipped by OpenCode 1.18.22 so dependency
+// Pins the built-in tool inventory shipped by OpenCode 1.18.29 so dependency
 // upgrades must reconcile every provider-owned tool with Garcon's contract.
 // https://github.com/anomalyco/opencode/blob/2b72179c663cadcb54f54d9f19221b3fb3d11fb6/packages/opencode/src/tool/registry.ts#L229-L249
 export const OPENCODE_BUILTIN_TOOL_IDS = Object.freeze([


### PR DESCRIPTION
Bumps the OpenCode integration from 1.18.22 to 1.18.29 across the SDK dependency, the scripted-tier binary pin, the supervisor pin, and the Dockerfile, with both lockfiles following. The upstream delta leaves the SDK generator byte-identical and touches none of the protocol surfaces Garcon consumes (serve readiness output, /global/event bus, session and message Part shapes, permission and question flows, retry behavior, tool registry, plugin install scheduling), so no source adaptation is needed; the seven behavior-pinning comments that cite 1.18.22 were each re-verified against the 1.18.29 tree and repinned. The one inherited runtime change, five-minute provider header and inter-chunk stream timeouts replacing unbounded 1.18.22 streams, is accepted and recorded beside OPENCODE_CONFIG_CONTENT since Garcon sets no turn deadline of its own and chunk stalls stay retryable inside OpenCode. The Docker contract test now cross-checks all four version pins against the integration tier. Validated with the full scripted real-binary tier (14 suites) against the 1.18.29 binary, agent unit tests, typecheck, the root suite, and a startup smoke.