### PR TITLE
Propagate OpenCode session identity to shell commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -193,6 +193,7 @@
         "@garcon/server-agent-common": "workspace:*",
         "@garcon/server-agent-interface": "workspace:*",
         "@opencode-ai/sdk": "1.18.29",
+        "jsonc-parser": "3.3.1",
       },
       "devDependencies": {
         "@types/bun": "^1.4.1",
@@ -1262,6 +1263,8 @@
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 

--- a/integration-tests/support/scripted-opencode.ts
+++ b/integration-tests/support/scripted-opencode.ts
@@ -11,7 +11,7 @@ import { Database } from 'bun:sqlite';
 import { readdirSync, readFileSync } from 'node:fs';
 import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import { join, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { AgentSettingsEnvelope } from '../../common/agent-integration.js';
 import type {
   AgentRunCommandRequest,
@@ -108,6 +108,7 @@ export interface OpenCodePaths {
   xdgCache: string;
   npmCache: string;
   managedConfig: string;
+  sessionIdentityProbePlugin: string;
   temp: string;
 }
 
@@ -128,6 +129,7 @@ export function openCodePaths(directories: IntegrationDirectories): OpenCodePath
     xdgCache: join(root, 'xdg-cache'),
     npmCache: join(root, 'npm-cache'),
     managedConfig: join(root, 'managed-config'),
+    sessionIdentityProbePlugin: join(root, 'session-identity-probe-plugin.js'),
     temp: join(root, 'tmp'),
   };
 }
@@ -246,6 +248,10 @@ export function startScriptedOpenCodeTestEnvironment(options: {
   proxy?: boolean;
   platform?: NodeJS.Platform;
   reasoningModel?: boolean;
+  sessionIdentityProbe?: {
+    ambientSessionId: string;
+    userPluginMarker: string;
+  };
   subagentDepth?: number;
 } = {}): ScriptedOpenCodeTestEnvironment {
   assertScriptedOpenCodePlatform(options.platform);
@@ -299,6 +305,16 @@ export function startScriptedOpenCodeTestEnvironment(options: {
     if (options.proxy) {
       environment.GARCON_TEST_OPENCODE_PROXY_DIR = paths.proxy;
     }
+    if (options.sessionIdentityProbe) {
+      environment.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+        formatter: false,
+        plugin: [[
+          pathToFileURL(paths.sessionIdentityProbePlugin).href,
+          { marker: options.sessionIdentityProbe.userPluginMarker },
+        ]],
+      });
+      environment.OPENCODE_SESSION_ID = options.sessionIdentityProbe.ambientSessionId;
+    }
     return environment;
   };
 
@@ -332,6 +348,16 @@ export function startScriptedOpenCodeTestEnvironment(options: {
       }), null, 2), {
         mode: 0o600,
       });
+      if (options.sessionIdentityProbe) {
+        await writeFile(paths.sessionIdentityProbePlugin, [
+          'export const SessionIdentityProbe = async (_input, options) => ({',
+          "  'shell.env': async (_hook, output) => {",
+          '    output.env.GARCON_TEST_USER_PLUGIN = options.marker;',
+          '  },',
+          '});',
+          '',
+        ].join('\n'), { mode: 0o600 });
+      }
       await writeOpenCodePluginSeed(paths.globalConfig);
       await writeOpenCodeSupervisorShim(paths.bin);
       const version = await verifyPinnedBinaryVersion({

--- a/integration-tests/tests/server/opencode-scripted-model.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-model.test.ts
@@ -407,6 +407,55 @@ describeOnLinux('OpenCode against a scripted model', () => {
     }, withScriptedOpenCode());
   }, 120_000);
 
