### PR TITLE
Align bottom-pinned recent activity ordering

### DIFF
--- a/integration-tests/tests/server/chat-sort.test.ts
+++ b/integration-tests/tests/server/chat-sort.test.ts
@@ -107,6 +107,13 @@ test('chat sort presets atomically reorder every persisted group and survive res
       await fixture.client.waitForTurnTerminal(chatId, run.turnId);
     }
 
+    expect(await fixture.client.updateSettings({
+      ui: { pinnedInsertPosition: 'bottom' },
+    })).toMatchObject({
+      success: true,
+      settings: { ui: { pinnedInsertPosition: 'bottom' } },
+    });
+
     const activityCursor = fixture.client.markEvents();
     expect(await fixture.client.sortChatOrder({ sortKey: 'activity' })).toEqual({
       success: true,
@@ -120,7 +127,7 @@ test('chat sort presets atomically reorder every persisted group and survive res
     ))).toHaveLength(1);
 
     listed = await fixture.client.listChats();
-    const expectedPinned = [chatIds[0], chatIds[1]];
+    const expectedPinned = [chatIds[1], chatIds[0]];
     const expectedNormal = [chatIds[4], hiddenChatId, chatIds[5]];
     const expectedArchived = [chatIds[2], chatIds[3]];
     expect(idsForGroup(listed.sessions, 'pinned')).toEqual(expectedPinned);

