### PR TITLE
Shrink chat gutters in narrow panes

### DIFF
--- a/integration-tests/tests/chromium/chat-max-width-layout.test.ts
+++ b/integration-tests/tests/chromium/chat-max-width-layout.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import type { Page } from 'playwright';
+import { withChromiumFixture, type ChromiumFixture } from '../../support/chromium-fixture.js';
+import { seedLocalSettings } from '../../support/local-settings-seed.js';
+
+interface ChatWidthMetrics {
+  browserWidth: number;
+  windowWidth: number;
+  viewportWidth: number;
+  viewportPadding: number;
+  contentPadding: number;
+  feedInsetLeft: number;
+  feedInsetRight: number;
+  usableFeedWidth: number;
+  composerPadding: number;
+  statusDockPadding: number;
+}
+
+async function createChat(fixture: ChromiumFixture): Promise<string> {
+  const chatId = fixture.integration.newChatId();
+  const started = await fixture.integration.client.startDirectChat({
+    chatId,
+    content: 'chat max-width pane-relative layout',
+    projectPath: fixture.integration.dirs.project,
+    agent: fixture.integration.directAgents.openAi,
+  });
+  await fixture.integration.client.waitForTurnTerminal(chatId, started.turnId);
+  return chatId;
+}
+
+async function openChat(fixture: ChromiumFixture, chatId: string): Promise<string> {
+  const response = await fixture.page.goto(
+    `${fixture.integration.garcon.baseUrl}/chat/${encodeURIComponent(chatId)}`,
+    { waitUntil: 'domcontentloaded' },
+  );
+  if (!response?.ok()) throw new Error(`SPA navigation failed with ${response?.status()}.`);
+  const currentWindow = fixture.page.locator('[data-workspace-window-current="true"]');
+  await currentWindow.waitFor({ state: 'visible' });
+  const windowId = await currentWindow.getAttribute('data-workspace-window-id');
+  if (!windowId) throw new Error('Missing the Chat workspace window.');
+  await fixture.page
+    .locator(`[data-conversation-panel="chat-view:${windowId}"] [data-chat-feed-content]`)
+    .waitFor({ state: 'visible' });
+  await fixture.page
+    .locator(`[data-conversation-composer-host="chat-view:${windowId}"] [data-composer]`)
+    .waitFor({ state: 'visible' });
+  return windowId;
+}
+
+async function measureChatWidth(page: Page, windowId: string): Promise<ChatWidthMetrics> {
+  return page.evaluate((expectedWindowId) => {
+    const surfaceId = `chat-view:${expectedWindowId}`;
+    const workspaceWindow = document.querySelector<HTMLElement>(
+      `[data-workspace-window-id="${expectedWindowId}"]`,
+    );
+    const panel = document.querySelector<HTMLElement>(
+      `[data-conversation-panel="${surfaceId}"]`,
+    );
+    const viewport = panel?.querySelector<HTMLElement>('[data-chat-scroll-viewport]');
+    const content = panel?.querySelector<HTMLElement>('[data-chat-feed-content]');
+    const composerShell = document.querySelector<HTMLElement>(
+      `[data-conversation-composer-host="${surfaceId}"] [data-composer-shell]`,
+    );
+    const statusDock = panel?.querySelector<HTMLElement>(
+      '[data-conversation-panel-status-dock]',
+    );
+    if (!workspaceWindow || !viewport || !content || !composerShell || !statusDock) {
+      throw new Error('Incomplete Chat max-width layout.');
+    }
+
+    const viewportRect = viewport.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    const viewportStyle = getComputedStyle(viewport);
+    const contentStyle = getComputedStyle(content);
+    const round = (value: number): number => Math.round(value * 10) / 10;
+    const padding = (style: CSSStyleDeclaration): number => Number.parseFloat(style.paddingLeft);
+    const viewportPadding = padding(viewportStyle);
+    const contentPadding = padding(contentStyle);
+    return {
+      browserWidth: window.innerWidth,
+      windowWidth: round(workspaceWindow.getBoundingClientRect().width),
+      viewportWidth: round(viewportRect.width),
+      viewportPadding: round(viewportPadding),
+      contentPadding: round(contentPadding),
+      feedInsetLeft: round(contentRect.left - viewportRect.left + contentPadding),
+      feedInsetRight: round(viewportRect.right - contentRect.right + contentPadding),
+      usableFeedWidth: round(content.clientWidth - contentPadding * 2),
+      composerPadding: round(padding(getComputedStyle(composerShell))),
+      statusDockPadding: round(padding(getComputedStyle(statusDock))),
+    };
+  }, windowId);
+}
+
+describe('Chromium Chat max-width layout', () => {
+  test('shrinks constrained gutters with a tiled Chat pane while preserving its state', async () => {
+    await withChromiumFixture('chat-max-width-pane-gutters', async (fixture, markPhase) => {
+      await fixture.page.setViewportSize({ width: 1440, height: 900 });
+      await fixture.page.addInitScript(seedLocalSettings, { chatMaxWidth: 'small' });
+      const chatId = await createChat(fixture);
+      const windowId = await openChat(fixture, chatId);
+      const composer = fixture.page.locator(
+        `[data-conversation-composer-host="chat-view:${windowId}"] textarea[placeholder="Reply..."]`,
+      );
+
+      markPhase('capturing the initial constrained layout');
+      await composer.fill('draft survives pane resizing');
+      await composer.evaluate((element) => {
+        (globalThis as typeof globalThis & { __chatMaxWidthComposer?: Element })
+          .__chatMaxWidthComposer = element;
+      });
+      const initial = await measureChatWidth(fixture.page, windowId);
+
+      markPhase('shrinking the allocated Chat pane');
+      const separator = fixture.page.getByRole('separator', { name: 'Resize windows' }).first();
+      const [windowBounds, separatorBounds] = await Promise.all([
+        fixture.page.locator(`[data-workspace-window-id="${windowId}"]`).boundingBox(),
+        separator.boundingBox(),
+      ]);
+      if (!windowBounds || !separatorBounds) throw new Error('Missing workspace resize geometry.');
+      const shrinkKey = windowBounds.x < separatorBounds.x ? 'ArrowLeft' : 'ArrowRight';
+      await separator.focus();
+      for (let step = 0; step < 20; step += 1) await fixture.page.keyboard.press(shrinkKey);
+      await fixture.page.waitForFunction(
+        (expectedWindowId) =>
+          (document
+            .querySelector<HTMLElement>(`[data-workspace-window-id="${expectedWindowId}"]`)
+            ?.getBoundingClientRect().width ?? Number.POSITIVE_INFINITY) <= 260,
+        windowId,
+      );
+      await fixture.page.evaluate(
+        () =>
+          new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+          ),
+      );
+      const narrow = await measureChatWidth(fixture.page, windowId);
+
+      markPhase('checking pane-relative gutters and retained Chat state');
+      expect(initial.browserWidth).toBe(1440);
+      expect(narrow.browserWidth).toBe(1440);
+      expect(narrow.windowWidth).toBeLessThanOrEqual(260);
+      expect(narrow.feedInsetLeft).toBeLessThan(initial.feedInsetLeft - 8);
+      expect(narrow.feedInsetLeft).toBeLessThanOrEqual(20);
+      expect(Math.abs(narrow.feedInsetLeft - narrow.feedInsetRight)).toBeLessThan(1);
+      expect(narrow.usableFeedWidth).toBeGreaterThanOrEqual(narrow.viewportWidth - 40);
+      expect(Math.abs(narrow.viewportPadding - narrow.composerPadding)).toBeLessThan(1);
+      expect(Math.abs(narrow.viewportPadding - narrow.statusDockPadding)).toBeLessThan(1);
+      expect(await composer.inputValue()).toBe('draft survives pane resizing');
+      expect(
+        await composer.evaluate(
+          (element) =>
+            (globalThis as typeof globalThis & { __chatMaxWidthComposer?: Element })
+              .__chatMaxWidthComposer === element,
+        ),
+      ).toBe(true);
+      fixture.assertNoBrowserErrors();
+    });
+  });
+});

