### PR TITLE
Require server typechecking before merge

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -30,6 +30,9 @@ jobs:
         working-directory: server
         run: bun install --frozen-lockfile
 
+      - name: Type-check server and provider agents
+        run: bun run typecheck:server
+
       - name: Run server tests
         run: bun run test:server
 

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "test:live:codex": "bun run --cwd integration-tests test:live:codex",
     "test:live:opencode": "bun run --cwd integration-tests test:live:opencode",
     "lint": "bun run --cwd web lint",
-    "check": "bun run lint && bun run --cwd web check",
-    "typecheck": "bun run --filter '@garcon/server-agent-*' --if-present typecheck && bun run --cwd server typecheck && bun run --cwd cli typecheck && bun run --cwd web check && bun run --cwd integration-tests typecheck",
+    "check": "bun run lint && bun run typecheck",
+    "typecheck:server": "bun run --filter '@garcon/server-agent-*' --if-present typecheck && bun run --cwd server typecheck",
+    "typecheck": "bun run typecheck:server && bun run --cwd cli typecheck && bun run --cwd web check && bun run --cwd integration-tests typecheck",
     "help": "bun run server --help"
   },
   "keywords": [

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -17,7 +17,6 @@ import {
   type SortChatOrderResponse,
 } from '../../common/chat-order-contracts.js';
 import type { ChatOrderIdComparator } from '../../common/chat-order-sort.js';
-import type { PinnedInsertPosition } from '../../common/settings.js';
 import { ModelSelectionError } from '../api-providers/endpoint-resolver.js';
 import type { AgentSessionSettingsPatch } from '../agents/session-types.js';
 import {
@@ -54,6 +53,7 @@ import type {
   ChatOrderComparatorOverrides,
   ChatReorderResult,
   ChatStartupPreferences,
+  UiSettings,
 } from '../settings/types.js';
 import type { RouteMap } from '../lib/http-route-types.js';
 import { InMemoryLastSelectedChatState, type LastSelectedChatState } from '../chats/last-selected-chat-state.js';
@@ -149,7 +149,7 @@ interface SettingsDep {
   getPinnedChatIds(): string[];
   getNormalChatIds(): string[];
   getArchivedChatIds(): string[];
-  getUiSettings(): { pinnedInsertPosition?: PinnedInsertPosition } | null | undefined;
+  getUiSettings(): UiSettings | null | undefined;
   getChatName(chatId: string): string | null;
   setSessionName(chatId: string, title: string): Promise<unknown>;
   setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;


### PR DESCRIPTION
Restores the chat route’s canonical UI settings contract so title generation and pinned sorting remain type-compatible, and makes server/provider typechecking part of both the root quality gate and required server CI check to prevent TypeScript regressions from merging.