--- a/server/routes/__tests__/chats-reorder.test.js
+++ b/server/routes/__tests__/chats-reorder.test.js
@@ -363,6 +363,7 @@ describe('POST /api/v1/chats/sort', () => {
     await callSort({ sortKey: 'activity' });
     const [compare, comparatorOverrides] = settings.sortChatOrder.mock.calls[0];
 
+    expect(typeof comparatorOverrides.pinned).toBe('function');
     expect(['older-active', 'newer-idle'].sort(comparatorOverrides.pinned))
       .toEqual(['newer-idle', 'older-active']);
     expect(['older-active', 'newer-idle'].sort(compare))

--- a/server/routes/__tests__/chats-reorder.test.js
+++ b/server/routes/__tests__/chats-reorder.test.js
@@ -39,6 +39,7 @@ const settings = {
   getPinnedChatIds: mock(() => []),
   getNormalChatIds: mock(() => []),
   getArchivedChatIds: mock(() => []),
+  getUiSettings: mock(() => ({ pinnedInsertPosition: 'top' })),
   removeFromAllOrderLists: mock(() => Promise.resolve(undefined)),
   insertNormalChatIdTop: mock(() => Promise.resolve(undefined)),
   ensureInNormal: mock(() => Promise.resolve(undefined)),
@@ -298,6 +299,8 @@ describe('POST /api/v1/chats/sort', () => {
     registry.getChat.mockClear();
     settings.sortChatOrder.mockClear();
     settings.sortChatOrder.mockResolvedValue({ changed: true });
+    settings.getUiSettings.mockClear();
+    settings.getUiSettings.mockReturnValue({ pinnedInsertPosition: 'top' });
     metadata.listAllChatMetadata.mockClear();
     metadata.listAllChatMetadata.mockReturnValue(new Map([
       ['older-active', {
@@ -336,17 +339,32 @@ describe('POST /api/v1/chats/sort', () => {
   });
 
   it('builds the creation comparator from metadata', async () => {
+    settings.getUiSettings.mockReturnValue({ pinnedInsertPosition: 'bottom' });
     await callSort({ sortKey: 'created' });
-    const compare = settings.sortChatOrder.mock.calls[0][0];
+    const [compare, comparatorOverrides] = settings.sortChatOrder.mock.calls[0];
 
     expect(['older-active', 'newer-idle'].sort(compare))
       .toEqual(['newer-idle', 'older-active']);
+    expect(comparatorOverrides).toEqual({});
   });
 
   it('builds the activity comparator from metadata', async () => {
     await callSort({ sortKey: 'activity' });
-    const compare = settings.sortChatOrder.mock.calls[0][0];
+    const [compare, comparatorOverrides] = settings.sortChatOrder.mock.calls[0];
 
+    expect(['older-active', 'newer-idle'].sort(compare))
+      .toEqual(['older-active', 'newer-idle']);
+    expect(comparatorOverrides).toEqual({});
+  });
+
+  it('inverts only pinned activity ordering when pinned chats are added at the bottom', async () => {
+    settings.getUiSettings.mockReturnValue({ pinnedInsertPosition: 'bottom' });
+
+    await callSort({ sortKey: 'activity' });
+    const [compare, comparatorOverrides] = settings.sortChatOrder.mock.calls[0];
+
+    expect(['older-active', 'newer-idle'].sort(comparatorOverrides.pinned))
+      .toEqual(['newer-idle', 'older-active']);
     expect(['older-active', 'newer-idle'].sort(compare))
       .toEqual(['older-active', 'newer-idle']);
   });

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -49,7 +49,11 @@ import {
 } from '../lib/domain-error.js';
 import { AttachmentValidationError, validateCommandAttachments } from '../attachments/validation.js';
 import { TranscriptHistoryUnavailableError } from '../chats/errors.js';
-import type { ChatReorderResult, ChatStartupPreferences } from '../settings/types.js';
+import type {
+  ChatOrderComparatorOverrides,
+  ChatReorderResult,
+  ChatStartupPreferences,
+} from '../settings/types.js';
 import type { RouteMap } from '../lib/http-route-types.js';
 import { InMemoryLastSelectedChatState, type LastSelectedChatState } from '../chats/last-selected-chat-state.js';
 import {
@@ -144,7 +148,10 @@ interface SettingsDep {
   getPinnedChatIds(): string[];
   getNormalChatIds(): string[];
   getArchivedChatIds(): string[];
-  getUiSettings(): { chatTitle?: unknown } | null | undefined;
+  getUiSettings(): {
+    chatTitle?: unknown;
+    pinnedInsertPosition?: 'top' | 'bottom';
+  } | null | undefined;
   getChatName(chatId: string): string | null;
   setSessionName(chatId: string, title: string): Promise<unknown>;
   setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;
@@ -158,7 +165,10 @@ interface SettingsDep {
     request: ReorderChatRequest,
     isKnownChat: (chatId: string) => boolean,
   ): Promise<ChatReorderResult>;
-  sortChatOrder(compareChatIds: ChatOrderIdComparator): Promise<{ changed: boolean }>;
+  sortChatOrder(
+    compareChatIds: ChatOrderIdComparator,
+    comparatorOverrides?: ChatOrderComparatorOverrides,
+  ): Promise<{ changed: boolean }>;
 }
 
 interface PathCacheDep {
@@ -741,7 +751,12 @@ export default function createChatRoutes({
         request.sortKey,
         metadata.listAllChatMetadata(),
       );
-      const result = await settings.sortChatOrder(compareChatIds);
+      const comparatorOverrides: ChatOrderComparatorOverrides =
+        request.sortKey === 'activity'
+        && settings.getUiSettings()?.pinnedInsertPosition === 'bottom'
+          ? { pinned: (leftChatId, rightChatId) => compareChatIds(rightChatId, leftChatId) }
+          : {};
+      const result = await settings.sortChatOrder(compareChatIds, comparatorOverrides);
       return Response.json({
         success: true,
         sortKey: request.sortKey,

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -17,6 +17,7 @@ import {
   type SortChatOrderResponse,
 } from '../../common/chat-order-contracts.js';
 import type { ChatOrderIdComparator } from '../../common/chat-order-sort.js';
+import type { PinnedInsertPosition } from '../../common/settings.js';
 import { ModelSelectionError } from '../api-providers/endpoint-resolver.js';
 import type { AgentSessionSettingsPatch } from '../agents/session-types.js';
 import {
@@ -148,10 +149,7 @@ interface SettingsDep {
   getPinnedChatIds(): string[];
   getNormalChatIds(): string[];
   getArchivedChatIds(): string[];
-  getUiSettings(): {
-    chatTitle?: unknown;
-    pinnedInsertPosition?: 'top' | 'bottom';
-  } | null | undefined;
+  getUiSettings(): { pinnedInsertPosition?: PinnedInsertPosition } | null | undefined;
   getChatName(chatId: string): string | null;
   setSessionName(chatId: string, title: string): Promise<unknown>;
   setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;

--- a/server/settings/__tests__/chat-order-store.test.js
+++ b/server/settings/__tests__/chat-order-store.test.js
@@ -282,6 +282,33 @@ describe('ChatOrderStore.sortChatOrder', () => {
     ]);
   });
 
+  it('applies a pinned comparator override without changing other groups', async () => {
+    const harness = createHarness({
+      pinnedChatIds: ['p-new', 'p-old'],
+      normalChatIds: ['n-old', 'n-new'],
+      archivedChatIds: ['a-old', 'a-new'],
+    });
+    const rank = new Map([
+      ['p-old', 1], ['p-new', 2],
+      ['n-old', 1], ['n-new', 2],
+      ['a-old', 1], ['a-new', 2],
+    ]);
+    const newestFirst = (left, right) => (
+      (rank.get(right) ?? 0) - (rank.get(left) ?? 0)
+    );
+
+    const result = await harness.store.sortChatOrder(newestFirst, {
+      pinned: (left, right) => newestFirst(right, left),
+    });
+
+    expect(result).toEqual({ changed: true });
+    expect(harness.settings.pinnedChatIds).toEqual(['p-old', 'p-new']);
+    expect(harness.settings.normalChatIds).toEqual(['n-new', 'n-old']);
+    expect(harness.settings.archivedChatIds).toEqual(['a-new', 'a-old']);
+    expect(harness.saveCalls).toEqual([true]);
+    expect(harness.settings.remoteSettingsVersion).toBe(1);
+  });
+
   it('preserves membership and stable ties', async () => {
     const harness = createHarness({
       pinnedChatIds: ['p-a', 'p-b'],

--- a/server/settings/domain-stores.ts
+++ b/server/settings/domain-stores.ts
@@ -19,6 +19,7 @@ import {
 } from './settings-shared.js';
 import type {
   ChatFolder,
+  ChatOrderComparatorOverrides,
   ChatReorderResult,
   ChatStartupPreferences,
   ExecutionDefaults,
@@ -52,6 +53,12 @@ const ORDER_GROUP_KEYS: Record<PersistedChatOrderGroup, OrderListKey> = {
   pinned: 'pinnedChatIds',
   normal: 'normalChatIds',
   archived: 'archivedChatIds',
+};
+
+const ORDER_GROUP_BY_LIST_KEY: Record<OrderListKey, PersistedChatOrderGroup> = {
+  pinnedChatIds: 'pinned',
+  normalChatIds: 'normal',
+  archivedChatIds: 'archived',
 };
 
 function bumpRemoteSettingsVersion(settings: ProjectSettings): void {
@@ -698,6 +705,7 @@ export class ChatOrderStore {
 
   async sortChatOrder(
     compareChatIds: ChatOrderIdComparator,
+    comparatorOverrides: ChatOrderComparatorOverrides = {},
   ): Promise<{ changed: boolean }> {
     return this.#context.mutate(async () => {
       const settings = this.#context.readSettings();
@@ -705,7 +713,8 @@ export class ChatOrderStore {
       let anchorChatId: string | null = null;
 
       for (const key of ORDER_LIST_KEYS) {
-        const sorted = [...before[key]].sort(compareChatIds);
+        const compare = comparatorOverrides[ORDER_GROUP_BY_LIST_KEY[key]] ?? compareChatIds;
+        const sorted = [...before[key]].sort(compare);
         settings[key] = sorted;
         if (!anchorChatId && !sameOrderedStringArray(before[key], sorted)) {
           anchorChatId = sorted[0] ?? null;

--- a/server/settings/store.ts
+++ b/server/settings/store.ts
@@ -44,6 +44,7 @@ import type { ChatOrderIdComparator } from '../../common/chat-order-sort.js';
 
 import type {
   ChatFolder,
+  ChatOrderComparatorOverrides,
   ChatReorderResult,
   ChatStartupPreferences,
   ProjectSettings,
@@ -485,8 +486,9 @@ export class SettingsStore extends EventEmitter<SettingsStoreEvents> {
 
   async sortChatOrder(
     compareChatIds: ChatOrderIdComparator,
+    comparatorOverrides?: ChatOrderComparatorOverrides,
   ): Promise<{ changed: boolean }> {
-    return this.#chatOrder.sortChatOrder(compareChatIds);
+    return this.#chatOrder.sortChatOrder(compareChatIds, comparatorOverrides);
   }
 
   getSavedSearches(): SavedChatSearch[] {

--- a/server/settings/types.ts
+++ b/server/settings/types.ts
@@ -5,9 +5,11 @@ import type {
 } from '../../common/chat-modes.js';
 import type { AgentSettingsEnvelope } from '../../common/agent-integration.js';
 import type {
+  PersistedChatOrderGroup,
   ReorderChatErrorCode,
   ReorderChatResponse,
 } from '../../common/chat-order-contracts.js';
+import type { ChatOrderIdComparator } from '../../common/chat-order-sort.js';
 import type {
   AppIdentityUiSettings,
   AgentCommandsFeatureSettings,
@@ -29,6 +31,10 @@ export interface UiSettings {
   appIdentity?: AppIdentityUiSettings;
   [key: string]: unknown;
 }
+
+export type ChatOrderComparatorOverrides = Partial<
+  Record<PersistedChatOrderGroup, ChatOrderIdComparator>
+>;
 
 export type PathSettings = Record<string, unknown>;
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1707,6 +1707,7 @@
 	"sidebar_chats_no_matching_chats": "No matching chats",
 	"sidebar_chats_pin": "Pin",
 	"sidebar_chats_pinned_insert_position": "Pinned chats are added to",
+	"sidebar_chats_pinned_insert_position_activity_hint": "When set to Bottom, recent-activity sorting also places the newest pinned chats at the bottom.",
 	"sidebar_chats_pinned_insert_top": "Top",
 	"sidebar_chats_pinned_insert_bottom": "Bottom",
 	"sidebar_chats_rename_chat": "Rename chat",

--- a/web/src/lib/components/layout/AppShell.svelte
+++ b/web/src/lib/components/layout/AppShell.svelte
@@ -29,6 +29,7 @@
 		getAppShell,
 		getWs,
 		getLocalSettings,
+		getRemoteSettings,
 		getMinuteClock,
 		getNotifications,
 		getSidebarSearch,
@@ -68,6 +69,7 @@
 	const appShell = getAppShell();
 	const ws = getWs();
 	const localSettings = getLocalSettings();
+	const remoteSettings = getRemoteSettings();
 	const notifications = getNotifications();
 	const sidebarSearch = getSidebarSearch();
 	const projectCollapse = getSidebarProjectCollapse();
@@ -181,6 +183,7 @@
 			currentTime: minuteClock.currentTime,
 			inactivityDuration: localSettings.sidebarInactivityDuration,
 			sortMode: localSettings.sidebarSortMode,
+			pinnedInsertPosition: remoteSettings.snapshot?.ui?.pinnedInsertPosition ?? 'top',
 			groupNestedProjectPaths: localSettings.sidebarGroupNestedProjectPaths,
 			collapsedProjectKeys: projectCollapse.collapsedProjectKeys,
 		}),

--- a/web/src/lib/components/layout/__tests__/AppShell.test.ts
+++ b/web/src/lib/components/layout/__tests__/AppShell.test.ts
@@ -31,6 +31,7 @@ vi.mock('$lib/context', () => ({
 	getMinuteClock: () => testContext.current?.minuteClock,
 	getNavigation: () => testContext.current?.navigation,
 	getNotifications: () => testContext.current?.notifications,
+	getRemoteSettings: () => testContext.current?.remoteSettings,
 	getSidebarProjectCollapse: () => testContext.current?.projectCollapse,
 	getSidebarSearch: () => testContext.current?.sidebarSearch,
 	getTerminalRegistry: () => testContext.current?.terminals,
@@ -184,6 +185,7 @@ function installContext(): AppShellBreakpointWorkspace {
 			},
 		},
 		localSettings: new AppShellLocalSettingsState(),
+		remoteSettings: { snapshot: null },
 		minuteClock: { currentTime: new Date('2025-01-02T00:00:00.000Z') },
 		terminals: { orderedSessions: [] },
 		notifications: {

--- a/web/src/lib/components/layout/__tests__/app-shell-chat-navigation.logic.test.ts
+++ b/web/src/lib/components/layout/__tests__/app-shell-chat-navigation.logic.test.ts
@@ -46,6 +46,7 @@ describe('resolveAdjacentChatId', () => {
 			currentTime: new Date('2025-06-01T12:00:00.000Z'),
 			inactivityDuration: '3-days',
 			sortMode: 'manual',
+			pinnedInsertPosition: 'top',
 		});
 
 		expect(displayedChatIds).toEqual(['pinned-c', 'normal-a', 'normal-b']);
@@ -71,6 +72,7 @@ describe('resolveAdjacentChatId', () => {
 			grouping: 'activity',
 			currentTime: new Date('2025-06-01T12:00:00.000Z'),
 			sortMode: 'manual',
+			pinnedInsertPosition: 'top',
 		} as const;
 
 		expect(
@@ -94,6 +96,7 @@ describe('resolveAdjacentChatId', () => {
 			currentTime: new Date('2025-06-01T12:00:00.000Z'),
 			inactivityDuration: '3-days',
 			sortMode: 'recent',
+			pinnedInsertPosition: 'top',
 		});
 
 		expect(displayedChatIds).toEqual(['newer', 'older']);
@@ -105,6 +108,43 @@ describe('resolveAdjacentChatId', () => {
 				offset: 1,
 			}),
 		).toBe('older');
+	});
+
+	it('follows oldest-first pinned activity when pins are added at the bottom', () => {
+		const displayedChatIds = buildSidebarDisplayChatIds({
+			displayedChats: [
+				chat('pinned-newer', {
+					isPinned: true,
+					lastActivityAt: '2025-05-31T12:00:00.000Z',
+				}),
+				chat('normal-newer', { lastActivityAt: '2025-05-31T12:00:00.000Z' }),
+				chat('pinned-older', {
+					isPinned: true,
+					lastActivityAt: '2025-05-30T12:00:00.000Z',
+				}),
+				chat('normal-older', { lastActivityAt: '2025-05-30T12:00:00.000Z' }),
+			],
+			grouping: 'none',
+			currentTime: new Date('2025-06-01T12:00:00.000Z'),
+			inactivityDuration: '3-days',
+			sortMode: 'recent',
+			pinnedInsertPosition: 'bottom',
+		});
+
+		expect(displayedChatIds).toEqual([
+			'pinned-older',
+			'pinned-newer',
+			'normal-newer',
+			'normal-older',
+		]);
+		expect(
+			resolveAdjacentChatId({
+				selectedChatId: 'pinned-older',
+				displayedChatIds,
+				fallbackOrder: [],
+				offset: 1,
+			}),
+		).toBe('pinned-newer');
 	});
 
 	it('falls back to raw session order when the sidebar is unmounted', () => {

--- a/web/src/lib/components/settings/RemoteSettingsSection.svelte
+++ b/web/src/lib/components/settings/RemoteSettingsSection.svelte
@@ -50,14 +50,21 @@
 			</div>
 		{/if}
 
-		<div class="bg-muted/50 border border-border rounded-lg">
-			<div class="flex items-center justify-between px-4 py-2">
-				<div class="text-sm font-medium text-foreground">
-					{m.sidebar_chats_pinned_insert_position()}
+		<div class="bg-muted/50 border border-border rounded-lg px-4 py-2">
+			<div class="flex items-center justify-between gap-4">
+				<div class="min-w-0">
+					<label class="text-sm font-medium text-foreground" for="remote-pinned-insert-position">
+						{m.sidebar_chats_pinned_insert_position()}
+					</label>
+					<p id="remote-pinned-insert-position-hint" class="mt-0.5 text-xs text-muted-foreground">
+						{m.sidebar_chats_pinned_insert_position_activity_hint()}
+					</p>
 				</div>
 				<select
-					class="text-sm bg-muted border border-border rounded-md px-2 py-1 text-foreground"
+					id="remote-pinned-insert-position"
+					class="shrink-0 rounded-md border border-border bg-muted px-2 py-1 text-base text-foreground sm:pointer-fine:text-sm"
 					aria-label={m.sidebar_chats_pinned_insert_position()}
+					aria-describedby="remote-pinned-insert-position-hint"
 					value={remoteSettings.snapshot?.ui.pinnedInsertPosition ?? 'top'}
 					onchange={(e) =>
 						onPinnedInsertPositionChange(

--- a/web/src/lib/components/settings/RemoteSettingsSection.svelte
+++ b/web/src/lib/components/settings/RemoteSettingsSection.svelte
@@ -63,7 +63,6 @@
 				<select
 					id="remote-pinned-insert-position"
 					class="shrink-0 rounded-md border border-border bg-muted px-2 py-1 text-base text-foreground sm:pointer-fine:text-sm"
-					aria-label={m.sidebar_chats_pinned_insert_position()}
 					aria-describedby="remote-pinned-insert-position-hint"
 					value={remoteSettings.snapshot?.ui.pinnedInsertPosition ?? 'top'}
 					onchange={(e) =>

--- a/web/src/lib/components/settings/__tests__/RemoteSettingsSection.test.ts
+++ b/web/src/lib/components/settings/__tests__/RemoteSettingsSection.test.ts
@@ -618,9 +618,16 @@ describe('RemoteSettingsSection', () => {
 
 		const githubCliTitle = screen.getByText('GitHub CLI');
 		const pinnedChatsSetting = screen.getByText('Pinned chats are added to');
+		const pinnedChatsSelect = screen.getByRole('combobox', { name: 'Pinned chats are added to' });
 		expect(
 			githubCliTitle.compareDocumentPosition(pinnedChatsSetting) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
+		expect(
+			screen.getByText(/recent-activity sorting also places the newest pinned chats/),
+		).toBeTruthy();
+		expect(pinnedChatsSelect.getAttribute('aria-describedby')).toBe(
+			'remote-pinned-insert-position-hint',
+		);
 	});
 
 	it('renders GitHub CLI guidance even while remote settings are loading', async () => {

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -141,6 +141,7 @@
 		groupNestedProjectPaths: localSettings.sidebarGroupNestedProjectPaths,
 		chatItemLayout: localSettings.sidebarChatItemLayout,
 		sortMode: localSettings.sidebarSortMode,
+		pinnedInsertPosition: remoteSettings.snapshot?.ui?.pinnedInsertPosition ?? 'top',
 	});
 	let transcriptSearchTarget = $derived(
 		sidebarSearch.searchDialogOpen ? sidebarSearch.draftQuery : sidebarSearch.activeQuery,
@@ -173,6 +174,7 @@
 			currentTime,
 			inactivityDuration: displayOptions.inactivityDuration,
 			sortMode: displayOptions.sortMode,
+			pinnedInsertPosition: displayOptions.pinnedInsertPosition,
 			groupNestedProjectPaths: displayOptions.groupNestedProjectPaths,
 			collapsedProjectKeys: projectCollapse.collapsedProjectKeys,
 		}),

--- a/web/src/lib/components/sidebar/SidebarChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatList.svelte
@@ -101,9 +101,7 @@
 
 	let isFiltered = $derived(searchFilter.trim().length > 0);
 	let sortByRecent = $derived(displayOptions.sortMode === 'recent');
-	// Recent-activity sort ranks every chat newest-first within its pin/archive
-	// group; manual order defers to the server-persisted drag order. Filtered
-	// results are already recency-ordered upstream, so re-sorting is idempotent.
+	// Re-sorting filtered results also applies the pinned placement policy.
 	let displayedChats = $derived.by(() => {
 		const source = isFiltered ? filteredChats : chats;
 		return sortByRecent

--- a/web/src/lib/components/sidebar/SidebarChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatList.svelte
@@ -101,7 +101,8 @@
 
 	let isFiltered = $derived(searchFilter.trim().length > 0);
 	let sortByRecent = $derived(displayOptions.sortMode === 'recent');
-	// Re-sorting filtered results also applies the pinned placement policy.
+	// Filtered results arrive recency-ordered upstream; re-sorting only applies
+	// the pinned placement policy.
 	let displayedChats = $derived.by(() => {
 		const source = isFiltered ? filteredChats : chats;
 		return sortByRecent

--- a/web/src/lib/components/sidebar/SidebarChatList.svelte
+++ b/web/src/lib/components/sidebar/SidebarChatList.svelte
@@ -17,7 +17,7 @@
 		DEFAULT_SIDEBAR_DISPLAY_OPTIONS,
 		type SidebarDisplayOptions,
 	} from './sidebar-display-options';
-	import { sortChatsByRecencyDesc } from './chat-recency-sort';
+	import { sortSidebarChatsByRecency } from './chat-recency-sort';
 	import type { ChatSessionRecord } from '$lib/types/chat-session';
 	import type { WorkspaceWindowEdge } from '$lib/workspace/surface-types.js';
 	import type { WorkspaceSplitAdmissions } from '$lib/workspace/window-geometry-policy.js';
@@ -106,7 +106,9 @@
 	// results are already recency-ordered upstream, so re-sorting is idempotent.
 	let displayedChats = $derived.by(() => {
 		const source = isFiltered ? filteredChats : chats;
-		return sortByRecent ? sortChatsByRecencyDesc(source) : source;
+		return sortByRecent
+			? sortSidebarChatsByRecency(source, displayOptions.pinnedInsertPosition)
+			: source;
 	});
 	let showChats = $derived(!isLoading && chats.length > 0 && displayedChats.length > 0);
 	let hasPinnedChats = $derived(partitionSidebarChats(chats).hasPinned);

--- a/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/SidebarVirtualSortableChatList.test.ts
@@ -495,6 +495,57 @@ describe('SidebarVirtualSortableChatList', () => {
 		expect(readVirtualRowOrder()).toEqual(['chat-1', 'chat-3', 'chat-0', 'chat-2']);
 	});
 
+	it('sorts only pinned chats oldest-first when pins are added at the bottom', () => {
+		const chats = [
+			makeChat(0, {
+				status: 'running',
+				isPinned: true,
+				lastActivityAt: '2025-04-01T00:00:00.000Z',
+			}),
+			makeChat(1, {
+				status: 'running',
+				lastActivityAt: '2025-01-01T00:00:00.000Z',
+			}),
+			makeChat(2, {
+				status: 'running',
+				isPinned: true,
+				lastActivityAt: '2025-02-01T00:00:00.000Z',
+			}),
+			makeChat(3, {
+				status: 'running',
+				lastActivityAt: '2025-05-01T00:00:00.000Z',
+			}),
+			makeChat(4, {
+				status: 'running',
+				isArchived: true,
+				lastActivityAt: '2025-06-01T00:00:00.000Z',
+			}),
+			makeChat(5, {
+				status: 'running',
+				isArchived: true,
+				lastActivityAt: '2025-03-01T00:00:00.000Z',
+			}),
+		];
+
+		render(SidebarChatListHost, {
+			chats,
+			displayOptions: {
+				grouping: 'none',
+				sortMode: 'recent',
+				pinnedInsertPosition: 'bottom',
+			},
+		});
+
+		expect(readVirtualRowOrder()).toEqual([
+			'chat-2',
+			'chat-0',
+			'chat-3',
+			'chat-1',
+			'chat-4',
+			'chat-5',
+		]);
+	});
+
 	it('keeps collapsed activity sections expandable across the reconciled reorder pass', async () => {
 		const chats = [
 			makeChat(0, {

--- a/web/src/lib/components/sidebar/__tests__/chat-recency-sort.logic.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/chat-recency-sort.logic.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { chatActivityTimeMs } from '$shared/chat-order-sort';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
 import { isSidebarChatInactive } from '../chat-inactivity';
-import { sortChatsByRecencyDesc } from '../chat-recency-sort';
+import { sortChatsByRecencyDesc, sortSidebarChatsByRecency } from '../chat-recency-sort';
 
 // 16-digit Unix-microsecond chat ids as minted by the browser clock.
 function chatIdAt(epochMs: number): string {
@@ -140,6 +140,61 @@ describe('sortChatsByRecencyDesc', () => {
 		];
 
 		expect(sortChatsByRecencyDesc(chats).map((chat) => chat.id)).toEqual(['a', 'b']);
+	});
+});
+
+describe('sortSidebarChatsByRecency', () => {
+	it('puts only the pinned subset oldest-first when pins are added at the bottom', () => {
+		const chats = [
+			makeChat('pinned-new', {
+				isPinned: true,
+				lastActivityAt: '2026-04-01T00:00:00.000Z',
+			}),
+			makeChat('normal-old', { lastActivityAt: '2026-01-01T00:00:00.000Z' }),
+			makeChat('archived-new', {
+				isArchived: true,
+				lastActivityAt: '2026-06-01T00:00:00.000Z',
+			}),
+			makeChat('pinned-old', {
+				isPinned: true,
+				lastActivityAt: '2026-02-01T00:00:00.000Z',
+			}),
+			makeChat('normal-new', { lastActivityAt: '2026-05-01T00:00:00.000Z' }),
+			makeChat('archived-old', {
+				isArchived: true,
+				lastActivityAt: '2026-03-01T00:00:00.000Z',
+			}),
+		];
+		const originalOrder = chats.map((chat) => chat.id);
+
+		const sorted = sortSidebarChatsByRecency(chats, 'bottom');
+
+		expect(sorted.filter((chat) => chat.isPinned).map((chat) => chat.id)).toEqual([
+			'pinned-old',
+			'pinned-new',
+		]);
+		expect(
+			sorted.filter((chat) => !chat.isPinned && !chat.isArchived).map((chat) => chat.id),
+		).toEqual(['normal-new', 'normal-old']);
+		expect(sorted.filter((chat) => chat.isArchived).map((chat) => chat.id)).toEqual([
+			'archived-new',
+			'archived-old',
+		]);
+		expect(chats.map((chat) => chat.id)).toEqual(originalOrder);
+	});
+
+	it('keeps stable pinned ties while placing pinned drafts last', () => {
+		const chats = [
+			makeChat('pinned-a', { isPinned: true }),
+			makeChat('pinned-b', { isPinned: true }),
+			makeChat('pinned-draft', { isPinned: true, status: 'draft' }),
+		];
+
+		expect(sortSidebarChatsByRecency(chats, 'bottom').map((chat) => chat.id)).toEqual([
+			'pinned-a',
+			'pinned-b',
+			'pinned-draft',
+		]);
 	});
 });
 

--- a/web/src/lib/components/sidebar/__tests__/sidebar-row-model.logic.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-row-model.logic.test.ts
@@ -28,15 +28,17 @@ function buildSidebarRowModel(
 function buildSidebarDisplayChatIds(
 	input: Omit<
 		Parameters<typeof buildSidebarDisplayChatIdsBase>[0],
-		'inactivityDuration' | 'sortMode'
+		'inactivityDuration' | 'sortMode' | 'pinnedInsertPosition'
 	> & {
 		inactivityDuration?: SidebarInactivityDuration;
 		sortMode?: 'manual' | 'recent';
+		pinnedInsertPosition?: 'top' | 'bottom';
 	},
 ) {
 	return buildSidebarDisplayChatIdsBase({
 		inactivityDuration: TEST_INACTIVITY_DURATION,
 		sortMode: 'manual',
+		pinnedInsertPosition: 'top',
 		...input,
 	});
 }

--- a/web/src/lib/components/sidebar/chat-recency-sort.ts
+++ b/web/src/lib/components/sidebar/chat-recency-sort.ts
@@ -3,6 +3,7 @@
 // cannot order a chat below its own creation.
 
 import { chatActivityTimeMs } from '$shared/chat-order-sort';
+import type { PinnedInsertPosition } from '$shared/settings';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
 
 /** Comparator ordering chats newest-first by activity, then creation time. */
@@ -17,4 +18,21 @@ export function compareChatsByRecencyDesc(a: ChatSessionRecord, b: ChatSessionRe
 /** Returns a new array of chats ordered newest-first. */
 export function sortChatsByRecencyDesc(chats: ChatSessionRecord[]): ChatSessionRecord[] {
 	return [...chats].sort(compareChatsByRecencyDesc);
+}
+
+/** Applies pin-placement policy without changing the order of unpinned chats. */
+export function sortSidebarChatsByRecency(
+	chats: ChatSessionRecord[],
+	pinnedInsertPosition: PinnedInsertPosition,
+): ChatSessionRecord[] {
+	const newestFirst = sortChatsByRecencyDesc(chats);
+	if (pinnedInsertPosition === 'top') return newestFirst;
+
+	const pinnedOldestFirst = chats
+		.filter((chat) => chat.isPinned)
+		.sort((left, right) => compareChatsByRecencyDesc(right, left));
+	let pinnedIndex = 0;
+	return newestFirst.map((chat) =>
+		chat.isPinned ? (pinnedOldestFirst[pinnedIndex++] ?? chat) : chat,
+	);
 }

--- a/web/src/lib/components/sidebar/sidebar-display-options.ts
+++ b/web/src/lib/components/sidebar/sidebar-display-options.ts
@@ -4,6 +4,7 @@ import type {
 	SidebarInactivityDuration,
 	SidebarSortMode,
 } from '$lib/stores/local-settings.svelte';
+import type { PinnedInsertPosition } from '$shared/settings';
 
 export interface SidebarDisplayOptions {
 	grouping: SidebarChatGrouping;
@@ -11,6 +12,7 @@ export interface SidebarDisplayOptions {
 	groupNestedProjectPaths: boolean;
 	chatItemLayout: SidebarChatItemLayout;
 	sortMode: SidebarSortMode;
+	pinnedInsertPosition: PinnedInsertPosition;
 }
 
 export const DEFAULT_SIDEBAR_DISPLAY_OPTIONS: SidebarDisplayOptions = {
@@ -19,6 +21,7 @@ export const DEFAULT_SIDEBAR_DISPLAY_OPTIONS: SidebarDisplayOptions = {
 	groupNestedProjectPaths: false,
 	chatItemLayout: 'compact',
 	sortMode: 'manual',
+	pinnedInsertPosition: 'top',
 };
 
 export function sidebarGroupingUsesProjects(grouping: SidebarChatGrouping): boolean {

--- a/web/src/lib/components/sidebar/sidebar-row-model.ts
+++ b/web/src/lib/components/sidebar/sidebar-row-model.ts
@@ -7,7 +7,8 @@ import type {
 } from '$lib/stores/local-settings.svelte';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
 import { isSidebarChatInactive } from './chat-inactivity';
-import { sortChatsByRecencyDesc } from './chat-recency-sort';
+import { sortSidebarChatsByRecency } from './chat-recency-sort';
+import type { PinnedInsertPosition } from '$shared/settings';
 import { isProjectPathAncestor, normalizeProjectPath } from '$lib/utils/project-path.js';
 import {
 	sidebarSectionKey,
@@ -507,12 +508,13 @@ export function buildSidebarDisplayChatIds(input: {
 	currentTime: Date;
 	inactivityDuration: SidebarInactivityDuration;
 	sortMode: SidebarSortMode;
+	pinnedInsertPosition: PinnedInsertPosition;
 	groupNestedProjectPaths?: boolean;
 	collapsedProjectKeys?: ReadonlySet<string>;
 }): string[] {
 	const displayedChats =
 		input.sortMode === 'recent'
-			? sortChatsByRecencyDesc(input.displayedChats)
+			? sortSidebarChatsByRecency(input.displayedChats, input.pinnedInsertPosition)
 			: input.displayedChats;
 	const orders = buildSidebarChatOrderMap(displayedChats);
 	return buildSidebarRowModel({


### PR DESCRIPTION
Aligns recent-activity ordering with the pinned-chat placement preference by placing the newest pinned chats at the bottom when bottom insertion is selected, while keeping normal and archived chats newest-first. The behavior applies to both automatic recent sorting and the one-off activity sort, keeps keyboard navigation consistent with rendered order, and adds localized help beneath the setting.