### PR TITLE
Navigate archived chats by displayed sidebar order

### DIFF
--- a/integration-tests/tests/e2e/archive-navigation.test.ts
+++ b/integration-tests/tests/e2e/archive-navigation.test.ts
@@ -12,7 +12,7 @@ type ArchiveGateGlobal = typeof globalThis & {
 };
 
 describe("Lightpanda archive navigation", () => {
-  test("moves the row before the request and preserves a later manual selection", async () => {
+  test("selects the recent-order neighbor before archiving and preserves a later selection", async () => {
     await withE2eFixture("archive-navigation", async (fixture) => {
       const app = new SpaDriver(fixture.page, fixture.integration);
       await app.open();
@@ -20,8 +20,8 @@ describe("Lightpanda archive navigation", () => {
 
       for (const prompt of [
         "already-archived",
-        "manual-destination",
-        "replacement",
+        "later-selection",
+        "manual-order-neighbor",
         "archive-source",
       ]) {
         await app.startOpenAiDirectChat(prompt);
@@ -32,13 +32,13 @@ describe("Lightpanda archive navigation", () => {
       const byPrompt = (prompt: string) =>
         chats.find((chat) => chat.preview.firstMessage === prompt);
       const alreadyArchived = byPrompt("already-archived");
-      const manualDestination = byPrompt("manual-destination");
-      const replacement = byPrompt("replacement");
+      const laterSelection = byPrompt("later-selection");
+      const manualOrderNeighbor = byPrompt("manual-order-neighbor");
       const archiveSource = byPrompt("archive-source");
       if (
         !alreadyArchived ||
-        !manualDestination ||
-        !replacement ||
+        !laterSelection ||
+        !manualOrderNeighbor ||
         !archiveSource
       ) {
         throw new Error("Archive navigation chats were not listed.");
@@ -46,6 +46,20 @@ describe("Lightpanda archive navigation", () => {
 
       await fixture.integration.client.toggleArchive(alreadyArchived.id);
       await app.waitForSidebarChatIds("archived", [alreadyArchived.id]);
+
+      await app.openChat(manualOrderNeighbor.id);
+      await app.submitComposerWithEnter(
+        "refresh-manual-order-neighbor-activity",
+        "Send message",
+      );
+      await app.waitForText("echo:refresh-manual-order-neighbor-activity");
+      await app.openChat(archiveSource.id);
+      await app.setRecentActivitySort(true);
+      await app.waitForSidebarChatIds("normal", [
+        manualOrderNeighbor.id,
+        archiveSource.id,
+        laterSelection.id,
+      ]);
 
       await fixture.page.evaluate(() => {
         const originalFetch = globalThis.fetch.bind(globalThis);
@@ -90,7 +104,7 @@ describe("Lightpanda archive navigation", () => {
             ?.requested === true,
       );
 
-      await app.waitForSelectedChat(replacement.id);
+      await app.waitForSelectedChat(laterSelection.id);
       await app.waitForSidebarChatIds("archived", [
         archiveSource.id,
         alreadyArchived.id,
@@ -101,8 +115,8 @@ describe("Lightpanda archive navigation", () => {
           ?.isArchived,
       ).toBe(false);
 
-      await app.clickSidebarChatById(manualDestination.id);
-      await app.waitForSelectedChat(manualDestination.id);
+      await app.clickSidebarChatById(manualOrderNeighbor.id);
+      await app.waitForSelectedChat(manualOrderNeighbor.id);
       await fixture.page.evaluate(() => {
         const release = (globalThis as ArchiveGateGlobal)
           .__garconArchiveRequestGate?.release;
@@ -116,7 +130,7 @@ describe("Lightpanda archive navigation", () => {
         archiveSource.id,
         alreadyArchived.id,
       ]);
-      await app.waitForSelectedChat(manualDestination.id);
+      await app.waitForSelectedChat(manualOrderNeighbor.id);
       const afterRelease = await fixture.integration.client.listChats();
       expect(
         afterRelease.sessions.find((chat) => chat.id === archiveSource.id)

--- a/web/src/lib/chat/actions/__tests__/archive-navigation.logic.test.ts
+++ b/web/src/lib/chat/actions/__tests__/archive-navigation.logic.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveArchiveReplacementChatId } from '../archive-navigation';
+
+describe('resolveArchiveReplacementChatId', () => {
+	it('selects the next displayed chat before the previous one', () => {
+		expect(
+			resolveArchiveReplacementChatId({
+				archivingChatId: 'selected',
+				displayedChatIds: ['previous', 'selected', 'next'],
+				isSelectableChat: () => true,
+			}),
+		).toBe('next');
+	});
+
+	it('falls back to the previous eligible displayed chat', () => {
+		expect(
+			resolveArchiveReplacementChatId({
+				archivingChatId: 'selected',
+				displayedChatIds: ['previous', 'selected', 'excluded'],
+				isSelectableChat: (chatId) => chatId !== 'excluded',
+			}),
+		).toBe('previous');
+	});
+
+	it('returns null when the archived chat is absent or has no eligible neighbor', () => {
+		const input = {
+			archivingChatId: 'selected',
+			displayedChatIds: ['selected'],
+			isSelectableChat: () => true,
+		};
+
+		expect(resolveArchiveReplacementChatId(input)).toBeNull();
+		expect(
+			resolveArchiveReplacementChatId({ ...input, displayedChatIds: ['another-chat'] }),
+		).toBeNull();
+	});
+});

--- a/web/src/lib/chat/actions/archive-navigation.ts
+++ b/web/src/lib/chat/actions/archive-navigation.ts
@@ -1,0 +1,19 @@
+export function resolveArchiveReplacementChatId(input: {
+	archivingChatId: string;
+	displayedChatIds: readonly string[];
+	isSelectableChat: (chatId: string) => boolean;
+}): string | null {
+	const { archivingChatId, displayedChatIds, isSelectableChat } = input;
+	const archivingChatIndex = displayedChatIds.indexOf(archivingChatId);
+	if (archivingChatIndex === -1) return null;
+
+	for (let index = archivingChatIndex + 1; index < displayedChatIds.length; index += 1) {
+		const chatId = displayedChatIds[index];
+		if (chatId && isSelectableChat(chatId)) return chatId;
+	}
+	for (let index = archivingChatIndex - 1; index >= 0; index -= 1) {
+		const chatId = displayedChatIds[index];
+		if (chatId && isSelectableChat(chatId)) return chatId;
+	}
+	return null;
+}

--- a/web/src/lib/components/chat/__tests__/chat-action-controller.test.ts
+++ b/web/src/lib/components/chat/__tests__/chat-action-controller.test.ts
@@ -92,6 +92,7 @@ function deferred<T>() {
 function createHarness(
 	options: {
 		chats?: ChatSessionRecord[];
+		displayedChatIds?: readonly string[];
 		selectedChatId?: string | null;
 		onReloadChat?: (chatId: string) => Promise<void> | void;
 	} = {},
@@ -129,6 +130,9 @@ function createHarness(
 	const deps = {
 		get chats() {
 			return chats;
+		},
+		get displayedChatIds() {
+			return options.displayedChatIds ?? chats.map((chat) => chat.id);
 		},
 		get selectedChatId() {
 			return selectedChatId;
@@ -205,6 +209,23 @@ describe('ChatActionController', () => {
 
 		expect(callbacks.onQuietRefresh).toHaveBeenCalledOnce();
 		expect(callbacks.onSelectChat).toHaveBeenCalledOnce();
+	});
+
+	it('selects an adjacent chat from the displayed recent-activity order', async () => {
+		const { controller, callbacks } = createHarness({
+			chats: [
+				makeChat({ id: 'selected' }),
+				makeChat({ id: 'manual-order-neighbor' }),
+				makeChat({ id: 'recent-order-neighbor' }),
+			],
+			displayedChatIds: ['manual-order-neighbor', 'selected', 'recent-order-neighbor'],
+			selectedChatId: 'selected',
+		});
+
+		await controller.toggleArchive('selected');
+
+		expect(callbacks.onSelectChat).toHaveBeenCalledOnce();
+		expect(callbacks.onSelectChat).toHaveBeenCalledWith('recent-order-neighbor');
 	});
 
 	it('creates a new chat when archiving the only selected chat', async () => {

--- a/web/src/lib/components/chat/chat-action-controller.svelte.ts
+++ b/web/src/lib/components/chat/chat-action-controller.svelte.ts
@@ -1,4 +1,5 @@
 import * as m from '$lib/paraglide/messages.js';
+import { resolveArchiveReplacementChatId } from '$lib/chat/actions/archive-navigation';
 import { SidebarController } from '$lib/components/sidebar/sidebar-controller.svelte';
 import type { ChatArchiveMutation } from '$lib/chat/sessions/chat-sessions.svelte';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
@@ -7,6 +8,7 @@ import type { ChatListEntry } from '$shared/chat-list';
 
 export interface ChatActionControllerDeps {
 	get chats(): ChatSessionRecord[];
+	get displayedChatIds(): readonly string[];
 	get selectedChatId(): string | null;
 	projectPathRevision: (chatId: string) => number;
 	onQuietRefresh: () => Promise<void> | void;
@@ -59,16 +61,17 @@ export class ChatActionController {
 	}
 
 	async toggleArchive(chatId: string): Promise<void> {
-		const chats = this.deps.chats;
-		const chatIndex = chats.findIndex((entry) => entry.id === chatId);
-		const chat = chats[chatIndex];
+		const chat = this.deps.chats.find((entry) => entry.id === chatId);
 		if (!chat || this.deps.isArchiveMutationPending(chatId)) return;
 		const wasArchived = chat.isArchived;
-		const isSelectedChat = this.deps.selectedChatId === chatId;
-		const isArchivingSelectedChat = !wasArchived && isSelectedChat;
+		const isArchivingSelectedChat = !wasArchived && this.deps.selectedChatId === chatId;
 		let replacementChatId: string | null = null;
 		if (isArchivingSelectedChat) {
-			replacementChatId = this.#findArchiveReplacementChatId(chats, chatIndex);
+			replacementChatId = resolveArchiveReplacementChatId({
+				archivingChatId: chatId,
+				displayedChatIds: this.deps.displayedChatIds,
+				isSelectableChat: (candidateId) => !this.deps.isArchiveMutationPending(candidateId),
+			});
 		}
 
 		const mutation = wasArchived
@@ -87,21 +90,6 @@ export class ChatActionController {
 				this.deps.requestSidebarRecenter();
 			}
 		});
-	}
-
-	#findArchiveReplacementChatId(
-		chats: readonly ChatSessionRecord[],
-		chatIndex: number,
-	): string | null {
-		for (let index = chatIndex + 1; index < chats.length; index += 1) {
-			const chat = chats[index];
-			if (chat && !this.deps.isArchiveMutationPending(chat.id)) return chat.id;
-		}
-		for (let index = chatIndex - 1; index >= 0; index -= 1) {
-			const chat = chats[index];
-			if (chat && !this.deps.isArchiveMutationPending(chat.id)) return chat.id;
-		}
-		return null;
 	}
 
 	async confirmDelete(dialogs: ChatActionDialogsState): Promise<void> {

--- a/web/src/lib/components/layout/AppShell.svelte
+++ b/web/src/lib/components/layout/AppShell.svelte
@@ -85,6 +85,20 @@
 		notifications,
 	});
 	const chatActionDialogs = new ChatActionDialogsState();
+	const displayedSidebarChatIds = $derived.by(() =>
+		buildSidebarDisplayChatIds({
+			displayedChats: sidebarSearch.filteredChats,
+			grouping: localSettings.sidebarGrouping,
+			currentTime: minuteClock.currentTime,
+			inactivityDuration: localSettings.sidebarInactivityDuration,
+			sortMode: localSettings.sidebarSortMode,
+			pinnedInsertPosition: remoteSettings.snapshot?.ui?.pinnedInsertPosition ?? 'top',
+			isChatOptimisticallyArchived: (chatId) => sessions.isChatOptimisticallyArchived(chatId),
+			optimisticArchiveOrder: sessions.orderedChats,
+			groupNestedProjectPaths: localSettings.sidebarGroupNestedProjectPaths,
+			collapsedProjectKeys: projectCollapse.collapsedProjectKeys,
+		}),
+	);
 	let mobileSidebarFocusReturnTarget: HTMLElement | null = null;
 	const mobileSidebarLayer = transientLayerAttachment({
 		registry: transientLayers,
@@ -100,6 +114,9 @@
 	const chatActionController = new ChatActionController({
 		get chats() {
 			return sessions.orderedChats;
+		},
+		get displayedChatIds() {
+			return displayedSidebarChatIds;
 		},
 		get selectedChatId() {
 			return sessions.selectedChatId;
@@ -185,20 +202,6 @@
 			: 16,
 	);
 	const sidebarMounted = $derived(!isMobile || appShell.sidebarOpen);
-	const displayedSidebarChatIds = $derived.by(() =>
-		buildSidebarDisplayChatIds({
-			displayedChats: sidebarSearch.filteredChats,
-			grouping: localSettings.sidebarGrouping,
-			currentTime: minuteClock.currentTime,
-			inactivityDuration: localSettings.sidebarInactivityDuration,
-			sortMode: localSettings.sidebarSortMode,
-			pinnedInsertPosition: remoteSettings.snapshot?.ui?.pinnedInsertPosition ?? 'top',
-			isChatOptimisticallyArchived: (chatId) => sessions.isChatOptimisticallyArchived(chatId),
-			optimisticArchiveOrder: sessions.orderedChats,
-			groupNestedProjectPaths: localSettings.sidebarGroupNestedProjectPaths,
-			collapsedProjectKeys: projectCollapse.collapsedProjectKeys,
-		}),
-	);
 	const chatNavigation = new AppShellChatNavigationController({
 		get routeChatId() {
 			return page.params.id as string | undefined;

--- a/web/src/lib/components/sidebar/Sidebar.svelte
+++ b/web/src/lib/components/sidebar/Sidebar.svelte
@@ -358,6 +358,7 @@
 		const operation = controller.startBulkOperation(action, {
 			selectedChats,
 			allChats: chats,
+			displayedChatIds,
 			selectedChatId,
 		});
 		if (operation.nextSelectedChatId) {

--- a/web/src/lib/components/sidebar/__tests__/sidebar-bulk-archive-flow.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-bulk-archive-flow.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as chatsApi from '$lib/api/chats';
 import { ChatSessionsStore } from '$lib/chat/sessions/chat-sessions.svelte';
@@ -62,12 +62,13 @@ describe('sidebar bulk archive flow', () => {
 		vi.mocked(chatsApi.toggleArchive).mockReturnValueOnce(archive.promise);
 		const listChats = vi.fn(async () => ({
 			sessions: [
-				makeServerChat('next', false, '2026-01-01T00:00:00.000Z'),
+				makeServerChat('recent-order-neighbor', false, '2026-01-01T00:00:00.000Z'),
 				makeServerChat('selected', true, '2026-02-01T00:00:00.000Z'),
+				makeServerChat('manual-order-neighbor', false, '2026-03-01T00:00:00.000Z'),
 				makeServerChat('archived', true, '2026-03-01T00:00:00.000Z'),
 			],
-			total: 3,
-			lastSelectedChatId: 'next',
+			total: 4,
+			lastSelectedChatId: 'recent-order-neighbor',
 		}));
 		const chatSessions = new ChatSessionsStore({
 			toggleArchive: chatsApi.toggleArchive,
@@ -75,7 +76,8 @@ describe('sidebar bulk archive flow', () => {
 		});
 		chatSessions.upsertFromServer([
 			makeServerChat('selected', false, '2026-02-01T00:00:00.000Z'),
-			makeServerChat('next', false, '2026-01-01T00:00:00.000Z'),
+			makeServerChat('manual-order-neighbor', false, '2026-03-01T00:00:00.000Z'),
+			makeServerChat('recent-order-neighbor', false, '2026-01-01T00:00:00.000Z'),
 			makeServerChat('archived', true, '2026-03-01T00:00:00.000Z'),
 		]);
 		const onChatSelect = vi.fn();
@@ -87,13 +89,17 @@ describe('sidebar bulk archive flow', () => {
 			onChatSelect,
 		});
 
-		await fireEvent.click(screen.getAllByRole('button', { name: 'Chat actions' })[0]);
+		const selectedRow = container.querySelector<HTMLElement>(
+			'[data-sidebar-virtual-row="selected"]',
+		);
+		if (!selectedRow) throw new Error('Selected chat row was not rendered.');
+		await fireEvent.click(within(selectedRow).getByRole('button', { name: 'Chat actions' }));
 		await fireEvent.click(await screen.findByRole('menuitem', { name: 'Select' }));
 		await fireEvent.click(await screen.findByRole('button', { name: 'Archive' }));
 
 		expect(chatsApi.toggleArchive).toHaveBeenCalledWith('selected');
 		expect(onChatSelect).toHaveBeenCalledOnce();
-		expect(onChatSelect).toHaveBeenCalledWith('next');
+		expect(onChatSelect).toHaveBeenCalledWith('recent-order-neighbor');
 		expect(
 			Array.from(container.querySelectorAll('[data-sidebar-virtual-list-row="archived"]')).map(
 				(row) => row.getAttribute('data-sidebar-virtual-row'),

--- a/web/src/lib/components/sidebar/__tests__/sidebar-controller.test.ts
+++ b/web/src/lib/components/sidebar/__tests__/sidebar-controller.test.ts
@@ -240,6 +240,7 @@ describe('SidebarController', () => {
 					makeChat({ id: 'c-2', isPinned: true }),
 				],
 				allChats: [],
+				displayedChatIds: [],
 				selectedChatId: null,
 			});
 
@@ -264,6 +265,7 @@ describe('SidebarController', () => {
 					makeChat({ id: 'c-1', isArchived: false }),
 					makeChat({ id: 'c-2', isArchived: false }),
 				],
+				displayedChatIds: ['c-1', 'c-2'],
 				selectedChatId: 'c-1',
 			});
 
@@ -281,6 +283,7 @@ describe('SidebarController', () => {
 			const operation = controller.startBulkOperation('archive', {
 				selectedChats: [makeChat({ id: 'c-1', isArchived: false })],
 				allChats: [makeChat({ id: 'c-1', isArchived: false })],
+				displayedChatIds: ['c-1'],
 				selectedChatId: 'c-1',
 			});
 
@@ -289,6 +292,23 @@ describe('SidebarController', () => {
 				nextSelectedChatId: null,
 				shouldCreateNewChat: true,
 			});
+		});
+
+		it('plans an adjacent survivor from the displayed recent-activity order', async () => {
+			mockToggleArchive.mockResolvedValue({ success: true, isArchived: true });
+			const operation = controller.startBulkOperation('archive', {
+				selectedChats: [makeChat({ id: 'selected', isArchived: false })],
+				allChats: [
+					makeChat({ id: 'selected', isArchived: false }),
+					makeChat({ id: 'manual-order-neighbor', isArchived: false }),
+					makeChat({ id: 'recent-order-neighbor', isArchived: false }),
+				],
+				displayedChatIds: ['manual-order-neighbor', 'selected', 'recent-order-neighbor'],
+				selectedChatId: 'selected',
+			});
+
+			expect(operation.nextSelectedChatId).toBe('recent-order-neighbor');
+			await operation.completion;
 		});
 	});
 });

--- a/web/src/lib/components/sidebar/sidebar-controller.svelte.ts
+++ b/web/src/lib/components/sidebar/sidebar-controller.svelte.ts
@@ -12,6 +12,7 @@ import {
 	setChatTags,
 	updateChatProjectPath,
 } from '$lib/api/chats.js';
+import { resolveArchiveReplacementChatId } from '$lib/chat/actions/archive-navigation';
 import { createClientChatId } from '$shared/client-chat-id';
 import type { ProjectPathPatchResponse } from '$shared/chat-command-contracts';
 import type { ChatSessionRecord } from '$lib/types/chat-session';
@@ -35,6 +36,7 @@ export type SidebarBulkAction = 'pin' | 'unpin' | 'archive' | 'unarchive';
 export interface SidebarBulkOperationInput {
 	selectedChats: ChatSessionRecord[];
 	allChats: ChatSessionRecord[];
+	displayedChatIds: readonly string[];
 	selectedChatId: string | null;
 }
 
@@ -166,13 +168,21 @@ export class SidebarController {
 			return { affectedIds, nextSelectedChatId: null, shouldCreateNewChat: false };
 		}
 
-		const remaining = input.allChats.find(
-			(chat) => !affectedIds.includes(chat.id) && !chat.isArchived,
+		const affectedIdSet = new Set(affectedIds);
+		const selectableChatIds = new Set(
+			input.allChats
+				.filter((chat) => !affectedIdSet.has(chat.id) && !chat.isArchived)
+				.map((chat) => chat.id),
 		);
+		const nextSelectedChatId = resolveArchiveReplacementChatId({
+			archivingChatId: input.selectedChatId,
+			displayedChatIds: input.displayedChatIds,
+			isSelectableChat: (chatId) => selectableChatIds.has(chatId),
+		});
 		return {
 			affectedIds,
-			nextSelectedChatId: remaining?.id ?? null,
-			shouldCreateNewChat: !remaining,
+			nextSelectedChatId,
+			shouldCreateNewChat: nextSelectedChatId === null,
 		};
 	}
 }


### PR DESCRIPTION
Archiving a selected chat while sorting by recent activity could jump according to persisted manual order instead of the neighboring visible row. This change derives replacement navigation from the canonical displayed sidebar order for both single and bulk archives, preserves immediate navigation and fallback behavior, and adds unit, component, and browser regression coverage.