+  test('propagates native session identity to shell calls without replacing user plugins', async () => {
+    environment?.dispose();
+    const ambientSessionId = marker('AMBIENT_SESSION_ID');
+    const userPluginMarker = marker('USER_PLUGIN');
+    environment = startScriptedOpenCodeTestEnvironment({
+      sessionIdentityProbe: { ambientSessionId, userPluginMarker },
+    });
+    const testEnvironment = requireEnvironment();
+    const reply = marker('SESSION_IDENTITY_REPLY');
+    const outputFileName = 'opencode-session-identity.txt';
+    const command = `printf '%s\\n%s\\n' "$OPENCODE_SESSION_ID" "$GARCON_TEST_USER_PLUGIN" > ${outputFileName}`;
+    testEnvironment.model.scriptTurn([chatCompletionsToolUse('call_session_identity', 'bash', {
+      command,
+    })]);
+    testEnvironment.model.scriptTurn([chatCompletionsText(reply)]);
+
+    await withIntegrationFixture('opencode-scripted-session-identity', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat(scriptedOpenCodeStartRequest({
+        chatId,
+        projectPath: fixture.dirs.project,
+        command: marker('SESSION_IDENTITY_PROMPT'),
+      }));
+      await waitForVisibleResponse({
+        fixture,
+        chatId,
+        turnId: turn.turnId,
+        marker: reply,
+        afterIndex: cursor,
+      });
+
+      const native = await openCodeNativeSession(fixture, chatId);
+      const transcript = await fixture.client.getMessages(chatId);
+      const bash = messagesOfType(transcript.messages, 'bash-tool-use').find(
+        (message) => message.command === command,
+      );
+      if (!bash) throw new Error('OpenCode session identity shell tool use was not rendered.');
+      const result = messagesOfType(transcript.messages, 'tool-result').find(
+        (message) => message.toolId === bash.toolId,
+      );
+      expect(result?.isError).toBe(false);
+      const shellEnvironment = await readFile(join(fixture.dirs.project, outputFileName), 'utf8');
+      expect(shellEnvironment).toBe(`${native.agentSessionId}\n${userPluginMarker}\n`);
+      expect(shellEnvironment).not.toContain(ambientSessionId);
+      testEnvironment.model.assertSettled();
+    }, withScriptedOpenCode());
+  }, 120_000);
+
   test('renders every non-blocking default built-in through the real binary', async () => {
     const testEnvironment = requireEnvironment();
     const webMarker = marker('WEBFETCH_BODY');

--- a/server-agents/opencode/package.json
+++ b/server-agents/opencode/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "exports": { ".": "./src/index.ts" },
   "scripts": { "typecheck": "bunx tsc -p tsconfig.json" },
-  "dependencies": { "@garcon/common": "workspace:*", "@garcon/server-agent-common": "workspace:*", "@garcon/server-agent-interface": "workspace:*", "@opencode-ai/sdk": "1.18.29" },
+  "dependencies": { "@garcon/common": "workspace:*", "@garcon/server-agent-common": "workspace:*", "@garcon/server-agent-interface": "workspace:*", "@opencode-ai/sdk": "1.18.29", "jsonc-parser": "3.3.1" },
   "devDependencies": { "@types/bun": "^1.4.1", "typescript": "^6.0.3" },
   "garconBuild": {
     "apiVersion": 2,
     "integrationId": "opencode",
-    "preMainModules": [],
+    "preMainModules": ["./src/build/prepare-compiled-runtime.ts"],
     "embeddedDependencyMetadata": []
   }
 }

--- a/server-agents/opencode/src/agents/opencode/__tests__/autocompaction-architecture.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/autocompaction-architecture.test.js
@@ -15,7 +15,7 @@ describe('OpenCode V1 automatic compaction architecture', () => {
       },
     );
 
-    expect(JSON.parse(environment.OPENCODE_CONFIG_CONTENT ?? '{}')).not.toHaveProperty('plugin');
+    expect(JSON.parse(environment.OPENCODE_CONFIG_CONTENT ?? '{}').plugin).toHaveLength(1);
     expect(environment).toMatchObject({
       KEEP_ME: 'yes',
       OPENCODE_DISABLE_AUTOCOMPACT: '0',
@@ -25,15 +25,16 @@ describe('OpenCode V1 automatic compaction architecture', () => {
     expect(environment).not.toHaveProperty('OPENCODE_PURE');
   });
 
-  it('[TLV5-OPENCODE.02-STATIC-01] keeps compaction enabled and ships no plugin or session-latest route', () => {
+  it('[TLV5-OPENCODE.02-STATIC-01] keeps compaction enabled without the retired operation identity plugin', () => {
     const serverInstance = readFileSync(new URL('../server-instance.ts', import.meta.url), 'utf8');
     const manifest = JSON.parse(readFileSync(new URL('package.json', PACKAGE_ROOT), 'utf8'));
 
     expect(serverInstance).not.toContain('OPENCODE_DISABLE_AUTOCOMPACT');
     expect(serverInstance).not.toContain('operation-identity-plugin');
-    expect(manifest.garconBuild).not.toHaveProperty('standaloneEntrypoints');
-    expect(manifest.exports).not.toHaveProperty('./operation-identity-plugin');
-    expect(existsSync(new URL('../operation-identity-plugin.js', import.meta.url))).toBe(false);
-    expect(existsSync(new URL('../operation-identity-plugin-host.ts', import.meta.url))).toBe(false);
+    expect(serverInstance).not.toContain("'--pure'");
+    expect(manifest.garconBuild.preMainModules).toEqual([
+      './src/build/prepare-compiled-runtime.ts',
+    ]);
+    expect(existsSync(new URL('../garcon-session-identity.mjs', import.meta.url))).toBe(true);
   });
 });

--- a/server-agents/opencode/src/agents/opencode/__tests__/models.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/models.test.js
@@ -64,9 +64,16 @@ describe('OpenCodeRuntime model discovery', () => {
       OPENCODE_DISABLE_AUTOCOMPACT: '0',
       OPENCODE_DISABLE_AUTOUPDATE: '0',
       OPENCODE_PURE: '1',
+      OPENCODE_SESSION_ID: 'ambient-session',
     }, 'file:///tmp/garcon-opencode-plugin.js')).toEqual({
       KEEP_ME: 'yes',
-      OPENCODE_CONFIG_CONTENT: '{}',
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        mode: 'user',
+        plugin: [
+          'file:///tmp/user-opencode-plugin.js',
+          'file:///tmp/garcon-opencode-plugin.js',
+        ],
+      }),
       OPENCODE_DISABLE_AUTOCOMPACT: '0',
       OPENCODE_DISABLE_AUTOUPDATE: '1',
     });

