### PR TITLE
Show live automatic compaction rows across providers

### DIFF
--- a/docs/provider-compaction-rows-design.md
+++ b/docs/provider-compaction-rows-design.md
@@ -68,6 +68,9 @@ publish an empty-summary automatic row on successful completion, and continue
 to suppress the provider's summary parts. Deduplicate by summary assistant ID
 so repeated terminal frames do not duplicate the row and separate automatic
 compactions in one turn remain visible.
+Adopted automatic summaries must remain excluded from prompt-failure terminal
+selection and fallback native anchors so internal compaction errors cannot
+replace the prompt's failure.
 
 Do not route `session.compacted` through the current session. That event has no
 operation identity, and using it would recreate the session-latest routing the

--- a/docs/provider-compaction-rows-design.md
+++ b/docs/provider-compaction-rows-design.md
@@ -1,0 +1,144 @@
+# Provider Automatic Compaction Rows
+
+Status: accepted implementation design.
+
+## Objective
+
+Show the existing provider-neutral `CompactionMessage` row when Claude,
+OpenCode, or Pi reports automatic context compaction during a live turn.
+Codex already shows this row.
+
+The row is informational. It does not participate in execution, settlement,
+queueing, transcript recovery, or model context.
+
+## Current Behavior
+
+- Codex converts live `contextCompaction` items to `CompactionMessage`.
+- Claude folds a live `compact_boundary` and its synthetic summary into one
+  `CompactionMessage`.
+- OpenCode routes automatic compaction control and continuation parts through
+  the owning turn but intentionally publishes no row.
+- Pi receives `compaction_end` over its long-lived RPC stream but ignores it.
+- The shared contract, parser, ledger, and Svelte renderer already support
+  automatic rows. No new message type or client branch is required.
+
+## Decision
+
+Automatic compaction rows are best-effort live presentation.
+
+- Publish only from a provider event already correlated to the active turn.
+- Use the existing `CompactionMessage` contract and `trigger: 'auto'`.
+- Do not add durable correlation, provider state machines, or new shared
+  fields solely for this row.
+- Do not change native-history loaders. Explicit native Reload may omit the
+  row or lose its original trigger. Ordinary Garcon restart retains rows that
+  were already committed to the ledger.
+- Failed, aborted, or incomplete compactions publish no new row when the
+  provider supplies a completion result.
+- Provider-generated summary bookkeeping remains hidden unless the existing
+  Claude or Pi event already supplies summary content as structured data.
+
+This deliberately favors a small display-only change over live/native replay
+parity.
+
+## Provider Changes
+
+### Claude
+
+No production change is required. The live transport already stores
+`compact_boundary` metadata, recognizes the following synthetic summary, and
+publishes one automatic row.
+
+Add a focused live-transport test covering trigger, summary, token counts,
+source identity, and suppression of the synthetic user message.
+
+### OpenCode
+
+OpenCode persists and streams a compaction control part with `auto: true`. Its
+summary assistant is linked to that control message by `parentID` and exposes
+a successful terminal state. The provider source documents those fields and
+the completion sequence:
+
+- <https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/session/compaction.ts#L392-L465>
+- <https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/session/compaction.ts#L559-L581>
+
+Reuse the existing operation route established by the compaction control.
+Allow its linked summary terminal to reach the compaction boundary converter,
+publish an empty-summary automatic row on successful completion, and continue
+to suppress the provider's summary parts. Deduplicate by summary assistant ID
+so repeated terminal frames do not duplicate the row and separate automatic
+compactions in one turn remain visible.
+
+Do not route `session.compacted` through the current session. That event has no
+operation identity, and using it would recreate the session-latest routing the
+ledger design removed.
+
+### Pi
+
+Pi 0.85.1 forwards structured `compaction_end` events over RPC. A successful
+result includes `summary`, `tokensBefore`, and optional
+`estimatedTokensAfter`; `reason` distinguishes manual, threshold, and overflow
+compaction:
+
+- <https://github.com/badlogic/pi-mono/blob/d981de1229ef899957bbe968bc8dcda02a21f477/packages/coding-agent/src/core/agent-session.ts#L157-L168>
+- <https://github.com/badlogic/pi-mono/blob/d981de1229ef899957bbe968bc8dcda02a21f477/packages/coding-agent/src/core/agent-session.ts#L2356-L2402>
+
+Add a narrow typed converter for this RPC event. Publish its resulting row
+through the active turn only when the result is structurally valid and the
+event is not aborted. Map `manual` to `manual`; map `threshold` and `overflow`
+to `auto`.
+
+Do not expose Pi's manual compaction capability in this change and do not
+alter persisted Pi history traversal.
+
+### Codex
+
+No production change is included. Codex's durable native item does not retain
+automatic versus manual trigger information:
+
+- <https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/history/src/lib.rs#L156-L173>
+- <https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L412-L416>
+
+Live behavior remains correct. Native Reload may label an earlier automatic
+row as manual; fixing that would require a broader shared representation for
+unknown trigger provenance and is intentionally outside this display-only
+scope.
+
+## Contracts And Ordering
+
+No WebSocket or HTTP payload changes are required. `CompactionMessage` is
+already a member of the shared `ChatMessage` union and is serialized by the
+existing chat-message path.
+
+Rows publish through the active provider operation. Existing server event
+wiring therefore commits and broadcasts the row before the turn's terminal
+processing events.
+
+The frontend remains provider agnostic. `ConversationMessage.svelte` already
+dispatches every `CompactionMessage` to `CompactionRow.svelte`.
+
+## Tests
+
+- Claude unit: live automatic boundary plus synthetic summary becomes one
+  row with summary, token counts, and native source identity.
+- OpenCode unit: a successful routed automatic summary publishes one row;
+  summary text stays hidden; replayed terminal frames do not duplicate it.
+- OpenCode scripted integration: threshold compaction through the pinned real
+  binary includes one live automatic row, survives Garcon restart through the
+  ledger, and may disappear after explicit native Reload.
+- Pi unit: successful threshold and overflow events publish automatic rows;
+  manual maps to manual; aborted, failed, malformed, and unowned events do not
+  publish rows.
+- Pi scripted integration: high reported usage triggers threshold compaction
+  in the pinned real CLI and publishes one automatic row before turn
+  settlement.
+
+Run focused provider tests first, then package type checks, `bun run check`,
+`bun run test`, and the relevant scripted server integration files.
+
+## Commit Boundaries
+
+- Design and governing transcript-ledger decision.
+- Claude live compaction coverage.
+- OpenCode live automatic row and its focused tests.
+- Pi live automatic row and its focused tests.

--- a/docs/transcript-ledger-v5-cts.md
+++ b/docs/transcript-ledger-v5-cts.md
@@ -1,6 +1,6 @@
 # Transcript Ledger V5 Conformance Test Suite
 
-Status: Revision 34 integrated catalog. PR #500 release acceptance is anchored
+Status: Revision 35 integrated catalog. PR #500 release acceptance is anchored
 historically at squash merge
 `80540fc80399957ebcfe18cb2c2a741938e5cf64`; the current post-merge corrections
 include PR #518, PR #521 presentation-only chat rows, the PR #527 native-drift
@@ -25,13 +25,15 @@ distinct same-length prefix during native sanitation.
 Revision 34 makes a native occurrence mandatory after a provider-origin
 terminal proves the preamble turn completed; persistence lag fails retryably
 before Reload cutover or native-fidelity target publication.
+Revision 35 makes automatic compaction boundaries visible as best-effort live
+provider rows without adding native Reload reconstruction.
 
 Governing artifact:
 
-- `docs/transcript-ledger-v5-design.md`, revision 34, SHA-256
-  `b24125600fb05861659e06b9d24242cdc45088479453a8109ab43e7c5a99347e`
+- `docs/transcript-ledger-v5-design.md`, revision 35, SHA-256
+  `0ccb3b7d0f99ae8cfd9abf3b6c31e5863e793eb648ae08d7bdcecf089a0f2fd3`
 
-Current inventory: 417 discovered stable IDs, validated by
+Current inventory: 419 discovered stable IDs, validated by
 `scripts/validate-transcript-ledger-v5-cases.js` against
 `scripts/conformance/transcript-ledger-v5-cases.txt`. The PR #500 squash merge
 above is the historical acceptance anchor for the first 256. Later cases are
@@ -536,7 +538,7 @@ cache restoration.
 
 | ID                | Obligation                                                                                                      | Required evidence   |
 | ----------------- | --------------------------------------------------------------------------------------------------------------- | ------------------- |
-| TLV5-OPENCODE.01  | Pinned V1 automatic compaction is marker-routed into the owning turn and continues with only user-facing output. | Provider scripted   |
+| TLV5-OPENCODE.01  | Pinned V1 automatic compaction is marker-routed into the owning turn; a successful summary publishes one informational boundary before user-facing output continues. | Provider scripted   |
 | TLV5-OPENCODE.02  | The owned process does not force autocompaction off and ships no plugin or session-latest continuation route.   | Static plus unit    |
 
 ### Observability and Release Hygiene
