### PR TITLE
Harden git discard routing, network command bounds, and chat registry isolation

### DIFF
--- a/server/chats/__tests__/store.test.js
+++ b/server/chats/__tests__/store.test.js
@@ -82,18 +82,26 @@ describe('ChatRegistry', () => {
     registry.addChat(newChat({
       tags: ['source'],
       agentSettingsById: { test: envelope('test') },
+      agentOwnershipEpoch: 'epoch-1',
+      pendingPreambleBoundary: { kind: 'new-chat', ownershipEpoch: 'epoch-1' },
     }));
 
     const chat = registry.getChat(CHAT_ID);
     chat.tags.push('injected');
     chat.agentSettingsById.test.values.injected = true;
+    chat.pendingPreambleBoundary.ownershipEpoch = 'injected';
 
     const updated = registry.updateChat(CHAT_ID, { model: 'other-model' });
     updated.tags.push('via-update');
     updated.agentSettingsById.test.values.injected = true;
+    updated.pendingPreambleBoundary.ownershipEpoch = 'injected';
 
     expect(registry.getChat(CHAT_ID).tags).toEqual(['source']);
     expect(registry.getChat(CHAT_ID).agentSettingsById.test.values).toEqual({});
+    expect(registry.getChat(CHAT_ID).pendingPreambleBoundary).toEqual({
+      kind: 'new-chat',
+      ownershipEpoch: 'epoch-1',
+    });
   });
 
   it('clones caller-owned collections on ingest', () => {

--- a/server/chats/store.ts
+++ b/server/chats/store.ts
@@ -972,12 +972,17 @@ export class ChatRegistry extends EventEmitter<ChatRegistryEvents> implements IC
 function cloneRegistryEntry(entry: ChatRegistryEntry): ChatRegistryEntry {
   return {
     ...entry,
-    // Frozen fields (parentChat, carryOverSegments) are safe to share; copy the mutable ones
-    // so callers cannot mutate registry state through a handed-out entry.
+    // Deeply frozen fields (parentChat, carryOverSegments) are safe to share; every
+    // other nested field must be copied here so callers cannot mutate registry
+    // state through a handed-out entry. New entry fields declare themselves by
+    // landing in one of these two groups.
     agentSettingsById: structuredClone(entry.agentSettingsById),
     tags: [...entry.tags],
     nativeSession: entry.nativeSession ? structuredClone(entry.nativeSession) : null,
     nativeSeedReceipt: entry.nativeSeedReceipt ? { ...entry.nativeSeedReceipt } : null,
+    pendingPreambleBoundary: entry.pendingPreambleBoundary
+      ? { ...entry.pendingPreambleBoundary }
+      : null,
     carryOverMigrationQuarantine: entry.carryOverMigrationQuarantine
       ? { ...entry.carryOverMigrationQuarantine }
       : null,

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1757,6 +1757,38 @@ describe("discard", () => {
     }
   });
 
+  it("resets only the destination when discarding a worktree copy", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "copies"]);
+      await fs.writeFile(path.join(projectPath, "z.txt"), "one\n", "utf-8");
+      await runGitCommand(projectPath, ["rm", "a.txt"]);
+      await runGitCommand(projectPath, ["add", "z.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add z"]);
+      // The copy source carries its own unstaged edit, which the discard of
+      // the copy destination must not touch.
+      await fs.copyFile(path.join(projectPath, "z.txt"), path.join(projectPath, "a2.txt"));
+      await runGitCommand(projectPath, ["add", "-N", "a2.txt"]);
+      await fs.writeFile(path.join(projectPath, "z.txt"), "one\nedit\n", "utf-8");
+      const listed = (await runGitCommand(projectPath, ["status", "--porcelain"])).stdout;
+      expect(listed).toContain("C z.txt -> a2.txt");
+
+      await git.discard({ projectPath, file: "a2.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("M z.txt\n?? a2.txt");
+      expect(await fs.readFile(path.join(projectPath, "z.txt"), "utf-8"))
+        .toBe("one\nedit\n");
+      expect(await fs.readFile(path.join(projectPath, "a2.txt"), "utf-8"))
+        .toBe("one\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
   it("leaves index-only deletions untouched instead of failing restore", async () => {
     const projectPath = await fs.mkdtemp(
       path.join(os.tmpdir(), "garcon-git-discard-"),

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1733,8 +1733,10 @@ describe("discard", () => {
       await runGitCommand(projectPath, ["add", "z.txt"]);
       await runGitCommand(projectPath, ["commit", "-m", "add z"]);
       // The copy destination sorts before its source, so the copy entry is
-      // listed first and an originalPath-first lookup would hijack the
-      // source's own modification entry.
+      // listed first. The rename-only fallback gate keeps that entry from
+      // ever matching the source: this fixture pins a copy-source discard
+      // reverting the source's own modification while the copy's index
+      // entry stays untouched.
       await fs.copyFile(path.join(projectPath, "z.txt"), path.join(projectPath, "a2.txt"));
       await runGitCommand(projectPath, ["add", "-N", "a2.txt"]);
       await fs.writeFile(path.join(projectPath, "z.txt"), "one\nedit\n", "utf-8");

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1814,6 +1814,61 @@ describe("discard", () => {
     }
   });
 
+  it("restores a staged addition consumed by a worktree rename", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "true"]);
+      await fs.writeFile(path.join(projectPath, "b.txt"), "staged content\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "b.txt"]);
+      await fs.rename(path.join(projectPath, "b.txt"), path.join(projectPath, "c.txt"));
+      await runGitCommand(projectPath, ["add", "-N", "c.txt"]);
+      // The staged-only entry for the source shadows the worktree rename that
+      // consumed it; the request names the rename's source side.
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("A  b.txt\n R b.txt -> c.txt");
+
+      await git.discard({ projectPath, file: "b.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("A  b.txt\n?? c.txt");
+      expect(await fs.readFile(path.join(projectPath, "b.txt"), "utf-8"))
+        .toBe("staged content\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("restores a staged modification consumed by a worktree rename", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "true"]);
+      await fs.writeFile(path.join(projectPath, "s.txt"), "base\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "s.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add s"]);
+      await fs.writeFile(path.join(projectPath, "s.txt"), "staged edit\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "s.txt"]);
+      await fs.rename(path.join(projectPath, "s.txt"), path.join(projectPath, "t.txt"));
+      await runGitCommand(projectPath, ["add", "-N", "t.txt"]);
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("M  s.txt\n R s.txt -> t.txt");
+
+      await git.discard({ projectPath, file: "s.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("M  s.txt\n?? t.txt");
+      expect(await fs.readFile(path.join(projectPath, "s.txt"), "utf-8"))
+        .toBe("staged edit\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
   it("leaves index-only deletions untouched instead of failing restore", async () => {
     const projectPath = await fs.mkdtemp(
       path.join(os.tmpdir(), "garcon-git-discard-"),

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1475,6 +1475,90 @@ describe("discard", () => {
       await fs.rm(projectPath, { recursive: true, force: true });
     }
   });
+
+  it("reverts both-added conflicts to the HEAD version without leaving markers", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      // A real add/add conflict: HEAD keeps its own version while the
+      // worktree holds the merge markers.
+      await runGitCommand(projectPath, ["checkout", "-b", "other"]);
+      await fs.writeFile(path.join(projectPath, "f.txt"), "theirs\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "f.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "theirs adds"]);
+      await runGitCommand(projectPath, ["checkout", "master"]);
+      await fs.writeFile(path.join(projectPath, "f.txt"), "ours\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "f.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "ours adds"]);
+      try {
+        await runGitCommand(projectPath, ["merge", "other"]);
+      } catch {
+        // Expected merge conflict.
+      }
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("AA f.txt");
+
+      await git.discard({ projectPath, file: "f.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("");
+      expect(await fs.readFile(path.join(projectPath, "f.txt"), "utf-8"))
+        .toBe("ours\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("reverts unstaged renames by restoring both source and destination", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "true"]);
+      await fs.copyFile(path.join(projectPath, "a.txt"), path.join(projectPath, "dst.txt"));
+      await runGitCommand(projectPath, ["add", "dst.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add dst"]);
+      await runGitCommand(projectPath, ["rm", "--cached", "dst.txt"]);
+      await runGitCommand(projectPath, ["add", "-N", "dst.txt"]);
+      await fs.rm(path.join(projectPath, "a.txt"));
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("DR a.txt -> dst.txt");
+
+      await git.discard({ projectPath, file: "dst.txt" });
+
+      // The source reappears at its index content and leaves the status; the
+      // destination keeps its intent-to-add index state.
+      expect(await fs.readFile(path.join(projectPath, "a.txt"), "utf-8"))
+        .toBe("one\n");
+      const status = (await runGitCommand(projectPath, ["status", "--porcelain"])).stdout;
+      expect(status.includes("a.txt")).toBe(false);
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves index-only deletions untouched instead of failing restore", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await fs.rm(path.join(projectPath, "a.txt"));
+      await runGitCommand(projectPath, ["rm", "--cached", "a.txt"]);
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("D  a.txt");
+
+      await git.discard({ projectPath, file: "a.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("D  a.txt");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("commit message generation", () => {

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1529,12 +1529,120 @@ describe("discard", () => {
 
       await git.discard({ projectPath, file: "dst.txt" });
 
-      // The source reappears at its index content and leaves the status; the
-      // destination keeps its intent-to-add index state.
+      // The source reappears at its index content and the destination returns
+      // to its committed state, so the tree is fully clean.
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("");
       expect(await fs.readFile(path.join(projectPath, "a.txt"), "utf-8"))
         .toBe("one\n");
-      const status = (await runGitCommand(projectPath, ["status", "--porcelain"])).stdout;
-      expect(status.includes("a.txt")).toBe(false);
+      expect(await fs.readFile(path.join(projectPath, "dst.txt"), "utf-8"))
+        .toBe("one\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves worktree content when discarding a rename onto a new path", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "true"]);
+      await fs.writeFile(path.join(projectPath, "a.txt"), "one\ntwo\nthree\nfour\n", "utf-8");
+      await runGitCommand(projectPath, ["commit", "-am", "longer source"]);
+      // The destination is an edited copy well above the rename similarity
+      // threshold, so git pairs it as an unstaged rename.
+      await fs.writeFile(
+        path.join(projectPath, "renamed.txt"),
+        "one\ntwo\nthree\nfour\nfive\n",
+        "utf-8",
+      );
+      await runGitCommand(projectPath, ["add", "-N", "renamed.txt"]);
+      await fs.rm(path.join(projectPath, "a.txt"));
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("R a.txt -> renamed.txt");
+
+      await git.discard({ projectPath, file: "renamed.txt" });
+
+      // The source restores to its index content; resetting the destination's
+      // intent-to-add entry keeps the edited worktree copy as untracked
+      // instead of truncating it to the empty index blob.
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("?? renamed.txt");
+      expect(await fs.readFile(path.join(projectPath, "a.txt"), "utf-8"))
+        .toBe("one\ntwo\nthree\nfour\n");
+      expect(await fs.readFile(path.join(projectPath, "renamed.txt"), "utf-8"))
+        .toBe("one\ntwo\nthree\nfour\nfive\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("discards worktree renames from their source path", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "true"]);
+      await fs.copyFile(path.join(projectPath, "a.txt"), path.join(projectPath, "renamed.txt"));
+      await runGitCommand(projectPath, ["add", "-N", "renamed.txt"]);
+      await fs.rm(path.join(projectPath, "a.txt"));
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("R a.txt -> renamed.txt");
+
+      await git.discard({ projectPath, file: "a.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("?? renamed.txt");
+      expect(await fs.readFile(path.join(projectPath, "a.txt"), "utf-8"))
+        .toBe("one\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves worktree content when discarding intent-to-add entries", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await fs.writeFile(path.join(projectPath, "new.txt"), "content\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "-N", "new.txt"]);
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("A new.txt");
+
+      await git.discard({ projectPath, file: "new.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("?? new.txt");
+      expect(await fs.readFile(path.join(projectPath, "new.txt"), "utf-8"))
+        .toBe("content\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("discards through a project path below the repository root", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await fs.mkdir(path.join(projectPath, "sub"));
+      await fs.writeFile(path.join(projectPath, "sub", "x.txt"), "sub content\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "sub/x.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add sub"]);
+      await fs.writeFile(path.join(projectPath, "sub", "x.txt"), "edited\n", "utf-8");
+
+      await git.discard({ projectPath: path.join(projectPath, "sub"), file: "x.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("");
+      expect(await fs.readFile(path.join(projectPath, "sub", "x.txt"), "utf-8"))
+        .toBe("sub content\n");
     } finally {
       await fs.rm(projectPath, { recursive: true, force: true });
     }

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1648,6 +1648,115 @@ describe("discard", () => {
     }
   });
 
+  it("keeps a tracked rename destination as a modification when its content differs", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "true"]);
+      await fs.writeFile(path.join(projectPath, "a.txt"), "one\ntwo\nthree\nfour\n", "utf-8");
+      await runGitCommand(projectPath, ["commit", "-am", "longer source"]);
+      await fs.copyFile(path.join(projectPath, "a.txt"), path.join(projectPath, "dst.txt"));
+      await runGitCommand(projectPath, ["add", "dst.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add dst"]);
+      await runGitCommand(projectPath, ["rm", "--cached", "dst.txt"]);
+      await runGitCommand(projectPath, ["add", "-N", "dst.txt"]);
+      // The destination drifts from its committed content while staying
+      // similar enough for the rename pairing.
+      await fs.writeFile(
+        path.join(projectPath, "dst.txt"),
+        "one\ntwo\nthree\nfour\nedited\n",
+        "utf-8",
+      );
+      await fs.rm(path.join(projectPath, "a.txt"));
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("DR a.txt -> dst.txt");
+
+      await git.discard({ projectPath, file: "dst.txt" });
+
+      // Resetting the destination leaves the never-hashed edit as an unstaged
+      // modification instead of truncating it to the committed content.
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("M dst.txt");
+      expect(await fs.readFile(path.join(projectPath, "a.txt"), "utf-8"))
+        .toBe("one\ntwo\nthree\nfour\n");
+      expect(await fs.readFile(path.join(projectPath, "dst.txt"), "utf-8"))
+        .toBe("one\ntwo\nthree\nfour\nedited\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a conflicted file named like a pathspec glob literally", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      // A conflicted path literally named "*" must not expand in the reset
+      // and restore pathspecs: globbed, it would rewrite every tracked file.
+      await fs.writeFile(path.join(projectPath, "*"), "head-star\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "*"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add star"]);
+      await plantUnmergedStages(projectPath, "*", [
+        [1, "base\n"],
+        [2, "ours\n"],
+        [3, "theirs\n"],
+      ]);
+      await fs.writeFile(path.join(projectPath, "a.txt"), "edited\n", "utf-8");
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("UU *\n M a.txt");
+
+      await git.discard({ projectPath, file: "*" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("M a.txt");
+      expect(await fs.readFile(path.join(projectPath, "*"), "utf-8"))
+        .toBe("head-star\n");
+      expect(await fs.readFile(path.join(projectPath, "a.txt"), "utf-8"))
+        .toBe("edited\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the requested path's own entry over a rename original", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await runGitCommand(projectPath, ["config", "status.renames", "copies"]);
+      await fs.writeFile(path.join(projectPath, "z.txt"), "one\n", "utf-8");
+      await runGitCommand(projectPath, ["rm", "a.txt"]);
+      await runGitCommand(projectPath, ["add", "z.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add z"]);
+      // The copy destination sorts before its source, so the copy entry is
+      // listed first and an originalPath-first lookup would hijack the
+      // source's own modification entry.
+      await fs.copyFile(path.join(projectPath, "z.txt"), path.join(projectPath, "a2.txt"));
+      await runGitCommand(projectPath, ["add", "-N", "a2.txt"]);
+      await fs.writeFile(path.join(projectPath, "z.txt"), "one\nedit\n", "utf-8");
+      const listed = (await runGitCommand(projectPath, ["status", "--porcelain"])).stdout;
+      expect(listed).toContain("C z.txt -> a2.txt");
+      expect(listed).toContain("M z.txt");
+
+      await git.discard({ projectPath, file: "z.txt" });
+
+      // The source's own modification entry governs: its edit reverts while
+      // the copy destination keeps its intent-to-add entry untouched.
+      expect(await fs.readFile(path.join(projectPath, "z.txt"), "utf-8"))
+        .toBe("one\n");
+      expect((await runGitCommand(projectPath, ["ls-files", "--cached", "a2.txt"])).stdout)
+        .toContain("a2.txt");
+      expect(await fs.readFile(path.join(projectPath, "a2.txt"), "utf-8"))
+        .toBe("one\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
   it("leaves index-only deletions untouched instead of failing restore", async () => {
     const projectPath = await fs.mkdtemp(
       path.join(os.tmpdir(), "garcon-git-discard-"),

--- a/server/git/__tests__/git-service.test.js
+++ b/server/git/__tests__/git-service.test.js
@@ -1789,6 +1789,29 @@ describe("discard", () => {
     }
   });
 
+  it("discards through a project path containing a newline", async () => {
+    const projectPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "garcon-git-discard-"),
+    );
+    try {
+      await initRepoWithCommit(projectPath);
+      await fs.mkdir(path.join(projectPath, "sub\nline"), { recursive: true });
+      await fs.writeFile(path.join(projectPath, "sub\nline", "x.txt"), "sub content\n", "utf-8");
+      await runGitCommand(projectPath, ["add", "--", "sub\nline/x.txt"]);
+      await runGitCommand(projectPath, ["commit", "-m", "add nested"]);
+      await fs.writeFile(path.join(projectPath, "sub\nline", "x.txt"), "edited\n", "utf-8");
+
+      await git.discard({ projectPath: path.join(projectPath, "sub\nline"), file: "x.txt" });
+
+      expect((await runGitCommand(projectPath, ["status", "--porcelain"])).stdout.trim())
+        .toBe("");
+      expect(await fs.readFile(path.join(projectPath, "sub\nline", "x.txt"), "utf-8"))
+        .toBe("sub content\n");
+    } finally {
+      await fs.rm(projectPath, { recursive: true, force: true });
+    }
+  });
+
   it("leaves index-only deletions untouched instead of failing restore", async () => {
     const projectPath = await fs.mkdtemp(
       path.join(os.tmpdir(), "garcon-git-discard-"),

--- a/server/git/__tests__/network-git-options.test.js
+++ b/server/git/__tests__/network-git-options.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createStatusOperations } from "../status.js";
+
+// The network timeout derives from the HTTP idle budget. Config re-reads the
+// environment on every call until initializeServerConfig() pins a value, so
+// setting the budget at file scope reaches the operations under test; 4s
+// yields a 2s bound (4s - 2s margin).
+process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS = "4";
+
+const fakeGitScript = `#!${process.execPath}
+const argv = process.argv.slice(2);
+const cmd = argv[0];
+if (cmd === "rev-parse") {
+  if (argv.includes("--is-inside-work-tree")) {
+    console.log("true");
+    process.exit(0);
+  }
+  const last = argv.at(-1) ?? "";
+  if (last.includes("@{upstream}")) process.exit(1);
+  console.log("main");
+  process.exit(0);
+}
+if (cmd === "fetch" || cmd === "pull" || cmd === "push") {
+  const fs = await import("node:fs");
+  fs.appendFileSync(
+    process.env.FAKE_GIT_RECORD,
+    JSON.stringify({ argv, terminalPrompt: process.env.GIT_TERMINAL_PROMPT ?? null }) + "\\n",
+  );
+  if (process.env.FAKE_GIT_SLEEP === "1") await new Promise(() => {});
+  console.log("network ok");
+  process.exit(0);
+}
+console.log("");
+process.exit(0);
+`;
+
+describe("network git options wiring", () => {
+  let commandDirectory;
+  let projectPath;
+  let originalPath;
+  let originalTerminalPrompt;
+  let originalIdleTimeout;
+  let operations;
+
+  beforeAll(() => {
+    commandDirectory = mkdtempSync(path.join(os.tmpdir(), "garcon-fake-git-net-"));
+    const fakeGitPath = path.join(commandDirectory, "git");
+    writeFileSync(fakeGitPath, fakeGitScript, { mode: 0o755 });
+    projectPath = mkdtempSync(path.join(os.tmpdir(), "garcon-net-project-"));
+    originalPath = process.env.PATH;
+    originalIdleTimeout = process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS;
+    // An inherited value would satisfy the spawn env even with the option
+    // unwired, masking the regression this suite pins.
+    originalTerminalPrompt = process.env.GIT_TERMINAL_PROMPT ?? null;
+    delete process.env.GIT_TERMINAL_PROMPT;
+    process.env.PATH = `${commandDirectory}${path.delimiter}${originalPath}`;
+    operations = createStatusOperations({
+      run: () => {
+        throw new Error("agent runner must not be used by network commands");
+      },
+    });
+  });
+
+  afterAll(() => {
+    process.env.PATH = originalPath;
+    if (originalIdleTimeout === undefined) delete process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS;
+    else process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS = originalIdleTimeout;
+    if (originalTerminalPrompt !== null) process.env.GIT_TERMINAL_PROMPT = originalTerminalPrompt;
+    delete process.env.FAKE_GIT_SLEEP;
+    delete process.env.FAKE_GIT_RECORD;
+    rmSync(commandDirectory, { recursive: true, force: true });
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  function recordedCalls() {
+    return readFileSync(process.env.FAKE_GIT_RECORD, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  }
+
+  function freshRecorder() {
+    const recordPath = path.join(commandDirectory, "record.log");
+    writeFileSync(recordPath, "");
+    process.env.FAKE_GIT_RECORD = recordPath;
+    return recordPath;
+  }
+
+  it("runs fetch, pull, and push with terminal prompts disabled", async () => {
+    freshRecorder();
+    await operations.fetch({ projectPath });
+    await operations.pull({ projectPath });
+    await operations.push({ projectPath });
+
+    const calls = recordedCalls().map(({ argv, terminalPrompt }) => ({
+      command: argv[0],
+      args: argv.slice(1),
+      terminalPrompt,
+    }));
+    expect(calls).toEqual([
+      { command: "fetch", args: ["origin"], terminalPrompt: "0" },
+      { command: "pull", args: ["origin", "main"], terminalPrompt: "0" },
+      { command: "push", args: ["origin", "main:main"], terminalPrompt: "0" },
+    ]);
+  });
+
+  it("bounds a hung fetch, pull, and push by the idle-budget timeout", async () => {
+    freshRecorder();
+    process.env.FAKE_GIT_SLEEP = "1";
+    try {
+      // Each operation runs concurrently: 4s idle budget minus the 2s margin
+      // bounds every network command at 2s, while the runner's 30s default
+      // would keep the request hanging far past the HTTP budget.
+      const runs = await Promise.all(["fetch", "pull", "push"].map(async (op) => {
+        const startedAt = performance.now();
+        await expect(operations[op]({ projectPath })).rejects.toMatchObject({
+          timedOut: true,
+        });
+        return performance.now() - startedAt;
+      }));
+      for (const elapsed of runs) {
+        // Above the 1s floor to pin the 4s derivation, below the 30s default.
+        expect(elapsed).toBeGreaterThan(1_500);
+        expect(elapsed).toBeLessThan(6_000);
+      }
+      const calls = recordedCalls();
+      expect(calls).toHaveLength(3);
+      for (const call of calls) {
+        expect(call.terminalPrompt).toBe("0");
+      }
+      expect(calls.map((call) => call.argv[0]).sort()).toEqual(["fetch", "pull", "push"]);
+    } finally {
+      delete process.env.FAKE_GIT_SLEEP;
+    }
+  }, 15_000);
+});

--- a/server/git/__tests__/network-git-options.test.js
+++ b/server/git/__tests__/network-git-options.test.js
@@ -7,7 +7,9 @@ import { createStatusOperations } from "../status.js";
 // The network timeout derives from the HTTP idle budget. Config re-reads the
 // environment on every call until initializeServerConfig() pins a value, so
 // setting the budget at file scope reaches the operations under test; 4s
-// yields a 2s bound (4s - 2s margin).
+// yields a 2s bound (4s - 2s margin). The inherited value is captured before
+// the assignment so teardown can restore it exactly.
+const inheritedIdleTimeout = process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS;
 process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS = "4";
 
 const fakeGitScript = `#!${process.execPath}
@@ -42,7 +44,6 @@ describe("network git options wiring", () => {
   let projectPath;
   let originalPath;
   let originalTerminalPrompt;
-  let originalIdleTimeout;
   let operations;
 
   beforeAll(() => {
@@ -51,7 +52,6 @@ describe("network git options wiring", () => {
     writeFileSync(fakeGitPath, fakeGitScript, { mode: 0o755 });
     projectPath = mkdtempSync(path.join(os.tmpdir(), "garcon-net-project-"));
     originalPath = process.env.PATH;
-    originalIdleTimeout = process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS;
     // An inherited value would satisfy the spawn env even with the option
     // unwired, masking the regression this suite pins.
     originalTerminalPrompt = process.env.GIT_TERMINAL_PROMPT ?? null;
@@ -66,8 +66,8 @@ describe("network git options wiring", () => {
 
   afterAll(() => {
     process.env.PATH = originalPath;
-    if (originalIdleTimeout === undefined) delete process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS;
-    else process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS = originalIdleTimeout;
+    if (inheritedIdleTimeout === undefined) delete process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS;
+    else process.env.GARCON_HTTP_IDLE_TIMEOUT_SECONDS = inheritedIdleTimeout;
     if (originalTerminalPrompt !== null) process.env.GIT_TERMINAL_PROMPT = originalTerminalPrompt;
     delete process.env.FAKE_GIT_SLEEP;
     delete process.env.FAKE_GIT_RECORD;

--- a/server/git/__tests__/run.test.js
+++ b/server/git/__tests__/run.test.js
@@ -197,10 +197,28 @@ stream.write(output);
       timedOut: true,
       stderr: expect.stringContaining('index.lock'),
     });
-    // A stalled first sleep can expire the budget before the second spawn,
-    // so pin the range: never a third spawn, never an unbounded retry loop.
+    // The delay is bounded by the remaining budget, so quick failing attempts
+    // can squeeze a third spawn in before expiry; pin the range instead: the
+    // budget always runs out, never an unbounded retry loop.
     expect(attempts).toBeGreaterThanOrEqual(1);
-    expect(attempts).toBeLessThanOrEqual(2);
+    expect(attempts).toBeLessThanOrEqual(3);
+  });
+
+  it('keeps the lock retry delay inside the timeout budget', async () => {
+    spawnMock.mockImplementation(() => ({
+      stdout: textStream(''),
+      stderr: textStream("fatal: Unable to create '.git/index.lock': File exists."),
+      exited: Promise.resolve(128),
+      kill: mock(() => undefined),
+    }));
+
+    const startedAt = performance.now();
+    await expect(
+      runGit('/repo', ['reset', 'HEAD', '--', 'a.txt'], { timeoutMs: 40 }),
+    ).rejects.toMatchObject({ timedOut: true });
+    // The delay used to sleep a full 100ms after the budget had already
+    // expired, overshooting timeoutMs by more than double.
+    expect(performance.now() - startedAt).toBeLessThan(90);
   });
 
   it('reports an already-aborted caller signal as aborted', async () => {

--- a/server/git/discard.ts
+++ b/server/git/discard.ts
@@ -26,12 +26,6 @@ async function headHasPath(projectPath: string, file: string): Promise<boolean> 
 export async function discard({ projectPath, file }: FileOptions): Promise<unknown> {
   await assertGitRepository(projectPath);
 
-  // Porcelain paths are repository-root relative; canonicalize the request
-  // and run every git command from the root so lookups and pathspecs agree
-  // even when projectPath sits below the root or reaches it through a
-  // symlink. --show-prefix is git's own answer for the offset, so the
-  // physical root never leaks a '..' segment, and only the newline is
-  // stripped so a root path ending in whitespace survives.
   const { stdout: rootOutput } = await runGit(
     projectPath,
     ['rev-parse', '--show-toplevel', '--show-prefix'],
@@ -39,7 +33,8 @@ export async function discard({ projectPath, file }: FileOptions): Promise<unkno
   );
   const [rootLine = '', prefixLine = ''] = rootOutput.split('\n');
   const repoRoot = rootLine || projectPath;
-  const canonicalFile = `${prefixLine}${file.replace(/\/+$/, '')}`;
+  const projectPrefix = prefixLine;
+  const canonicalFile = `${projectPrefix}${file.replace(/\/+$/, '')}`;
 
   const { stdout: statusOutput } = await runGit(
     repoRoot,
@@ -50,17 +45,17 @@ export async function discard({ projectPath, file }: FileOptions): Promise<unkno
   // pathspec cannot pair the rename and reports DA, hiding the source path
   // that the worktree side of the change spans. An exact path match wins,
   // because a copy source keeps an entry of its own; the rename-source
-  // fallback (worktree-column R or C only) lets the same entry discard from
-  // either side of the rename. Untracked directories expand to their files
-  // under -uall, so a directory-shaped request only matches when it names a
-  // nested repository.
+  // fallback is rename-only, since a copy source is not an alias for its
+  // destination and discarding it must not touch the copy. Untracked
+  // directories expand to their files under -uall, so a directory-shaped
+  // request only matches when it names a nested repository.
   const entries = parsePorcelainV1Z(statusOutput);
   const entry = entries.find(
     (candidate) => candidate.path.replace(/\/+$/, '') === canonicalFile,
   ) ?? entries.find(
     (candidate) =>
       candidate.originalPath === canonicalFile
-      && (candidate.workTreeStatus === 'R' || candidate.workTreeStatus === 'C'),
+      && candidate.workTreeStatus === 'R',
   );
   if (!entry) {
     throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
@@ -76,15 +71,17 @@ export async function discard({ projectPath, file }: FileOptions): Promise<unkno
       await fs.unlink(filePath);
     }
   } else if (entry.workTreeStatus === 'R' || entry.workTreeStatus === 'C') {
-    // A worktree rename or copy spans two paths: the source restores to its
-    // index content, while the destination resets its intent-to-add entry
-    // instead of restoring, because the index side of an intent-to-add is
-    // the empty blob and restore would truncate the worktree copy. Reset
-    // keeps that content: untracked when HEAD lacks the destination, or
-    // compared against HEAD's version when HEAD has it - a destination HEAD
-    // tracks with different worktree content intentionally lands as a
-    // modification rather than losing the never-hashed bytes.
-    if (entry.originalPath) {
+    // A rename or copy destination is an intent-to-add entry, so it resets
+    // instead of restoring: the index side of an intent-to-add is the empty
+    // blob and restore would truncate the worktree copy. Reset keeps that
+    // content: untracked when HEAD lacks the destination, or compared
+    // against HEAD's version when HEAD has it - a destination HEAD tracks
+    // with different worktree content intentionally lands as a modification
+    // rather than losing the never-hashed bytes. A rename additionally
+    // restores the source the rename removed from the worktree; a copy
+    // leaves its source in place, and restoring that path would erase the
+    // source's own unstaged edits, so only the destination resets.
+    if (entry.workTreeStatus === 'R' && entry.originalPath) {
       await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.originalPath)]);
     }
     await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);

--- a/server/git/discard.ts
+++ b/server/git/discard.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'fs';
+import { GitDomainError } from './git-types.js';
+import { literalGitPathspec } from './pathspecs.js';
+import { parsePorcelainV1Z, UNMERGED_STATUSES } from './porcelain-status.js';
+import {
+  assertGitRepository,
+  readOnlyGitOptions,
+  resolvePathWithinProject,
+  runGit,
+} from './run.js';
+import type { FileOptions } from './types.js';
+
+async function headHasPath(projectPath: string, file: string): Promise<boolean> {
+  // ls-tree reports a path HEAD lacks as a successful empty result, so any
+  // command failure stays a real error instead of masquerading as absence
+  // and skipping the worktree restore. The literal pathspec keeps a file
+  // named like a glob from matching every path HEAD holds.
+  const { stdout } = await runGit(
+    projectPath,
+    ['ls-tree', '-z', 'HEAD', '--', literalGitPathspec(file)],
+    readOnlyGitOptions(),
+  );
+  return stdout.length > 0;
+}
+
+export async function discard({ projectPath, file }: FileOptions): Promise<unknown> {
+  await assertGitRepository(projectPath);
+
+  // Porcelain paths are repository-root relative; canonicalize the request
+  // and run every git command from the root so lookups and pathspecs agree
+  // even when projectPath sits below the root or reaches it through a
+  // symlink. --show-prefix is git's own answer for the offset, so the
+  // physical root never leaks a '..' segment, and only the newline is
+  // stripped so a root path ending in whitespace survives.
+  const { stdout: rootOutput } = await runGit(
+    projectPath,
+    ['rev-parse', '--show-toplevel', '--show-prefix'],
+    readOnlyGitOptions(),
+  );
+  const [rootLine = '', prefixLine = ''] = rootOutput.split('\n');
+  const repoRoot = rootLine || projectPath;
+  const canonicalFile = `${prefixLine}${file.replace(/\/+$/, '')}`;
+
+  const { stdout: statusOutput } = await runGit(
+    repoRoot,
+    ['status', '--porcelain=v1', '-z', '-uall'],
+    readOnlyGitOptions(),
+  );
+  // The global read keeps rename entries intact: a destination-only
+  // pathspec cannot pair the rename and reports DA, hiding the source path
+  // that the worktree side of the change spans. An exact path match wins,
+  // because a copy source keeps an entry of its own; the rename-source
+  // fallback (worktree-column R or C only) lets the same entry discard from
+  // either side of the rename. Untracked directories expand to their files
+  // under -uall, so a directory-shaped request only matches when it names a
+  // nested repository.
+  const entries = parsePorcelainV1Z(statusOutput);
+  const entry = entries.find(
+    (candidate) => candidate.path.replace(/\/+$/, '') === canonicalFile,
+  ) ?? entries.find(
+    (candidate) =>
+      candidate.originalPath === canonicalFile
+      && (candidate.workTreeStatus === 'R' || candidate.workTreeStatus === 'C'),
+  );
+  if (!entry) {
+    throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
+  }
+  const status = `${entry.indexStatus}${entry.workTreeStatus}`;
+
+  if (status === '??') {
+    const filePath = resolvePathWithinProject(projectPath, file);
+    const stats = await fs.stat(filePath);
+    if (stats.isDirectory()) {
+      await fs.rm(filePath, { recursive: true, force: true });
+    } else {
+      await fs.unlink(filePath);
+    }
+  } else if (entry.workTreeStatus === 'R' || entry.workTreeStatus === 'C') {
+    // A worktree rename or copy spans two paths: the source restores to its
+    // index content, while the destination resets its intent-to-add entry
+    // instead of restoring, because the index side of an intent-to-add is
+    // the empty blob and restore would truncate the worktree copy. Reset
+    // keeps that content: untracked when HEAD lacks the destination, or
+    // compared against HEAD's version when HEAD has it - a destination HEAD
+    // tracks with different worktree content intentionally lands as a
+    // modification rather than losing the never-hashed bytes.
+    if (entry.originalPath) {
+      await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.originalPath)]);
+    }
+    await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
+  } else if (UNMERGED_STATUSES.has(status)) {
+    // Conflicts resolve against HEAD: reset clears the stages, and restore
+    // rewrites the worktree to HEAD's version only when HEAD has the path
+    // (it does for UU/UD/AA and an ours-added AU). When HEAD lacks the path
+    // (DD/DU/UA) reset leaves any worktree leftover untracked.
+    await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
+    if (await headHasPath(repoRoot, entry.path)) {
+      await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.path)]);
+    }
+  } else if (status === 'A ' || entry.workTreeStatus === 'A') {
+    // The workbench only offers discard on unstaged changes, so AM/AD/AT land
+    // in the restore branch below and keep their staged addition. Reset
+    // remains for index-only additions (endpoint-reachable, no worktree
+    // changes to restore) and for an unstaged A column, which marks an
+    // intent-to-add entry whose worktree content HEAD does not track: reset
+    // drops the index entry and preserves the copy as untracked.
+    await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
+  } else if (entry.workTreeStatus !== ' ' && 'MDT'.includes(entry.workTreeStatus)) {
+    // Unstaged modifications, deletions, and typechanges revert the worktree
+    // to the index, keeping any staged facet: AT lands back at a staged
+    // addition once restore rewrites the worktree entry to the indexed
+    // type. Staged-only states ('M ', 'D ', 'T ') have no worktree side to
+    // discard and fall through as no-ops.
+    await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.path)]);
+  }
+
+  return { success: true, message: `Changes discarded for ${file}` };
+}

--- a/server/git/discard.ts
+++ b/server/git/discard.ts
@@ -26,14 +26,12 @@ async function headHasPath(projectPath: string, file: string): Promise<boolean> 
 export async function discard({ projectPath, file }: FileOptions): Promise<unknown> {
   await assertGitRepository(projectPath);
 
-  const { stdout: rootOutput } = await runGit(
-    projectPath,
-    ['rev-parse', '--show-toplevel', '--show-prefix'],
-    readOnlyGitOptions(),
-  );
-  const [rootLine = '', prefixLine = ''] = rootOutput.split('\n');
-  const repoRoot = rootLine || projectPath;
-  const projectPrefix = prefixLine;
+  const [rootResult, prefixResult] = await Promise.all([
+    runGit(projectPath, ['rev-parse', '--show-toplevel'], readOnlyGitOptions()),
+    runGit(projectPath, ['rev-parse', '--show-prefix'], readOnlyGitOptions()),
+  ]);
+  const repoRoot = rootResult.stdout.replace(/\n$/, '') || projectPath;
+  const projectPrefix = prefixResult.stdout.replace(/\n$/, '');
   const canonicalFile = `${projectPrefix}${file.replace(/\/+$/, '')}`;
 
   const { stdout: statusOutput } = await runGit(

--- a/server/git/discard.ts
+++ b/server/git/discard.ts
@@ -41,20 +41,28 @@ export async function discard({ projectPath, file }: FileOptions): Promise<unkno
   );
   // The global read keeps rename entries intact: a destination-only
   // pathspec cannot pair the rename and reports DA, hiding the source path
-  // that the worktree side of the change spans. An exact path match wins,
-  // because a copy source keeps an entry of its own; the rename-source
-  // fallback is rename-only, since a copy source is not an alias for its
-  // destination and discarding it must not touch the copy. Untracked
+  // that the worktree side of the change spans. An exact match with a
+  // worktree facet always wins, because a copy source keeps an entry of its
+  // own. But a staged-only exact entry can shadow the worktree rename that
+  // consumed the path - staging b, moving it to c, and add -N c reports
+  // 'A  b' plus ' R c -> b', and a request for b means the rename's source
+  // side, not the staged entry - so a staged-only match defers to the rename
+  // source. The fallback is rename-only, since a copy source is not an alias
+  // for its destination and discarding it must not touch the copy. Untracked
   // directories expand to their files under -uall, so a directory-shaped
   // request only matches when it names a nested repository.
   const entries = parsePorcelainV1Z(statusOutput);
-  const entry = entries.find(
+  const exactEntry = entries.find(
     (candidate) => candidate.path.replace(/\/+$/, '') === canonicalFile,
-  ) ?? entries.find(
+  );
+  const renameSourceEntry = entries.find(
     (candidate) =>
       candidate.originalPath === canonicalFile
       && candidate.workTreeStatus === 'R',
   );
+  const entry = exactEntry && exactEntry.workTreeStatus !== ' '
+    ? exactEntry
+    : renameSourceEntry ?? exactEntry;
   if (!entry) {
     throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
   }

--- a/server/git/porcelain-status.ts
+++ b/server/git/porcelain-status.ts
@@ -1,5 +1,11 @@
 import type { GitChangeKind, PorcelainStatusEntry } from './types.js';
 
+// The seven two-column codes git reports for index conflicts; shared by every
+// consumer that needs to recognize unmerged entries.
+export const UNMERGED_STATUSES: ReadonlySet<string> = new Set([
+  'UU', 'AA', 'DD', 'AU', 'UA', 'DU', 'UD',
+]);
+
 const CHANGE_KIND_BY_STATUS = Object.freeze({
   M: 'modified',
   A: 'added',

--- a/server/git/porcelain.ts
+++ b/server/git/porcelain.ts
@@ -26,8 +26,8 @@ import type {
   StashRefOptions,
 } from './types.js';
 import { GitDomainError } from './git-types.js';
+import { UNMERGED_STATUSES } from './porcelain-status.js';
 
-const UNMERGED_STATUSES = new Set<GitConflictStatus>(['UU', 'AA', 'DD', 'AU', 'UA', 'DU', 'UD']);
 const MAX_HISTORY_LIMIT = 200;
 const MAX_BLAME_LINES = 2_000;
 const MAX_GRAPH_LIMIT = 500;

--- a/server/git/run.ts
+++ b/server/git/run.ts
@@ -198,7 +198,10 @@ async function runGitProcess(
 
     if (isLockError(stderr) && attempt < GIT_LOCK_MAX_RETRIES) {
       lastFailure = { exitCode, stdout, stderr };
-      await sleep(GIT_LOCK_RETRY_DELAY_MS);
+      // The attempt's timer was already cleaned up, so the delay itself must
+      // respect the absolute budget; otherwise the total runtime overshoots
+      // timeoutMs by up to a full retry delay.
+      await sleep(Math.min(GIT_LOCK_RETRY_DELAY_MS, Math.max(0, deadlineAt - performance.now())));
       // aborted() reads the live caller signal, so an abort during the retry
       // delay is reported here instead of spawning another attempt.
       const timedOut = abortState.timedOut();

--- a/server/git/status.ts
+++ b/server/git/status.ts
@@ -14,6 +14,7 @@ import { KeyedPromiseLock } from '../lib/keyed-lock.js';
 import { probeWorktreeLayout } from './worktree-layout.js';
 import { isExpectedMissingGitResult } from './comparison-errors.js';
 import { commitSelectedFiles } from './selected-file-commit.js';
+import { parsePorcelainV1Z, UNMERGED_STATUSES } from './porcelain-status.js';
 import type {
   BranchOptions,
   CheckoutOptions,
@@ -784,19 +785,34 @@ export function createStatusOperations(agents: GitAgentRunner) {
     };
   }
 
+  async function headHasPath(projectPath: string, file: string): Promise<boolean> {
+    try {
+      await runGit(projectPath, ['cat-file', '-e', `HEAD:${file}`], readOnlyGitOptions());
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async function discard({ projectPath, file }: FileOptions): Promise<unknown> {
     await assertGitRepository(projectPath);
 
     const { stdout: statusOutput } = await runGit(
       projectPath,
-      ['status', '--porcelain', '--', file],
+      ['status', '--porcelain=v1', '-z', '-uall'],
       readOnlyGitOptions(),
     );
-    if (!statusOutput.trim()) {
+    // The global read keeps rename entries intact: a destination-only
+    // pathspec cannot pair the rename and reports DA, hiding the source path
+    // that the worktree side of the change spans.
+    const entry = parsePorcelainV1Z(statusOutput).find(
+      (candidate) => candidate.path.replace(/\/+$/, '') === file.replace(/\/+$/, ''),
+    );
+    if (!entry) {
       throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
     }
+    const status = `${entry.indexStatus}${entry.workTreeStatus}`;
 
-    const status = statusOutput.substring(0, 2);
     if (status === '??') {
       const filePath = resolvePathWithinProject(projectPath, file);
       const stats = await fs.stat(filePath);
@@ -805,29 +821,33 @@ export function createStatusOperations(agents: GitAgentRunner) {
       } else {
         await fs.unlink(filePath);
       }
-    } else if (status === 'A ' || status[1] === 'A' || status === 'AU') {
+    } else if (entry.workTreeStatus === 'R' || entry.workTreeStatus === 'C') {
+      // A worktree rename or copy is one change spanning two paths: revert
+      // both sides to the index so the source reappears and the destination
+      // drops its worktree copy.
+      const renamePaths = entry.originalPath ? [entry.originalPath, entry.path] : [entry.path];
+      await runGit(projectPath, ['restore', '--', ...renamePaths]);
+    } else if (UNMERGED_STATUSES.has(status)) {
+      // Conflicts resolve against HEAD: reset clears the stages, and restore
+      // rewrites the worktree to HEAD's version only when HEAD has the path
+      // (it does for UU/UD/AA and an ours-added AU). When HEAD lacks the path
+      // (DD/DU/UA) reset leaves any worktree leftover untracked.
+      await runGit(projectPath, ['reset', 'HEAD', '--', file]);
+      if (await headHasPath(projectPath, file)) {
+        await runGit(projectPath, ['restore', '--', file]);
+      }
+    } else if (status === 'A ') {
       // The workbench only offers discard on unstaged changes, so AM/AD/AT land
       // in the restore branch below and keep their staged addition. Reset
       // remains for index-only additions (endpoint-reachable, no worktree
-      // changes to restore) and unmerged-added states (AA/AU/UA), where it
-      // clears the conflict instead of falling through as a silent no-op.
+      // changes to restore).
       await runGit(projectPath, ['reset', 'HEAD', '--', file]);
-    } else if (status === 'UU' || status === 'UD' || status === 'DU' || status === 'DD') {
-      // Unmerged conflicts resolve by reverting to HEAD. Reset clears the
-      // conflict stages; when our side kept the file (X=U: UU/UD) restore also
-      // rewrites the worktree to HEAD's version. When our side deleted it
-      // (X=D: DU/DD) HEAD has no version to restore to, so reset leaves any
-      // worktree leftover untracked, matching the AA/AU/UA behavior above.
-      await runGit(projectPath, ['reset', 'HEAD', '--', file]);
-      if (status[0] === 'U') {
-        await runGit(projectPath, ['restore', '--', file]);
-      }
-    } else if (status.includes('M') || status.includes('D') || status.includes('T')) {
-      // T routes worktree typechanges (regular file versus symlink) through
-      // restore, which rewrites the worktree entry back to the indexed type,
-      // so AT lands back at a staged addition. Staged-only typechanges ('T ')
-      // land here as a no-op, exactly like 'M ', because the workbench only
-      // offers discard on unstaged changes.
+    } else if (entry.workTreeStatus !== ' ' && 'MDT'.includes(entry.workTreeStatus)) {
+      // Unstaged modifications, deletions, and typechanges revert the worktree
+      // to the index, keeping any staged facet: AT lands back at a staged
+      // addition once restore rewrites the worktree entry to the indexed
+      // type. Staged-only states ('M ', 'D ', 'T ') have no worktree side to
+      // discard and fall through as no-ops.
       await runGit(projectPath, ['restore', '--', file]);
     }
 

--- a/server/git/status.ts
+++ b/server/git/status.ts
@@ -694,7 +694,7 @@ export function createStatusOperations(agents: GitAgentRunner) {
       logger.info('No upstream configured, using origin as fallback');
     }
 
-    const { stdout } = await runGit(projectPath, ["fetch", remoteName], readOnlyGitOptions());
+    const { stdout } = await runGit(projectPath, ['fetch', remoteName], readOnlyGitOptions());
     return { success: true, output: stdout || 'Fetch completed successfully', remoteName };
   }
 
@@ -788,10 +788,11 @@ export function createStatusOperations(agents: GitAgentRunner) {
   async function headHasPath(projectPath: string, file: string): Promise<boolean> {
     // ls-tree reports a path HEAD lacks as a successful empty result, so any
     // command failure stays a real error instead of masquerading as absence
-    // and skipping the worktree restore.
+    // and skipping the worktree restore. The literal pathspec keeps a file
+    // named like a glob from matching every path HEAD holds.
     const { stdout } = await runGit(
       projectPath,
-      ['ls-tree', '-z', 'HEAD', '--', file],
+      ['ls-tree', '-z', 'HEAD', '--', literalGitPathspec(file)],
       readOnlyGitOptions(),
     );
     return stdout.length > 0;
@@ -802,17 +803,18 @@ export function createStatusOperations(agents: GitAgentRunner) {
 
     // Porcelain paths are repository-root relative; canonicalize the request
     // and run every git command from the root so lookups and pathspecs agree
-    // even when projectPath sits below it.
-    const { stdout: repoRootOutput } = await runGit(
+    // even when projectPath sits below the root or reaches it through a
+    // symlink. --show-prefix is git's own answer for the offset, so the
+    // physical root never leaks a '..' segment, and only the newline is
+    // stripped so a root path ending in whitespace survives.
+    const { stdout: rootOutput } = await runGit(
       projectPath,
-      ['rev-parse', '--show-toplevel'],
+      ['rev-parse', '--show-toplevel', '--show-prefix'],
       readOnlyGitOptions(),
     );
-    const repoRoot = repoRootOutput.trim() || projectPath;
-    const projectPrefix = path.relative(repoRoot, projectPath);
-    const canonicalFile = projectPrefix && !projectPrefix.startsWith('..')
-      ? [projectPrefix.split(path.sep).join('/'), file.replace(/\/+$/, '')].join('/')
-      : file.replace(/\/+$/, '');
+    const [rootLine = '', prefixLine = ''] = rootOutput.split('\n');
+    const repoRoot = rootLine || projectPath;
+    const canonicalFile = `${prefixLine}${file.replace(/\/+$/, '')}`;
 
     const { stdout: statusOutput } = await runGit(
       repoRoot,
@@ -821,14 +823,19 @@ export function createStatusOperations(agents: GitAgentRunner) {
     );
     // The global read keeps rename entries intact: a destination-only
     // pathspec cannot pair the rename and reports DA, hiding the source path
-    // that the worktree side of the change spans. Matching the rename source
-    // lets the same entry discard from either side. Untracked directories
-    // expand to their files under -uall, so a directory-shaped request only
-    // matches when it names a nested repository.
-    const entry = parsePorcelainV1Z(statusOutput).find(
+    // that the worktree side of the change spans. An exact path match wins,
+    // because a copy source keeps an entry of its own; the rename-source
+    // fallback (worktree-column R or C only) lets the same entry discard from
+    // either side of the rename. Untracked directories expand to their files
+    // under -uall, so a directory-shaped request only matches when it names a
+    // nested repository.
+    const entries = parsePorcelainV1Z(statusOutput);
+    const entry = entries.find(
+      (candidate) => candidate.path.replace(/\/+$/, '') === canonicalFile,
+    ) ?? entries.find(
       (candidate) =>
-        candidate.path.replace(/\/+$/, '') === canonicalFile
-        || candidate.originalPath === canonicalFile,
+        candidate.originalPath === canonicalFile
+        && (candidate.workTreeStatus === 'R' || candidate.workTreeStatus === 'C'),
     );
     if (!entry) {
       throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
@@ -849,19 +856,21 @@ export function createStatusOperations(agents: GitAgentRunner) {
       // instead of restoring, because the index side of an intent-to-add is
       // the empty blob and restore would truncate the worktree copy. Reset
       // keeps that content: untracked when HEAD lacks the destination, or
-      // compared against HEAD's version when HEAD has it.
+      // compared against HEAD's version when HEAD has it - a destination HEAD
+      // tracks with different worktree content intentionally lands as a
+      // modification rather than losing the never-hashed bytes.
       if (entry.originalPath) {
-        await runGit(repoRoot, ['restore', '--', entry.originalPath]);
+        await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.originalPath)]);
       }
-      await runGit(repoRoot, ['reset', 'HEAD', '--', entry.path]);
+      await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
     } else if (UNMERGED_STATUSES.has(status)) {
       // Conflicts resolve against HEAD: reset clears the stages, and restore
       // rewrites the worktree to HEAD's version only when HEAD has the path
       // (it does for UU/UD/AA and an ours-added AU). When HEAD lacks the path
       // (DD/DU/UA) reset leaves any worktree leftover untracked.
-      await runGit(repoRoot, ['reset', 'HEAD', '--', entry.path]);
+      await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
       if (await headHasPath(repoRoot, entry.path)) {
-        await runGit(repoRoot, ['restore', '--', entry.path]);
+        await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.path)]);
       }
     } else if (status === 'A ' || entry.workTreeStatus === 'A') {
       // The workbench only offers discard on unstaged changes, so AM/AD/AT land
@@ -870,14 +879,14 @@ export function createStatusOperations(agents: GitAgentRunner) {
       // changes to restore) and for an unstaged A column, which marks an
       // intent-to-add entry whose worktree content HEAD does not track: reset
       // drops the index entry and preserves the copy as untracked.
-      await runGit(repoRoot, ['reset', 'HEAD', '--', entry.path]);
+      await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
     } else if (entry.workTreeStatus !== ' ' && 'MDT'.includes(entry.workTreeStatus)) {
       // Unstaged modifications, deletions, and typechanges revert the worktree
       // to the index, keeping any staged facet: AT lands back at a staged
       // addition once restore rewrites the worktree entry to the indexed
       // type. Staged-only states ('M ', 'D ', 'T ') have no worktree side to
       // discard and fall through as no-ops.
-      await runGit(repoRoot, ['restore', '--', entry.path]);
+      await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.path)]);
     }
 
     return { success: true, message: `Changes discarded for ${file}` };

--- a/server/git/status.ts
+++ b/server/git/status.ts
@@ -694,7 +694,7 @@ export function createStatusOperations(agents: GitAgentRunner) {
       logger.info('No upstream configured, using origin as fallback');
     }
 
-    const { stdout } = await runGit(projectPath, ['fetch', remoteName], readOnlyGitOptions());
+    const { stdout } = await runGit(projectPath, ['fetch', remoteName], networkGitOptions());
     return { success: true, output: stdout || 'Fetch completed successfully', remoteName };
   }
 

--- a/server/git/status.ts
+++ b/server/git/status.ts
@@ -14,7 +14,7 @@ import { KeyedPromiseLock } from '../lib/keyed-lock.js';
 import { probeWorktreeLayout } from './worktree-layout.js';
 import { isExpectedMissingGitResult } from './comparison-errors.js';
 import { commitSelectedFiles } from './selected-file-commit.js';
-import { parsePorcelainV1Z, UNMERGED_STATUSES } from './porcelain-status.js';
+import { discard } from './discard.js';
 import type {
   BranchOptions,
   CheckoutOptions,
@@ -783,113 +783,6 @@ export function createStatusOperations(agents: GitAgentRunner) {
       remoteName: targetRemote,
       remoteBranch: targetBranch,
     };
-  }
-
-  async function headHasPath(projectPath: string, file: string): Promise<boolean> {
-    // ls-tree reports a path HEAD lacks as a successful empty result, so any
-    // command failure stays a real error instead of masquerading as absence
-    // and skipping the worktree restore. The literal pathspec keeps a file
-    // named like a glob from matching every path HEAD holds.
-    const { stdout } = await runGit(
-      projectPath,
-      ['ls-tree', '-z', 'HEAD', '--', literalGitPathspec(file)],
-      readOnlyGitOptions(),
-    );
-    return stdout.length > 0;
-  }
-
-  async function discard({ projectPath, file }: FileOptions): Promise<unknown> {
-    await assertGitRepository(projectPath);
-
-    // Porcelain paths are repository-root relative; canonicalize the request
-    // and run every git command from the root so lookups and pathspecs agree
-    // even when projectPath sits below the root or reaches it through a
-    // symlink. --show-prefix is git's own answer for the offset, so the
-    // physical root never leaks a '..' segment, and only the newline is
-    // stripped so a root path ending in whitespace survives.
-    const { stdout: rootOutput } = await runGit(
-      projectPath,
-      ['rev-parse', '--show-toplevel', '--show-prefix'],
-      readOnlyGitOptions(),
-    );
-    const [rootLine = '', prefixLine = ''] = rootOutput.split('\n');
-    const repoRoot = rootLine || projectPath;
-    const canonicalFile = `${prefixLine}${file.replace(/\/+$/, '')}`;
-
-    const { stdout: statusOutput } = await runGit(
-      repoRoot,
-      ['status', '--porcelain=v1', '-z', '-uall'],
-      readOnlyGitOptions(),
-    );
-    // The global read keeps rename entries intact: a destination-only
-    // pathspec cannot pair the rename and reports DA, hiding the source path
-    // that the worktree side of the change spans. An exact path match wins,
-    // because a copy source keeps an entry of its own; the rename-source
-    // fallback (worktree-column R or C only) lets the same entry discard from
-    // either side of the rename. Untracked directories expand to their files
-    // under -uall, so a directory-shaped request only matches when it names a
-    // nested repository.
-    const entries = parsePorcelainV1Z(statusOutput);
-    const entry = entries.find(
-      (candidate) => candidate.path.replace(/\/+$/, '') === canonicalFile,
-    ) ?? entries.find(
-      (candidate) =>
-        candidate.originalPath === canonicalFile
-        && (candidate.workTreeStatus === 'R' || candidate.workTreeStatus === 'C'),
-    );
-    if (!entry) {
-      throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
-    }
-    const status = `${entry.indexStatus}${entry.workTreeStatus}`;
-
-    if (status === '??') {
-      const filePath = resolvePathWithinProject(projectPath, file);
-      const stats = await fs.stat(filePath);
-      if (stats.isDirectory()) {
-        await fs.rm(filePath, { recursive: true, force: true });
-      } else {
-        await fs.unlink(filePath);
-      }
-    } else if (entry.workTreeStatus === 'R' || entry.workTreeStatus === 'C') {
-      // A worktree rename or copy spans two paths: the source restores to its
-      // index content, while the destination resets its intent-to-add entry
-      // instead of restoring, because the index side of an intent-to-add is
-      // the empty blob and restore would truncate the worktree copy. Reset
-      // keeps that content: untracked when HEAD lacks the destination, or
-      // compared against HEAD's version when HEAD has it - a destination HEAD
-      // tracks with different worktree content intentionally lands as a
-      // modification rather than losing the never-hashed bytes.
-      if (entry.originalPath) {
-        await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.originalPath)]);
-      }
-      await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
-    } else if (UNMERGED_STATUSES.has(status)) {
-      // Conflicts resolve against HEAD: reset clears the stages, and restore
-      // rewrites the worktree to HEAD's version only when HEAD has the path
-      // (it does for UU/UD/AA and an ours-added AU). When HEAD lacks the path
-      // (DD/DU/UA) reset leaves any worktree leftover untracked.
-      await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
-      if (await headHasPath(repoRoot, entry.path)) {
-        await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.path)]);
-      }
-    } else if (status === 'A ' || entry.workTreeStatus === 'A') {
-      // The workbench only offers discard on unstaged changes, so AM/AD/AT land
-      // in the restore branch below and keep their staged addition. Reset
-      // remains for index-only additions (endpoint-reachable, no worktree
-      // changes to restore) and for an unstaged A column, which marks an
-      // intent-to-add entry whose worktree content HEAD does not track: reset
-      // drops the index entry and preserves the copy as untracked.
-      await runGit(repoRoot, ['reset', 'HEAD', '--', literalGitPathspec(entry.path)]);
-    } else if (entry.workTreeStatus !== ' ' && 'MDT'.includes(entry.workTreeStatus)) {
-      // Unstaged modifications, deletions, and typechanges revert the worktree
-      // to the index, keeping any staged facet: AT lands back at a staged
-      // addition once restore rewrites the worktree entry to the indexed
-      // type. Staged-only states ('M ', 'D ', 'T ') have no worktree side to
-      // discard and fall through as no-ops.
-      await runGit(repoRoot, ['restore', '--', literalGitPathspec(entry.path)]);
-    }
-
-    return { success: true, message: `Changes discarded for ${file}` };
   }
 
   async function deleteUntracked({ projectPath, file }: FileOptions): Promise<unknown> {

--- a/server/git/status.ts
+++ b/server/git/status.ts
@@ -694,7 +694,7 @@ export function createStatusOperations(agents: GitAgentRunner) {
       logger.info('No upstream configured, using origin as fallback');
     }
 
-    const { stdout } = await runGit(projectPath, ['fetch', remoteName], networkGitOptions());
+    const { stdout } = await runGit(projectPath, ["fetch", remoteName], readOnlyGitOptions());
     return { success: true, output: stdout || 'Fetch completed successfully', remoteName };
   }
 
@@ -786,27 +786,49 @@ export function createStatusOperations(agents: GitAgentRunner) {
   }
 
   async function headHasPath(projectPath: string, file: string): Promise<boolean> {
-    try {
-      await runGit(projectPath, ['cat-file', '-e', `HEAD:${file}`], readOnlyGitOptions());
-      return true;
-    } catch {
-      return false;
-    }
+    // ls-tree reports a path HEAD lacks as a successful empty result, so any
+    // command failure stays a real error instead of masquerading as absence
+    // and skipping the worktree restore.
+    const { stdout } = await runGit(
+      projectPath,
+      ['ls-tree', '-z', 'HEAD', '--', file],
+      readOnlyGitOptions(),
+    );
+    return stdout.length > 0;
   }
 
   async function discard({ projectPath, file }: FileOptions): Promise<unknown> {
     await assertGitRepository(projectPath);
 
-    const { stdout: statusOutput } = await runGit(
+    // Porcelain paths are repository-root relative; canonicalize the request
+    // and run every git command from the root so lookups and pathspecs agree
+    // even when projectPath sits below it.
+    const { stdout: repoRootOutput } = await runGit(
       projectPath,
+      ['rev-parse', '--show-toplevel'],
+      readOnlyGitOptions(),
+    );
+    const repoRoot = repoRootOutput.trim() || projectPath;
+    const projectPrefix = path.relative(repoRoot, projectPath);
+    const canonicalFile = projectPrefix && !projectPrefix.startsWith('..')
+      ? [projectPrefix.split(path.sep).join('/'), file.replace(/\/+$/, '')].join('/')
+      : file.replace(/\/+$/, '');
+
+    const { stdout: statusOutput } = await runGit(
+      repoRoot,
       ['status', '--porcelain=v1', '-z', '-uall'],
       readOnlyGitOptions(),
     );
     // The global read keeps rename entries intact: a destination-only
     // pathspec cannot pair the rename and reports DA, hiding the source path
-    // that the worktree side of the change spans.
+    // that the worktree side of the change spans. Matching the rename source
+    // lets the same entry discard from either side. Untracked directories
+    // expand to their files under -uall, so a directory-shaped request only
+    // matches when it names a nested repository.
     const entry = parsePorcelainV1Z(statusOutput).find(
-      (candidate) => candidate.path.replace(/\/+$/, '') === file.replace(/\/+$/, ''),
+      (candidate) =>
+        candidate.path.replace(/\/+$/, '') === canonicalFile
+        || candidate.originalPath === canonicalFile,
     );
     if (!entry) {
       throw new GitDomainError('INVALID_INPUT', 'No local working-tree changes were found for this file.');
@@ -822,33 +844,40 @@ export function createStatusOperations(agents: GitAgentRunner) {
         await fs.unlink(filePath);
       }
     } else if (entry.workTreeStatus === 'R' || entry.workTreeStatus === 'C') {
-      // A worktree rename or copy is one change spanning two paths: revert
-      // both sides to the index so the source reappears and the destination
-      // drops its worktree copy.
-      const renamePaths = entry.originalPath ? [entry.originalPath, entry.path] : [entry.path];
-      await runGit(projectPath, ['restore', '--', ...renamePaths]);
+      // A worktree rename or copy spans two paths: the source restores to its
+      // index content, while the destination resets its intent-to-add entry
+      // instead of restoring, because the index side of an intent-to-add is
+      // the empty blob and restore would truncate the worktree copy. Reset
+      // keeps that content: untracked when HEAD lacks the destination, or
+      // compared against HEAD's version when HEAD has it.
+      if (entry.originalPath) {
+        await runGit(repoRoot, ['restore', '--', entry.originalPath]);
+      }
+      await runGit(repoRoot, ['reset', 'HEAD', '--', entry.path]);
     } else if (UNMERGED_STATUSES.has(status)) {
       // Conflicts resolve against HEAD: reset clears the stages, and restore
       // rewrites the worktree to HEAD's version only when HEAD has the path
       // (it does for UU/UD/AA and an ours-added AU). When HEAD lacks the path
       // (DD/DU/UA) reset leaves any worktree leftover untracked.
-      await runGit(projectPath, ['reset', 'HEAD', '--', file]);
-      if (await headHasPath(projectPath, file)) {
-        await runGit(projectPath, ['restore', '--', file]);
+      await runGit(repoRoot, ['reset', 'HEAD', '--', entry.path]);
+      if (await headHasPath(repoRoot, entry.path)) {
+        await runGit(repoRoot, ['restore', '--', entry.path]);
       }
-    } else if (status === 'A ') {
+    } else if (status === 'A ' || entry.workTreeStatus === 'A') {
       // The workbench only offers discard on unstaged changes, so AM/AD/AT land
       // in the restore branch below and keep their staged addition. Reset
       // remains for index-only additions (endpoint-reachable, no worktree
-      // changes to restore).
-      await runGit(projectPath, ['reset', 'HEAD', '--', file]);
+      // changes to restore) and for an unstaged A column, which marks an
+      // intent-to-add entry whose worktree content HEAD does not track: reset
+      // drops the index entry and preserves the copy as untracked.
+      await runGit(repoRoot, ['reset', 'HEAD', '--', entry.path]);
     } else if (entry.workTreeStatus !== ' ' && 'MDT'.includes(entry.workTreeStatus)) {
       // Unstaged modifications, deletions, and typechanges revert the worktree
       // to the index, keeping any staged facet: AT lands back at a staged
       // addition once restore rewrites the worktree entry to the indexed
       // type. Staged-only states ('M ', 'D ', 'T ') have no worktree side to
       // discard and fall through as no-ops.
-      await runGit(projectPath, ['restore', '--', file]);
+      await runGit(repoRoot, ['restore', '--', entry.path]);
     }
 
     return { success: true, message: `Changes discarded for ${file}` };


### PR DESCRIPTION
Git discard mishandled several working-tree states: discarding an add/add conflict reported success but left raw conflict markers as a committable modification, discarding an unstaged rename destructively applied it and left the source as an untracked deletion, an intent-to-add rename destination was truncated to the empty index blob (losing never-hashed content), and unstaged additions, subproject paths, symlinked project roots, and paths named like pathspec globs were each misrouted. This branch reworks discard around a single global porcelain read with literal pathspecs and entry-driven routing, extracts it to its own module, bounds the git lock-retry delay by the remaining timeout budget so commands cannot overrun their budget, restores the network options wiring on fetch (prompt suppression plus the idle-budget timeout) with the fetch/pull/push coverage that caught its loss, and clones the pending preamble boundary field in chat registry hand-outs so callers cannot mutate registry state through a handed-out entry.