--- a/server-agents/opencode/src/agents/opencode/__tests__/session-identity-plugin.test.js
+++ b/server-agents/opencode/src/agents/opencode/__tests__/session-identity-plugin.test.js
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { GarconSessionIdentity } from '../garcon-session-identity.mjs';
+import {
+  buildOpenCodeServerEnv,
+  mergeOpenCodeConfigContent,
+} from '../server-instance.ts';
+import { resolveSessionIdentityPluginUrl } from '../session-identity-plugin.ts';
+
+const GARCON_PLUGIN_URL = 'file:///opt/garcon/garcon-session-identity.mjs';
+
+describe('OpenCode session identity plugin', () => {
+  it('uses each shell invocation session ID without retaining another call', async () => {
+    const hooks = await GarconSessionIdentity();
+    const first = { env: { KEEP_FIRST: 'yes' } };
+    const second = { env: { KEEP_SECOND: 'yes' } };
+
+    await Promise.all([
+      hooks['shell.env']({ sessionID: 'session-first' }, first),
+      hooks['shell.env']({ sessionID: 'session-second' }, second),
+    ]);
+
+    expect(first.env).toEqual({ KEEP_FIRST: 'yes', OPENCODE_SESSION_ID: 'session-first' });
+    expect(second.env).toEqual({ KEEP_SECOND: 'yes', OPENCODE_SESSION_ID: 'session-second' });
+  });
+
+  it('removes inherited and prior values when an invocation has no session ID', async () => {
+    const hooks = await GarconSessionIdentity();
+    const output = { env: { KEEP_ME: 'yes', OPENCODE_SESSION_ID: 'ambient' } };
+
+    await hooks['shell.env']({ sessionID: 'session-present' }, output);
+    await hooks['shell.env']({}, output);
+
+    expect(output.env).toEqual({ KEEP_ME: 'yes' });
+  });
+});
+
+describe('OpenCode inline configuration composition', () => {
+  it('adds the Garcon plugin without inherited inline content', () => {
+    expect(JSON.parse(mergeOpenCodeConfigContent(undefined, GARCON_PLUGIN_URL))).toEqual({
+      plugin: [GARCON_PLUGIN_URL],
+    });
+  });
+
+  it('treats blank inherited inline content as absent', () => {
+    expect(JSON.parse(mergeOpenCodeConfigContent('  \n', GARCON_PLUGIN_URL))).toEqual({
+      plugin: [GARCON_PLUGIN_URL],
+    });
+  });
+
+  it('preserves JSONC fields, string plugins, and plugin tuples', () => {
+    const content = `{
+      // Operator-owned inline settings stay intact.
+      "mode": "user",
+      "plugin": [
+        "file:///opt/user/plugin.js",
+        ["package-plugin", { "enabled": true }],
+      ],
+    }`;
+
+    expect(JSON.parse(mergeOpenCodeConfigContent(content, GARCON_PLUGIN_URL))).toEqual({
+      mode: 'user',
+      plugin: [
+        'file:///opt/user/plugin.js',
+        ['package-plugin', { enabled: true }],
+        GARCON_PLUGIN_URL,
+      ],
+    });
+  });
+
+  it('does not duplicate an identical Garcon plugin tuple', () => {
+    const existing = [GARCON_PLUGIN_URL, { configured: true }];
+    const merged = JSON.parse(mergeOpenCodeConfigContent(
+      JSON.stringify({ plugin: ['user-plugin', existing] }),
+      GARCON_PLUGIN_URL,
+    ));
+
+    expect(merged.plugin).toEqual(['user-plugin', existing]);
+  });
+
+  it('preserves URL-sensitive path characters through a file URL', () => {
+    const pluginUrl = pathToFileURL('/opt/Garçon plugins/100% session #1.mjs').href;
+    const merged = JSON.parse(mergeOpenCodeConfigContent(undefined, pluginUrl));
+
+    expect(merged.plugin).toEqual([
+      'file:///opt/Gar%C3%A7on%20plugins/100%25%20session%20%231.mjs',
+    ]);
+  });
+
+  it.each([
+    {
+      description: 'invalid JSONC',
+      content: '{ broken',
+      expected: 'Invalid inherited OPENCODE_CONFIG_CONTENT at offset',
+    },
+    {
+      description: 'trailing content',
+      content: '{} trailing',
+      expected: 'Invalid inherited OPENCODE_CONFIG_CONTENT at offset',
+    },
+    {
+      description: 'a non-object root',
+      content: '[]',
+      expected: 'Invalid inherited OPENCODE_CONFIG_CONTENT: expected a JSONC object.',
+    },
+    {
+      description: 'a non-array plugin field',
+      content: '{ "plugin": "wrong" }',
+      expected: 'Invalid inherited OPENCODE_CONFIG_CONTENT: "plugin" must be an array.',
+    },
+    {
+      description: 'an invalid plugin tuple',
+      content: '{ "plugin": [["incomplete"]] }',
+      expected:
+        'Invalid inherited OPENCODE_CONFIG_CONTENT: "plugin[0]" must be a string or [specifier, options] tuple.',
+    },
+  ])('fails clearly for $description', ({ content, expected }) => {
+    expect(() => mergeOpenCodeConfigContent(content, GARCON_PLUGIN_URL)).toThrow(expected);
+  });
+});
+
+describe('OpenCode server plugin startup asset', () => {
+  it('removes ambient identity and pure mode while preserving merged configuration', () => {
+    const environment = buildOpenCodeServerEnv({
+      KEEP_ME: 'yes',
+      OPENCODE_CONFIG_CONTENT: '{ "formatter": false }',
+      OPENCODE_PURE: '1',
+      OPENCODE_SESSION_ID: 'ambient-session',
+    }, GARCON_PLUGIN_URL);
+
+    expect(environment).not.toHaveProperty('OPENCODE_PURE');
+    expect(environment).not.toHaveProperty('OPENCODE_SESSION_ID');
+    expect(environment.KEEP_ME).toBe('yes');
+    expect(JSON.parse(environment.OPENCODE_CONFIG_CONTENT)).toEqual({
+      formatter: false,
+      plugin: [GARCON_PLUGIN_URL],
+    });
+  });
+
+  it('removes case-insensitive ambient aliases on Windows', () => {
+    const environment = buildOpenCodeServerEnv({
+      Opencode_Config_Content: '{ "formatter": false }',
+      opencode_pure: '1',
+      opencode_session_id: 'ambient-session',
+    }, GARCON_PLUGIN_URL, 'win32');
+
+    expect(environment).not.toHaveProperty('Opencode_Config_Content');
+    expect(environment).not.toHaveProperty('opencode_pure');
+    expect(environment).not.toHaveProperty('opencode_session_id');
+    expect(JSON.parse(environment.OPENCODE_CONFIG_CONTENT)).toEqual({
+      formatter: false,
+      plugin: [GARCON_PLUGIN_URL],
+    });
+  });
+
+  it('resolves the checked-in plugin through an absolute file URL', () => {
+    const pluginUrl = resolveSessionIdentityPluginUrl();
+
+    expect(pluginUrl.startsWith('file://')).toBe(true);
+    expect(existsSync(fileURLToPath(pluginUrl))).toBe(true);
+  });
+
+  it('includes the dependency-free plugin in the compiled pre-main artifact', async () => {
+    const entrypoint = fileURLToPath(
+      new URL('../../../build/prepare-compiled-runtime.ts', import.meta.url),
+    );
+    const result = await Bun.build({
+      entrypoints: [entrypoint],
+      target: 'bun',
+      format: 'esm',
+      naming: { asset: '[dir]/[name].[ext]' },
+    });
+
+    expect(result.success).toBe(true);
+    const pluginOutput = result.outputs.find((output) => (
+      output.kind === 'asset' && output.path.replaceAll('\\', '/').endsWith(
+        '/garcon-session-identity.mjs',
+      )
+    ));
+    expect(pluginOutput).toBeDefined();
+    expect(await pluginOutput.text()).toBe(readFileSync(
+      new URL('../garcon-session-identity.mjs', import.meta.url),
+      'utf8',
+    ));
+  });
+});