@@ -765,7 +767,7 @@ not merely that the final transcript matched.
 
 | ID                | Current evidence                                                                                                      | State          |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------- | -------------- |
-| TLV5-OPENCODE.01  | Pinned real-binary fixtures assert threshold and first-turn overflow compaction continue through the owning turn's route, replay inherits operation metadata, and interruption leaves the next turn clean. | Covered |
+| TLV5-OPENCODE.01  | Pinned real-binary fixtures assert threshold and first-turn overflow compaction publish a live informational boundary through the owning turn's route, replay inherits operation metadata, and interruption leaves the next turn clean. | Covered |
 | TLV5-OPENCODE.02  | Static and unit guards keep autocompaction unforced and require absence of the plugin and session-latest route.       | Covered |
 
 Parsing already stored compaction summaries remains supported.
@@ -1011,7 +1013,7 @@ for each atomic requirement and records any required complementary tier.
 | TLV5-UX.17-WEB-UNIT-04         | `web/src/lib/chat/transcript/__tests__/active-transcript-state.test.ts`: switching discards expansion and restores the exact bounded tail with earlier paging available | R4 switch restoration |
 | TLV5-UX.17-COMPACT-CHROMIUM-01 | `integration-tests/tests/chromium/transcript-virtualization.test.ts`: compact live-edge expansion survives the retired delay and later growth in canonical order with the final row visible | R4 compact geometry |
 | TLV5-UX.17-WIDE-CHROMIUM-01    | `integration-tests/tests/chromium/transcript-virtualization.test.ts`: wide live-edge expansion survives the retired delay and later growth in canonical order with the final row visible    | R4 wide geometry    |
-| TLV5-OPENCODE.01-SCRIPTED-01   | `integration-tests/tests/server/opencode-scripted-compaction.test.ts`: threshold compaction continues with only user-facing output and pinned markers    | OPENCODE.01                 |
+| TLV5-OPENCODE.01-SCRIPTED-01   | `integration-tests/tests/server/opencode-scripted-compaction.test.ts`: threshold compaction shows a boundary and pins native markers              | OPENCODE.01                 |
 | TLV5-OPENCODE.02-STATIC-01     | `server-agents/opencode/src/agents/opencode/__tests__/autocompaction-architecture.test.js`: compaction stays enabled with no plugin or session-latest route | OPENCODE.02              |
 | TLV5-PAGE.07-LIGHTPANDA-01     | `integration-tests/tests/e2e/transcript-scrolling.test.ts`: `pages earlier history while keeping the virtual DOM bounded`                                 | PAGE.05, PAGE.07            |
 

--- a/docs/transcript-ledger-v5-design.md
+++ b/docs/transcript-ledger-v5-design.md
@@ -1,10 +1,20 @@
 # Garcon Transcript Ledger V5: Core-Owned Append-Only Authority
 
-Status: revision 34 integrated design. Supersedes
+Status: revision 35 integrated design. Supersedes
 `AGENT_OWNED_TRANSCRIPT_PROJECTION_DESIGN.md`
 (V4, SHA-256 `12e6efbcbd30419c0b4580d8159f60e2b1948d8dd790857a070dee5b3f6873cf`),
 which remains untouched as the historical record of the reconciliation-based
 architecture and its implementation through commit `f029424c`.
+
+Revision 35 makes automatic compaction boundaries visible as best-effort live
+provider rows. Claude and Codex retain their existing conversion. OpenCode
+publishes from the successfully completed summary assistant already correlated
+to the owning operation; Pi publishes from a successful structured
+`compaction_end`. These informational rows add no session-latest routing,
+durable provider correlation, or native-history reconstruction. They survive
+ordinary restart once committed to the ledger, while explicit native Reload
+may omit them or lose trigger provenance. The bounded scope and provider
+evidence are recorded in `docs/provider-compaction-rows-design.md`.
 
 Revision 34 prevents native-history persistence lag from deleting the only
 receipt evidence for a completed preamble turn. A provider-origin `run-ended`
@@ -2141,9 +2151,10 @@ relevant-entry definition under the 10.2 obligation.
   Normal execution, previews, and Reload remain directory-scoped. Pinned V1
   automatic compaction runs with marker-part routing (#529): OpenCode marks
   its compaction control and continuation parts, the runtime adopts them into
-  the owning turn's route, and a successful overflow summary continues the
-  turn with only user-facing output. Session-latest routing remains forbidden
-  and deleted. The integration has no manual compaction facet. Native-fidelity
+  the owning turn's route, and a successful summary adds one informational
+  compaction row before the turn continues with user-facing output.
+  Session-latest routing remains forbidden and deleted. The integration has no
+  manual compaction facet. Native-fidelity
   fork uses the provider's server-side session fork at an exclusive
   message boundary resolved from the anchor row's `providerMeta`; the boundary
   is message-granular, an unpersisted anchor refuses as not settled, and
@@ -2581,10 +2592,10 @@ The catalog cites this revision, but its inventory is not repeated here.
 - **OpenCode V1 compaction**: the owned process does not force autocompaction
   off and preserves operator overrides; the session-latest continuation map
   and plugin remain absent. Scripted fixtures prove threshold and first-turn
-  overflow compaction continue with only user-facing output through the
-  owning turn's route, overflow replay inherits operation metadata without
-  duplicating the user row, and interruption during summary and continuation
-  leaves the next turn clean.
+  overflow compaction add one informational boundary through the owning
+  turn's route before continuing with user-facing output, overflow replay
+  inherits operation metadata without duplicating the user row, and
+  interruption during summary and continuation leaves the next turn clean.
 - **Handoff**: the 12.1 ordering (reservation, empty queue, close,
   verified checkpoint, then decision) with fault injection at an
   injected sync/rename seam; crash before the decision restores the
@@ -2899,11 +2910,12 @@ stabilization defects. The current case inventory and gate status live in
     machine are deleted.
 24. Pinned OpenCode V1 automatic compaction is marker-routed: OpenCode marks
     its compaction control and continuation parts, the runtime adopts them
-    into the owning turn's route, and a successful overflow summary continues
-    the turn with only user-facing output, while an unmarked or failed
-    compaction surfaces as that operation's visible failure. Session-latest
-    continuation routing stays deleted. Directoryless legacy import remains
-    an explicit follow-up.
+    into the owning turn's route, and a successful summary publishes one
+    informational compaction boundary before the turn continues with
+    user-facing output. An unmarked or failed compaction surfaces as that
+    operation's visible failure. Session-latest continuation routing stays
+    deleted. Native Reload reconstruction and directoryless legacy import
+    remain explicit follow-ups.
 25. Preambles are provider-neutral core composition. The current enabled
     catalog resolves once at the first ordinary input after new chat, fork,
     continuation, or in-place agent switch. Each active `{{chat_id}}` in a

--- a/integration-tests/support/scripted-pi.ts
+++ b/integration-tests/support/scripted-pi.ts
@@ -40,7 +40,9 @@ export interface ScriptedPiTestEnvironment {
   dispose(): void;
 }
 
-export function startScriptedPiTestEnvironment(): ScriptedPiTestEnvironment {
+export function startScriptedPiTestEnvironment(
+  options: { readonly compactionKeepRecentTokens?: number } = {},
+): ScriptedPiTestEnvironment {
   const model = FakeChatCompletionsModel.start();
   // The Pi bin uses /usr/bin/env node, so only the runner's node executable is exposed below.
   // Adding its whole directory would also expose ambient agent binaries to catalog discovery.
@@ -92,6 +94,11 @@ export function startScriptedPiTestEnvironment(): ScriptedPiTestEnvironment {
           },
         },
       }), { mode: 0o600 });
+      if (options.compactionKeepRecentTokens !== undefined) {
+        await writeFile(join(agentDir, 'settings.json'), JSON.stringify({
+          compaction: { keepRecentTokens: options.compactionKeepRecentTokens },
+        }), { mode: 0o600 });
+      }
     },
     dispose: () => model.stop(),
   };

--- a/integration-tests/tests/server/opencode-scripted-compaction.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-compaction.test.ts
@@ -125,9 +125,10 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
       await reloadFromNativeHistory(fixture, chatId);
       const imported = await fixture.client.getMessages(chatId);
       expect(imported.transcriptViewId).not.toBe(restored.transcriptViewId);
-      expect(renderingProjection(imported.messages)).toEqual(renderingProjection(
+      const reloadableProjection = renderingProjection(
         live.messages.filter(({ message }) => message.type !== 'compaction'),
-      ));
+      );
+      expect(renderingProjection(imported.messages)).toEqual(reloadableProjection);
       expect(messagesOfType(imported.messages, 'compaction')).toEqual([]);
       expectCompactionInternalsHidden(imported.messages, [summary]);
     }, withScriptedOpenCode());
