### PR TITLE
Respect max chat width for project recovery

### DIFF
--- a/web/src/lib/components/chat/PromptComposer.svelte
+++ b/web/src/lib/components/chat/PromptComposer.svelte
@@ -944,30 +944,27 @@
 {/snippet}
 
 <div class={composerShellClass} data-composer-shell>
-	{#if selectedProjectTarget && selectedProjectResolution.kind === 'unavailable'}
-		<div class="mb-2 rounded-lg border border-border bg-card px-4 py-3">
-			<ProjectAvailabilityNotice
-				projectPath={selectedProjectTarget.projectPath}
-				reason={selectedProjectResolution.reason}
-				onRetry={() => projectState.retry()}
-				onChooseFolder={canChooseProjectFolder && sessions.selectedChat
-					? () => onChooseProjectFolder?.(sessions.selectedChat!.id)
-					: undefined}
-			/>
-		</div>
-	{:else if selectedProjectTarget && selectedProjectResolution.kind === 'request-failed'}
-		<div class="mb-2 rounded-lg border border-border bg-card px-4 py-3">
-			<ProjectAvailabilityNotice
-				projectPath={selectedProjectTarget.projectPath}
-				requestError={selectedProjectResolution.message}
-				onRetry={() => projectState.retry()}
-				onChooseFolder={canChooseProjectFolder && sessions.selectedChat
-					? () => onChooseProjectFolder?.(sessions.selectedChat!.id)
-					: undefined}
-			/>
-		</div>
-	{/if}
 	<div class={composerFrameWrapperClass}>
+		{#if selectedProjectTarget && (selectedProjectResolution.kind === 'unavailable' || selectedProjectResolution.kind === 'request-failed')}
+			<div
+				class="mb-2 rounded-lg border border-border bg-card px-4 py-3"
+				data-project-availability-notice
+			>
+				<ProjectAvailabilityNotice
+					projectPath={selectedProjectTarget.projectPath}
+					reason={selectedProjectResolution.kind === 'unavailable'
+						? selectedProjectResolution.reason
+						: undefined}
+					requestError={selectedProjectResolution.kind === 'request-failed'
+						? selectedProjectResolution.message
+						: undefined}
+					onRetry={() => projectState.retry()}
+					onChooseFolder={canChooseProjectFolder && sessions.selectedChat
+						? () => onChooseProjectFolder?.(sessions.selectedChat!.id)
+						: undefined}
+				/>
+			</div>
+		{/if}
 		{@render composerFrame()}
 	</div>
 </div>

--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -1846,9 +1846,10 @@ describe('PromptComposer focus', () => {
 			resolution: { kind: 'unavailable' as const, reason: 'not-found' as const },
 		}));
 		const onChooseProjectFolder = vi.fn();
-		render(PromptComposerTestHost, {
+		const { container } = render(PromptComposerTestHost, {
 			selectedChatId: 'chat-project-unavailable',
 			selectedStatus: 'running',
+			chatMaxWidth: 'small',
 			fetchProjectResolution,
 			onChooseProjectFolder,
 		});
@@ -1856,6 +1857,12 @@ describe('PromptComposer focus', () => {
 		await fireEvent.input(textarea, { target: { value: '/' } });
 
 		await screen.findByText('Project folder unavailable');
+		const notice = container.querySelector('[data-project-availability-notice]');
+		const noticeFrame = notice?.parentElement;
+		expect(noticeFrame?.querySelector('[data-composer]')).toBeTruthy();
+		expect(noticeFrame?.className).toContain('w-full');
+		expect(noticeFrame?.className).toContain('lg:mx-auto');
+		expect(noticeFrame?.className).toContain('lg:max-w-3xl');
 		await fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
 		expect(onChooseProjectFolder).toHaveBeenCalledWith('chat-project-unavailable');
 		await fireEvent.click(screen.getByRole('button', { name: 'Retry' }));

--- a/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
+++ b/web/src/lib/components/chat/__tests__/PromptComposerTestHost.svelte
@@ -28,6 +28,7 @@
 	import type { ModelCatalogStore, ModelOption } from '$lib/agents/model-catalog-store.svelte';
 	import type { GitQuickSummaryReady } from '$lib/api/git.js';
 	import type { RecentAgentSetting, RemoteSettingsSnapshot } from '$shared/settings';
+	import type { ChatMaxWidth } from '$lib/stores/local-settings.svelte';
 	import { WorkspaceInteractionGate } from '$lib/workspace/workspace-interaction-gate.svelte';
 	import KeyboardShortcuts from '$lib/components/shared/KeyboardShortcuts.svelte';
 	import { TransientLayerRegistry } from '$lib/workspace/transient-layers.svelte';
@@ -65,6 +66,7 @@
 		allowDirectChats?: boolean;
 		reduceMotion?: boolean;
 		steerWithCtrlEnter?: boolean;
+		chatMaxWidth?: ChatMaxWidth;
 		snippetTrigger?: string;
 		snippetTemplate?: string;
 		snippetDefaultArguments?: string;
@@ -98,6 +100,7 @@
 		allowDirectChats = false,
 		reduceMotion = false,
 		steerWithCtrlEnter = true,
+		chatMaxWidth = 'medium',
 		snippetTrigger = ';;',
 		snippetTemplate = 'Review {{arguments}} in {{project_path}}',
 		snippetDefaultArguments = '',
@@ -284,6 +287,9 @@
 		get snippetTrigger() {
 			return snippetTrigger;
 		},
+		get chatMaxWidth() {
+			return chatMaxWidth;
+		},
 		get showQuickCommitTray() {
 			return true;
 		},
@@ -434,7 +440,7 @@
 
 <KeyboardShortcuts />
 <ConversationPanelStatusDock
-	chatMaxWidth="medium"
+	{chatMaxWidth}
 	isProcessing={selectedIsProcessing}
 	status={lifecycle.loadingStatus}
 	agentId={selectedAgentId}


### PR DESCRIPTION
The unavailable-project recovery card stretched across the chat even when a maximum chat width was configured. This change places the card inside the composer’s shared width frame and adds regression coverage for the configured cap while preserving the existing recovery actions.