--- a/web/src/lib/chat/conversation/__tests__/chat-max-width.logic.test.ts
+++ b/web/src/lib/chat/conversation/__tests__/chat-max-width.logic.test.ts
@@ -7,6 +7,7 @@ import {
 	CHAT_MAX_WIDTH_DOCK_FRAME_CLASS,
 	CHAT_MAX_WIDTH_DOCK_SHELL_CLASS,
 	CHAT_MAX_WIDTH_FEED_CONTENT_CLASS,
+	CHAT_MAX_WIDTH_FEED_VIEWPORT_CLASS,
 	chatDockFrameClass,
 } from '$lib/chat/conversation/chat-max-width.js';
 
@@ -50,6 +51,7 @@ describe('chat max width classes', () => {
 
 	it('keeps the elevated composer shell transparent', () => {
 		expect(CHAT_DOCK_SHELL_BASE_CLASS).not.toContain('bg-');
+		expect(CHAT_DOCK_SHELL_BASE_CLASS).not.toContain('px-');
 	});
 
 	it('reduces the none transcript inset below the previous values', () => {
@@ -62,7 +64,7 @@ describe('chat max width classes', () => {
 	it('keeps the none transcript width inside the composer in both layouts', () => {
 		// Mobile (small layout): feed px-4 (16px) must exceed composer px-2 (8px).
 		const feedMobile = extractPx(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS.none, '');
-		const composerMobile = extractPx(CHAT_DOCK_SHELL_BASE_CLASS, '');
+		const composerMobile = extractPx(CHAT_MAX_WIDTH_DOCK_SHELL_CLASS.none, '');
 		expect(feedMobile).toBe(16);
 		expect(composerMobile).toBe(8);
 		expect(feedMobile!).toBeGreaterThan(composerMobile!);
@@ -75,10 +77,21 @@ describe('chat max width classes', () => {
 		expect(feedDesktop!).toBeGreaterThan(composerDesktop!);
 	});
 
-	it('preserves the mobile transcript inset for constrained width options', () => {
-		expect(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS.large).toContain('px-[29px]');
-		expect(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS.medium).toContain('px-[29px]');
-		expect(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS.small).toContain('px-[29px]');
+	it('shrinks constrained gutters against each chat pane while preserving wide caps', () => {
+		for (const option of ['large', 'medium', 'small'] as const) {
+			expect(CHAT_MAX_WIDTH_FEED_VIEWPORT_CLASS[option]).toBe(
+				'px-2 lg:px-[clamp(0.5rem,3%,1.5rem)]',
+			);
+			expect(CHAT_MAX_WIDTH_DOCK_SHELL_CLASS[option]).toBe(
+				CHAT_MAX_WIDTH_FEED_VIEWPORT_CLASS[option],
+			);
+			expect(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS[option]).toContain(
+				'px-[clamp(0.5rem,3%,1.3125rem)]',
+			);
+			expect(CHAT_MAX_WIDTH_FEED_CONTENT_CLASS[option]).toContain(
+				'lg:px-[clamp(0.5rem,3%,1.25rem)]',
+			);
+		}
 	});
 
 	it('defines one shared frame for the composer and queued-input tray', () => {

--- a/web/src/lib/chat/conversation/chat-max-width.ts
+++ b/web/src/lib/chat/conversation/chat-max-width.ts
@@ -6,30 +6,36 @@ import { cn } from '$lib/utils/cn';
 export const CHAT_FEED_CONTENT_BASE_CLASS = 'flex w-full flex-col gap-2 sm:gap-3';
 
 // The elevated composer uses this shared layout shell without repainting panel-owned status caps.
-export const CHAT_DOCK_SHELL_BASE_CLASS = 'flex-shrink-0 px-2';
+export const CHAT_DOCK_SHELL_BASE_CLASS = 'flex-shrink-0';
 
 export const CHAT_DOCK_SURFACE_CLASS =
 	'overflow-hidden rounded-2xl border border-border bg-card shadow-sm';
 
+// Shrinks constrained gutters against each allocated chat pane while retaining their wide cap.
+const CHAT_CONSTRAINED_OUTER_GUTTER_CLASS =
+	'px-2 lg:px-[clamp(0.5rem,3%,1.5rem)]';
+const CHAT_CONSTRAINED_FEED_INSET_CLASS =
+	'px-[clamp(0.5rem,3%,1.3125rem)] lg:px-[clamp(0.5rem,3%,1.25rem)]';
+
 export const CHAT_MAX_WIDTH_FEED_VIEWPORT_CLASS: Record<ChatMaxWidth, string> = {
 	none: 'lg:px-0',
-	large: 'lg:px-6',
-	medium: 'lg:px-6',
-	small: 'lg:px-6',
+	large: CHAT_CONSTRAINED_OUTER_GUTTER_CLASS,
+	medium: CHAT_CONSTRAINED_OUTER_GUTTER_CLASS,
+	small: CHAT_CONSTRAINED_OUTER_GUTTER_CLASS,
 };
 
 export const CHAT_MAX_WIDTH_FEED_CONTENT_CLASS: Record<ChatMaxWidth, string> = {
 	none: 'px-4 lg:px-5',
-	large: 'px-[29px] lg:mx-auto lg:max-w-5xl lg:px-5',
-	medium: 'px-[29px] lg:mx-auto lg:max-w-4xl lg:px-5',
-	small: 'px-[29px] lg:mx-auto lg:max-w-3xl lg:px-5',
+	large: cn(CHAT_CONSTRAINED_FEED_INSET_CLASS, 'lg:mx-auto lg:max-w-5xl'),
+	medium: cn(CHAT_CONSTRAINED_FEED_INSET_CLASS, 'lg:mx-auto lg:max-w-4xl'),
+	small: cn(CHAT_CONSTRAINED_FEED_INSET_CLASS, 'lg:mx-auto lg:max-w-3xl'),
 };
 
 export const CHAT_MAX_WIDTH_DOCK_SHELL_CLASS: Record<ChatMaxWidth, string> = {
-	none: 'lg:px-3',
-	large: 'lg:px-6',
-	medium: 'lg:px-6',
-	small: 'lg:px-6',
+	none: 'px-2 lg:px-3',
+	large: CHAT_CONSTRAINED_OUTER_GUTTER_CLASS,
+	medium: CHAT_CONSTRAINED_OUTER_GUTTER_CLASS,
+	small: CHAT_CONSTRAINED_OUTER_GUTTER_CLASS,
 };
 
 export const CHAT_MAX_WIDTH_COMPOSER_SPACING_CLASS: Record<ChatMaxWidth, string> = {


### PR DESCRIPTION
Keeps configured chat max-width caps on roomy panes while shrinking transcript and dock gutters relative to each allocated pane, preserving readable line width in tiled layouts. Adds unit coverage for the shared width policy and a Chromium regression test that verifies narrow-pane alignment and composer identity retention.