@@ -598,9 +599,11 @@ async function exerciseInterruptedCompaction(
     expect(userContents(stopped.messages)).toEqual([prompt]);
     expect(assistantContents(stopped.messages)).toEqual([]);
     expect(messagesOfType(stopped.messages, 'error')).toEqual([]);
-    const stoppedBoundaries = messagesOfType(stopped.messages, 'compaction');
-    expect(stoppedBoundaries).toHaveLength(phase === 'continuation' ? 1 : 0);
-    expect(stoppedBoundaries.every((boundary) => boundary.trigger === 'auto')).toBe(true);
+    expect(messagesOfType(stopped.messages, 'compaction')).toEqual(
+      phase === 'continuation'
+        ? [expect.objectContaining({ trigger: 'auto' })]
+        : [],
+    );
     expectCompactionInternalsHidden(stopped.messages, [overflow, summary, stoppedAnswer]);
     await reloadFromNativeHistory(fixture, chatId);
     const reloaded = await fixture.client.getMessages(chatId);

--- a/integration-tests/tests/server/opencode-scripted-compaction.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-compaction.test.ts
@@ -604,6 +604,7 @@ async function exerciseInterruptedCompaction(
     expectCompactionInternalsHidden(stopped.messages, [overflow, summary, stoppedAnswer]);
     await reloadFromNativeHistory(fixture, chatId);
     const reloaded = await fixture.client.getMessages(chatId);
+    // Automatic boundaries are live-only and intentionally absent after native Reload.
     expect(messagesOfType(reloaded.messages, 'compaction')).toEqual([]);
     expectCompactionInternalsHidden(reloaded.messages, [overflow, summary, stoppedAnswer]);
 

--- a/integration-tests/tests/server/opencode-scripted-compaction.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-compaction.test.ts
@@ -55,7 +55,7 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
     environment = undefined;
   });
 
-  test('[TLV5-OPENCODE.01-SCRIPTED-01] [TLV5-OPENCODE.01-SCRIPTED-05] threshold compaction continues with only user-facing output and pins native markers', async () => {
+  test('[TLV5-OPENCODE.01-SCRIPTED-01] [TLV5-OPENCODE.01-SCRIPTED-05] threshold compaction shows a boundary and pins native markers', async () => {
     const testEnvironment = requireEnvironment();
     const prompt = marker('THRESHOLD_PROMPT');
     const toolOutput = marker('THRESHOLD_TOOL_OUTPUT');
@@ -93,6 +93,7 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
         'user-message',
         'bash-tool-use',
         'tool-result',
+        'compaction',
         'assistant-message',
       ]);
       expect(userContents(live.messages)).toEqual([prompt]);
@@ -101,6 +102,9 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
         expect.objectContaining({ command }),
       ]);
       expect(JSON.stringify(messagesOfType(live.messages, 'tool-result'))).toContain(toolOutput);
+      expect(messagesOfType(live.messages, 'compaction')).toEqual([
+        expect.objectContaining({ trigger: 'auto' }),
+      ]);
       expectCompactionInternalsHidden(live.messages, [summary]);
       expectTurnTerminalCount(fixture, eventCursor, chatId, turn.turnId, 'agent-run-finished');
       expect(testEnvironment.model.requestsSince(requestCursor)).toHaveLength(3);
@@ -121,7 +125,10 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
       await reloadFromNativeHistory(fixture, chatId);
       const imported = await fixture.client.getMessages(chatId);
       expect(imported.transcriptViewId).not.toBe(restored.transcriptViewId);
-      expect(renderingProjection(imported.messages)).toEqual(liveProjection);
+      expect(renderingProjection(imported.messages)).toEqual(renderingProjection(
+        live.messages.filter(({ message }) => message.type !== 'compaction'),
+      ));
+      expect(messagesOfType(imported.messages, 'compaction')).toEqual([]);
       expectCompactionInternalsHidden(imported.messages, [summary]);
     }, withScriptedOpenCode());
   }, 120_000);
@@ -161,10 +168,14 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
       const transcript = await fixture.client.getMessages(chatId);
       expect(transcript.messages.map((entry) => entry.message.type)).toEqual([
         'user-message',
+        'compaction',
         'assistant-message',
       ]);
       expect(userContents(transcript.messages)).toEqual([prompt]);
       expect(assistantContents(transcript.messages)).toEqual([answer]);
+      expect(messagesOfType(transcript.messages, 'compaction')).toEqual([
+        expect.objectContaining({ trigger: 'auto' }),
+      ]);
       expect(messagesOfType(transcript.messages, 'error')).toEqual([]);
       expectCompactionInternalsHidden(transcript.messages, [overflow, summary]);
       expectTurnTerminalCount(fixture, eventCursor, chatId, turn.turnId, 'agent-run-finished');
@@ -226,10 +237,14 @@ describeOnLinux('OpenCode V1 automatic compaction against a scripted model', () 
         'user-message',
         'assistant-message',
         'user-message',
+        'compaction',
         'assistant-message',
       ]);
       expect(userContents(transcript.messages)).toEqual([firstPrompt, secondPrompt]);
       expect(assistantContents(transcript.messages)).toEqual([firstAnswer, secondAnswer]);
