### PR TITLE
fix(model-selector): prevent provider selector form submission

### DIFF
--- a/web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts
+++ b/web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts
@@ -191,6 +191,26 @@ describe('ModelSelectorPopover', () => {
 		});
 	});
 
+	it('does not submit a surrounding form when the compact provider selector opens', async () => {
+		installMatchMedia(true);
+		const onSubmit = vi.fn();
+
+		render(ModelSelectorPopoverHost, {
+			value: { agentId: 'claude', model: 'model-0' },
+			mode: { agent: 'select', source: 'select', surface: 'composer' },
+			onChange: vi.fn(),
+			wrapInForm: true,
+			onFormSubmit: onSubmit,
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: /Claude .* Model 0/ }));
+		await fireEvent.click(await screen.findByRole('button', { name: 'Back' }));
+		await fireEvent.click(await screen.findByRole('button', { name: 'Codex' }));
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(screen.getByText('Codex Model 0')).toBeTruthy();
+	});
+
 	it('stages a desktop generation model until an effort is selected', async () => {
 		const onChange = vi.fn();
 

--- a/web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte
+++ b/web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte
@@ -34,6 +34,8 @@
 		selectableAgentIds?: readonly SessionAgentId[];
 		recents?: ModelSelectorRecentOption[];
 		preferRecentsOnOpen?: boolean;
+		wrapInForm?: boolean;
+		onFormSubmit?: () => void;
 	}
 
 	let {
@@ -48,6 +50,8 @@
 		selectableAgentIds,
 		recents = [],
 		preferRecentsOnOpen = false,
+		wrapInForm = false,
+		onFormSubmit = () => {},
 	}: Props = $props();
 
 	let claudeModels = $derived.by<ModelOption[]>(() => {
@@ -169,11 +173,26 @@
 	} as unknown as ModelCatalogStore);
 </script>
 
-<ModelSelectorPopover
-	{value}
-	{mode}
-	{onChange}
-	{recents}
-	{preferRecentsOnOpen}
-	{selectableAgentIds}
-/>
+{#snippet selector()}
+	<ModelSelectorPopover
+		{value}
+		{mode}
+		{onChange}
+		{recents}
+		{preferRecentsOnOpen}
+		{selectableAgentIds}
+	/>
+{/snippet}
+
+{#if wrapInForm}
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			onFormSubmit();
+		}}
+	>
+		{@render selector()}
+	</form>
+{:else}
+	{@render selector()}
+{/if}

--- a/web/src/lib/components/ui/dialog/dialog-trigger.svelte
+++ b/web/src/lib/components/ui/dialog/dialog-trigger.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from 'bits-ui';
 
-	let { ref = $bindable(null), ...restProps }: DialogPrimitive.TriggerProps = $props();
+	let {
+		ref = $bindable(null),
+		type = 'button',
+		...restProps
+	}: DialogPrimitive.TriggerProps = $props();
 </script>
 
-<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {...restProps} />
+<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {...restProps} {type} />


### PR DESCRIPTION
## Before

- The compact provider selector is rendered inside the chat composer form.
- Its dialog trigger omitted the button type, so the browser could submit existing draft text while opening or changing provider.

```mermaid
flowchart LR
  Draft[Existing draft text] --> Trigger[Provider selector trigger]
  Trigger --> ImplicitSubmit[Implicit form submit]
  ImplicitSubmit --> Sent[Draft is sent]
```

## After

```mermaid
flowchart LR
  Draft[Existing draft text] --> Trigger[Provider selector trigger]
  Trigger --> ButtonAction[type=button]
  ButtonAction --> Selector[Provider selection remains open]
  Selector --> Draft
```

The shared Svelte dialog trigger now defaults to `type="button"`, matching the popover trigger and preserving explicit caller overrides. A compact provider-selector regression test verifies that a surrounding form is not submitted while navigating from the current model to another provider.

## Files
- `web/src/lib/components/ui/dialog/dialog-trigger.svelte` — defaults dialog triggers to non-submit button semantics.
- `web/src/lib/components/model-selector/__tests__/ModelSelectorPopoverHost.svelte` — supports a form-wrapped selector test harness.
- `web/src/lib/components/model-selector/__tests__/ModelSelectorPopover.test.ts` — covers compact provider navigation without form submission.

## Tests
- `bun run check` — passed.
- `bun run --cwd web test -- --maxWorkers 1 --no-file-parallelism` — 463 files, 5,067 tests passed.
- Focused selector test — 43 tests passed.
- `bun run start --port 0` with an isolated workspace — started successfully and shut down cleanly.
- `bun run test` — blocked by the unrelated 5-second timeout in `server-agents/common/src/search/__tests__/reader-worker.test.ts`; the isolated test reproduces the same timeout.

Prompted by: yk (@chiayong)