--- a/server-agents/opencode/src/agents/opencode/garcon-session-identity.mjs
+++ b/server-agents/opencode/src/agents/opencode/garcon-session-identity.mjs
@@ -1,5 +1,12 @@
+/**
+ * Propagates each OpenCode shell invocation's native session identity.
+ *
+ * The hook remains stateless because one OpenCode process may serve concurrent,
+ * resumed, forked, and child sessions.
+ */
 export const GarconSessionIdentity = async () => ({
   'shell.env': async ({ sessionID }, output) => {
+    // Removes prior hook values so an unidentified invocation cannot inherit stale identity.
     delete output.env.OPENCODE_SESSION_ID;
     if (sessionID) {
       output.env.OPENCODE_SESSION_ID = sessionID;

--- a/server-agents/opencode/src/agents/opencode/garcon-session-identity.mjs
+++ b/server-agents/opencode/src/agents/opencode/garcon-session-identity.mjs
@@ -1,0 +1,8 @@
+export const GarconSessionIdentity = async () => ({
+  'shell.env': async ({ sessionID }, output) => {
+    delete output.env.OPENCODE_SESSION_ID;
+    if (sessionID) {
+      output.env.OPENCODE_SESSION_ID = sessionID;
+    }
+  },
+});

--- a/server-agents/opencode/src/agents/opencode/server-instance.ts
+++ b/server-agents/opencode/src/agents/opencode/server-instance.ts
@@ -1,17 +1,92 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { parse, printParseErrorCode, type ParseError } from 'jsonc-parser';
 import type { OpenCodeInstance, OpenCodeServerTermination } from './instance-lifecycle.js';
+import { resolveSessionIdentityPluginUrl } from './session-identity-plugin.js';
+
+function pluginSpecifier(entry: unknown): string | null {
+  if (typeof entry === 'string') return entry;
+  if (
+    Array.isArray(entry)
+    && entry.length === 2
+    && typeof entry[0] === 'string'
+    && entry[1] !== null
+    && typeof entry[1] === 'object'
+    && !Array.isArray(entry[1])
+  ) {
+    return entry[0];
+  }
+  return null;
+}
+
+export function mergeOpenCodeConfigContent(
+  inheritedContent: string | undefined,
+  sessionIdentityPluginUrl: string,
+): string {
+  let inherited: unknown = {};
+  if (inheritedContent !== undefined && inheritedContent.trim() !== '') {
+    const errors: ParseError[] = [];
+    inherited = parse(inheritedContent, errors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    if (errors.length > 0) {
+      const first = errors[0]!;
+      throw new Error(
+        'Invalid inherited OPENCODE_CONFIG_CONTENT'
+        + ` at offset ${first.offset}: ${printParseErrorCode(first.error)}.`,
+      );
+    }
+  }
+  if (inherited === null || typeof inherited !== 'object' || Array.isArray(inherited)) {
+    throw new Error('Invalid inherited OPENCODE_CONFIG_CONTENT: expected a JSONC object.');
+  }
+
+  const config = inherited as Record<string, unknown>;
+  if (config.plugin !== undefined && !Array.isArray(config.plugin)) {
+    throw new Error('Invalid inherited OPENCODE_CONFIG_CONTENT: "plugin" must be an array.');
+  }
+  const plugins: unknown[] = config.plugin ?? [];
+  const invalidPluginIndex = plugins.findIndex((entry) => pluginSpecifier(entry) === null);
+  if (invalidPluginIndex >= 0) {
+    throw new Error(
+      'Invalid inherited OPENCODE_CONFIG_CONTENT:'
+      + ` "plugin[${invalidPluginIndex}]" must be a string or [specifier, options] tuple.`,
+    );
+  }
+  const sessionIdentityPluginEntry = plugins.findLast(
+    (entry) => pluginSpecifier(entry) === sessionIdentityPluginUrl,
+  ) ?? sessionIdentityPluginUrl;
+  return JSON.stringify({
+    ...config,
+    plugin: [
+      ...plugins.filter((entry) => pluginSpecifier(entry) !== sessionIdentityPluginUrl),
+      sessionIdentityPluginEntry,
+    ],
+  });
+}
 
 export function buildOpenCodeServerEnv(
   baseEnv: Record<string, string | undefined> = process.env,
+  sessionIdentityPluginUrl: string = resolveSessionIdentityPluginUrl(),
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string | undefined> {
-  const { OPENCODE_PURE: _pureMode, ...serverEnv } = baseEnv;
+  const serverEnv = { ...baseEnv };
+  let inheritedConfigContent = serverEnv.OPENCODE_CONFIG_CONTENT;
+  for (const key of Object.keys(serverEnv)) {
+    const normalizedKey = platform === 'win32' ? key.toUpperCase() : key;
+    if (normalizedKey === 'OPENCODE_CONFIG_CONTENT') {
+      inheritedConfigContent ??= serverEnv[key];
+      delete serverEnv[key];
+    } else if (normalizedKey === 'OPENCODE_PURE' || normalizedKey === 'OPENCODE_SESSION_ID') {
+      delete serverEnv[key];
+    }
+  }
   return {
     ...serverEnv,
-    // Empty content keeps OpenCode's built-in provider defaults active, including
-    // the five-minute header and inter-chunk stream timeouts adopted in 1.18.29;
-    // Garcon sets no turn deadline of its own, and chunk stalls stay retryable
-    // inside OpenCode.
-    OPENCODE_CONFIG_CONTENT: '{}',
+    OPENCODE_CONFIG_CONTENT: mergeOpenCodeConfigContent(
+      inheritedConfigContent,
+      sessionIdentityPluginUrl,
+    ),
     OPENCODE_DISABLE_AUTOUPDATE: '1',
   };
 }

--- a/server-agents/opencode/src/agents/opencode/session-identity-plugin.ts
+++ b/server-agents/opencode/src/agents/opencode/session-identity-plugin.ts
@@ -1,0 +1,17 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const COMPILED_SESSION_IDENTITY_PLUGIN_PATH = Symbol.for(
+  'garcon.opencode-session-identity-plugin-path.v1',
+);
+
+export function resolveSessionIdentityPluginUrl(): string {
+  const compiledPath = Reflect.get(globalThis, COMPILED_SESSION_IDENTITY_PLUGIN_PATH);
+  const pluginPath = typeof compiledPath === 'string'
+    ? compiledPath
+    : fileURLToPath(new URL('./garcon-session-identity.mjs', import.meta.url));
+  if (!existsSync(pluginPath)) {
+    throw new Error(`Garcon's bundled OpenCode session identity plugin is missing: ${pluginPath}`);
+  }
+  return pathToFileURL(pluginPath).href;
+}

--- a/server-agents/opencode/src/build/prepare-compiled-runtime.ts
+++ b/server-agents/opencode/src/build/prepare-compiled-runtime.ts
@@ -1,0 +1,45 @@
+import '../agents/opencode/garcon-session-identity.mjs' with { type: 'file' };
+import { rmSync } from 'node:fs';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { COMPILED_SESSION_IDENTITY_PLUGIN_PATH } from '../agents/opencode/session-identity-plugin.js';
+
+const PLUGIN_FILE_NAME = 'garcon-session-identity.mjs';
+
+function embeddedFileName(file: Blob): string | null {
+  return 'name' in file && typeof file.name === 'string'
+    ? file.name.replaceAll('\\', '/')
+    : null;
+}
+
+async function prepareCompiledSessionIdentityPlugin(): Promise<void> {
+  const plugin = Bun.embeddedFiles.find((file) => (
+    embeddedFileName(file)?.endsWith(`/${PLUGIN_FILE_NAME}`)
+  ));
+  if (!(plugin instanceof Blob)) {
+    throw new Error('Garcon executable is missing the bundled OpenCode session identity plugin.');
+  }
+
+  const directory = await mkdtemp(join(tmpdir(), 'garcon-opencode-session-identity-'));
+  const cleanup = () => rmSync(directory, { recursive: true, force: true });
+  process.once('exit', cleanup);
+  const pluginPath = join(directory, PLUGIN_FILE_NAME);
+  try {
+    await writeFile(pluginPath, new Uint8Array(await plugin.arrayBuffer()), {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    Object.defineProperty(globalThis, COMPILED_SESSION_IDENTITY_PLUGIN_PATH, {
+      value: pluginPath,
+      writable: false,
+      configurable: false,
+    });
+  } catch (error) {
+    process.off('exit', cleanup);
+    cleanup();
+    throw error;
+  }
+}
+
+await prepareCompiledSessionIdentityPlugin();


### PR DESCRIPTION
Garcon-managed OpenCode shell commands need the native session ID so nested tooling can associate work with the correct chat without relying on global session state. This bundles a dependency-free shell environment plugin, merges it into existing inline OpenCode configuration while preserving user plugins and settings, removes ambient identity and pure-mode overrides from the owned server process, packages the asset for source and compiled runtimes, and adds focused unit and scripted integration coverage.