+      expect(messagesOfType(transcript.messages, 'compaction')).toEqual([
+        expect.objectContaining({ trigger: 'auto' }),
+      ]);
       expectCompactionInternalsHidden(transcript.messages, [overflow, summary]);
       expectTurnTerminalCount(
         fixture,
@@ -583,9 +598,10 @@ async function exerciseInterruptedCompaction(
     expect(userContents(stopped.messages)).toEqual([prompt]);
     expect(assistantContents(stopped.messages)).toEqual([]);
     expect(messagesOfType(stopped.messages, 'error')).toEqual([]);
+    const stoppedBoundaries = messagesOfType(stopped.messages, 'compaction');
+    expect(stoppedBoundaries).toHaveLength(phase === 'continuation' ? 1 : 0);
+    expect(stoppedBoundaries.every((boundary) => boundary.trigger === 'auto')).toBe(true);
     expectCompactionInternalsHidden(stopped.messages, [overflow, summary, stoppedAnswer]);
-    // The aborted summary replaced nothing, so reloading must not resurrect a
-    // compaction boundary the live transcript never published.
     await reloadFromNativeHistory(fixture, chatId);
     const reloaded = await fixture.client.getMessages(chatId);
     expect(messagesOfType(reloaded.messages, 'compaction')).toEqual([]);
@@ -613,6 +629,7 @@ async function exerciseInterruptedCompaction(
       expect(userContents(recovered.messages)).toEqual([prompt, recoveryPrompt]);
       expect(assistantContents(recovered.messages)).toEqual([recoveryAnswer]);
       expect(messagesOfType(recovered.messages, 'error')).toEqual([]);
+      expect(messagesOfType(recovered.messages, 'compaction')).toEqual([]);
       expectCompactionInternalsHidden(recovered.messages, [
         overflow,
         summary,
@@ -688,7 +705,6 @@ function expectCompactionInternalsHidden(
   for (const value of [...markers, AUTOCONTINUE_TEXT]) {
     expect(rendered).not.toContain(value);
   }
-  expect(messages.map((entry) => entry.message.type)).not.toContain('compaction');
 }
 
 function expectTurnTerminalCount(

--- a/integration-tests/tests/server/pi-scripted-model.test.ts
+++ b/integration-tests/tests/server/pi-scripted-model.test.ts
@@ -97,6 +97,57 @@ describe('Pi against a scripted model', () => {
     }, withScriptedPi());
   }, 120_000);
 
+  test('publishes a boundary when the pinned Pi CLI automatically compacts', async () => {
+    environment?.dispose();
+    environment = startScriptedPiTestEnvironment({ compactionKeepRecentTokens: 1 });
+    const testEnvironment = environment;
+    const prompt = marker('COMPACTION_PROMPT');
+    const reply = marker('COMPACTION_REPLY');
+    const summary = marker('COMPACTION_SUMMARY');
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply, {
+      usage: {
+        prompt_tokens: 120_000,
+        completion_tokens: 1_000,
+        total_tokens: 121_000,
+      },
+    })]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(summary)]);
+
+    await withIntegrationFixture('pi-scripted-compaction', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedPiStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: prompt,
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+
+      const native = await piNativeSession(fixture, chatId);
+      expect(await readFile(native.path, 'utf8')).toContain('"totalTokens":121000');
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(transcript.messages.map(({ message }) => message.type)).toEqual([
+        'user-message',
+        'assistant-message',
+        'compaction',
+      ]);
+      expect(messagesOfType(transcript.messages, 'compaction')).toEqual([
+        expect.objectContaining({
+          trigger: 'auto',
+          summary: expect.stringContaining(summary),
+          preTokens: 121_000,
+        }),
+      ]);
+      testEnvironment.model.assertSettled();
+    }, withScriptedPi());
+  }, 120_000);
+
   test('accepts Pi-clamped thinking for a model without an off level', async () => {
     const testEnvironment = requireEnvironment();
     const reply = marker('CLAMPED_THINKING_REPLY');

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { getNativeMessageRevisionSource } from '@garcon/server-agent-common/shared/native-message-source';
 
 import { ClaudeCliRuntime } from '../claude-cli.js';
 
@@ -259,6 +260,67 @@ function startOptions(overrides = {}) {
 }
 
 describe('ClaudeCliRuntime stdout protocol handling', () => {
+  it('publishes live automatic compaction metadata without exposing the synthetic user message', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    Bun.spawn = mock(() => fake.proc);
+
+    try {
+      const runtime = createRuntime();
+      const published = collectOperation('run-auto-compaction');
+      const start = runtime.startClaudeCliSession(startOptions({
+        operation: published.operation,
+      }));
+      const input = await enqueueInputStarted(fake);
+      enqueueCliMessage(fake, {
+        type: 'system',
+        subtype: 'compact_boundary',
+        compact_metadata: {
+          trigger: 'auto',
+          pre_tokens: 81_000,
+          post_tokens: 12_000,
+        },
+      });
+      enqueueCliMessage(fake, {
+        type: 'user',
+        uuid: 'compaction-summary-uuid',
+        message: {
+          role: 'user',
+          content: 'This session is being continued from a previous conversation.\n\nSummary:\nKept context.',
+        },
+      });
+      enqueueCliMessage(fake, {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'done',
+        user_message_uuid: input.uuid,
+      });
+      enqueueProviderState(fake, 'idle');
+
+      await expect(start).resolves.toBe('expected-session');
+      const messages = publishedMessages(published.events);
+      const compactionMessages = messages.filter((message) => message.type === 'compaction');
+      expect(compactionMessages).toEqual([
+        expect.objectContaining({
+          type: 'compaction',
+          trigger: 'auto',
+          summary: 'Kept context.',
+          preTokens: 81_000,
+          postTokens: 12_000,
+        }),
+      ]);
+      expect(getNativeMessageRevisionSource(compactionMessages[0])).toEqual({
+        entryId: 'compaction-summary-uuid',
+        withinSourceOrdinal: 0,
+      });
+      expect(messages.some((message) => message.type === 'user-message')).toBe(false);
+      await runtime.shutdown();
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+
   it('[TLV5-L07.03-CLAUDE-UNIT-01] publishes two turns on one native session through their concrete operations', async () => {
     const originalSpawn = Bun.spawn;
     const fake = createFakeClaudeProcess();

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routes.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routes.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
+import { adoptOpenCodeCompactionPartRoute } from '../compaction-routing.js';
 import { OpenCodeOperationRoutes } from '../operation-routes.js';
 import {
   isOpenCodeCompactionContinuationPart,
@@ -547,7 +548,7 @@ describe('OpenCodeOperationRoutes', () => {
     }))).toBe(true);
   });
 
-  it('adopts an automatic compaction control part and resolves the invisible summary chain', () => {
+  it('adopts an automatic compaction control part and resolves its internal summary chain', () => {
     const { logger, routes } = createFixture();
     const operation = register(routes, {
       sessionId: 'session-1',
@@ -557,10 +558,25 @@ describe('OpenCodeOperationRoutes', () => {
     routes.observe(operation.route, promptEvent(operation.turn, 'user-a', 'event-a'));
     operation.turn.providerMessageId = 'user-a';
 
-    expect(routes.adoptCompactionPart(operation.turn, compactionPartEvent())).toEqual({
-      kind: 'adopted',
-      route: operation.route,
-    });
+    expect(adoptOpenCodeCompactionPartRoute({
+      event: compactionPartEvent(),
+      logger,
+      operationRoutes: routes,
+      session: {
+        status: 'running',
+        chatId: 'chat-1',
+        permissionMode: 'default',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        lastActivityAt: 0,
+        providerWorkRequiresQuiescence: false,
+        activeSteeringDeliveries: 0,
+        deferredTerminal: null,
+        pendingSteeringRevertMessageId: null,
+        turn: operation.turn,
+      },
+      sessionId: 'session-1',
+    })).toBe(operation.route);
+    expect(operation.turn.automaticCompactionMessageIds).toContain('user-compaction');
     const summary = {
       id: 'event-summary',
       type: 'message.updated',
@@ -577,7 +593,7 @@ describe('OpenCodeOperationRoutes', () => {
       },
     };
     expect(routes.resolveNamed('session-1', summary)).toBe(operation.route);
-    expect(openCodeEventBelongsToTurn(operation.turn, summary)).toBe(false);
+    expect(openCodeEventBelongsToTurn(operation.turn, summary)).toBe(true);
     routes.observe(operation.route, summary);
 
     const summaryPart = {
@@ -600,9 +616,10 @@ describe('OpenCodeOperationRoutes', () => {
     };
     expect(routes.resolveNamed('session-1', summaryPart)).toBe(operation.route);
     expect(routes.resolveNamed('session-1', summaryDelta)).toBe(operation.route);
-    expect(openCodeEventBelongsToTurn(operation.turn, summaryPart)).toBe(false);
-    expect(openCodeEventBelongsToTurn(operation.turn, summaryDelta)).toBe(false);
-    expect(operation.turn.assistantMessageIds).not.toContain('assistant-summary');
+    expect(openCodeEventBelongsToTurn(operation.turn, summaryPart)).toBe(true);
+    expect(openCodeEventBelongsToTurn(operation.turn, summaryDelta)).toBe(true);
+    expect(operation.turn.automaticCompactionMessageIds).toContain('assistant-summary');
+    expect(operation.turn.assistantMessageIds).toContain('assistant-summary');
     expect(operation.turn.assistantTerminals).toHaveLength(0);
     expect(logger.warn).not.toHaveBeenCalled();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -163,6 +163,29 @@ function pushCompactionPart(eventStream, {
   });
 }
 
+function pushCompletedCompactionSummary(eventStream, {
+  eventId,
+  messageId,
+  parentId,
+  sessionId,
+}) {
+  eventStream.push({
+    id: eventId,
+    type: 'message.updated',
+    properties: {
+      sessionID: sessionId,
+      info: {
+        id: messageId,
+        role: 'assistant',
+        parentID: parentId,
+        summary: true,
+        finish: 'stop',
+        time: { completed: 1 },
+      },
+    },
+  }, { completePrompt: false });
+}
+
 function pushAssistant(eventStream, {
   eventNumber,
   messageId,
@@ -1538,7 +1561,7 @@ describe('OpenCode operation routing', () => {
     await runtime.shutdown();
   });
 
-  it('publishes one automatic boundary while hiding the compaction summary chain', async () => {
+  it('publishes separate automatic boundaries while hiding compaction summary chains', async () => {
     const diagnostics = diagnosticLogger();
     const { eventStream, promptAsync, runtime } = createRuntime(['session-1'], {
       logger: diagnostics.logger,
@@ -1562,21 +1585,12 @@ describe('OpenCode operation routing', () => {
       eventId: 'event-control',
       sessionId: 'session-1',
     });
-    eventStream.push({
-      id: 'event-summary-message',
-      type: 'message.updated',
-      properties: {
-        sessionID: 'session-1',
-        info: {
-          id: 'assistant-summary',
-          role: 'assistant',
-          parentID: 'user-compaction',
-          summary: true,
-          finish: 'stop',
-          time: { completed: 1 },
-        },
-      },
-    }, { completePrompt: false });
+    pushCompletedCompactionSummary(eventStream, {
+      eventId: 'event-summary-message',
+      messageId: 'assistant-summary',
+      parentId: 'user-compaction',
+      sessionId: 'session-1',
+    });
     eventStream.push({
       id: 'event-summary-part',
       type: 'message.part.updated',
@@ -1600,21 +1614,24 @@ describe('OpenCode operation routing', () => {
         delta: 'provider-created summary delta',
       },
     });
-    eventStream.push({
-      id: 'event-summary-message-replayed',
-      type: 'message.updated',
-      properties: {
-        sessionID: 'session-1',
-        info: {
-          id: 'assistant-summary',
-          role: 'assistant',
-          parentID: 'user-compaction',
-          summary: true,
-          finish: 'stop',
-          time: { completed: 1 },
-        },
-      },
-    }, { completePrompt: false });
+    pushCompletedCompactionSummary(eventStream, {
+      eventId: 'event-summary-message-replayed',
+      messageId: 'assistant-summary',
+      parentId: 'user-compaction',
+      sessionId: 'session-1',
+    });
+    pushCompactionPart(eventStream, {
+      eventId: 'event-control-second',
+      messageId: 'user-compaction-second',
+      partId: 'part-compaction-second',
+      sessionId: 'session-1',
+    });
+    pushCompletedCompactionSummary(eventStream, {
+      eventId: 'event-summary-message-second',
+      messageId: 'assistant-summary-second',
+      parentId: 'user-compaction-second',
+      sessionId: 'session-1',
+    });
     eventStream.push({
       id: 'event-barrier',
       type: 'session.compacted',
@@ -1631,6 +1648,18 @@ describe('OpenCode operation routing', () => {
             trigger: 'auto',
             summary: '',
           }),
+          providerMeta: { entryId: 'assistant-summary' },
+        })],
+      }),
+      expect.objectContaining({
+        type: 'rows',
+        rows: [expect.objectContaining({
+          message: expect.objectContaining({
+            type: 'compaction',
+            trigger: 'auto',
+            summary: '',
+          }),
+          providerMeta: { entryId: 'assistant-summary-second' },
         })],
       }),
     ]);
@@ -1638,7 +1667,7 @@ describe('OpenCode operation routing', () => {
     expect(diagnostics.warnings).toEqual([]);
     expect(diagnostics.debug.filter(([message]) => (
       message === 'Adopted an OpenCode compaction part'
-    ))).toHaveLength(1);
+    ))).toHaveLength(2);
     eventStream.close();
     await runtime.shutdown();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -1532,7 +1532,7 @@ describe('OpenCode operation routing', () => {
     await runtime.shutdown();
   });
 
-  it('routes an automatic compaction summary chain without rows, terminals, or warnings', async () => {
+  it('publishes one automatic boundary while hiding the compaction summary chain', async () => {
     const diagnostics = diagnosticLogger();
     const { eventStream, promptAsync, runtime } = createRuntime(['session-1'], {
       logger: diagnostics.logger,
@@ -1595,13 +1595,40 @@ describe('OpenCode operation routing', () => {
       },
     });
     eventStream.push({
+      id: 'event-summary-message-replayed',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: {
+          id: 'assistant-summary',
+          role: 'assistant',
+          parentID: 'user-compaction',
+          summary: true,
+          finish: 'stop',
+          time: { completed: 1 },
+        },
+      },
+    }, { completePrompt: false });
+    eventStream.push({
       id: 'event-barrier',
       type: 'session.compacted',
       properties: { sessionID: 'session-1' },
     });
     await waitFor(() => diagnostics.debug.some((entry) => entry[1]?.eventId === 'event-barrier'));
 
-    expect(events).toEqual([]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'rows',
+        rows: [expect.objectContaining({
+          message: expect.objectContaining({
+            type: 'compaction',
+            trigger: 'auto',
+            summary: '',
+          }),
+        })],
+      }),
+    ]);
+    expect(JSON.stringify(events)).not.toContain('provider-created summary');
     expect(diagnostics.warnings).toEqual([]);
     expect(diagnostics.debug.filter(([message]) => (
       message === 'Adopted an OpenCode compaction part'

--- a/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/operation-routing.test.js
@@ -39,6 +39,12 @@ function createEventStream() {
       observe(event, completePrompt);
     },
     resolvePrompt,
+    failPrompt(messageId, message) {
+      const request = promptRequestsByMessage.get(messageId);
+      if (request) setImmediate(() => request.resolve({
+        error: { name: 'ProviderError', data: { message } },
+      }));
+    },
     prompt(input, options) {
       return new Promise((resolve, reject) => {
         const partId = input.parts[0].id;
@@ -1633,6 +1639,64 @@ describe('OpenCode operation routing', () => {
     expect(diagnostics.debug.filter(([message]) => (
       message === 'Adopted an OpenCode compaction part'
     ))).toHaveLength(1);
+    eventStream.close();
+    await runtime.shutdown();
+  });
+
+  it('keeps an automatic summary failure internal when the prompt fails', async () => {
+    const diagnostics = diagnosticLogger();
+    const { eventStream, promptAsync, runtime } = createRuntime(['session-1'], {
+      logger: diagnostics.logger,
+    });
+    const events = [];
+    await runtime.startSession({
+      command: 'first',
+      chatId: 'chat-1',
+      projectPath: '/repo',
+      permissionMode: 'default',
+      operation: operation('run-a', events),
+    });
+    pushPrompt(eventStream, {
+      eventId: 'event-prompt',
+      messageId: 'user-prompt',
+      partId: promptPart(promptAsync, 0),
+      sessionId: 'session-1',
+      text: 'first',
+    });
+    pushCompactionPart(eventStream, {
+      eventId: 'event-control',
+      sessionId: 'session-1',
+    });
+    eventStream.push({
+      id: 'event-summary-failed',
+      type: 'message.updated',
+      properties: {
+        sessionID: 'session-1',
+        info: {
+          id: 'assistant-summary',
+          role: 'assistant',
+          parentID: 'user-compaction',
+          summary: true,
+          time: { completed: 1 },
+          error: { name: 'ProviderError', data: { message: 'internal summary failure' } },
+        },
+      },
+    }, { completePrompt: false });
+    eventStream.push({
+      id: 'event-barrier',
+      type: 'session.compacted',
+      properties: { sessionID: 'session-1' },
+    });
+    await waitFor(() => diagnostics.debug.some((entry) => entry[1]?.eventId === 'event-barrier'));
+    eventStream.failPrompt('user-prompt', 'visible prompt failure');
+    await waitFor(() => events.some((event) => event.type === 'run-ended'));
+
+    expect(events).toEqual([expect.objectContaining({
+      type: 'run-ended',
+      outcome: 'failed',
+      error: { code: 'PROVIDER_FAILURE', message: 'visible prompt failure' },
+    })]);
+    expect(JSON.stringify(events)).not.toContain('internal summary failure');
     eventStream.close();
     await runtime.shutdown();
   });

--- a/server-agents/opencode/src/agents/opencode/__tests__/turn-failure.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/turn-failure.test.js
@@ -1,0 +1,33 @@
+import { expect, it } from 'bun:test';
+import { getNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
+import {
+  latestOpenCodePromptTerminal,
+  openCodeProviderFailureRow,
+} from '../turn-failure.js';
+
+it('excludes automatic compaction summaries from failure attribution', () => {
+  const visibleTerminal = {
+    outcome: 'failed',
+    messageId: 'assistant-visible',
+    error: 'visible failure',
+  };
+  const turn = {
+    assistantMessageIds: new Set(['assistant-visible', 'assistant-summary']),
+    automaticCompactionMessageIds: new Set(['assistant-summary']),
+    assistantTerminals: new Map([
+      ['assistant-visible', visibleTerminal],
+      ['assistant-summary', {
+        outcome: 'failed',
+        messageId: 'assistant-summary',
+        error: 'internal failure',
+      }],
+    ]),
+  };
+
+  expect(latestOpenCodePromptTerminal(turn)).toBe(visibleTerminal);
+  expect(getNativeMessageSource(
+    openCodeProviderFailureRow('control failure', undefined, turn),
+  )).toEqual({
+    entryId: 'assistant-visible',
+  });
+});

--- a/server-agents/opencode/src/agents/opencode/compaction-routing.ts
+++ b/server-agents/opencode/src/agents/opencode/compaction-routing.ts
@@ -1,6 +1,6 @@
 import type { AgentLogger } from '@garcon/server-agent-interface';
 import { isRecord } from '@garcon/common/json';
-import { CompactionMessage } from '@garcon/common/chat-types';
+import { CompactionMessage, type CompactionTrigger } from '@garcon/common/chat-types';
 import type {
   OpenCodeOperationRoute,
   OpenCodeOperationRoutes,
@@ -77,6 +77,9 @@ export function adoptOpenCodeCompactionPartRoute(
   switch (adoption.kind) {
     case 'adopted': {
       const part = event.properties?.part;
+      if (isRecord(part) && part.auto === true) {
+        session.turn.automaticCompactionMessageIds.add(messageId);
+      }
       logger.debug('Adopted an OpenCode compaction part', {
         agentSessionId: sessionId,
         partId: typeof part?.id === 'string' ? part.id : null,
@@ -120,18 +123,19 @@ function dropCompactionPart(
   return null;
 }
 
-export interface OpenCodeManualCompactionBoundary {
+export interface OpenCodeCompactionBoundary {
   readonly row: CompactionMessage;
   // The successful summary assistant's id anchors the boundary so point-fork
   // boundaries match across live and reloaded transcripts.
   readonly summaryMessageId: string;
 }
 
-// The single boundary row a manual compaction turn publishes: only a summary
-// assistant that finished successfully replaced prior context; a failed or
-// aborted summary leaves the boundary unmarked. Summary text and control parts
-// stay internal to the native session.
-export function manualCompactionBoundaryRow(event: SSEEvent): OpenCodeManualCompactionBoundary | null {
+// Only a summary assistant that finished successfully replaced prior context.
+// Summary text and control parts stay internal to the native session.
+export function compactionBoundaryRow(
+  event: SSEEvent,
+  trigger: CompactionTrigger,
+): OpenCodeCompactionBoundary | null {
   if (event.type !== 'message.updated') return null;
   const info = event.properties?.info;
   if (!isRecord(info) || !isOpenCodeCompactionAssistant(info)) return null;
@@ -142,7 +146,7 @@ export function manualCompactionBoundaryRow(event: SSEEvent): OpenCodeManualComp
     : null;
   if (completed === null) return null;
   return {
-    row: new CompactionMessage(new Date(completed).toISOString(), 'manual', ''),
+    row: new CompactionMessage(new Date(completed).toISOString(), trigger, ''),
     summaryMessageId: terminal.messageId,
   };
 }

--- a/server-agents/opencode/src/agents/opencode/compaction-routing.ts
+++ b/server-agents/opencode/src/agents/opencode/compaction-routing.ts
@@ -7,7 +7,7 @@ import type {
 } from './operation-routes.js';
 import { isOpenCodeCompactionAssistant, openCodeAssistantTerminal } from './sse-events.js';
 import type { SSEEvent } from './sse-events.js';
-import type { OpenCodeSession } from './turn-events.js';
+import type { OpenCodeSession, OpenCodeTurnContext } from './turn-events.js';
 
 type OpenCodeCompactionPartDropCode =
   | 'COMPACTION_PART_NO_SESSION'
@@ -128,6 +128,19 @@ export interface OpenCodeCompactionBoundary {
   // The successful summary assistant's id anchors the boundary so point-fork
   // boundaries match across live and reloaded transcripts.
   readonly summaryMessageId: string;
+}
+
+export function compactionBoundaryTrigger(
+  event: SSEEvent,
+  turn: OpenCodeTurnContext,
+): CompactionTrigger | null {
+  if (turn.compaction) return 'manual';
+  const messageId = event.properties?.info?.id
+    ?? event.properties?.part?.messageID
+    ?? event.properties?.messageID;
+  return typeof messageId === 'string' && turn.automaticCompactionMessageIds.has(messageId)
+    ? 'auto'
+    : null;
 }
 
 // Only a summary assistant that finished successfully replaced prior context.

--- a/server-agents/opencode/src/agents/opencode/compaction-routing.ts
+++ b/server-agents/opencode/src/agents/opencode/compaction-routing.ts
@@ -76,7 +76,6 @@ export function adoptOpenCodeCompactionPartRoute(
   const adoption = operationRoutes.adoptCompactionPart(session.turn, event);
   switch (adoption.kind) {
     case 'adopted': {
-      const part = event.properties?.part;
       if (isRecord(part) && part.auto === true) {
         session.turn.automaticCompactionMessageIds.add(messageId);
       }
@@ -130,7 +129,9 @@ export interface OpenCodeCompactionBoundary {
   readonly summaryMessageId: string;
 }
 
-export function compactionBoundaryTrigger(
+// Classifies every internal compaction event so control parts, summary parts,
+// and the successful boundary all stay out of the ordinary message converter.
+export function compactionEventTrigger(
   event: SSEEvent,
   turn: OpenCodeTurnContext,
 ): CompactionTrigger | null {

--- a/server-agents/opencode/src/agents/opencode/compaction-routing.ts
+++ b/server-agents/opencode/src/agents/opencode/compaction-routing.ts
@@ -125,8 +125,8 @@ function dropCompactionPart(
 
 export interface OpenCodeCompactionBoundary {
   readonly row: CompactionMessage;
-  // The successful summary assistant's id anchors the boundary so point-fork
-  // boundaries match across live and reloaded transcripts.
+  // Manual boundaries retain their reload-stable point-fork anchor. Automatic
+  // boundaries use the same live anchor but are intentionally absent after Reload.
   readonly summaryMessageId: string;
 }
 

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -27,7 +27,7 @@ import {
   type OpenCodeSession,
   type OpenCodeTurnContext,
 } from './turn-events.js';
-import { CompactionMessage, type CompactionTrigger } from '@garcon/common/chat-types';
+import type { CompactionTrigger } from '@garcon/common/chat-types';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import {
   runtimeRows,
@@ -88,7 +88,7 @@ import {
   modelsFromProviders,
   type OpenCodeModelOption,
 } from './model-catalog.js';
-import { adoptOpenCodeCompactionPartRoute, compactionBoundaryRow } from './compaction-routing.js';
+import { adoptOpenCodeCompactionPartRoute, compactionBoundaryRow, compactionBoundaryTrigger } from './compaction-routing.js';
 import { OpenCodeIdleLifecycle } from './idle-lifecycle.js';
 import {
   OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE,
@@ -917,29 +917,17 @@ export class OpenCodeRuntime {
   }
 
   #dispatchOpenCodeEvent(event: SSEEvent, route: OpenCodeOperationRoute): void {
-    if (route.turn.compaction) {
-      this.#dispatchCompactionBoundary(event, route, 'manual');
-      return;
-    }
-    const messageId = event.properties?.info?.id
-      ?? event.properties?.part?.messageID
-      ?? event.properties?.messageID;
-    if (
-      typeof messageId === 'string'
-      && route.turn.automaticCompactionMessageIds.has(messageId)
-    ) {
-      this.#dispatchCompactionBoundary(event, route, 'auto');
+    const compactionTrigger = compactionBoundaryTrigger(event, route.turn);
+    if (compactionTrigger) {
+      this.#dispatchCompactionBoundary(event, route, compactionTrigger);
       return;
     }
     const chatMessages = convertOpenCodeEventToChatMessages(event, route.turn, this.#logger);
-    if (!chatMessages || !chatMessages.length) {
-      return;
-    }
+    if (!chatMessages?.length) return;
 
     this.#publishRows(route.sessionId, route.turn.operation, chatMessages);
   }
 
-  // Compaction summary text and control parts stay internal to the native session.
   #dispatchCompactionBoundary(
     event: SSEEvent,
     route: OpenCodeOperationRoute,

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -27,7 +27,7 @@ import {
   type OpenCodeSession,
   type OpenCodeTurnContext,
 } from './turn-events.js';
-import { CompactionMessage } from '@garcon/common/chat-types';
+import { CompactionMessage, type CompactionTrigger } from '@garcon/common/chat-types';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import {
   runtimeRows,
@@ -88,7 +88,7 @@ import {
   modelsFromProviders,
   type OpenCodeModelOption,
 } from './model-catalog.js';
-import { adoptOpenCodeCompactionPartRoute, manualCompactionBoundaryRow } from './compaction-routing.js';
+import { adoptOpenCodeCompactionPartRoute, compactionBoundaryRow } from './compaction-routing.js';
 import { OpenCodeIdleLifecycle } from './idle-lifecycle.js';
 import {
   OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE,
@@ -918,7 +918,17 @@ export class OpenCodeRuntime {
 
   #dispatchOpenCodeEvent(event: SSEEvent, route: OpenCodeOperationRoute): void {
     if (route.turn.compaction) {
-      this.#dispatchCompactionBoundary(event, route);
+      this.#dispatchCompactionBoundary(event, route, 'manual');
+      return;
+    }
+    const messageId = event.properties?.info?.id
+      ?? event.properties?.part?.messageID
+      ?? event.properties?.messageID;
+    if (
+      typeof messageId === 'string'
+      && route.turn.automaticCompactionMessageIds.has(messageId)
+    ) {
+      this.#dispatchCompactionBoundary(event, route, 'auto');
       return;
     }
     const chatMessages = convertOpenCodeEventToChatMessages(event, route.turn, this.#logger);
@@ -929,13 +939,16 @@ export class OpenCodeRuntime {
     this.#publishRows(route.sessionId, route.turn.operation, chatMessages);
   }
 
-  // A manual compaction turn surfaces only the boundary marker; the provider's
-  // summary text and control parts stay internal to the native session.
-  #dispatchCompactionBoundary(event: SSEEvent, route: OpenCodeOperationRoute): void {
-    if (route.turn.compactionBoundaryPublished) return;
-    const boundary = manualCompactionBoundaryRow(event);
+  // Compaction summary text and control parts stay internal to the native session.
+  #dispatchCompactionBoundary(
+    event: SSEEvent,
+    route: OpenCodeOperationRoute,
+    trigger: CompactionTrigger,
+  ): void {
+    if (trigger === 'manual' && route.turn.compactionBoundaryPublished) return;
+    const boundary = compactionBoundaryRow(event, trigger);
     if (!boundary) return;
-    route.turn.compactionBoundaryPublished = true;
+    if (trigger === 'manual') route.turn.compactionBoundaryPublished = true;
     this.#publishRows(route.sessionId, route.turn.operation, [
       attachNativeMessageSource(boundary.row, { entryId: boundary.summaryMessageId }),
     ]);

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -92,6 +92,7 @@ import { adoptOpenCodeCompactionPartRoute, compactionBoundaryRow, compactionBoun
 import { OpenCodeIdleLifecycle } from './idle-lifecycle.js';
 import {
   OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE,
+  latestOpenCodePromptTerminal,
   openCodeProviderFailureRow,
 } from './turn-failure.js';
 
@@ -679,7 +680,7 @@ export class OpenCodeRuntime {
     session.lastActivityAt = Date.now();
     this.#decisions.cancelForSession(agentSessionId, 'cancelled');
     this.#rejectTurnWaiter(agentSessionId, new Error(message));
-    const row = openCodeProviderFailureRow(message, entryId, session.turn.assistantMessageIds);
+    const row = openCodeProviderFailureRow(message, entryId, session.turn);
     this.#publishRows(agentSessionId, session.turn.operation, [row]);
     this.#publishFailed(agentSessionId, session.turn.operation, message);
   }
@@ -695,7 +696,7 @@ export class OpenCodeRuntime {
       if (this.isTemporarilyUnavailable()) this.#idleLifecycle.closeInstanceIfIdle();
       return;
     }
-    const providerTerminal = Array.from(route.turn.assistantTerminals.values()).at(-1);
+    const providerTerminal = latestOpenCodePromptTerminal(route.turn);
     if (providerTerminal?.outcome === 'failed') {
       this.#failTurnForProviderError(
         route.sessionId, session, providerTerminal.error, providerTerminal.messageId,

--- a/server-agents/opencode/src/agents/opencode/opencode.ts
+++ b/server-agents/opencode/src/agents/opencode/opencode.ts
@@ -88,7 +88,7 @@ import {
   modelsFromProviders,
   type OpenCodeModelOption,
 } from './model-catalog.js';
-import { adoptOpenCodeCompactionPartRoute, compactionBoundaryRow, compactionBoundaryTrigger } from './compaction-routing.js';
+import { adoptOpenCodeCompactionPartRoute, compactionBoundaryRow, compactionEventTrigger } from './compaction-routing.js';
 import { OpenCodeIdleLifecycle } from './idle-lifecycle.js';
 import {
   OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE,
@@ -918,7 +918,7 @@ export class OpenCodeRuntime {
   }
 
   #dispatchOpenCodeEvent(event: SSEEvent, route: OpenCodeOperationRoute): void {
-    const compactionTrigger = compactionBoundaryTrigger(event, route.turn);
+    const compactionTrigger = compactionEventTrigger(event, route.turn);
     if (compactionTrigger) {
       this.#dispatchCompactionBoundary(event, route, compactionTrigger);
       return;
@@ -934,10 +934,10 @@ export class OpenCodeRuntime {
     route: OpenCodeOperationRoute,
     trigger: CompactionTrigger,
   ): void {
-    if (trigger === 'manual' && route.turn.compactionBoundaryPublished) return;
+    if (trigger === 'manual' && route.turn.manualCompactionBoundaryPublished) return;
     const boundary = compactionBoundaryRow(event, trigger);
     if (!boundary) return;
-    if (trigger === 'manual') route.turn.compactionBoundaryPublished = true;
+    if (trigger === 'manual') route.turn.manualCompactionBoundaryPublished = true;
     this.#publishRows(route.sessionId, route.turn.operation, [
       attachNativeMessageSource(boundary.row, { entryId: boundary.summaryMessageId }),
     ]);

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -25,6 +25,8 @@ export interface OpenCodeTurnContext {
   // status frames for the same scheduled attempt append one row, not many.
   lastRetryNoticeKey: string | null;
   providerContinuationMessageIds: Set<string>;
+  // Tracks automatic control messages and linked summary assistants so prompt
+  // failures exclude internal compaction work.
   automaticCompactionMessageIds: Set<string>;
   recentEventIds: Set<string>;
   providerSteeringPartIds: Set<string>;

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -210,6 +210,8 @@ export function openCodeEventBelongsToTurn(
     if (isOpenCodeCompactionAssistant(info)) {
       if (!turn.compaction) {
         if (!turn.automaticCompactionMessageIds.has(info.parentID)) return false;
+        // A recorded terminal means this automatic boundary already dispatched;
+        // terminal recording follows dispatch in the global event handler.
         if (turn.assistantTerminals.has(messageId)) return false;
         turn.automaticCompactionMessageIds.add(messageId);
       }

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -13,9 +13,9 @@ export interface OpenCodeTurnContext {
   // A manual compaction turn: the provider's summary assistant settles the turn
   // and its internals stay out of the transcript.
   compaction?: boolean;
-  // One boundary row per manual compaction turn; completed timestamps persist
-  // across later message updates.
-  compactionBoundaryPublished?: boolean;
+  // Later message updates retain the completed timestamp, so a manual turn
+  // would otherwise republish its boundary.
+  manualCompactionBoundaryPublished?: boolean;
   // OpenCode assigns this ID and Garcon resolves it from the submitted prompt part event.
   providerMessageId: string | null;
   providerPromptPartId: string;

--- a/server-agents/opencode/src/agents/opencode/turn-events.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-events.ts
@@ -25,6 +25,7 @@ export interface OpenCodeTurnContext {
   // status frames for the same scheduled attempt append one row, not many.
   lastRetryNoticeKey: string | null;
   providerContinuationMessageIds: Set<string>;
+  automaticCompactionMessageIds: Set<string>;
   recentEventIds: Set<string>;
   providerSteeringPartIds: Set<string>;
   pendingSteeringMessageIds: Set<string>;
@@ -110,6 +111,7 @@ export function createOpenCodeTurnContext(
     providerSteeringDeliveryUnconfirmed: false,
     lastRetryNoticeKey: null,
     providerContinuationMessageIds: new Set(),
+    automaticCompactionMessageIds: new Set(),
     recentEventIds: new Set(),
     providerSteeringPartIds: new Set(),
     pendingSteeringMessageIds: new Set(),
@@ -206,9 +208,11 @@ export function openCodeEventBelongsToTurn(
       return false;
     }
     if (isOpenCodeCompactionAssistant(info)) {
-      // The summary assistant is internal to ordinary turns; a compaction turn
-      // owns it as its terminal message.
-      if (!turn.compaction) return false;
+      if (!turn.compaction) {
+        if (!turn.automaticCompactionMessageIds.has(info.parentID)) return false;
+        if (turn.assistantTerminals.has(messageId)) return false;
+        turn.automaticCompactionMessageIds.add(messageId);
+      }
       turn.assistantMessageIds.add(messageId);
       return true;
     }

--- a/server-agents/opencode/src/agents/opencode/turn-failure.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-failure.ts
@@ -1,18 +1,30 @@
 import { ErrorMessage } from '@garcon/common/chat-types';
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
+import type { OpenCodeAssistantTerminal } from './sse-events.js';
+import type { OpenCodeTurnContext } from './turn-events.js';
 
 // Early cancellation can poison later prompts without a new user Stop.
 // https://github.com/anomalyco/opencode/issues/30144
 export const OPEN_CODE_ABORTED_TURN_FAILURE_MESSAGE = 'OpenCode interrupted the turn';
 
+export function latestOpenCodePromptTerminal(
+  turn: OpenCodeTurnContext,
+): OpenCodeAssistantTerminal | undefined {
+  return Array.from(turn.assistantTerminals.values())
+    .filter((terminal) => !turn.automaticCompactionMessageIds.has(terminal.messageId))
+    .at(-1);
+}
+
 export function openCodeProviderFailureRow(
   message: string,
   entryId: string | undefined,
-  fallbackEntryIds: Iterable<string>,
+  turn: OpenCodeTurnContext,
 ): ErrorMessage {
   const row = new ErrorMessage(new Date().toISOString(), message);
-  const sourceEntryId = entryId ?? Array.from(fallbackEntryIds).at(-1);
+  const sourceEntryId = entryId ?? Array.from(turn.assistantMessageIds)
+    .filter((candidate) => !turn.automaticCompactionMessageIds.has(candidate))
+    .at(-1);
   // Terminal failures use their exact assistant; control failures retain the last observed
-  // assistant as the stable native occurrence used before this helper was extracted.
+  // non-compaction assistant as the stable native occurrence used before this helper was extracted.
   return sourceEntryId ? attachNativeMessageSource(row, { entryId: sourceEntryId }) : row;
 }

--- a/server-agents/opencode/src/agents/opencode/turn-failure.ts
+++ b/server-agents/opencode/src/agents/opencode/turn-failure.ts
@@ -25,6 +25,6 @@ export function openCodeProviderFailureRow(
     .filter((candidate) => !turn.automaticCompactionMessageIds.has(candidate))
     .at(-1);
   // Terminal failures use their exact assistant; control failures retain the last observed
-  // non-compaction assistant as the stable native occurrence used before this helper was extracted.
+  // non-compaction assistant as a stable native occurrence.
   return sourceEntryId ? attachNativeMessageSource(row, { entryId: sourceEntryId }) : row;
 }

--- a/server-agents/pi/src/agents/pi/__tests__/pi-rpc-runtime.test.ts
+++ b/server-agents/pi/src/agents/pi/__tests__/pi-rpc-runtime.test.ts
@@ -752,6 +752,92 @@ describe('PiRpcRuntime', () => {
     await runtime.shutdown();
   });
 
+  it('publishes successful live compactions through the active turn', async () => {
+    await fs.writeFile(baseResumeRequest().nativePath, '');
+    const runtime = createRuntime();
+    const published = collectOperation('run-compaction');
+    const turn = runtime.runTurn(baseResumeRequest({ operation: published.operation }));
+    await waitForActive(runtime);
+    const fake = fakes[0];
+
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'threshold',
+      aborted: false,
+      result: {
+        summary: 'Threshold summary',
+        tokensBefore: 96_000,
+        estimatedTokensAfter: 18_000,
+      },
+    });
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'overflow',
+      aborted: false,
+      result: { summary: 'Overflow summary', tokensBefore: 101_000 },
+    });
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'manual',
+      aborted: false,
+      result: { summary: 'Manual summary', tokensBefore: 42_000 },
+    });
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'threshold',
+      aborted: true,
+      result: { summary: 'Aborted', tokensBefore: 50_000 },
+    });
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'overflow',
+      aborted: false,
+    });
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'threshold',
+      aborted: false,
+      result: { summary: 'Malformed', tokensBefore: 'many' },
+    });
+    await settleIo();
+
+    const compactions = published.events
+      .flatMap((event) => event.type === 'rows' ? event.rows.map((row) => row.message) : [])
+      .filter((message) => message.type === 'compaction');
+    expect(compactions).toEqual([
+      expect.objectContaining({
+        trigger: 'auto',
+        summary: 'Threshold summary',
+        preTokens: 96_000,
+        postTokens: 18_000,
+      }),
+      expect.objectContaining({
+        trigger: 'auto',
+        summary: 'Overflow summary',
+        preTokens: 101_000,
+      }),
+      expect.objectContaining({
+        trigger: 'manual',
+        summary: 'Manual summary',
+        preTokens: 42_000,
+      }),
+    ]);
+
+    fake.pushEvent({ type: 'agent_settled' });
+    await turn;
+    fake.pushEvent({
+      type: 'compaction_end',
+      reason: 'threshold',
+      aborted: false,
+      result: { summary: 'Unowned', tokensBefore: 60_000 },
+    });
+    await settleIo();
+    expect(published.events
+      .flatMap((event) => event.type === 'rows' ? event.rows : []))
+      .toHaveLength(3);
+    await runtime.shutdown();
+  });
+
   it('[TLV5-L07.03-PI-UNIT-01] publishes sequential turns through the concrete operation that started each turn', async () => {
     const runtime = createRuntime();
     const first = collectOperation('run-a');

--- a/server-agents/pi/src/agents/pi/pi-rpc-protocol.ts
+++ b/server-agents/pi/src/agents/pi/pi-rpc-protocol.ts
@@ -1,5 +1,6 @@
 import type { AgentAttachment } from '@garcon/common/agent-execution';
 import { CompactionMessage } from '@garcon/common/chat-types';
+import { isRecord } from '@garcon/common/json';
 import { parseAttachmentDataUrl } from '@garcon/server-agent-common/shared/attachments';
 import type { ModelThinkingLevel } from '@earendil-works/pi-ai';
 import {
@@ -74,23 +75,10 @@ export function piCompactionMessage(
   timestamp: string,
 ): CompactionMessage | null {
   if (event.type !== 'compaction_end' || event.aborted !== false) return null;
-  if (!event.result || typeof event.result !== 'object' || Array.isArray(event.result)) return null;
-  const result = event.result as Record<string, unknown>;
-  const { summary, tokensBefore, estimatedTokensAfter } = result;
-  if (
-    typeof summary !== 'string'
-    || typeof tokensBefore !== 'number'
-    || !Number.isFinite(tokensBefore)
-    || tokensBefore < 0
-    || (
-      estimatedTokensAfter !== undefined
-      && (
-        typeof estimatedTokensAfter !== 'number'
-        || !Number.isFinite(estimatedTokensAfter)
-        || estimatedTokensAfter < 0
-      )
-    )
-  ) return null;
+  if (!isRecord(event.result)) return null;
+  const { summary, tokensBefore, estimatedTokensAfter } = event.result;
+  if (typeof summary !== 'string' || !isPiTokenCount(tokensBefore)) return null;
+  if (estimatedTokensAfter !== undefined && !isPiTokenCount(estimatedTokensAfter)) return null;
   const reason = event.reason;
   if (reason !== 'manual' && reason !== 'threshold' && reason !== 'overflow') return null;
   return new CompactionMessage(
@@ -100,6 +88,10 @@ export function piCompactionMessage(
     tokensBefore,
     estimatedTokensAfter,
   );
+}
+
+function isPiTokenCount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 
 export function occurrenceCounts(values: readonly string[]): Map<string, number> {

--- a/server-agents/pi/src/agents/pi/pi-rpc-protocol.ts
+++ b/server-agents/pi/src/agents/pi/pi-rpc-protocol.ts
@@ -1,4 +1,5 @@
 import type { AgentAttachment } from '@garcon/common/agent-execution';
+import { CompactionMessage } from '@garcon/common/chat-types';
 import { parseAttachmentDataUrl } from '@garcon/server-agent-common/shared/attachments';
 import type { ModelThinkingLevel } from '@earendil-works/pi-ai';
 import {
@@ -66,6 +67,39 @@ export function piUserMessageText(value: unknown): string | null {
     && typeof (part as Record<string, unknown>).text === 'string'
   )) as Record<string, unknown> | undefined;
   return typeof text?.text === 'string' ? text.text : null;
+}
+
+export function piCompactionMessage(
+  event: Record<string, unknown>,
+  timestamp: string,
+): CompactionMessage | null {
+  if (event.type !== 'compaction_end' || event.aborted !== false) return null;
+  if (!event.result || typeof event.result !== 'object' || Array.isArray(event.result)) return null;
+  const result = event.result as Record<string, unknown>;
+  const { summary, tokensBefore, estimatedTokensAfter } = result;
+  if (
+    typeof summary !== 'string'
+    || typeof tokensBefore !== 'number'
+    || !Number.isFinite(tokensBefore)
+    || tokensBefore < 0
+    || (
+      estimatedTokensAfter !== undefined
+      && (
+        typeof estimatedTokensAfter !== 'number'
+        || !Number.isFinite(estimatedTokensAfter)
+        || estimatedTokensAfter < 0
+      )
+    )
+  ) return null;
+  const reason = event.reason;
+  if (reason !== 'manual' && reason !== 'threshold' && reason !== 'overflow') return null;
+  return new CompactionMessage(
+    timestamp,
+    reason === 'manual' ? 'manual' : 'auto',
+    summary,
+    tokensBefore,
+    estimatedTokensAfter,
+  );
 }
 
 export function occurrenceCounts(values: readonly string[]): Map<string, number> {

--- a/server-agents/pi/src/agents/pi/pi-rpc-runtime.ts
+++ b/server-agents/pi/src/agents/pi/pi-rpc-runtime.ts
@@ -37,6 +37,7 @@ import {
 import {
   classifyPiSteerRejection,
   occurrenceCounts,
+  piCompactionMessage,
   piUserMessageText,
   preparePiRpcPrompt,
   rejectedPiSteer,
@@ -649,6 +650,14 @@ export class PiRpcRuntime {
         sessionId: session.id,
         method: typeof event.method === 'string' ? event.method : 'unknown',
       });
+      return;
+    }
+
+    if (type === 'compaction_end') {
+      const turn = session.turn;
+      if (!turn) return;
+      const message = piCompactionMessage(event, timestamp);
+      if (message) this.#publishMessages(session, turn, [message]);
       return;
     }
 


### PR DESCRIPTION
Automatic context compaction should be visible consistently when providers expose a reliable live completion signal. This adds best-effort live compaction rows for OpenCode and Pi, regression coverage for Claude’s existing behavior, safeguards OpenCode failure attribution and summary suppression, and documents the intentionally live-only policy without adding reload reconstruction or shared contract complexity.