### PR TITLE
fix(claude): use unversioned Fable model label

### DIFF
--- a/common/models.ts
+++ b/common/models.ts
@@ -12,7 +12,7 @@ export const CLAUDE_MODELS = {
     { value: 'opus', label: 'Opus', supportsImages: true },
     { value: 'sonnet', label: 'Sonnet', supportsImages: true },
     { value: 'haiku', label: 'Haiku', supportsImages: true },
-    { value: 'fable', label: 'Fable 5', supportsImages: true },
+    { value: 'fable', label: 'Fable', supportsImages: true },
   ] satisfies SharedModelOption[],
   DEFAULT: 'opus',
 };


### PR DESCRIPTION
The Claude picker labels the rolling `fable` alias as “Fable 5”, which becomes stale when Claude Code changes its default. Rename the label to “Fable”, matching Opus, Sonnet, and Haiku.

Keep `value: 'fable'` and existing execution behavior so Claude Code continues to own alias resolution, environment overrides, and provider-specific model selection. This replaces the runtime pinning proposed in #656.

Validation:
- `bun run check`: pass, zero diagnostics.
- Production build and isolated startup via `bun run start --port 0`: pass.
- Local server and CLI suites: pass. The bounded full run reached frontend tests before its seven-minute limit; separate `bun run --cwd web test --maxWorkers=4` passed all 454 files and 4,804 tests.
- All hosted CI checks pass, including server integration and both browser suites.
