### PR TITLE
Complete CLI discovery and search administration

### DIFF
--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -736,6 +736,29 @@ describe('parseCliArgs', () => {
       '--run', 'run-1', '--server-instance', 'instance-1',
     ], ENV)).toThrow('option may be specified only once: --answers');
   });
+
+  test('parses transcript search administration actions', () => {
+    for (const action of ['enable', 'disable', 'status'] as const) {
+      expect(parseCliArgs([
+        '--workspace', 'work', 'transcript-search', action, '--json',
+      ], ENV)).toEqual({
+        kind: 'transcript-search',
+        workspace: 'work',
+        configDir: '/home/test/.garcon',
+        action,
+        json: true,
+      });
+    }
+  });
+
+  test.each([
+    [['transcript-search'], 'requires one action'],
+    [['transcript-search', 'rebuild'], 'requires one action'],
+    [['transcript-search', 'status', 'extra'], 'requires one action'],
+    [['transcript-search', 'enable', '--filter', 'tag:ops'], '--filter cannot be used'],
+  ])('rejects invalid transcript search administration arguments', (args, message) => {
+    expect(() => parseCliArgs(args, ENV)).toThrow(message);
+  });
 });
 
 describe('chat research arguments', () => {

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -133,6 +133,13 @@ describe('parseCliArgs', () => {
       configDir: '/home/test/.garcon',
       json: false,
     });
+    expect(parseCliArgs(['list', 'preambles', '--json'], ENV)).toEqual({
+      kind: 'list',
+      resource: 'preambles',
+      workspace: 'default',
+      configDir: '/home/test/.garcon',
+      json: true,
+    });
   });
 
   test('normalizes and deduplicates repeatable additional tags', () => {
@@ -211,6 +218,7 @@ describe('parseCliArgs', () => {
     { args: ['list', 'endpoints'], message: 'requires --provider' },
     { args: ['list', 'models', '--agent', 'codex', '--endpoint', 'east'], message: 'requires --provider' },
     { args: ['list', 'agents', '--agent', 'codex'], message: '--agent cannot be used' },
+    { args: ['list', 'preambles', '--provider', 'acme'], message: '--provider cannot be used' },
     { args: ['start', '--json', '--agent', 'codex', '--model', 'gpt', 'prompt'], message: '--json cannot be used with start' },
     { args: ['list', 'agents', '--title', 'Review'], message: '--title cannot be used' },
     { args: ['start', '--title', '  ', '--agent', 'codex', '--model', 'gpt', 'prompt'], message: '--title must not be empty' },

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { PREAMBLE_MAX_COUNT } from '@garcon/common/preambles';
 import { CLI_HELP, parseCliArgs } from '../args.js';
 import { CliError } from '../errors.js';
 
@@ -272,6 +273,24 @@ describe('parseCliArgs', () => {
       orderedPreambleIds: [],
       json: true,
     });
+  });
+
+  test('accepts at most the shared preamble selection limit', () => {
+    const preambleIds = Array.from(
+      { length: PREAMBLE_MAX_COUNT },
+      (_, index) => `3502b645-222b-49d2-ac39-${index.toString().padStart(12, '0')}`,
+    );
+    const selectionArgs = preambleIds.flatMap((id) => ['--preamble', id]);
+
+    expect(parseCliArgs([
+      'start', '--agent', 'codex', '--model', 'gpt', ...selectionArgs, 'Review',
+    ], ENV)).toMatchObject({ orderedPreambleIds: preambleIds });
+    expect(() => parseCliArgs([
+      'start', '--agent', 'codex', '--model', 'gpt',
+      ...selectionArgs,
+      '--preamble', '3502b645-222b-49d2-ac39-000000000100',
+      'Review',
+    ], ENV)).toThrow(`--preamble may be specified at most ${PREAMBLE_MAX_COUNT} times`);
   });
 
   test('documents presentation on conversational commands and its native-history boundary', () => {

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import {
+  ASK_USER_QUESTION_ID_MAX_BYTES,
+  ASK_USER_QUESTION_MAX_ANSWERS,
+  ASK_USER_QUESTION_MAX_SELECTED_OPTIONS,
+} from '@garcon/common/chat-command-contracts';
 import { PREAMBLE_MAX_COUNT } from '@garcon/common/preambles';
 import { CLI_HELP, parseCliArgs } from '../args.js';
 import { CliError } from '../errors.js';
@@ -631,6 +636,31 @@ describe('parseCliArgs', () => {
       allow: true,
       json: true,
     });
+    expect(parseCliArgs([
+      'permission-answer', CHAT_ID, 'permission-1',
+      '--answers', JSON.stringify([{
+        questionId: 'question-1',
+        selectedOptionIds: ['option-1', 'option-2'],
+      }]),
+      '--run', 'run-1', '--server-instance', 'instance-1', '--json',
+    ], ENV)).toEqual({
+      kind: 'permission-answer',
+      workspace: 'default',
+      configDir: '/home/test/.garcon',
+      chatId: CHAT_ID,
+      permissionOccurrenceId: 'permission-1',
+      runId: 'run-1',
+      serverInstanceId: 'instance-1',
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [{
+          questionId: 'question-1',
+          selectedOptionIds: ['option-1', 'option-2'],
+        }],
+      },
+      json: true,
+    });
     expect(parseCliArgs(['unarchive', CHAT_ID], ENV)).toMatchObject({
       kind: 'unarchive', chatId: CHAT_ID, json: false,
     });
@@ -661,6 +691,50 @@ describe('parseCliArgs', () => {
     [['resume', CHAT_ID, '--no-preamble', 'prompt'], '--no-preamble cannot be used with resume'],
   ])('rejects invalid automation arguments: %s', (args, message) => {
     expect(() => parseCliArgs(args, ENV)).toThrow(message);
+  });
+
+  test.each([
+    [undefined, 'requires --answers'],
+    ['not-json', 'valid JSON'],
+    [JSON.stringify({ questionId: 'question-1' }), 'bounded array'],
+    [JSON.stringify([
+      { questionId: 'question-1', selectedOptionIds: [] },
+      { questionId: 'question-1', selectedOptionIds: [] },
+    ]), 'bounded array'],
+    [JSON.stringify([{
+      questionId: 'question-1',
+      selectedOptionIds: ['option-1', 'option-1'],
+    }]), 'bounded array'],
+    [JSON.stringify(Array.from(
+      { length: ASK_USER_QUESTION_MAX_ANSWERS + 1 },
+      (_, index) => ({ questionId: `question-${index}`, selectedOptionIds: [] }),
+    )), 'bounded array'],
+    [JSON.stringify([{
+      questionId: 'question-1',
+      selectedOptionIds: Array.from(
+        { length: ASK_USER_QUESTION_MAX_SELECTED_OPTIONS + 1 },
+        (_, index) => `option-${index}`,
+      ),
+    }]), 'bounded array'],
+    [JSON.stringify([{
+      questionId: 'q'.repeat(ASK_USER_QUESTION_ID_MAX_BYTES + 1),
+      selectedOptionIds: [],
+    }]), 'bounded array'],
+  ])('rejects invalid structured permission answers', (answers, message) => {
+    const args = [
+      'permission-answer', CHAT_ID, 'permission-1',
+      '--run', 'run-1', '--server-instance', 'instance-1',
+    ];
+    if (answers !== undefined) args.push('--answers', answers);
+    expect(() => parseCliArgs(args, ENV)).toThrow(message);
+  });
+
+  test('rejects repeated structured permission answer payloads', () => {
+    expect(() => parseCliArgs([
+      'permission-answer', CHAT_ID, 'permission-1',
+      '--answers', '[]', '--answers', '[]',
+      '--run', 'run-1', '--server-instance', 'instance-1',
+    ], ENV)).toThrow('option may be specified only once: --answers');
   });
 });
 

--- a/cli/__tests__/args.test.ts
+++ b/cli/__tests__/args.test.ts
@@ -738,7 +738,7 @@ describe('parseCliArgs', () => {
   });
 
   test('parses transcript search administration actions', () => {
-    for (const action of ['enable', 'disable', 'status'] as const) {
+    for (const action of ['enable', 'disable', 'rebuild', 'status'] as const) {
       expect(parseCliArgs([
         '--workspace', 'work', 'transcript-search', action, '--json',
       ], ENV)).toEqual({
@@ -753,7 +753,7 @@ describe('parseCliArgs', () => {
 
   test.each([
     [['transcript-search'], 'requires one action'],
-    [['transcript-search', 'rebuild'], 'requires one action'],
+    [['transcript-search', 'unknown'], 'requires one action'],
     [['transcript-search', 'status', 'extra'], 'requires one action'],
     [['transcript-search', 'enable', '--filter', 'tag:ops'], '--filter cannot be used'],
   ])('rejects invalid transcript search administration arguments', (args, message) => {

--- a/cli/__tests__/catalog-query.test.ts
+++ b/cli/__tests__/catalog-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
+import type { PreamblesSnapshot } from '@garcon/common/preambles';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
 import type { ListCliCommand } from '../args.js';
 import { runCatalogQuery, type CatalogQueryClient } from '../catalog-query.js';
@@ -79,9 +80,28 @@ const settings = {
   },
 } as RemoteSettingsSnapshot;
 
+const preambles: PreamblesSnapshot = {
+  revision: 3,
+  preambles: [{
+    id: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+    enabled: true,
+    title: 'Repository guidance',
+    content: 'Follow the repository guidance.',
+    scope: {
+      type: 'project-paths',
+      rules: [{ projectPath: '/repo', includeNested: true }],
+    },
+    agentIds: [],
+    tagFilter: { mode: 'all', tags: [] },
+    createdAt: '2026-09-08T00:00:00.000Z',
+    updatedAt: '2026-09-08T00:00:00.000Z',
+  }],
+};
+
 function client(modelCatalog: ModelCatalogResponse = catalog): CatalogQueryClient {
   return {
     async getModelCatalog() { return modelCatalog; },
+    async getPreambles() { return preambles; },
     async getSettings() { return settings; },
   };
 }
@@ -113,6 +133,26 @@ function command(
 }
 
 describe('runCatalogQuery', () => {
+  test('lists preamble IDs directly without loading the model catalog', async () => {
+    let modelCatalogRequested = false;
+    const queryClient = client();
+    queryClient.getModelCatalog = async () => {
+      modelCatalogRequested = true;
+      return catalog;
+    };
+    const plain = output();
+    await runCatalogQuery(command('preambles'), queryClient, plain);
+    expect(plain.listings[0]).toContain('ID                                    TITLE                ENABLED  SCOPE');
+    expect(plain.listings[0]).toContain(
+      '3502b645-222b-49d2-ac39-1c91f9fb1174  Repository guidance  yes      /repo/**',
+    );
+
+    const json = output();
+    await runCatalogQuery(command('preambles', { json: true }), queryClient, json);
+    expect(JSON.parse(json.listings[0]!)).toEqual(preambles);
+    expect(modelCatalogRequested).toBe(false);
+  });
+
   test('provider names and IDs produce identical canonical catalog listings', async () => {
     for (const resource of ['providers', 'endpoints', 'models'] as const) {
       const byId = output();
@@ -268,6 +308,7 @@ describe('runCatalogQuery', () => {
         requestedAgents.push(agentId);
         return catalog;
       },
+      async getPreambles() { return preambles; },
       async getSettings() { return settings; },
     };
 

--- a/cli/__tests__/chat-permission.test.ts
+++ b/cli/__tests__/chat-permission.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import type { PermissionDecisionCommandRequest } from '@garcon/common/chat-command-contracts';
-import type { PermissionDecisionCliCommand } from '../args.js';
+import type { PermissionAnswerCliCommand, PermissionDecisionCliCommand } from '../args.js';
 import {
   permissionDecisionClientRequestId,
+  runPermissionAnswer,
   runPermissionDecision,
 } from '../chat-permission.js';
 import type { CliOutput } from '../output.js';
@@ -17,6 +18,16 @@ const command: PermissionDecisionCliCommand = {
   serverInstanceId: 'instance-1',
   allow: true,
   json: false,
+};
+
+const answerCommand: PermissionAnswerCliCommand = {
+  ...command,
+  kind: 'permission-answer',
+  response: {
+    type: 'ask-user-question-response',
+    outcome: 'answered',
+    answers: [{ questionId: 'question-1', selectedOptionIds: ['option-1'] }],
+  },
 };
 
 function captureOutput(): CliOutput & { readonly results: string[] } {
@@ -84,5 +95,46 @@ describe('permission decision', () => {
       chatId: command.chatId,
       status: 'accepted',
     });
+  });
+
+  test('submits structured answers through the same occurrence-bound identity', async () => {
+    let request: PermissionDecisionCommandRequest | undefined;
+    const output = captureOutput();
+    await runPermissionAnswer(answerCommand, {
+      async decidePermission(value) {
+        request = value;
+        return {
+          success: true,
+          commandType: 'permission-decision',
+          clientRequestId: value.clientRequestId,
+          chatId: value.chatId,
+          status: 'duplicate',
+          acceptedAt: '2026-09-08T00:00:00.000Z',
+        };
+      },
+    }, output);
+
+    expect(request).toEqual({
+      clientRequestId: permissionDecisionClientRequestId(answerCommand),
+      chatId: answerCommand.chatId,
+      permissionOccurrenceId: 'permission-1',
+      allow: true,
+      alwaysAllow: false,
+      response: answerCommand.response,
+      control: {
+        serverInstanceId: 'instance-1',
+        chatId: answerCommand.chatId,
+        runId: 'run-1',
+        permissionOccurrenceId: 'permission-1',
+      },
+    });
+    expect(output.results).toEqual([
+      [
+        `chat id: ${answerCommand.chatId}`,
+        'permission occurrence: permission-1',
+        'answers: 1',
+        'status: duplicate',
+      ].join('\n'),
+    ]);
   });
 });

--- a/cli/__tests__/chat-permission.test.ts
+++ b/cli/__tests__/chat-permission.test.ts
@@ -6,6 +6,7 @@ import {
   runPermissionAnswer,
   runPermissionDecision,
 } from '../chat-permission.js';
+import { GarconHttpError } from '../garcon-client.js';
 import type { CliOutput } from '../output.js';
 
 const command: PermissionDecisionCliCommand = {
@@ -136,5 +137,22 @@ describe('permission decision', () => {
         'status: duplicate',
       ].join('\n'),
     ]);
+  });
+
+  test('maps a rejected structured answer to an invalid request', async () => {
+    await expect(runPermissionAnswer(answerCommand, {
+      async decidePermission() {
+        throw new GarconHttpError(
+          'submission',
+          'Structured answers contain an unknown option ID',
+          400,
+          'VALIDATION_FAILED',
+          false,
+        );
+      },
+    }, captureOutput())).rejects.toMatchObject({
+      phase: 'arguments',
+      exitCode: 2,
+    });
   });
 });

--- a/cli/__tests__/chat-search.test.ts
+++ b/cli/__tests__/chat-search.test.ts
@@ -327,7 +327,7 @@ describe('chat search', () => {
       },
     }, output)).rejects.toMatchObject({
       exitCode: 2,
-      message: expect.stringContaining('features.transcriptSearch.enabled'),
+      message: expect.stringContaining('garcon-cli transcript-search enable'),
     } satisfies Partial<CliError>);
   });
 

--- a/cli/__tests__/chat-search.test.ts
+++ b/cli/__tests__/chat-search.test.ts
@@ -314,7 +314,13 @@ describe('chat search', () => {
 
   test('maps disabled search to an actionable argument error', async () => {
     const output = { result() {}, diagnostic() {} } as CliOutput;
-    await expect(runChatSearch(command, {
+    const connectedCommand: SearchCliCommand = {
+      ...command,
+      workspace: "research'archive",
+      configDir: "/config/with space/it's",
+      serverUrl: 'https://garcon.example.test:8443',
+    };
+    await expect(runChatSearch(connectedCommand, {
       async listChats() { return chatList([]); },
       async searchChats() {
         throw new GarconHttpError(
@@ -327,7 +333,11 @@ describe('chat search', () => {
       },
     }, output)).rejects.toMatchObject({
       exitCode: 2,
-      message: expect.stringContaining('garcon-cli transcript-search enable'),
+      message: expect.stringContaining(
+        `garcon-cli --workspace 'research'"'"'archive' `
+          + `--config-dir '/config/with space/it'"'"'s' `
+          + `--server 'https://garcon.example.test:8443' transcript-search enable`,
+      ),
     } satisfies Partial<CliError>);
   });
 

--- a/cli/__tests__/chat-status.test.ts
+++ b/cli/__tests__/chat-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { ChatSnapshotResponse } from '@garcon/common/chat-snapshot';
 import {
   AssistantMessage,
+  AskUserQuestionToolUseMessage,
   BashToolUseMessage,
   CliRowMessage,
   ErrorMessage,
@@ -196,6 +197,46 @@ describe('chat status', () => {
       `permission-decision '${CHAT_ID}' '${permissionOccurrenceId}' allow --run 'run-1' --server-instance 'instance-1'`,
     );
     expect(value).not.toContain('transcript:');
+  });
+
+  test('renders a typed answer template for structured permission requests', () => {
+    const permissionOccurrenceId = 'permission-occurrence-1';
+    const value = formatChatStatus(snapshot({
+      transientFeed: {
+        serverInstanceId: 'instance-1',
+        chatId: CHAT_ID,
+        transcriptViewId: 'view-1',
+        transientRevision: 1,
+        rows: [{
+          permissionOccurrenceId,
+          runId: 'run-1',
+          transcript: { transcriptViewId: 'view-1', afterOrdinal: 2 },
+          displayOrder: 2,
+          message: new PermissionRequestMessage(
+            TIMESTAMP,
+            permissionOccurrenceId,
+            new AskUserQuestionToolUseMessage(TIMESTAMP, 'tool-1', 'Choose a mode', [{
+              id: 'question-1',
+              prompt: 'Which mode?',
+              options: [{ id: 'option-1', label: 'Fast' }],
+            }]),
+          ),
+        }],
+      },
+    }), command);
+
+    expect(value).toContain('"id": "question-1"');
+    expect(value).toContain('"id": "option-1"');
+    expect(value).toContain(
+      `permission-answer '${CHAT_ID}' '${permissionOccurrenceId}' --answers `
+        + `'[{"questionId":"QUESTION_ID","selectedOptionIds":["OPTION_ID"]}]' `
+        + `--run 'run-1' --server-instance 'instance-1'`,
+    );
+    expect(value).toContain(
+      `permission-decision '${CHAT_ID}' '${permissionOccurrenceId}' deny `
+        + `--run 'run-1' --server-instance 'instance-1'`,
+    );
+    expect(value).not.toContain('allow command:');
   });
 
   test('redacts images and data URLs while preserving unrelated data fields', () => {

--- a/cli/__tests__/garcon-client.test.ts
+++ b/cli/__tests__/garcon-client.test.ts
@@ -416,6 +416,38 @@ describe('GarconClient', () => {
     });
   });
 
+  test('rebuilds transcript search and strictly validates the returned status', async () => {
+    let requestedUrl = '';
+    let method = '';
+    const response = { success: true, status: validSearchStatus() };
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (input, init) => {
+        requestedUrl = String(input);
+        method = init?.method ?? '';
+        return Response.json(response);
+      },
+    });
+
+    await expect(client.rebuildTranscriptSearch()).resolves.toEqual(response);
+    expect(requestedUrl).toBe(`${connection.baseUrl}/api/v1/chats/search/rebuild`);
+    expect(method).toBe('POST');
+
+    for (const value of [
+      { ...response, success: false },
+      { ...response, status: { ...validSearchStatus(), phase: 'unknown' } },
+    ]) {
+      const malformed = new GarconClient({
+        ...connection,
+        fetch: async () => Response.json(value),
+      });
+      await expect(malformed.rebuildTranscriptSearch()).rejects.toMatchObject({
+        phase: 'chat search',
+        exitCode: 3,
+      });
+    }
+  });
+
   test('updates transcript search through the settings contract and verifies desired state', async () => {
     let requestedUrl = '';
     let submitted: unknown;

--- a/cli/__tests__/garcon-client.test.ts
+++ b/cli/__tests__/garcon-client.test.ts
@@ -7,6 +7,7 @@ import type {
   SteerCommandRequest,
 } from '@garcon/common/chat-command-contracts';
 import { runtimeProofPayload } from '@garcon/common/server-runtime';
+import { DEFAULT_REMOTE_FEATURE_SETTINGS } from '@garcon/common/settings';
 import { GarconClient, GarconHttpError, GarconTransportError } from '../garcon-client.js';
 
 const connection = {
@@ -190,6 +191,64 @@ function validSearch(): Record<string, unknown> {
   };
 }
 
+function validSearchStatus(): Record<string, unknown> {
+  return {
+    version: 1,
+    phase: 'ready',
+    chats: { total: 1, indexed: 1, pending: 0, failed: 0, unindexed: 0 },
+    queuedJobs: 0,
+    resync: null,
+    backlogRows: 0,
+    activeChat: null,
+    lastErrorCode: null,
+    updatedAt: '2026-09-08T00:00:00.000Z',
+    queryStats: {
+      served: 2,
+      timedOut: 0,
+      rejectedBusy: 0,
+      p50Ms: 10,
+      p95Ms: 20,
+      maxMs: 20,
+      admissionP50Ms: 1,
+      admissionP95Ms: 2,
+      admissionMaxMs: 2,
+      totalP50Ms: 11,
+      totalP95Ms: 22,
+      totalMaxMs: 22,
+    },
+  };
+}
+
+function validRemoteSettings(enabled: boolean): Record<string, unknown> {
+  return {
+    version: 2,
+    features: {
+      ...DEFAULT_REMOTE_FEATURE_SETTINGS,
+      transcriptSearch: { enabled },
+    },
+    ui: {},
+    uiEffective: {},
+    paths: { pinnedProjectPaths: [], browseStartPath: '', recentProjectPaths: [] },
+    pinnedChatIds: [],
+    recentAgentSettings: [],
+    executionDefaults: {
+      global: { permissionMode: 'default', thinkingMode: 'none', agentSettingsById: {} },
+      byAgent: {},
+    },
+    projectBasePath: '/project',
+    telegram: {
+      botTokenAvailable: false,
+      botUsername: null,
+      botFirstName: null,
+      recipientUsername: null,
+      recipientDisplayName: null,
+      recipientLinked: false,
+      pendingLink: false,
+      linkUrl: null,
+    },
+  };
+}
+
 describe('GarconClient', () => {
   test('fetches and validates the preamble catalog', async () => {
     const snapshot = {
@@ -329,6 +388,67 @@ describe('GarconClient', () => {
       exitCode: 2,
       errorCode: 'VALIDATION_FAILED',
     });
+  });
+
+  test('fetches and strictly validates transcript search status', async () => {
+    let requestedUrl = '';
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (input) => {
+        requestedUrl = String(input);
+        return Response.json(validSearchStatus());
+      },
+    });
+
+    await expect(client.getTranscriptSearchStatus()).resolves.toEqual(validSearchStatus());
+    expect(requestedUrl).toBe(`${connection.baseUrl}/api/v1/chats/search/status`);
+
+    const malformed = new GarconClient({
+      ...connection,
+      fetch: async () => Response.json({
+        ...validSearchStatus(),
+        queryStats: { ...(validSearchStatus().queryStats as object), served: '2' },
+      }),
+    });
+    await expect(malformed.getTranscriptSearchStatus()).rejects.toMatchObject({
+      phase: 'chat search',
+      exitCode: 3,
+    });
+  });
+
+  test('updates transcript search through the settings contract and verifies desired state', async () => {
+    let requestedUrl = '';
+    let submitted: unknown;
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (input, init) => {
+        requestedUrl = String(input);
+        submitted = JSON.parse(String(init?.body));
+        return Response.json({ success: true, settings: validRemoteSettings(true) });
+      },
+    });
+
+    await expect(client.setTranscriptSearchEnabled(true)).resolves.toMatchObject({
+      version: 2,
+      features: { transcriptSearch: { enabled: true } },
+    });
+    expect(requestedUrl).toBe(`${connection.baseUrl}/api/v1/app/settings`);
+    expect(submitted).toEqual({ features: { transcriptSearch: { enabled: true } } });
+
+    for (const value of [
+      { success: true, settings: validRemoteSettings(false) },
+      { success: false, settings: validRemoteSettings(true) },
+      { success: true, settings: { ...validRemoteSettings(true), features: {} } },
+    ]) {
+      const malformed = new GarconClient({
+        ...connection,
+        fetch: async () => Response.json(value),
+      });
+      await expect(malformed.setTranscriptSearchEnabled(true)).rejects.toMatchObject({
+        phase: 'chat search',
+        exitCode: 3,
+      });
+    }
   });
 
   test('fetches and validates a correlated transcript export', async () => {

--- a/cli/__tests__/garcon-client.test.ts
+++ b/cli/__tests__/garcon-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 import crypto from 'node:crypto';
 import type {
   AgentRunCommandRequest,
@@ -481,6 +481,54 @@ describe('GarconClient', () => {
         exitCode: 3,
       });
     }
+  });
+
+  test('leaves transcript search maintenance unbounded', async () => {
+    const timeout = spyOn(AbortSignal, 'timeout');
+    const signals: (AbortSignal | null | undefined)[] = [];
+    const responses = [
+      { success: true, status: validSearchStatus() },
+      { success: true, settings: validRemoteSettings(true) },
+    ];
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (_input, init) => {
+        signals.push(init?.signal);
+        await Promise.resolve();
+        return Response.json(responses.shift());
+      },
+    });
+
+    try {
+      await client.rebuildTranscriptSearch();
+      await client.setTranscriptSearchEnabled(true);
+
+      expect(timeout).not.toHaveBeenCalled();
+      expect(signals).toEqual([undefined, undefined]);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
+
+  test('preserves caller cancellation for transcript search maintenance', async () => {
+    const controller = new AbortController();
+    const reason = new Error('maintenance cancelled');
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (_input, init) => {
+        const signal = init?.signal;
+        expect(signal).toBe(controller.signal);
+        return await new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      },
+    });
+
+    const request = client.rebuildTranscriptSearch(controller.signal);
+    await Promise.resolve();
+    controller.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
   });
 
   test('fetches and validates a correlated transcript export', async () => {

--- a/cli/__tests__/garcon-client.test.ts
+++ b/cli/__tests__/garcon-client.test.ts
@@ -191,6 +191,43 @@ function validSearch(): Record<string, unknown> {
 }
 
 describe('GarconClient', () => {
+  test('fetches and validates the preamble catalog', async () => {
+    const snapshot = {
+      revision: 1,
+      preambles: [{
+        id: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+        enabled: true,
+        title: 'Repository guidance',
+        content: 'Follow the repository guidance.',
+        scope: { type: 'global' },
+        agentIds: [],
+        tagFilter: { mode: 'all', tags: [] },
+        createdAt: '2026-09-08T00:00:00.000Z',
+        updatedAt: '2026-09-08T00:00:00.000Z',
+      }],
+    };
+    let requestedUrl = '';
+    const client = new GarconClient({
+      ...connection,
+      fetch: async (input) => {
+        requestedUrl = String(input);
+        return Response.json(snapshot);
+      },
+    });
+
+    await expect(client.getPreambles()).resolves.toEqual(snapshot);
+    expect(requestedUrl).toBe(`${connection.baseUrl}/api/v1/preambles`);
+
+    const malformed = new GarconClient({
+      ...connection,
+      fetch: async () => Response.json({ ...snapshot, revision: -1 }),
+    });
+    await expect(malformed.getPreambles()).rejects.toMatchObject({
+      phase: 'catalog resolution',
+      exitCode: 3,
+    });
+  });
+
   test('fetches and strictly validates the complete chat catalog', async () => {
     let requestedUrl = '';
     const client = new GarconClient({

--- a/cli/__tests__/main.test.ts
+++ b/cli/__tests__/main.test.ts
@@ -241,7 +241,7 @@ function transcriptSearchStatusResponse(): Record<string, unknown> {
 }
 
 describe('main', () => {
-  test('routes transcript search administration through typed settings and status endpoints', async () => {
+  test('routes transcript search administration through typed settings and search endpoints', async () => {
     const requests: Array<{ url: string; method: string; body: unknown }> = [];
     const enableCapture = capturedOutput();
     const enableExit = await main(['transcript-search', 'enable', '--json'], {
@@ -280,6 +280,27 @@ describe('main', () => {
       body: undefined,
     });
     expect(JSON.parse(statusCapture.results[0]!)).toEqual(transcriptSearchStatusResponse());
+
+    const rebuildCapture = capturedOutput();
+    const rebuildResponse = {
+      success: true,
+      status: transcriptSearchStatusResponse(),
+    };
+    const rebuildExit = await main(['transcript-search', 'rebuild', '--json'], {
+      discoverRuntime: stubDiscovery,
+      output: rebuildCapture.output,
+      fetch: async (input, init) => {
+        requests.push({ url: String(input), method: init?.method ?? 'GET', body: undefined });
+        return Response.json(rebuildResponse);
+      },
+    });
+    expect(rebuildExit).toBe(0);
+    expect(requests[2]).toEqual({
+      url: 'http://127.0.0.1:8080/api/v1/chats/search/rebuild',
+      method: 'POST',
+      body: undefined,
+    });
+    expect(JSON.parse(rebuildCapture.results[0]!)).toEqual(rebuildResponse);
   });
 
   test('prints only the native session lookup chat ID', async () => {

--- a/cli/__tests__/main.test.ts
+++ b/cli/__tests__/main.test.ts
@@ -178,11 +178,11 @@ function startModelCatalogResponse(): Response {
   });
 }
 
-function remoteSettingsResponse(): Response {
-  return Response.json({
+function remoteSettingsSnapshot(transcriptSearchEnabled = false): Record<string, unknown> {
+  return {
     version: 1,
     features: {
-      transcriptSearch: { enabled: false },
+      transcriptSearch: { enabled: transcriptSearchEnabled },
       agentCommands: { enabled: true, chatIdDiscovery: true, sendMessage: true },
     },
     ui: {},
@@ -205,10 +205,83 @@ function remoteSettingsResponse(): Response {
       pendingLink: false,
       linkUrl: null,
     },
-  });
+  };
+}
+
+function remoteSettingsResponse(): Response {
+  return Response.json(remoteSettingsSnapshot());
+}
+
+function transcriptSearchStatusResponse(): Record<string, unknown> {
+  return {
+    version: 1,
+    phase: 'ready',
+    chats: { total: 1, indexed: 1, pending: 0, failed: 0, unindexed: 0 },
+    queuedJobs: 0,
+    resync: null,
+    backlogRows: 0,
+    activeChat: null,
+    lastErrorCode: null,
+    updatedAt: '2026-09-08T00:00:00.000Z',
+    queryStats: {
+      served: 2,
+      timedOut: 0,
+      rejectedBusy: 0,
+      p50Ms: 10,
+      p95Ms: 20,
+      maxMs: 20,
+      admissionP50Ms: 1,
+      admissionP95Ms: 2,
+      admissionMaxMs: 2,
+      totalP50Ms: 11,
+      totalP95Ms: 22,
+      totalMaxMs: 22,
+    },
+  };
 }
 
 describe('main', () => {
+  test('routes transcript search administration through typed settings and status endpoints', async () => {
+    const requests: Array<{ url: string; method: string; body: unknown }> = [];
+    const enableCapture = capturedOutput();
+    const enableExit = await main(['transcript-search', 'enable', '--json'], {
+      discoverRuntime: stubDiscovery,
+      output: enableCapture.output,
+      fetch: async (input, init) => {
+        requests.push({
+          url: String(input),
+          method: init?.method ?? 'GET',
+          body: init?.body === undefined ? undefined : JSON.parse(String(init.body)),
+        });
+        return Response.json({ success: true, settings: remoteSettingsSnapshot(true) });
+      },
+    });
+    expect(enableExit).toBe(0);
+    expect(requests[0]).toEqual({
+      url: 'http://127.0.0.1:8080/api/v1/app/settings',
+      method: 'PUT',
+      body: { features: { transcriptSearch: { enabled: true } } },
+    });
+    expect(JSON.parse(enableCapture.results[0]!)).toEqual({ enabled: true, settingsVersion: 1 });
+
+    const statusCapture = capturedOutput();
+    const statusExit = await main(['transcript-search', 'status', '--json'], {
+      discoverRuntime: stubDiscovery,
+      output: statusCapture.output,
+      fetch: async (input, init) => {
+        requests.push({ url: String(input), method: init?.method ?? 'GET', body: undefined });
+        return Response.json(transcriptSearchStatusResponse());
+      },
+    });
+    expect(statusExit).toBe(0);
+    expect(requests[1]).toEqual({
+      url: 'http://127.0.0.1:8080/api/v1/chats/search/status',
+      method: 'GET',
+      body: undefined,
+    });
+    expect(JSON.parse(statusCapture.results[0]!)).toEqual(transcriptSearchStatusResponse());
+  });
+
   test('prints only the native session lookup chat ID', async () => {
     const capture = capturedStreams();
     let submitted: unknown;

--- a/cli/__tests__/transcript-search.test.ts
+++ b/cli/__tests__/transcript-search.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'bun:test';
+import type { TranscriptSearchStatusResponse } from '@garcon/common/chat-search';
+import {
+  DEFAULT_REMOTE_FEATURE_SETTINGS,
+  type RemoteSettingsSnapshot,
+} from '@garcon/common/settings';
+import type { TranscriptSearchCliCommand } from '../args.js';
+import type { CliOutput } from '../output.js';
+import {
+  formatTranscriptSearchStatus,
+  runTranscriptSearchAdministration,
+  type TranscriptSearchAdministrationClient,
+} from '../transcript-search.js';
+
+const status = {
+  version: 1,
+  phase: 'rebuilding',
+  chats: { total: 5, indexed: 2, pending: 1, failed: 1, unindexed: 1 },
+  queuedJobs: 2,
+  resync: { completedChats: 3, totalChats: 5 },
+  backlogRows: 7,
+  activeChat: { position: 4, total: 8 },
+  lastErrorCode: 'SEARCH_READER_RESTARTED',
+  updatedAt: '2026-09-08T00:00:00.000Z',
+  queryStats: {
+    served: 20,
+    timedOut: 2,
+    rejectedBusy: 1,
+    p50Ms: 12,
+    p95Ms: 40,
+    maxMs: 80,
+    admissionP50Ms: 1,
+    admissionP95Ms: 3,
+    admissionMaxMs: 5,
+    totalP50Ms: 13,
+    totalP95Ms: 43,
+    totalMaxMs: 85,
+  },
+} satisfies TranscriptSearchStatusResponse;
+
+function settings(enabled: boolean): RemoteSettingsSnapshot {
+  return {
+    version: 4,
+    features: {
+      ...DEFAULT_REMOTE_FEATURE_SETTINGS,
+      transcriptSearch: { enabled },
+    },
+    ui: {},
+    uiEffective: {},
+    paths: { pinnedProjectPaths: [], browseStartPath: '', recentProjectPaths: [] },
+    pinnedChatIds: [],
+    recentAgentSettings: [],
+    executionDefaults: {
+      global: { permissionMode: 'default', thinkingMode: 'none', agentSettingsById: {} },
+      byAgent: {},
+    },
+    projectBasePath: '/project',
+    telegram: {
+      botTokenAvailable: false,
+      botUsername: null,
+      botFirstName: null,
+      recipientUsername: null,
+      recipientDisplayName: null,
+      recipientLinked: false,
+      pendingLink: false,
+      linkUrl: null,
+    },
+  };
+}
+
+function command(
+  action: TranscriptSearchCliCommand['action'],
+  json = false,
+): TranscriptSearchCliCommand {
+  return {
+    kind: 'transcript-search',
+    workspace: 'default',
+    configDir: '/config',
+    action,
+    json,
+  };
+}
+
+function captureOutput(): CliOutput & { readonly results: string[] } {
+  const results: string[] = [];
+  return {
+    results,
+    accepted() {},
+    completed() {},
+    diagnostic() {},
+    result(value) { results.push(value); },
+    sent() {},
+    stopped() {},
+  };
+}
+
+describe('transcript search administration', () => {
+  test('formats complete operational status', () => {
+    expect(formatTranscriptSearchStatus(status)).toBe([
+      'transcript search: rebuilding',
+      'updated at: 2026-09-08T00:00:00.000Z',
+      'chats total: 5',
+      'chats indexed: 2',
+      'chats pending: 1',
+      'chats failed: 1',
+      'chats unindexed: 1',
+      'queued jobs: 2',
+      'backlog rows: 7',
+      'resync: 3/5',
+      'active chat: 4/8',
+      'last error: SEARCH_READER_RESTARTED',
+      'queries served: 20',
+      'queries timed out: 2',
+      'queries rejected busy: 1',
+      'execution latency ms: p50 12, p95 40, max 80',
+      'admission latency ms: p50 1, p95 3, max 5',
+      'total latency ms: p50 13, p95 43, max 85',
+    ].join('\n'));
+  });
+
+  test('emits the validated status as one JSON document', async () => {
+    const output = captureOutput();
+    const client = {
+      async getTranscriptSearchStatus() { return status; },
+      async setTranscriptSearchEnabled() { throw new Error('must not update settings'); },
+    } satisfies TranscriptSearchAdministrationClient;
+
+    await runTranscriptSearchAdministration(command('status', true), client, output);
+
+    expect(output.results).toEqual([JSON.stringify(status, null, 2)]);
+  });
+
+  test('sets explicit desired state and reports the authoritative settings version', async () => {
+    const enabledValues: boolean[] = [];
+    const client = {
+      async getTranscriptSearchStatus() { throw new Error('must not fetch status'); },
+      async setTranscriptSearchEnabled(enabled: boolean) {
+        enabledValues.push(enabled);
+        return settings(enabled);
+      },
+    } satisfies TranscriptSearchAdministrationClient;
+    const output = captureOutput();
+
+    await runTranscriptSearchAdministration(command('enable'), client, output);
+    await runTranscriptSearchAdministration(command('disable', true), client, output);
+
+    expect(enabledValues).toEqual([true, false]);
+    expect(output.results).toEqual([
+      'transcript search: enabled\nsettings version: 4',
+      JSON.stringify({ enabled: false, settingsVersion: 4 }, null, 2),
+    ]);
+  });
+});

--- a/cli/__tests__/transcript-search.test.ts
+++ b/cli/__tests__/transcript-search.test.ts
@@ -122,6 +122,7 @@ describe('transcript search administration', () => {
     const output = captureOutput();
     const client = {
       async getTranscriptSearchStatus() { return status; },
+      async rebuildTranscriptSearch() { throw new Error('must not rebuild'); },
       async setTranscriptSearchEnabled() { throw new Error('must not update settings'); },
     } satisfies TranscriptSearchAdministrationClient;
 
@@ -134,6 +135,7 @@ describe('transcript search administration', () => {
     const enabledValues: boolean[] = [];
     const client = {
       async getTranscriptSearchStatus() { throw new Error('must not fetch status'); },
+      async rebuildTranscriptSearch() { throw new Error('must not rebuild'); },
       async setTranscriptSearchEnabled(enabled: boolean) {
         enabledValues.push(enabled);
         return settings(enabled);
@@ -148,6 +150,21 @@ describe('transcript search administration', () => {
     expect(output.results).toEqual([
       'transcript search: enabled\nsettings version: 4',
       JSON.stringify({ enabled: false, settingsVersion: 4 }, null, 2),
+    ]);
+  });
+
+  test('starts a rebuild and reports its immediate authoritative status', async () => {
+    const output = captureOutput();
+    const client = {
+      async getTranscriptSearchStatus() { throw new Error('must not fetch status'); },
+      async rebuildTranscriptSearch() { return { success: true as const, status }; },
+      async setTranscriptSearchEnabled() { throw new Error('must not update settings'); },
+    } satisfies TranscriptSearchAdministrationClient;
+
+    await runTranscriptSearchAdministration(command('rebuild', true), client, output);
+
+    expect(output.results).toEqual([
+      JSON.stringify({ success: true, status }, null, 2),
     ]);
   });
 });

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -119,6 +119,7 @@ Reload and provider-native fork segments may drop Garcon-only presentation.
 
 List resources:
   agents
+  preambles                 Lists IDs, titles, enabled state, and scope
   providers                 Optionally filter with --agent or --provider
   endpoints                 Requires --provider; optionally filter with --agent or --endpoint
   models                    Requires --agent; optionally filter with --provider and --endpoint
@@ -246,6 +247,7 @@ export type CliInvocation = StartCliInvocation | ResumeCliInvocation;
 
 export const LIST_RESOURCE_VALUES = [
   'agents',
+  'preambles',
   'providers',
   'endpoints',
   'models',
@@ -1415,6 +1417,15 @@ export function parseCliArgs(
       if (agentId !== undefined) throw argumentError('--agent cannot be used with list agents');
       if (providerId !== undefined) throw argumentError('--provider cannot be used with list agents');
       if (endpointId !== undefined) throw argumentError('--endpoint cannot be used with list agents');
+    }
+    if (resource === 'preambles') {
+      if (agentId !== undefined) throw argumentError('--agent cannot be used with list preambles');
+      if (providerId !== undefined) {
+        throw argumentError('--provider cannot be used with list preambles');
+      }
+      if (endpointId !== undefined) {
+        throw argumentError('--endpoint cannot be used with list preambles');
+      }
     }
     if (resource === 'providers' && endpointId !== undefined) {
       throw argumentError('--endpoint cannot be used with list providers');

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -24,7 +24,11 @@ import {
   type CliPresentation,
   type CliRowFormat,
 } from '@garcon/common/cli-presentation';
-import { isCommandCorrelationIdWithinLimit } from '@garcon/common/chat-command-contracts';
+import {
+  isCommandCorrelationIdWithinLimit,
+  normalizeAskUserQuestionDecisionResponse,
+  type AskUserQuestionAnsweredResponse,
+} from '@garcon/common/chat-command-contracts';
 import {
   isPreambleId,
   PREAMBLE_MAX_COUNT,
@@ -85,6 +89,7 @@ export const CLI_HELP = `Usage:
   garcon-cli [options] list <resource>
   garcon-cli [options] stop <chat-id> [--json]
   garcon-cli [connection options] permission-decision <chat-id> <occurrence-id> <allow|deny> --run <run-id> --server-instance <instance-id> [--json]
+  garcon-cli [connection options] permission-answer <chat-id> <occurrence-id> --answers <json> --run <run-id> --server-instance <instance-id> [--json]
   garcon-cli [connection options] archive|unarchive|pin|unpin <chat-id> [--json]
   garcon-cli [connection options] rename <chat-id> <title> [--json]
   garcon-cli [connection options] set-tags <chat-id> (--tag <tag>... | --clear) [--json]
@@ -161,6 +166,7 @@ Options:
   --allow-steer                With resume-async, steer the active turn when busy; never queues
   --run <run-id>               Exact permission request run fence
   --server-instance <id>       Exact permission request server-instance fence
+  --answers <json>             Structured question answers as typed JSON rows
   --clear                      Replace the complete tag set with no tags
   --messages <count>           Status transcript entries, 0-${CHAT_SNAPSHOT_MAX_MESSAGE_LIMIT} (default: ${CHAT_SNAPSHOT_DEFAULT_MESSAGE_LIMIT})
   --turn <turn-id>             Exact accepted turn to wait for
@@ -292,6 +298,16 @@ export interface PermissionDecisionCliCommand extends CliConnectionOptions {
   readonly json: boolean;
 }
 
+export interface PermissionAnswerCliCommand extends CliConnectionOptions {
+  readonly kind: 'permission-answer';
+  readonly chatId: ChatId;
+  readonly permissionOccurrenceId: string;
+  readonly runId: string;
+  readonly serverInstanceId: string;
+  readonly response: AskUserQuestionAnsweredResponse;
+  readonly json: boolean;
+}
+
 export type ChatOrderMutationKind = 'archive' | 'unarchive' | 'pin' | 'unpin';
 
 export type ChatOrderMutationCliCommand = {
@@ -401,6 +417,7 @@ export type ParsedCliCommand =
   | ResumeAsyncCliCommand
   | StopCliCommand
   | PermissionDecisionCliCommand
+  | PermissionAnswerCliCommand
   | ChatOrderMutationCliCommand
   | RenameCliCommand
   | SetTagsCliCommand
@@ -448,6 +465,7 @@ const SINGLE_STRING_OPTIONS = [
   'transcript-view-id',
   'run',
   'server-instance',
+  'answers',
 ] as const;
 
 type ParsedOptionValue = boolean | string | string[] | undefined;
@@ -574,6 +592,7 @@ type ControlCommandKind =
   | 'add-row'
   | 'read'
   | 'permission-decision'
+  | 'permission-answer'
   | ChatOrderMutationKind
   | 'rename'
   | 'set-tags';
@@ -606,6 +625,7 @@ const RESUME_ASYNC_OPTIONS = optionSet(
 );
 const STOP_OPTIONS = optionSet('json');
 const PERMISSION_DECISION_OPTIONS = optionSet('run', 'server-instance', 'json');
+const PERMISSION_ANSWER_OPTIONS = optionSet('run', 'server-instance', 'answers', 'json');
 const CHAT_ORDER_MUTATION_OPTIONS = optionSet('json');
 const RENAME_OPTIONS = optionSet('json');
 const SET_TAGS_OPTIONS = optionSet('tag', 'clear', 'json');
@@ -751,6 +771,50 @@ function parsePermissionDecision(
     runId: parseOpaqueControlId(values.run, '--run'),
     serverInstanceId: parseOpaqueControlId(values['server-instance'], '--server-instance'),
     allow: decision === 'allow',
+    json: values.json === true,
+  };
+}
+
+function parsePermissionAnswer(
+  parsed: ReturnType<typeof parseArgs>,
+  values: Record<string, ParsedOptionValue>,
+  connection: CliConnectionOptions,
+): PermissionAnswerCliCommand {
+  rejectOptionsExcept(values, PERMISSION_ANSWER_OPTIONS, 'permission-answer');
+  if (parsed.positionals.length !== 3) {
+    throw argumentError('permission-answer requires a chat ID and permission occurrence ID');
+  }
+  const rawAnswers = values.answers;
+  if (typeof rawAnswers !== 'string') {
+    throw argumentError('permission-answer requires --answers with a JSON array');
+  }
+  let answers: unknown;
+  try {
+    answers = JSON.parse(rawAnswers);
+  } catch (error) {
+    throw argumentError('--answers must be valid JSON', { cause: error });
+  }
+  const response = normalizeAskUserQuestionDecisionResponse({
+    type: 'ask-user-question-response',
+    outcome: 'answered',
+    answers,
+  });
+  if (!response || response.outcome !== 'answered') {
+    throw argumentError(
+      '--answers must be a bounded array of unique question IDs and selected option IDs',
+    );
+  }
+  return {
+    kind: 'permission-answer',
+    ...connection,
+    chatId: parseControlChatId(parsed.positionals[1]!, 'permission-answer'),
+    permissionOccurrenceId: parseOpaqueControlId(
+      parsed.positionals[2],
+      'permission occurrence ID',
+    ),
+    runId: parseOpaqueControlId(values.run, '--run'),
+    serverInstanceId: parseOpaqueControlId(values['server-instance'], '--server-instance'),
+    response,
     json: values.json === true,
   };
 }
@@ -1313,6 +1377,7 @@ export function parseCliArgs(
         'transcript-view-id': { type: 'string' },
         run: { type: 'string' },
         'server-instance': { type: 'string' },
+        answers: { type: 'string' },
         force: { type: 'boolean' },
         'allow-steer': { type: 'boolean' },
         'no-preamble': { type: 'boolean' },
@@ -1381,6 +1446,9 @@ export function parseCliArgs(
   if (commandName === 'stop') return parseStop(parsed, values, connection);
   if (commandName === 'permission-decision') {
     return parsePermissionDecision(parsed, values, connection);
+  }
+  if (commandName === 'permission-answer') {
+    return parsePermissionAnswer(parsed, values, connection);
   }
   if (
     commandName === 'archive'

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -97,7 +97,7 @@ export const CLI_HELP = `Usage:
   garcon-cli [connection options] status <chat-id> [--messages <count>] [--json]
   garcon-cli [connection options] chats [--filter <expression>] [--limit <count>] [--offset <count>] [--json]
   garcon-cli [connection options] search <query> [--filter <expression>] [--sort <relevance|activity|created>] [--limit <count>] [--offset <count>] [--snippets <count>] [--json]
-  garcon-cli [connection options] transcript-search <enable|disable|status> [--json]
+  garcon-cli [connection options] transcript-search <enable|disable|rebuild|status> [--json]
   garcon-cli [connection options] read <chat-id> <ordinal> [-B <count>] [-A <count>] [--include <category>]... [--transcript-view-id <id>] [--json]
   garcon-cli [connection options] wait <chat-id> --turn <turn-id> [--json]
   garcon-cli [connection options] export <chat-id> [--format <markdown|xml>] [--exclude <category>]... [--output <path>] [--force]
@@ -311,7 +311,7 @@ export interface PermissionAnswerCliCommand extends CliConnectionOptions {
 
 export interface TranscriptSearchCliCommand extends CliConnectionOptions {
   readonly kind: 'transcript-search';
-  readonly action: 'enable' | 'disable' | 'status';
+  readonly action: 'enable' | 'disable' | 'rebuild' | 'status';
   readonly json: boolean;
 }
 
@@ -837,9 +837,16 @@ function parseTranscriptSearch(
   const action = parsed.positionals[1];
   if (
     parsed.positionals.length !== 2
-    || (action !== 'enable' && action !== 'disable' && action !== 'status')
+    || (
+      action !== 'enable'
+      && action !== 'disable'
+      && action !== 'rebuild'
+      && action !== 'status'
+    )
   ) {
-    throw argumentError('transcript-search requires one action: enable, disable, or status');
+    throw argumentError(
+      'transcript-search requires one action: enable, disable, rebuild, or status',
+    );
   }
   return {
     kind: 'transcript-search',

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -309,9 +309,12 @@ export interface PermissionAnswerCliCommand extends CliConnectionOptions {
   readonly json: boolean;
 }
 
+const TRANSCRIPT_SEARCH_ACTIONS = ['enable', 'disable', 'rebuild', 'status'] as const;
+type TranscriptSearchAction = (typeof TRANSCRIPT_SEARCH_ACTIONS)[number];
+
 export interface TranscriptSearchCliCommand extends CliConnectionOptions {
   readonly kind: 'transcript-search';
-  readonly action: 'enable' | 'disable' | 'rebuild' | 'status';
+  readonly action: TranscriptSearchAction;
   readonly json: boolean;
 }
 
@@ -835,15 +838,7 @@ function parseTranscriptSearch(
 ): TranscriptSearchCliCommand {
   rejectOptionsExcept(values, TRANSCRIPT_SEARCH_OPTIONS, 'transcript-search');
   const action = parsed.positionals[1];
-  if (
-    parsed.positionals.length !== 2
-    || (
-      action !== 'enable'
-      && action !== 'disable'
-      && action !== 'rebuild'
-      && action !== 'status'
-    )
-  ) {
+  if (parsed.positionals.length !== 2 || !isTranscriptSearchAction(action)) {
     throw argumentError(
       'transcript-search requires one action: enable, disable, rebuild, or status',
     );
@@ -854,6 +849,11 @@ function parseTranscriptSearch(
     action,
     json: values.json === true,
   };
+}
+
+function isTranscriptSearchAction(value: unknown): value is TranscriptSearchAction {
+  return typeof value === 'string'
+    && TRANSCRIPT_SEARCH_ACTIONS.includes(value as TranscriptSearchAction);
 }
 
 function parseChatOrderMutation(
@@ -1521,18 +1521,15 @@ export function parseCliArgs(
     if (endpointId !== undefined && providerId === undefined) {
       throw argumentError('--endpoint requires --provider');
     }
-    if (resource === 'agents') {
-      if (agentId !== undefined) throw argumentError('--agent cannot be used with list agents');
-      if (providerId !== undefined) throw argumentError('--provider cannot be used with list agents');
-      if (endpointId !== undefined) throw argumentError('--endpoint cannot be used with list agents');
-    }
-    if (resource === 'preambles') {
-      if (agentId !== undefined) throw argumentError('--agent cannot be used with list preambles');
+    if (resource === 'agents' || resource === 'preambles') {
+      if (agentId !== undefined) {
+        throw argumentError(`--agent cannot be used with list ${resource}`);
+      }
       if (providerId !== undefined) {
-        throw argumentError('--provider cannot be used with list preambles');
+        throw argumentError(`--provider cannot be used with list ${resource}`);
       }
       if (endpointId !== undefined) {
-        throw argumentError('--endpoint cannot be used with list preambles');
+        throw argumentError(`--endpoint cannot be used with list ${resource}`);
       }
     }
     if (resource === 'providers' && endpointId !== undefined) {

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -25,7 +25,11 @@ import {
   type CliRowFormat,
 } from '@garcon/common/cli-presentation';
 import { isCommandCorrelationIdWithinLimit } from '@garcon/common/chat-command-contracts';
-import { isPreambleId, type PreambleId } from '@garcon/common/preambles';
+import {
+  isPreambleId,
+  PREAMBLE_MAX_COUNT,
+  type PreambleId,
+} from '@garcon/common/preambles';
 import type { UserMessagePresentation } from '@garcon/common/chat-types';
 import {
   CHAT_SNAPSHOT_DEFAULT_MESSAGE_LIMIT,
@@ -820,6 +824,9 @@ function parsePreambleSelection(
   }
   if (noPreamble) return [];
   if (rawIds === undefined) return undefined;
+  if (rawIds.length > PREAMBLE_MAX_COUNT) {
+    throw argumentError(`--preamble may be specified at most ${PREAMBLE_MAX_COUNT} times`);
+  }
   const ids: PreambleId[] = [];
   const seen = new Set<string>();
   for (const rawId of rawIds) {

--- a/cli/args.ts
+++ b/cli/args.ts
@@ -97,6 +97,7 @@ export const CLI_HELP = `Usage:
   garcon-cli [connection options] status <chat-id> [--messages <count>] [--json]
   garcon-cli [connection options] chats [--filter <expression>] [--limit <count>] [--offset <count>] [--json]
   garcon-cli [connection options] search <query> [--filter <expression>] [--sort <relevance|activity|created>] [--limit <count>] [--offset <count>] [--snippets <count>] [--json]
+  garcon-cli [connection options] transcript-search <enable|disable|status> [--json]
   garcon-cli [connection options] read <chat-id> <ordinal> [-B <count>] [-A <count>] [--include <category>]... [--transcript-view-id <id>] [--json]
   garcon-cli [connection options] wait <chat-id> --turn <turn-id> [--json]
   garcon-cli [connection options] export <chat-id> [--format <markdown|xml>] [--exclude <category>]... [--output <path>] [--force]
@@ -308,6 +309,12 @@ export interface PermissionAnswerCliCommand extends CliConnectionOptions {
   readonly json: boolean;
 }
 
+export interface TranscriptSearchCliCommand extends CliConnectionOptions {
+  readonly kind: 'transcript-search';
+  readonly action: 'enable' | 'disable' | 'status';
+  readonly json: boolean;
+}
+
 export type ChatOrderMutationKind = 'archive' | 'unarchive' | 'pin' | 'unpin';
 
 export type ChatOrderMutationCliCommand = {
@@ -418,6 +425,7 @@ export type ParsedCliCommand =
   | StopCliCommand
   | PermissionDecisionCliCommand
   | PermissionAnswerCliCommand
+  | TranscriptSearchCliCommand
   | ChatOrderMutationCliCommand
   | RenameCliCommand
   | SetTagsCliCommand
@@ -626,6 +634,7 @@ const RESUME_ASYNC_OPTIONS = optionSet(
 const STOP_OPTIONS = optionSet('json');
 const PERMISSION_DECISION_OPTIONS = optionSet('run', 'server-instance', 'json');
 const PERMISSION_ANSWER_OPTIONS = optionSet('run', 'server-instance', 'answers', 'json');
+const TRANSCRIPT_SEARCH_OPTIONS = optionSet('json');
 const CHAT_ORDER_MUTATION_OPTIONS = optionSet('json');
 const RENAME_OPTIONS = optionSet('json');
 const SET_TAGS_OPTIONS = optionSet('tag', 'clear', 'json');
@@ -815,6 +824,27 @@ function parsePermissionAnswer(
     runId: parseOpaqueControlId(values.run, '--run'),
     serverInstanceId: parseOpaqueControlId(values['server-instance'], '--server-instance'),
     response,
+    json: values.json === true,
+  };
+}
+
+function parseTranscriptSearch(
+  parsed: ReturnType<typeof parseArgs>,
+  values: Record<string, ParsedOptionValue>,
+  connection: CliConnectionOptions,
+): TranscriptSearchCliCommand {
+  rejectOptionsExcept(values, TRANSCRIPT_SEARCH_OPTIONS, 'transcript-search');
+  const action = parsed.positionals[1];
+  if (
+    parsed.positionals.length !== 2
+    || (action !== 'enable' && action !== 'disable' && action !== 'status')
+  ) {
+    throw argumentError('transcript-search requires one action: enable, disable, or status');
+  }
+  return {
+    kind: 'transcript-search',
+    ...connection,
+    action,
     json: values.json === true,
   };
 }
@@ -1449,6 +1479,9 @@ export function parseCliArgs(
   }
   if (commandName === 'permission-answer') {
     return parsePermissionAnswer(parsed, values, connection);
+  }
+  if (commandName === 'transcript-search') {
+    return parseTranscriptSearch(parsed, values, connection);
   }
   if (
     commandName === 'archive'

--- a/cli/catalog-output.ts
+++ b/cli/catalog-output.ts
@@ -1,4 +1,5 @@
 import type { ApiProtocol } from '@garcon/common/api-providers';
+import type { Preamble } from '@garcon/common/preambles';
 import { formatTextTable } from './text-table.js';
 
 export type CatalogQueryResult =
@@ -14,6 +15,11 @@ export type CatalogQueryResult =
         permissions: string[];
         reasoningEfforts: string[];
       }>;
+    }
+  | {
+      resource: 'preambles';
+      revision: number;
+      preambles: readonly Preamble[];
     }
   | {
       resource: 'providers';
@@ -61,12 +67,29 @@ export type CatalogQueryResult =
       reasoningEfforts: string[];
     };
 
+function preambleScopeLabel(preamble: Preamble): string {
+  if (preamble.scope.type === 'global') return 'global';
+  return preamble.scope.rules
+    .map((rule) => `${rule.projectPath}${rule.includeNested ? '/**' : ''}`)
+    .join(', ');
+}
+
 function humanListing(result: CatalogQueryResult): string {
   switch (result.resource) {
     case 'agents':
       return formatTextTable(
         ['AGENT', 'LABEL', 'DEFAULT MODEL'],
         result.agents.map((agent) => [agent.id, agent.label, agent.defaultModel]),
+      );
+    case 'preambles':
+      return formatTextTable(
+        ['ID', 'TITLE', 'ENABLED', 'SCOPE'],
+        result.preambles.map((preamble) => [
+          preamble.id,
+          preamble.title,
+          preamble.enabled ? 'yes' : 'no',
+          preambleScopeLabel(preamble),
+        ]),
       );
     case 'providers':
       return formatTextTable(

--- a/cli/catalog-query.ts
+++ b/cli/catalog-query.ts
@@ -10,6 +10,7 @@ import {
   normalizeSupportedThinkingMode,
 } from '@garcon/common/execution-defaults';
 import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
+import type { PreamblesSnapshot } from '@garcon/common/preambles';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
 import type { ListCliCommand } from './args.js';
 import {
@@ -27,6 +28,7 @@ import type { CliOutput } from './output.js';
 
 export interface CatalogQueryClient {
   getModelCatalog(agentId?: string, signal?: AbortSignal): Promise<ModelCatalogResponse>;
+  getPreambles(signal?: AbortSignal): Promise<PreamblesSnapshot>;
   getSettings(signal?: AbortSignal): Promise<RemoteSettingsSnapshot>;
 }
 
@@ -295,6 +297,14 @@ export async function runCatalogQuery(
   output: CliOutput,
   signal?: AbortSignal,
 ): Promise<void> {
+  if (command.resource === 'preambles') {
+    const snapshot = await client.getPreambles(signal);
+    output.result(formatCatalogQueryResult({
+      resource: 'preambles',
+      ...snapshot,
+    }, command.json));
+    return;
+  }
   const needsSettings = command.resource === 'permissions'
     || command.resource === 'reasoning-efforts';
   const [catalog, settings] = await Promise.all([

--- a/cli/chat-permission.ts
+++ b/cli/chat-permission.ts
@@ -3,7 +3,10 @@ import type {
   CommandAcceptedResponse,
   PermissionDecisionCommandRequest,
 } from '@garcon/common/chat-command-contracts';
-import type { PermissionDecisionCliCommand } from './args.js';
+import type {
+  PermissionAnswerCliCommand,
+  PermissionDecisionCliCommand,
+} from './args.js';
 import type { CliOutput } from './output.js';
 
 export interface PermissionDecisionClient {
@@ -53,6 +56,36 @@ export async function runPermissionDecision(
       `chat id: ${response.chatId}`,
       `permission occurrence: ${command.permissionOccurrenceId}`,
       `decision: ${command.allow ? 'allow' : 'deny'}`,
+      `status: ${response.status}`,
+    ].join('\n'));
+}
+
+export async function runPermissionAnswer(
+  command: PermissionAnswerCliCommand,
+  client: PermissionDecisionClient,
+  output: CliOutput,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await client.decidePermission({
+    clientRequestId: permissionDecisionClientRequestId(command),
+    chatId: command.chatId,
+    permissionOccurrenceId: command.permissionOccurrenceId,
+    allow: true,
+    alwaysAllow: false,
+    response: command.response,
+    control: {
+      serverInstanceId: command.serverInstanceId,
+      chatId: command.chatId,
+      runId: command.runId,
+      permissionOccurrenceId: command.permissionOccurrenceId,
+    },
+  }, signal);
+  output.result(command.json
+    ? JSON.stringify(response, null, 2)
+    : [
+      `chat id: ${response.chatId}`,
+      `permission occurrence: ${command.permissionOccurrenceId}`,
+      `answers: ${command.response.answers.length}`,
       `status: ${response.status}`,
     ].join('\n'));
 }

--- a/cli/chat-permission.ts
+++ b/cli/chat-permission.ts
@@ -18,6 +18,8 @@ export interface PermissionDecisionClient {
   ): Promise<CommandAcceptedResponse>;
 }
 
+type PermissionCliCommand = PermissionDecisionCliCommand | PermissionAnswerCliCommand;
+
 export function permissionDecisionClientRequestId(
   command: Pick<
     PermissionDecisionCliCommand,
@@ -33,6 +35,31 @@ export function permissionDecisionClientRequestId(
   return `permission-v1:${digest}`;
 }
 
+function permissionControl(
+  command: PermissionCliCommand,
+): PermissionDecisionCommandRequest['control'] {
+  return {
+    serverInstanceId: command.serverInstanceId,
+    chatId: command.chatId,
+    runId: command.runId,
+    permissionOccurrenceId: command.permissionOccurrenceId,
+  };
+}
+
+function formatPermissionReceipt(
+  command: PermissionCliCommand,
+  response: CommandAcceptedResponse,
+  detail: string,
+): string {
+  if (command.json) return JSON.stringify(response, null, 2);
+  return [
+    `chat id: ${response.chatId}`,
+    `permission occurrence: ${command.permissionOccurrenceId}`,
+    detail,
+    `status: ${response.status}`,
+  ].join('\n');
+}
+
 export async function runPermissionDecision(
   command: PermissionDecisionCliCommand,
   client: PermissionDecisionClient,
@@ -45,21 +72,13 @@ export async function runPermissionDecision(
     permissionOccurrenceId: command.permissionOccurrenceId,
     allow: command.allow,
     alwaysAllow: false,
-    control: {
-      serverInstanceId: command.serverInstanceId,
-      chatId: command.chatId,
-      runId: command.runId,
-      permissionOccurrenceId: command.permissionOccurrenceId,
-    },
+    control: permissionControl(command),
   }, signal);
-  output.result(command.json
-    ? JSON.stringify(response, null, 2)
-    : [
-      `chat id: ${response.chatId}`,
-      `permission occurrence: ${command.permissionOccurrenceId}`,
-      `decision: ${command.allow ? 'allow' : 'deny'}`,
-      `status: ${response.status}`,
-    ].join('\n'));
+  output.result(formatPermissionReceipt(
+    command,
+    response,
+    `decision: ${command.allow ? 'allow' : 'deny'}`,
+  ));
 }
 
 export async function runPermissionAnswer(
@@ -77,12 +96,7 @@ export async function runPermissionAnswer(
       allow: true,
       alwaysAllow: false,
       response: command.response,
-      control: {
-        serverInstanceId: command.serverInstanceId,
-        chatId: command.chatId,
-        runId: command.runId,
-        permissionOccurrenceId: command.permissionOccurrenceId,
-      },
+      control: permissionControl(command),
     }, signal);
   } catch (error) {
     if (
@@ -94,12 +108,9 @@ export async function runPermissionAnswer(
     }
     throw error;
   }
-  output.result(command.json
-    ? JSON.stringify(response, null, 2)
-    : [
-      `chat id: ${response.chatId}`,
-      `permission occurrence: ${command.permissionOccurrenceId}`,
-      `answers: ${command.response.answers.length}`,
-      `status: ${response.status}`,
-    ].join('\n'));
+  output.result(formatPermissionReceipt(
+    command,
+    response,
+    `answers: ${command.response.answers.length}`,
+  ));
 }

--- a/cli/chat-permission.ts
+++ b/cli/chat-permission.ts
@@ -7,6 +7,8 @@ import type {
   PermissionAnswerCliCommand,
   PermissionDecisionCliCommand,
 } from './args.js';
+import { argumentError } from './errors.js';
+import { GarconHttpError } from './garcon-client.js';
 import type { CliOutput } from './output.js';
 
 export interface PermissionDecisionClient {
@@ -66,20 +68,32 @@ export async function runPermissionAnswer(
   output: CliOutput,
   signal?: AbortSignal,
 ): Promise<void> {
-  const response = await client.decidePermission({
-    clientRequestId: permissionDecisionClientRequestId(command),
-    chatId: command.chatId,
-    permissionOccurrenceId: command.permissionOccurrenceId,
-    allow: true,
-    alwaysAllow: false,
-    response: command.response,
-    control: {
-      serverInstanceId: command.serverInstanceId,
+  let response: CommandAcceptedResponse;
+  try {
+    response = await client.decidePermission({
+      clientRequestId: permissionDecisionClientRequestId(command),
       chatId: command.chatId,
-      runId: command.runId,
       permissionOccurrenceId: command.permissionOccurrenceId,
-    },
-  }, signal);
+      allow: true,
+      alwaysAllow: false,
+      response: command.response,
+      control: {
+        serverInstanceId: command.serverInstanceId,
+        chatId: command.chatId,
+        runId: command.runId,
+        permissionOccurrenceId: command.permissionOccurrenceId,
+      },
+    }, signal);
+  } catch (error) {
+    if (
+      error instanceof GarconHttpError
+      && error.status === 400
+      && error.errorCode === 'VALIDATION_FAILED'
+    ) {
+      throw argumentError(error.message, { cause: error });
+    }
+    throw error;
+  }
   output.result(command.json
     ? JSON.stringify(response, null, 2)
     : [

--- a/cli/chat-search.ts
+++ b/cli/chat-search.ts
@@ -212,7 +212,7 @@ export async function runChatSearch(
     if (error instanceof GarconHttpError && error.errorCode === 'TRANSCRIPT_SEARCH_DISABLED') {
       throw new CliError(
         'chat search',
-        'transcript search is disabled; run `garcon-cli transcript-search enable`',
+        `transcript search is disabled; run \`${formatTranscriptSearchEnableCommand(command)}\``,
         2,
         { cause: error },
       );
@@ -230,6 +230,21 @@ export async function runChatSearch(
   const result = buildChatSearchResult(command, chats, response, candidateChatCount);
   output.result(formatChatSearchResult(result, command.json, command));
   for (const diagnostic of searchDiagnostics(result)) output.diagnostic(diagnostic);
+}
+
+function formatTranscriptSearchEnableCommand(connection: CliConnectionOptions): string {
+  return [
+    'garcon-cli',
+    '--workspace',
+    shellQuote(connection.workspace),
+    '--config-dir',
+    shellQuote(connection.configDir),
+    ...(connection.serverUrl === undefined
+      ? []
+      : ['--server', shellQuote(connection.serverUrl)]),
+    'transcript-search',
+    'enable',
+  ].join(' ');
 }
 
 function formatReadCommand(

--- a/cli/chat-search.ts
+++ b/cli/chat-search.ts
@@ -212,7 +212,7 @@ export async function runChatSearch(
     if (error instanceof GarconHttpError && error.errorCode === 'TRANSCRIPT_SEARCH_DISABLED') {
       throw new CliError(
         'chat search',
-        'transcript search is disabled; enable features.transcriptSearch.enabled in Garcon settings',
+        'transcript search is disabled; run `garcon-cli transcript-search enable`',
         2,
         { cause: error },
       );

--- a/cli/chat-status.ts
+++ b/cli/chat-status.ts
@@ -3,7 +3,6 @@ import type { StatusCliCommand } from './args.js';
 import { CliError } from './errors.js';
 import { GarconHttpError } from './garcon-client.js';
 import type { CliOutput } from './output.js';
-import { PermissionRequestMessage } from '@garcon/common/chat-types';
 import { shellQuote } from './shell-quote.js';
 import {
   formatPermissionRequestedTool,
@@ -82,7 +81,6 @@ export function formatChatStatus(
     lines.push(`pending permissions: ${snapshot.transientFeed.rows.length}`);
     for (const row of snapshot.transientFeed.rows) {
       const message = row.message;
-      if (!(message instanceof PermissionRequestMessage)) continue;
       const structured = message.requestedTool.type === 'ask-user-question-tool-use'
         || message.requestedTool.type === 'cursor-ask-question-tool-use';
       lines.push(

--- a/cli/chat-status.ts
+++ b/cli/chat-status.ts
@@ -95,11 +95,18 @@ export function formatChatStatus(
       );
       if (structured) {
         lines.push(
-          'action: answer this structured question in Garcon; allow does not supply question answers',
+          'action: use permission-answer with the exact question and option IDs above',
         );
       }
       if (connection) {
-        if (!structured) {
+        if (structured) {
+          lines.push(`answer command template: ${permissionAnswerCommand(
+            connection,
+            snapshot,
+            row.permissionOccurrenceId,
+            row.runId,
+          )}`);
+        } else {
           lines.push(`allow command: ${permissionDecisionCommand(
             connection,
             snapshot,
@@ -138,6 +145,26 @@ export function formatChatStatus(
   return lines.join('\n');
 }
 
+function permissionAnswerCommand(
+  connection: Pick<StatusCliCommand, 'workspace' | 'configDir' | 'serverUrl'>,
+  snapshot: ChatSnapshotResponse,
+  permissionOccurrenceId: string,
+  runId: string,
+): string {
+  return [
+    ...permissionCommandPrefix(connection),
+    'permission-answer',
+    shellQuote(snapshot.chat.id),
+    shellQuote(permissionOccurrenceId),
+    '--answers',
+    shellQuote('[{"questionId":"QUESTION_ID","selectedOptionIds":["OPTION_ID"]}]'),
+    '--run',
+    shellQuote(runId),
+    '--server-instance',
+    shellQuote(snapshot.transientFeed.serverInstanceId),
+  ].join(' ');
+}
+
 function permissionDecisionCommand(
   connection: Pick<StatusCliCommand, 'workspace' | 'configDir' | 'serverUrl'>,
   snapshot: ChatSnapshotResponse,
@@ -146,14 +173,7 @@ function permissionDecisionCommand(
   decision: 'allow' | 'deny',
 ): string {
   return [
-    'garcon-cli',
-    '--workspace',
-    shellQuote(connection.workspace),
-    '--config-dir',
-    shellQuote(connection.configDir),
-    ...(connection.serverUrl === undefined
-      ? []
-      : ['--server', shellQuote(connection.serverUrl)]),
+    ...permissionCommandPrefix(connection),
     'permission-decision',
     shellQuote(snapshot.chat.id),
     shellQuote(permissionOccurrenceId),
@@ -163,4 +183,19 @@ function permissionDecisionCommand(
     '--server-instance',
     shellQuote(snapshot.transientFeed.serverInstanceId),
   ].join(' ');
+}
+
+function permissionCommandPrefix(
+  connection: Pick<StatusCliCommand, 'workspace' | 'configDir' | 'serverUrl'>,
+): string[] {
+  return [
+    'garcon-cli',
+    '--workspace',
+    shellQuote(connection.workspace),
+    '--config-dir',
+    shellQuote(connection.configDir),
+    ...(connection.serverUrl === undefined
+      ? []
+      : ['--server', shellQuote(connection.serverUrl)]),
+  ];
 }

--- a/cli/garcon-client.ts
+++ b/cli/garcon-client.ts
@@ -30,8 +30,10 @@ import {
 } from '@garcon/common/chat-view';
 import {
   parseChatSearchResponse,
+  parseTranscriptSearchStatusResponse,
   type ChatSearchRequest,
   type ChatSearchResponse,
+  type TranscriptSearchStatusResponse,
 } from '@garcon/common/chat-search';
 import { stableJsonStringify } from '@garcon/common/json';
 import {
@@ -419,6 +421,50 @@ export class GarconClient {
         cause: error,
       });
     }
+  }
+
+  async getTranscriptSearchStatus(signal?: AbortSignal): Promise<TranscriptSearchStatusResponse> {
+    const value = await this.#request(
+      'chat search',
+      'GET',
+      '/api/v1/chats/search/status',
+      undefined,
+      signal,
+    );
+    try {
+      return parseTranscriptSearchStatusResponse(value);
+    } catch (error) {
+      throw new CliError('chat search', 'server returned an invalid transcript search status', 3, {
+        cause: error,
+      });
+    }
+  }
+
+  async setTranscriptSearchEnabled(
+    enabled: boolean,
+    signal?: AbortSignal,
+  ): Promise<RemoteSettingsSnapshot> {
+    const value = await this.#request(
+      'chat search',
+      'PUT',
+      '/api/v1/app/settings',
+      { features: { transcriptSearch: { enabled } } },
+      signal,
+    );
+    const response = record(value);
+    const rawSettings = record(response?.settings);
+    const rawFeatures = record(rawSettings?.features);
+    const rawTranscriptSearch = record(rawFeatures?.transcriptSearch);
+    const settings = normalizeRemoteSettingsSnapshot(rawSettings);
+    if (
+      response?.success !== true
+      || rawTranscriptSearch?.enabled !== enabled
+      || !settings
+      || settings.features.transcriptSearch.enabled !== enabled
+    ) {
+      throw new CliError('chat search', 'server returned an invalid transcript search setting', 3);
+    }
+    return settings;
   }
 
   async getChatSnapshot(

--- a/cli/garcon-client.ts
+++ b/cli/garcon-client.ts
@@ -31,9 +31,11 @@ import {
 import {
   parseChatSearchResponse,
   parseTranscriptSearchStatusResponse,
+  parseTranscriptSearchRebuildResponse,
   type ChatSearchRequest,
   type ChatSearchResponse,
   type TranscriptSearchStatusResponse,
+  type TranscriptSearchRebuildResponse,
 } from '@garcon/common/chat-search';
 import { stableJsonStringify } from '@garcon/common/json';
 import {
@@ -435,6 +437,23 @@ export class GarconClient {
       return parseTranscriptSearchStatusResponse(value);
     } catch (error) {
       throw new CliError('chat search', 'server returned an invalid transcript search status', 3, {
+        cause: error,
+      });
+    }
+  }
+
+  async rebuildTranscriptSearch(signal?: AbortSignal): Promise<TranscriptSearchRebuildResponse> {
+    const value = await this.#request(
+      'chat search',
+      'POST',
+      '/api/v1/chats/search/rebuild',
+      undefined,
+      signal,
+    );
+    try {
+      return parseTranscriptSearchRebuildResponse(value);
+    } catch (error) {
+      throw new CliError('chat search', 'server returned an invalid transcript search rebuild response', 3, {
         cause: error,
       });
     }

--- a/cli/garcon-client.ts
+++ b/cli/garcon-client.ts
@@ -55,6 +55,10 @@ import {
   type SetChatTagsResponse,
 } from '@garcon/common/chat-tags-contracts';
 import type { ModelCatalogResponse } from '@garcon/common/model-catalog';
+import {
+  normalizePreamblesSnapshot,
+  type PreamblesSnapshot,
+} from '@garcon/common/preambles';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
 import {
   parseNativeSessionLookupResponse,
@@ -338,6 +342,21 @@ export class GarconClient {
     const settings = normalizeRemoteSettingsSnapshot(value);
     if (!settings) throw new CliError('catalog resolution', 'server returned invalid settings', 3);
     return settings;
+  }
+
+  async getPreambles(signal?: AbortSignal): Promise<PreamblesSnapshot> {
+    const value = await this.#request(
+      'catalog resolution',
+      'GET',
+      '/api/v1/preambles',
+      undefined,
+      signal,
+    );
+    const snapshot = normalizePreamblesSnapshot(value);
+    if (!snapshot) {
+      throw new CliError('catalog resolution', 'server returned an invalid preamble catalog', 3);
+    }
+    return snapshot;
   }
 
   async listChats(signal?: AbortSignal): Promise<ChatListResponse> {

--- a/cli/garcon-client.ts
+++ b/cli/garcon-client.ts
@@ -449,6 +449,7 @@ export class GarconClient {
       '/api/v1/chats/search/rebuild',
       undefined,
       signal,
+      null,
     );
     try {
       return parseTranscriptSearchRebuildResponse(value);
@@ -469,6 +470,7 @@ export class GarconClient {
       '/api/v1/app/settings',
       { features: { transcriptSearch: { enabled } } },
       signal,
+      null,
     );
     const response = record(value);
     const rawSettings = record(response?.settings);

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -14,6 +14,7 @@ import { runChatSearch } from './chat-search.js';
 import { runChatRead } from './chat-read.js';
 import { runPermissionAnswer, runPermissionDecision } from './chat-permission.js';
 import { runChatOrderMutation, runRename, runSetTags } from './chat-metadata.js';
+import { runTranscriptSearchAdministration } from './transcript-search.js';
 import {
   resumeAsyncJsonEnvelope,
   startAsyncJsonEnvelope,
@@ -144,6 +145,11 @@ function interruptDiagnostic(command: ParsedCliCommand | undefined): string {
   if (command?.kind === 'handoff') {
     return 'terminal interrupted; no handoff artifact was written';
   }
+  if (command?.kind === 'transcript-search') {
+    return command.action === 'status'
+      ? 'terminal interrupted; the read-only operation was canceled'
+      : 'terminal interrupted; the command may have reached Garcon; inspect transcript-search status before retrying';
+  }
   if (
     command !== undefined
     && ['list', 'chats', 'search', 'read', 'status', 'wait', 'lookup-native-session']
@@ -211,6 +217,11 @@ export async function main(
     if (command.kind === 'search') {
       const client = await connectedClient(command, options);
       await runChatSearch(command, client, output, options.signal);
+      return 0;
+    }
+    if (command.kind === 'transcript-search') {
+      const client = await connectedClient(command, options);
+      await runTranscriptSearchAdministration(command, client, output, options.signal);
       return 0;
     }
     if (command.kind === 'read') {

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -12,7 +12,7 @@ import { runConsultation, startConsultationAsync } from './consultation.js';
 import { runChatCatalog } from './chat-catalog.js';
 import { runChatSearch } from './chat-search.js';
 import { runChatRead } from './chat-read.js';
-import { runPermissionDecision } from './chat-permission.js';
+import { runPermissionAnswer, runPermissionDecision } from './chat-permission.js';
 import { runChatOrderMutation, runRename, runSetTags } from './chat-metadata.js';
 import {
   resumeAsyncJsonEnvelope,
@@ -156,6 +156,7 @@ function interruptDiagnostic(command: ParsedCliCommand | undefined): string {
       'resume-async',
       'stop',
       'permission-decision',
+      'permission-answer',
       'archive',
       'unarchive',
       'pin',
@@ -239,6 +240,11 @@ export async function main(
     if (command.kind === 'permission-decision') {
       const client = await connectedClient(command, options);
       await runPermissionDecision(command, client, output, options.signal);
+      return 0;
+    }
+    if (command.kind === 'permission-answer') {
+      const client = await connectedClient(command, options);
+      await runPermissionAnswer(command, client, output, options.signal);
       return 0;
     }
     if (

--- a/cli/transcript-search.ts
+++ b/cli/transcript-search.ts
@@ -1,10 +1,14 @@
-import type { TranscriptSearchStatusResponse } from '@garcon/common/chat-search';
+import type {
+  TranscriptSearchRebuildResponse,
+  TranscriptSearchStatusResponse,
+} from '@garcon/common/chat-search';
 import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
 import type { TranscriptSearchCliCommand } from './args.js';
 import type { CliOutput } from './output.js';
 
 export interface TranscriptSearchAdministrationClient {
   getTranscriptSearchStatus(signal?: AbortSignal): Promise<TranscriptSearchStatusResponse>;
+  rebuildTranscriptSearch(signal?: AbortSignal): Promise<TranscriptSearchRebuildResponse>;
   setTranscriptSearchEnabled(
     enabled: boolean,
     signal?: AbortSignal,
@@ -20,6 +24,17 @@ export async function runTranscriptSearchAdministration(
   if (command.action === 'status') {
     const status = await client.getTranscriptSearchStatus(signal);
     output.result(command.json ? JSON.stringify(status, null, 2) : formatTranscriptSearchStatus(status));
+    return;
+  }
+
+  if (command.action === 'rebuild') {
+    const result = await client.rebuildTranscriptSearch(signal);
+    output.result(command.json
+      ? JSON.stringify(result, null, 2)
+      : [
+        'transcript search: rebuild started',
+        `phase: ${result.status.phase}`,
+      ].join('\n'));
     return;
   }
 

--- a/cli/transcript-search.ts
+++ b/cli/transcript-search.ts
@@ -21,35 +21,44 @@ export async function runTranscriptSearchAdministration(
   output: CliOutput,
   signal?: AbortSignal,
 ): Promise<void> {
-  if (command.action === 'status') {
-    const status = await client.getTranscriptSearchStatus(signal);
-    output.result(command.json ? JSON.stringify(status, null, 2) : formatTranscriptSearchStatus(status));
-    return;
+  switch (command.action) {
+    case 'status': {
+      const status = await client.getTranscriptSearchStatus(signal);
+      const formatted = command.json
+        ? JSON.stringify(status, null, 2)
+        : formatTranscriptSearchStatus(status);
+      output.result(formatted);
+      return;
+    }
+    case 'rebuild': {
+      const result = await client.rebuildTranscriptSearch(signal);
+      const formatted = command.json
+        ? JSON.stringify(result, null, 2)
+        : [
+          'transcript search: rebuild started',
+          `phase: ${result.status.phase}`,
+        ].join('\n');
+      output.result(formatted);
+      return;
+    }
+    case 'enable':
+    case 'disable': {
+      const enabled = command.action === 'enable';
+      const settings = await client.setTranscriptSearchEnabled(enabled, signal);
+      const result = {
+        enabled: settings.features.transcriptSearch.enabled,
+        settingsVersion: settings.version,
+      };
+      const formatted = command.json
+        ? JSON.stringify(result, null, 2)
+        : [
+          `transcript search: ${result.enabled ? 'enabled' : 'disabled'}`,
+          `settings version: ${result.settingsVersion}`,
+        ].join('\n');
+      output.result(formatted);
+      return;
+    }
   }
-
-  if (command.action === 'rebuild') {
-    const result = await client.rebuildTranscriptSearch(signal);
-    output.result(command.json
-      ? JSON.stringify(result, null, 2)
-      : [
-        'transcript search: rebuild started',
-        `phase: ${result.status.phase}`,
-      ].join('\n'));
-    return;
-  }
-
-  const enabled = command.action === 'enable';
-  const settings = await client.setTranscriptSearchEnabled(enabled, signal);
-  const result = {
-    enabled: settings.features.transcriptSearch.enabled,
-    settingsVersion: settings.version,
-  };
-  output.result(command.json
-    ? JSON.stringify(result, null, 2)
-    : [
-      `transcript search: ${result.enabled ? 'enabled' : 'disabled'}`,
-      `settings version: ${result.settingsVersion}`,
-    ].join('\n'));
 }
 
 export function formatTranscriptSearchStatus(status: TranscriptSearchStatusResponse): string {

--- a/cli/transcript-search.ts
+++ b/cli/transcript-search.ts
@@ -1,0 +1,88 @@
+import type { TranscriptSearchStatusResponse } from '@garcon/common/chat-search';
+import type { RemoteSettingsSnapshot } from '@garcon/common/settings';
+import type { TranscriptSearchCliCommand } from './args.js';
+import type { CliOutput } from './output.js';
+
+export interface TranscriptSearchAdministrationClient {
+  getTranscriptSearchStatus(signal?: AbortSignal): Promise<TranscriptSearchStatusResponse>;
+  setTranscriptSearchEnabled(
+    enabled: boolean,
+    signal?: AbortSignal,
+  ): Promise<RemoteSettingsSnapshot>;
+}
+
+export async function runTranscriptSearchAdministration(
+  command: TranscriptSearchCliCommand,
+  client: TranscriptSearchAdministrationClient,
+  output: CliOutput,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (command.action === 'status') {
+    const status = await client.getTranscriptSearchStatus(signal);
+    output.result(command.json ? JSON.stringify(status, null, 2) : formatTranscriptSearchStatus(status));
+    return;
+  }
+
+  const enabled = command.action === 'enable';
+  const settings = await client.setTranscriptSearchEnabled(enabled, signal);
+  const result = {
+    enabled: settings.features.transcriptSearch.enabled,
+    settingsVersion: settings.version,
+  };
+  output.result(command.json
+    ? JSON.stringify(result, null, 2)
+    : [
+      `transcript search: ${result.enabled ? 'enabled' : 'disabled'}`,
+      `settings version: ${result.settingsVersion}`,
+    ].join('\n'));
+}
+
+export function formatTranscriptSearchStatus(status: TranscriptSearchStatusResponse): string {
+  const lines = [
+    `transcript search: ${status.phase}`,
+    `updated at: ${status.updatedAt}`,
+    `chats total: ${status.chats.total}`,
+    `chats indexed: ${status.chats.indexed}`,
+    `chats pending: ${status.chats.pending}`,
+    `chats failed: ${status.chats.failed}`,
+    `chats unindexed: ${status.chats.unindexed}`,
+    `queued jobs: ${status.queuedJobs}`,
+    `backlog rows: ${status.backlogRows}`,
+    `resync: ${formatProgress(status.resync)}`,
+    `active chat: ${formatProgress(status.activeChat)}`,
+    `last error: ${status.lastErrorCode ?? 'none'}`,
+    `queries served: ${status.queryStats.served}`,
+    `queries timed out: ${status.queryStats.timedOut}`,
+    `queries rejected busy: ${status.queryStats.rejectedBusy}`,
+    `execution latency ms: ${formatLatency(
+      status.queryStats.p50Ms,
+      status.queryStats.p95Ms,
+      status.queryStats.maxMs,
+    )}`,
+    `admission latency ms: ${formatLatency(
+      status.queryStats.admissionP50Ms,
+      status.queryStats.admissionP95Ms,
+      status.queryStats.admissionMaxMs,
+    )}`,
+    `total latency ms: ${formatLatency(
+      status.queryStats.totalP50Ms,
+      status.queryStats.totalP95Ms,
+      status.queryStats.totalMaxMs,
+    )}`,
+  ];
+  return lines.join('\n');
+}
+
+function formatProgress(
+  progress: { readonly completedChats: number; readonly totalChats: number }
+    | { readonly position: number; readonly total: number }
+    | null,
+): string {
+  if (!progress) return 'none';
+  if ('completedChats' in progress) return `${progress.completedChats}/${progress.totalChats}`;
+  return `${progress.position}/${progress.total}`;
+}
+
+function formatLatency(p50Ms: number, p95Ms: number, maxMs: number): string {
+  return `p50 ${p50Ms}, p95 ${p95Ms}, max ${maxMs}`;
+}

--- a/common/__tests__/ask-user-question-response.test.js
+++ b/common/__tests__/ask-user-question-response.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  askUserQuestionDecisionValidationError,
+} from '../ask-user-question-response.ts';
+import {
+  AskUserQuestionToolUseMessage,
+  BashToolUseMessage,
+  CursorAskQuestionToolUseMessage,
+} from '../chat-types.ts';
+
+const TIMESTAMP = '2026-09-08T00:00:00.000Z';
+const answered = {
+  type: 'ask-user-question-response',
+  outcome: 'answered',
+  answers: [
+    { questionId: 'mode', selectedOptionIds: ['careful'] },
+    { questionId: 'databases', selectedOptionIds: ['postgres', 'sqlite'] },
+    { questionId: 'confirmation', selectedOptionIds: [] },
+  ],
+};
+
+function questionTool() {
+  return new AskUserQuestionToolUseMessage(TIMESTAMP, 'tool-1', 'Configure', [
+    {
+      id: 'mode',
+      prompt: 'Which mode?',
+      options: [
+        { id: 'fast', label: 'Fast' },
+        { id: 'careful', label: 'Careful' },
+      ],
+    },
+    {
+      id: 'databases',
+      prompt: 'Which databases?',
+      options: [
+        { id: 'postgres', label: 'Postgres' },
+        { id: 'sqlite', label: 'SQLite' },
+      ],
+      allowMultiple: true,
+    },
+    {
+      id: 'confirmation',
+      prompt: 'Continue?',
+      options: [],
+    },
+  ]);
+}
+
+describe('structured question decision validation', () => {
+  it('accepts exact generic and Cursor question answers', () => {
+    expect(askUserQuestionDecisionValidationError(questionTool(), true, answered)).toBeNull();
+    expect(askUserQuestionDecisionValidationError(
+      new CursorAskQuestionToolUseMessage(TIMESTAMP, 'tool-2', 'Configure', [{
+        id: 'mode',
+        prompt: 'Which mode?',
+        options: [{ id: 'careful', label: 'Careful' }],
+      }]),
+      true,
+      {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [{ questionId: 'mode', selectedOptionIds: ['careful'] }],
+      },
+    )).toBeNull();
+    expect(askUserQuestionDecisionValidationError(questionTool(), false, {
+      type: 'ask-user-question-response',
+      outcome: 'skipped',
+      reason: 'Not now',
+    })).toBeNull();
+  });
+
+  it('rejects structured responses for non-question permissions', () => {
+    expect(askUserQuestionDecisionValidationError(
+      new BashToolUseMessage(TIMESTAMP, 'tool-1', 'echo hello'),
+      true,
+      answered,
+    )).toBe('Structured answers require a pending question request');
+  });
+
+  it('requires exact question and option identities with valid cardinality', () => {
+    const tool = questionTool();
+    const invalidAnswers = [
+      {
+        ...answered,
+        answers: answered.answers.filter((answer) => answer.questionId !== 'confirmation'),
+      },
+      {
+        ...answered,
+        answers: answered.answers.map((answer) => answer.questionId === 'mode'
+          ? { ...answer, questionId: 'unknown' }
+          : answer),
+      },
+      {
+        ...answered,
+        answers: answered.answers.map((answer) => answer.questionId === 'mode'
+          ? { ...answer, selectedOptionIds: ['unknown'] }
+          : answer),
+      },
+      {
+        ...answered,
+        answers: answered.answers.map((answer) => answer.questionId === 'mode'
+          ? { ...answer, selectedOptionIds: [] }
+          : answer),
+      },
+      {
+        ...answered,
+        answers: answered.answers.map((answer) => answer.questionId === 'mode'
+          ? { ...answer, selectedOptionIds: ['fast', 'careful'] }
+          : answer),
+      },
+      {
+        ...answered,
+        answers: answered.answers.map((answer) => answer.questionId === 'confirmation'
+          ? { ...answer, selectedOptionIds: ['yes'] }
+          : answer),
+      },
+    ];
+
+    for (const response of invalidAnswers) {
+      expect(askUserQuestionDecisionValidationError(tool, true, response)).not.toBeNull();
+    }
+    expect(askUserQuestionDecisionValidationError(tool, false, answered))
+      .toBe('An answered question response must allow the request');
+    expect(askUserQuestionDecisionValidationError(tool, true, {
+      type: 'ask-user-question-response',
+      outcome: 'skipped',
+    })).toBe('A skipped question response must deny the request');
+  });
+});

--- a/common/__tests__/chat-command-contracts.test.js
+++ b/common/__tests__/chat-command-contracts.test.js
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  ASK_USER_QUESTION_MAX_ANSWERS,
+  ASK_USER_QUESTION_MAX_SELECTED_OPTIONS,
   COMMAND_CORRELATION_ID_MAX_BYTES,
   QUEUE_ENTRY_ID_MAX_BYTES,
   CommandRequestValidationError,
+  normalizeAskUserQuestionDecisionResponse,
   parseAgentRunCommandRequest,
   parseForkChatCommandRequest,
   parseForkRunCommandRequest,
@@ -497,6 +500,39 @@ describe('chat command request parsers', () => {
       ...request,
       control: { ...control, runId: '' },
     })).toThrow('control is invalid');
+  });
+
+  it('strictly normalizes bounded structured question answers', () => {
+    const response = {
+      type: 'ask-user-question-response',
+      outcome: 'answered',
+      answers: [{ questionId: 'question-1', selectedOptionIds: ['option-1', 'option-2'] }],
+    };
+    expect(normalizeAskUserQuestionDecisionResponse(response)).toEqual(response);
+
+    for (const invalid of [
+      { ...response, extra: true },
+      { ...response, answers: [{ ...response.answers[0], extra: true }] },
+      { ...response, answers: [{ questionId: '', selectedOptionIds: ['option-1'] }] },
+      { ...response, answers: [{ questionId: 'question-1', selectedOptionIds: ['same', 'same'] }] },
+      {
+        ...response,
+        answers: Array.from(
+          { length: ASK_USER_QUESTION_MAX_ANSWERS + 1 },
+          (_, index) => ({ questionId: `question-${index}`, selectedOptionIds: [] }),
+        ),
+      },
+      {
+        ...response,
+        answers: [{
+          questionId: 'question-1',
+          selectedOptionIds: Array.from(
+            { length: ASK_USER_QUESTION_MAX_SELECTED_OPTIONS + 1 },
+            (_, index) => `option-${index}`,
+          ),
+        }],
+      },
+    ]) expect(normalizeAskUserQuestionDecisionResponse(invalid)).toBeNull();
   });
 
   it('parses queue entry moves with explicit concurrency preconditions', () => {

--- a/common/__tests__/chat-search.test.js
+++ b/common/__tests__/chat-search.test.js
@@ -87,6 +87,10 @@ describe('chat search contracts', () => {
     expect(parseChatSearchResponse(request, response())).toEqual(response());
     expect(() => parseChatSearchResponse(request, {
       ...response(),
+      query: 'different',
+    })).toThrow('query does not match request');
+    expect(() => parseChatSearchResponse(request, {
+      ...response(),
       page: { ...response().page, offset: 1 },
     })).toThrow('offset does not match request');
     expect(() => parseChatSearchResponse(request, {

--- a/common/__tests__/chat-search.test.js
+++ b/common/__tests__/chat-search.test.js
@@ -4,6 +4,7 @@ import {
   classifyChatSearchFailureRecovery,
   compileChatSearchQuery,
   parseChatSearchResponse,
+  parseTranscriptSearchStatusResponse,
 } from '../chat-search.ts';
 
 const request = {
@@ -158,6 +159,47 @@ describe('chat search contracts', () => {
     };
     expect(() => parseChatSearchResponse(request, countMismatch))
       .toThrow('failed chat details');
+  });
+
+  it('strictly parses transcript search status and query statistics', () => {
+    const status = {
+      version: 1,
+      phase: 'rebuilding',
+      chats: { total: 3, indexed: 1, pending: 1, failed: 0, unindexed: 1 },
+      queuedJobs: 2,
+      resync: { completedChats: 1, totalChats: 3 },
+      backlogRows: 7,
+      activeChat: { position: 2, total: 5 },
+      lastErrorCode: null,
+      updatedAt: '2026-09-08T00:00:00.000Z',
+      queryStats: {
+        served: 4,
+        timedOut: 1,
+        rejectedBusy: 2,
+        p50Ms: 10,
+        p95Ms: 20,
+        maxMs: 30,
+        admissionP50Ms: 1,
+        admissionP95Ms: 2,
+        admissionMaxMs: 3,
+        totalP50Ms: 11,
+        totalP95Ms: 22,
+        totalMaxMs: 33,
+      },
+    };
+    expect(parseTranscriptSearchStatusResponse(status)).toEqual(status);
+
+    for (const invalid of [
+      { ...status, extra: true },
+      { ...status, updatedAt: '2026-09-08' },
+      { ...status, lastErrorCode: 'invalid code' },
+      { ...status, chats: { ...status.chats, extra: 1 } },
+      { ...status, resync: { completedChats: 4, totalChats: 3 } },
+      { ...status, queryStats: { ...status.queryStats, served: -1 } },
+      { ...status, queryStats: { ...status.queryStats, extra: 1 } },
+    ]) expect(() => parseTranscriptSearchStatusResponse(invalid)).toThrow(
+      'Invalid transcript search status response',
+    );
   });
 
   it('classifies failure recovery without treating source loss as an index retry', () => {

--- a/common/__tests__/chat-search.test.js
+++ b/common/__tests__/chat-search.test.js
@@ -4,6 +4,7 @@ import {
   classifyChatSearchFailureRecovery,
   compileChatSearchQuery,
   parseChatSearchResponse,
+  parseTranscriptSearchRebuildResponse,
   parseTranscriptSearchStatusResponse,
 } from '../chat-search.ts';
 
@@ -200,6 +201,44 @@ describe('chat search contracts', () => {
     ]) expect(() => parseTranscriptSearchStatusResponse(invalid)).toThrow(
       'Invalid transcript search status response',
     );
+  });
+
+  it('strictly parses transcript search rebuild responses', () => {
+    const status = {
+      version: 1,
+      phase: 'rebuilding',
+      chats: { total: 0, indexed: 0, pending: 0, failed: 0, unindexed: 0 },
+      queuedJobs: 0,
+      resync: null,
+      backlogRows: 0,
+      activeChat: null,
+      lastErrorCode: null,
+      updatedAt: '2026-09-08T00:00:00.000Z',
+      queryStats: {
+        served: 0,
+        timedOut: 0,
+        rejectedBusy: 0,
+        p50Ms: 0,
+        p95Ms: 0,
+        maxMs: 0,
+        admissionP50Ms: 0,
+        admissionP95Ms: 0,
+        admissionMaxMs: 0,
+        totalP50Ms: 0,
+        totalP95Ms: 0,
+        totalMaxMs: 0,
+      },
+    };
+    const response = { success: true, status };
+    expect(parseTranscriptSearchRebuildResponse(response)).toEqual(response);
+    for (const invalid of [
+      { ...response, success: false },
+      { ...response, extra: true },
+      { ...response, status: { ...status, phase: 'unknown' } },
+    ]) {
+      expect(() => parseTranscriptSearchRebuildResponse(invalid))
+        .toThrow('Invalid transcript search rebuild response');
+    }
   });
 
   it('classifies failure recovery without treating source loss as an index retry', () => {

--- a/common/ask-user-question-response.ts
+++ b/common/ask-user-question-response.ts
@@ -155,14 +155,14 @@ function normalizeAnswers(response: Record<string, unknown>): AskUserQuestionAns
   const questionIds = new Set<string>();
   for (const value of response.answers) {
     const answer = asRecord(value);
+    if (!answer || !hasExactKeys(answer, ['questionId', 'selectedOptionIds'])) return null;
+    if (!boundedId(answer.questionId) || questionIds.has(answer.questionId)) return null;
     if (
-      !answer
-      || !hasExactKeys(answer, ['questionId', 'selectedOptionIds'])
-      || !boundedId(answer.questionId)
-      || questionIds.has(answer.questionId)
-      || !Array.isArray(answer.selectedOptionIds)
+      !Array.isArray(answer.selectedOptionIds)
       || answer.selectedOptionIds.length > ASK_USER_QUESTION_MAX_SELECTED_OPTIONS
-    ) return null;
+    ) {
+      return null;
+    }
     const selectedOptionIds = normalizeOptionIds(answer.selectedOptionIds);
     if (!selectedOptionIds) return null;
     questionIds.add(answer.questionId);

--- a/common/ask-user-question-response.ts
+++ b/common/ask-user-question-response.ts
@@ -1,0 +1,123 @@
+export interface AskUserQuestionAnswerPayload {
+  questionId: string;
+  selectedOptionIds: string[];
+}
+
+export const ASK_USER_QUESTION_MAX_ANSWERS = 100;
+export const ASK_USER_QUESTION_MAX_SELECTED_OPTIONS = 100;
+export const ASK_USER_QUESTION_ID_MAX_BYTES = 1_024;
+export const ASK_USER_QUESTION_REASON_MAX_BYTES = 4_096;
+export const ASK_USER_QUESTION_RESPONSE_MAX_BYTES = 64 * 1_024;
+
+const responseEncoder = new TextEncoder();
+
+export interface AskUserQuestionAnsweredResponse extends Record<string, unknown> {
+  type: 'ask-user-question-response';
+  outcome: 'answered';
+  answers: AskUserQuestionAnswerPayload[];
+}
+
+export interface AskUserQuestionSkippedResponse extends Record<string, unknown> {
+  type: 'ask-user-question-response';
+  outcome: 'skipped';
+  reason?: string;
+}
+
+export type AskUserQuestionDecisionResponse =
+  | AskUserQuestionAnsweredResponse
+  | AskUserQuestionSkippedResponse;
+
+export function normalizeAskUserQuestionDecisionResponse(
+  value: unknown,
+): AskUserQuestionDecisionResponse | null {
+  const response = asRecord(value);
+  if (!response || response.type !== 'ask-user-question-response') return null;
+
+  let normalized: AskUserQuestionDecisionResponse;
+  if (response.outcome === 'answered') {
+    const answers = normalizeAnswers(response);
+    if (!answers) return null;
+    normalized = { type: 'ask-user-question-response', outcome: 'answered', answers };
+  } else if (response.outcome === 'skipped') {
+    if (!hasExactKeys(response, ['type', 'outcome'], ['reason'])) return null;
+    if (
+      response.reason !== undefined
+      && !boundedText(response.reason, ASK_USER_QUESTION_REASON_MAX_BYTES)
+    ) return null;
+    normalized = {
+      type: 'ask-user-question-response',
+      outcome: 'skipped',
+      ...(response.reason === undefined ? {} : { reason: response.reason }),
+    };
+  } else {
+    return null;
+  }
+
+  if (responseEncoder.encode(JSON.stringify(normalized)).byteLength > ASK_USER_QUESTION_RESPONSE_MAX_BYTES) {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeAnswers(response: Record<string, unknown>): AskUserQuestionAnswerPayload[] | null {
+  if (
+    !hasExactKeys(response, ['type', 'outcome', 'answers'])
+    || !Array.isArray(response.answers)
+    || response.answers.length > ASK_USER_QUESTION_MAX_ANSWERS
+  ) return null;
+
+  const answers: AskUserQuestionAnswerPayload[] = [];
+  const questionIds = new Set<string>();
+  for (const value of response.answers) {
+    const answer = asRecord(value);
+    if (
+      !answer
+      || !hasExactKeys(answer, ['questionId', 'selectedOptionIds'])
+      || !boundedId(answer.questionId)
+      || questionIds.has(answer.questionId)
+      || !Array.isArray(answer.selectedOptionIds)
+      || answer.selectedOptionIds.length > ASK_USER_QUESTION_MAX_SELECTED_OPTIONS
+    ) return null;
+    const selectedOptionIds = normalizeOptionIds(answer.selectedOptionIds);
+    if (!selectedOptionIds) return null;
+    questionIds.add(answer.questionId);
+    answers.push({ questionId: answer.questionId, selectedOptionIds });
+  }
+  return answers;
+}
+
+function normalizeOptionIds(values: unknown[]): string[] | null {
+  const optionIds = new Set<string>();
+  for (const value of values) {
+    if (!boundedId(value) || optionIds.has(value)) return null;
+    optionIds.add(value);
+  }
+  return [...optionIds];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function boundedId(value: unknown): value is string {
+  return boundedText(value, ASK_USER_QUESTION_ID_MAX_BYTES);
+}
+
+function boundedText(value: unknown, maxBytes: number): value is string {
+  return typeof value === 'string'
+    && value.trim().length > 0
+    && value.isWellFormed()
+    && responseEncoder.encode(value).byteLength <= maxBytes;
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean {
+  const keys = Object.keys(value);
+  return required.every((key) => Object.hasOwn(value, key))
+    && keys.every((key) => required.includes(key) || optional.includes(key));
+}

--- a/common/ask-user-question-response.ts
+++ b/common/ask-user-question-response.ts
@@ -1,3 +1,5 @@
+import type { ToolUseChatMessage } from './chat-types.js';
+
 export interface AskUserQuestionAnswerPayload {
   questionId: string;
   selectedOptionIds: string[];
@@ -26,6 +28,13 @@ export interface AskUserQuestionSkippedResponse extends Record<string, unknown> 
 export type AskUserQuestionDecisionResponse =
   | AskUserQuestionAnsweredResponse
   | AskUserQuestionSkippedResponse;
+
+type StructuredQuestionTool = Extract<
+  ToolUseChatMessage,
+  { type: 'ask-user-question-tool-use' | 'cursor-ask-question-tool-use' }
+>;
+
+type StructuredQuestion = StructuredQuestionTool['questions'][number];
 
 export function normalizeAskUserQuestionDecisionResponse(
   value: unknown,
@@ -57,6 +66,82 @@ export function normalizeAskUserQuestionDecisionResponse(
     return null;
   }
   return normalized;
+}
+
+export function askUserQuestionDecisionValidationError(
+  requestedTool: ToolUseChatMessage,
+  allow: boolean,
+  response: AskUserQuestionDecisionResponse,
+): string | null {
+  const questions = structuredQuestions(requestedTool);
+  if (!questions) return 'Structured answers require a pending question request';
+
+  if (response.outcome === 'skipped') {
+    return allow ? 'A skipped question response must deny the request' : null;
+  }
+  if (!allow) return 'An answered question response must allow the request';
+
+  const questionsById = new Map(questions.map((question) => [question.id, question]));
+  if (questionsById.size !== questions.length) {
+    return 'The pending question request contains duplicate question IDs';
+  }
+
+  const answersById = new Map(response.answers.map((answer) => [answer.questionId, answer]));
+  for (const answer of response.answers) {
+    if (!questionsById.has(answer.questionId)) {
+      return `Structured answers contain an unknown question ID: ${answer.questionId}`;
+    }
+  }
+  if (answersById.size !== questions.length) {
+    return 'Structured answers must answer every pending question exactly once';
+  }
+
+  for (const question of questions) {
+    const answer = answersById.get(question.id)!;
+    const error = selectedOptionsValidationError(question, answer.selectedOptionIds);
+    if (error) return error;
+  }
+  return null;
+}
+
+function structuredQuestions(
+  requestedTool: ToolUseChatMessage,
+): readonly StructuredQuestion[] | null {
+  switch (requestedTool.type) {
+    case 'ask-user-question-tool-use':
+    case 'cursor-ask-question-tool-use':
+      return requestedTool.questions;
+    default:
+      return null;
+  }
+}
+
+function selectedOptionsValidationError(
+  question: StructuredQuestion,
+  selectedOptionIds: readonly string[],
+): string | null {
+  const optionIds = new Set(question.options.map((option) => option.id));
+  if (optionIds.size !== question.options.length) {
+    return `Pending question ${question.id} contains duplicate option IDs`;
+  }
+  for (const optionId of selectedOptionIds) {
+    if (!optionIds.has(optionId)) {
+      return `Structured answers contain an unknown option ID for ${question.id}: ${optionId}`;
+    }
+  }
+
+  if (question.options.length === 0) {
+    return selectedOptionIds.length === 0
+      ? null
+      : `Question ${question.id} does not accept option selections`;
+  }
+  if (selectedOptionIds.length === 0) {
+    return `Question ${question.id} requires an option selection`;
+  }
+  if (!question.allowMultiple && selectedOptionIds.length !== 1) {
+    return `Question ${question.id} accepts exactly one option`;
+  }
+  return null;
 }
 
 function normalizeAnswers(response: Record<string, unknown>): AskUserQuestionAnswerPayload[] | null {

--- a/common/chat-command-contracts.ts
+++ b/common/chat-command-contracts.ts
@@ -18,11 +18,24 @@ import type { ParentChatRef } from './chat-parentage.js';
 import type { ErrorCode } from './error-codes.js';
 import { normalizeTags } from './tags.js';
 import { parseHandoffForkConsent } from './chat-fork-command-parsing.js';
+import { normalizeAskUserQuestionDecisionResponse } from './ask-user-question-response.js';
 
 export {
   parseDeleteChatCommandRequest,
   parseForkChatCommandRequest,
 } from './chat-fork-command-parsing.js';
+export {
+  ASK_USER_QUESTION_ID_MAX_BYTES,
+  ASK_USER_QUESTION_MAX_ANSWERS,
+  ASK_USER_QUESTION_MAX_SELECTED_OPTIONS,
+  ASK_USER_QUESTION_REASON_MAX_BYTES,
+  ASK_USER_QUESTION_RESPONSE_MAX_BYTES,
+  normalizeAskUserQuestionDecisionResponse,
+  type AskUserQuestionAnswerPayload,
+  type AskUserQuestionAnsweredResponse,
+  type AskUserQuestionDecisionResponse,
+  type AskUserQuestionSkippedResponse,
+} from './ask-user-question-response.js';
 import { isPreambleId, PREAMBLE_MAX_COUNT, type PreambleId } from './preambles.js';
 import {
   parseUserMessagePresentation,
@@ -376,115 +389,6 @@ export interface QueueMutationResponse {
   success: true;
   chatId: string;
   control: ChatExecutionControlState;
-}
-
-export interface AskUserQuestionAnswerPayload {
-  questionId: string;
-  selectedOptionIds: string[];
-}
-
-export const ASK_USER_QUESTION_MAX_ANSWERS = 100;
-export const ASK_USER_QUESTION_MAX_SELECTED_OPTIONS = 100;
-export const ASK_USER_QUESTION_ID_MAX_BYTES = 1_024;
-export const ASK_USER_QUESTION_REASON_MAX_BYTES = 4_096;
-export const ASK_USER_QUESTION_RESPONSE_MAX_BYTES = 64 * 1_024;
-
-const permissionResponseEncoder = new TextEncoder();
-
-export interface AskUserQuestionAnsweredResponse extends Record<string, unknown> {
-  type: 'ask-user-question-response';
-  outcome: 'answered';
-  answers: AskUserQuestionAnswerPayload[];
-}
-
-export interface AskUserQuestionSkippedResponse extends Record<string, unknown> {
-  type: 'ask-user-question-response';
-  outcome: 'skipped';
-  reason?: string;
-}
-
-export type AskUserQuestionDecisionResponse = AskUserQuestionAnsweredResponse | AskUserQuestionSkippedResponse;
-
-export function normalizeAskUserQuestionDecisionResponse(
-  value: unknown,
-): AskUserQuestionDecisionResponse | null {
-  const response = value && typeof value === 'object' && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null;
-  if (!response || response.type !== 'ask-user-question-response') return null;
-
-  let normalized: AskUserQuestionDecisionResponse;
-  if (response.outcome === 'answered') {
-    if (
-      !hasExactKeys(response, ['type', 'outcome', 'answers'])
-      || !Array.isArray(response.answers)
-      || response.answers.length > ASK_USER_QUESTION_MAX_ANSWERS
-    ) return null;
-    const answers: AskUserQuestionAnswerPayload[] = [];
-    const questionIds = new Set<string>();
-    for (const valueAnswer of response.answers) {
-      const answer = valueAnswer && typeof valueAnswer === 'object' && !Array.isArray(valueAnswer)
-        ? valueAnswer as Record<string, unknown>
-        : null;
-      if (
-        !answer
-        || !hasExactKeys(answer, ['questionId', 'selectedOptionIds'])
-        || !boundedQuestionResponseId(answer.questionId)
-        || questionIds.has(answer.questionId)
-        || !Array.isArray(answer.selectedOptionIds)
-        || answer.selectedOptionIds.length > ASK_USER_QUESTION_MAX_SELECTED_OPTIONS
-      ) return null;
-      const selectedOptionIds: string[] = [];
-      const optionIds = new Set<string>();
-      for (const optionId of answer.selectedOptionIds) {
-        if (!boundedQuestionResponseId(optionId) || optionIds.has(optionId)) return null;
-        optionIds.add(optionId);
-        selectedOptionIds.push(optionId);
-      }
-      questionIds.add(answer.questionId);
-      answers.push({ questionId: answer.questionId, selectedOptionIds });
-    }
-    normalized = { type: 'ask-user-question-response', outcome: 'answered', answers };
-  } else if (response.outcome === 'skipped') {
-    if (!hasExactKeys(response, ['type', 'outcome'], ['reason'])) return null;
-    if (
-      response.reason !== undefined
-      && (!boundedQuestionResponseText(response.reason, ASK_USER_QUESTION_REASON_MAX_BYTES))
-    ) return null;
-    normalized = {
-      type: 'ask-user-question-response',
-      outcome: 'skipped',
-      ...(response.reason === undefined ? {} : { reason: response.reason }),
-    };
-  } else {
-    return null;
-  }
-
-  return permissionResponseEncoder.encode(JSON.stringify(normalized)).byteLength
-    <= ASK_USER_QUESTION_RESPONSE_MAX_BYTES
-    ? normalized
-    : null;
-}
-
-function boundedQuestionResponseId(value: unknown): value is string {
-  return boundedQuestionResponseText(value, ASK_USER_QUESTION_ID_MAX_BYTES);
-}
-
-function boundedQuestionResponseText(value: unknown, maxBytes: number): value is string {
-  return typeof value === 'string'
-    && value.trim().length > 0
-    && value.isWellFormed()
-    && permissionResponseEncoder.encode(value).byteLength <= maxBytes;
-}
-
-function hasExactKeys(
-  value: Record<string, unknown>,
-  required: readonly string[],
-  optional: readonly string[] = [],
-): boolean {
-  const keys = Object.keys(value);
-  return required.every((key) => Object.hasOwn(value, key))
-    && keys.every((key) => required.includes(key) || optional.includes(key));
 }
 
 export interface PermissionDecisionPayload {

--- a/common/chat-command-contracts.ts
+++ b/common/chat-command-contracts.ts
@@ -383,6 +383,14 @@ export interface AskUserQuestionAnswerPayload {
   selectedOptionIds: string[];
 }
 
+export const ASK_USER_QUESTION_MAX_ANSWERS = 100;
+export const ASK_USER_QUESTION_MAX_SELECTED_OPTIONS = 100;
+export const ASK_USER_QUESTION_ID_MAX_BYTES = 1_024;
+export const ASK_USER_QUESTION_REASON_MAX_BYTES = 4_096;
+export const ASK_USER_QUESTION_RESPONSE_MAX_BYTES = 64 * 1_024;
+
+const permissionResponseEncoder = new TextEncoder();
+
 export interface AskUserQuestionAnsweredResponse extends Record<string, unknown> {
   type: 'ask-user-question-response';
   outcome: 'answered';
@@ -396,6 +404,88 @@ export interface AskUserQuestionSkippedResponse extends Record<string, unknown> 
 }
 
 export type AskUserQuestionDecisionResponse = AskUserQuestionAnsweredResponse | AskUserQuestionSkippedResponse;
+
+export function normalizeAskUserQuestionDecisionResponse(
+  value: unknown,
+): AskUserQuestionDecisionResponse | null {
+  const response = value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+  if (!response || response.type !== 'ask-user-question-response') return null;
+
+  let normalized: AskUserQuestionDecisionResponse;
+  if (response.outcome === 'answered') {
+    if (
+      !hasExactKeys(response, ['type', 'outcome', 'answers'])
+      || !Array.isArray(response.answers)
+      || response.answers.length > ASK_USER_QUESTION_MAX_ANSWERS
+    ) return null;
+    const answers: AskUserQuestionAnswerPayload[] = [];
+    const questionIds = new Set<string>();
+    for (const valueAnswer of response.answers) {
+      const answer = valueAnswer && typeof valueAnswer === 'object' && !Array.isArray(valueAnswer)
+        ? valueAnswer as Record<string, unknown>
+        : null;
+      if (
+        !answer
+        || !hasExactKeys(answer, ['questionId', 'selectedOptionIds'])
+        || !boundedQuestionResponseId(answer.questionId)
+        || questionIds.has(answer.questionId)
+        || !Array.isArray(answer.selectedOptionIds)
+        || answer.selectedOptionIds.length > ASK_USER_QUESTION_MAX_SELECTED_OPTIONS
+      ) return null;
+      const selectedOptionIds: string[] = [];
+      const optionIds = new Set<string>();
+      for (const optionId of answer.selectedOptionIds) {
+        if (!boundedQuestionResponseId(optionId) || optionIds.has(optionId)) return null;
+        optionIds.add(optionId);
+        selectedOptionIds.push(optionId);
+      }
+      questionIds.add(answer.questionId);
+      answers.push({ questionId: answer.questionId, selectedOptionIds });
+    }
+    normalized = { type: 'ask-user-question-response', outcome: 'answered', answers };
+  } else if (response.outcome === 'skipped') {
+    if (!hasExactKeys(response, ['type', 'outcome'], ['reason'])) return null;
+    if (
+      response.reason !== undefined
+      && (!boundedQuestionResponseText(response.reason, ASK_USER_QUESTION_REASON_MAX_BYTES))
+    ) return null;
+    normalized = {
+      type: 'ask-user-question-response',
+      outcome: 'skipped',
+      ...(response.reason === undefined ? {} : { reason: response.reason }),
+    };
+  } else {
+    return null;
+  }
+
+  return permissionResponseEncoder.encode(JSON.stringify(normalized)).byteLength
+    <= ASK_USER_QUESTION_RESPONSE_MAX_BYTES
+    ? normalized
+    : null;
+}
+
+function boundedQuestionResponseId(value: unknown): value is string {
+  return boundedQuestionResponseText(value, ASK_USER_QUESTION_ID_MAX_BYTES);
+}
+
+function boundedQuestionResponseText(value: unknown, maxBytes: number): value is string {
+  return typeof value === 'string'
+    && value.trim().length > 0
+    && value.isWellFormed()
+    && permissionResponseEncoder.encode(value).byteLength <= maxBytes;
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean {
+  const keys = Object.keys(value);
+  return required.every((key) => Object.hasOwn(value, key))
+    && keys.every((key) => required.includes(key) || optional.includes(key));
+}
 
 export interface PermissionDecisionPayload {
   allow: boolean;
@@ -869,7 +959,14 @@ export function parsePermissionDecisionCommandRequest(value: unknown): Permissio
   const body = requestRecord(value);
   if (typeof body.allow !== 'boolean') throw new CommandRequestValidationError('allow must be a boolean');
   if (typeof body.alwaysAllow !== 'boolean') throw new CommandRequestValidationError('alwaysAllow must be a boolean');
-  const response = optionalRecord(body.response, 'response');
+  let response = optionalRecord(body.response, 'response');
+  if (response?.type === 'ask-user-question-response') {
+    const normalized = normalizeAskUserQuestionDecisionResponse(response);
+    if (!normalized) {
+      throw new CommandRequestValidationError('response contains an invalid structured answer');
+    }
+    response = normalized;
+  }
   const control = parseChatTransientControlAction(body.control);
   if (!control) throw new CommandRequestValidationError('control is invalid');
   const chatId = requiredChatId(body, 'chatId');

--- a/common/chat-search.ts
+++ b/common/chat-search.ts
@@ -448,6 +448,23 @@ const TRANSCRIPT_SEARCH_STATUS_KEYS = [
   'updatedAt',
 ] as const;
 
+const TRANSCRIPT_SEARCH_CHAT_KEYS = [
+  'total',
+  'indexed',
+  'pending',
+  'failed',
+  'unindexed',
+] as const;
+
+const TRANSCRIPT_SEARCH_PHASES: readonly TranscriptSearchPhase[] = [
+  'disabled',
+  'opening',
+  'rebuilding',
+  'ready',
+  'degraded',
+  'failed',
+];
+
 const TRANSCRIPT_SEARCH_QUERY_STAT_KEYS = [
   'served',
   'timedOut',
@@ -512,7 +529,7 @@ function isTranscriptSearchQueryStatsV1(
   value: unknown,
 ): value is TranscriptSearchQueryStatsV1 {
   const queryStats = chatSearchRecord(value);
-  return !!queryStats
+  return queryStats !== null
     && hasExactChatSearchKeys(queryStats, TRANSCRIPT_SEARCH_QUERY_STAT_KEYS)
     && TRANSCRIPT_SEARCH_QUERY_STAT_KEYS.every(
       (key) => isNonNegativeSafeInteger(queryStats[key]),
@@ -522,54 +539,66 @@ function isTranscriptSearchQueryStatsV1(
 export function isTranscriptSearchStatusV1(value: unknown): value is TranscriptSearchStatusV1 {
   const raw = chatSearchRecord(value);
   if (!raw || !hasExactChatSearchKeys(raw, TRANSCRIPT_SEARCH_STATUS_KEYS)) return false;
-  const candidate = raw as Partial<TranscriptSearchStatusV1>;
-  const chats = candidate.chats;
-  const resync = candidate.resync;
-  const activeChat = candidate.activeChat;
-  return !!chats
-    && typeof chats === 'object'
-    && candidate.version === 1
-    && ['disabled', 'opening', 'rebuilding', 'ready', 'degraded', 'failed']
-      .includes(candidate.phase as TranscriptSearchPhase)
-    && [
-      chats.indexed,
-      chats.pending,
-      chats.failed,
-      chats.total,
-      chats.unindexed,
-      candidate.queuedJobs,
-      candidate.backlogRows,
-    ].every((count) => typeof count === 'number' && Number.isSafeInteger(count) && count >= 0)
-    && chats.indexed + chats.pending + chats.failed + chats.unindexed >= chats.total
-    && (resync === null
-      || (!!resync
-        && typeof resync === 'object'
-        && Number.isSafeInteger(resync.completedChats)
-        && Number.isSafeInteger(resync.totalChats)
-        && resync.completedChats >= 0
-        && resync.totalChats >= resync.completedChats))
-    && (activeChat === null
-      || (!!activeChat
-        && typeof activeChat === 'object'
-        && Number.isSafeInteger(activeChat.position)
-        && Number.isSafeInteger(activeChat.total)
-        && activeChat.position >= 0
-        && activeChat.total >= activeChat.position))
-    && (candidate.lastErrorCode === null
-      || (typeof candidate.lastErrorCode === 'string'
-        && /^[A-Z][A-Z0-9_]{0,63}$/u.test(candidate.lastErrorCode)))
-    && isCanonicalChatSearchTimestamp(candidate.updatedAt)
-    && hasExactChatSearchKeys(chats, [
-      'total', 'indexed', 'pending', 'failed', 'unindexed',
-    ])
-    && (resync === null || hasExactChatSearchKeys(
-      resync,
-      ['completedChats', 'totalChats'],
-    ))
-    && (activeChat === null || hasExactChatSearchKeys(
-      activeChat,
-      ['position', 'total'],
-    ));
+  return raw.version === 1
+    && isTranscriptSearchPhase(raw.phase)
+    && isTranscriptSearchChatCounts(raw.chats)
+    && isNonNegativeSafeInteger(raw.queuedJobs)
+    && isNonNegativeSafeInteger(raw.backlogRows)
+    && isTranscriptSearchResync(raw.resync)
+    && isTranscriptSearchActiveChat(raw.activeChat)
+    && isTranscriptSearchErrorCode(raw.lastErrorCode)
+    && isCanonicalChatSearchTimestamp(raw.updatedAt);
+}
+
+function isTranscriptSearchPhase(value: unknown): value is TranscriptSearchPhase {
+  return typeof value === 'string'
+    && TRANSCRIPT_SEARCH_PHASES.includes(value as TranscriptSearchPhase);
+}
+
+function isTranscriptSearchChatCounts(
+  value: unknown,
+): value is TranscriptSearchStatusV1['chats'] {
+  const chats = chatSearchRecord(value);
+  if (!chats || !hasExactChatSearchKeys(chats, TRANSCRIPT_SEARCH_CHAT_KEYS)) return false;
+  if (
+    !isNonNegativeSafeInteger(chats.total)
+    || !isNonNegativeSafeInteger(chats.indexed)
+    || !isNonNegativeSafeInteger(chats.pending)
+    || !isNonNegativeSafeInteger(chats.failed)
+    || !isNonNegativeSafeInteger(chats.unindexed)
+  ) {
+    return false;
+  }
+  return chats.indexed + chats.pending + chats.failed + chats.unindexed >= chats.total;
+}
+
+function isTranscriptSearchResync(
+  value: unknown,
+): value is TranscriptSearchStatusV1['resync'] {
+  if (value === null) return true;
+  const progress = chatSearchRecord(value);
+  return progress !== null
+    && hasExactChatSearchKeys(progress, ['completedChats', 'totalChats'])
+    && isNonNegativeSafeInteger(progress.completedChats)
+    && isNonNegativeSafeInteger(progress.totalChats)
+    && progress.totalChats >= progress.completedChats;
+}
+
+function isTranscriptSearchActiveChat(
+  value: unknown,
+): value is TranscriptSearchStatusV1['activeChat'] {
+  if (value === null) return true;
+  const progress = chatSearchRecord(value);
+  return progress !== null
+    && hasExactChatSearchKeys(progress, ['position', 'total'])
+    && isNonNegativeSafeInteger(progress.position)
+    && isNonNegativeSafeInteger(progress.total)
+    && progress.total >= progress.position;
+}
+
+function isTranscriptSearchErrorCode(value: unknown): value is string | null {
+  return value === null
+    || (typeof value === 'string' && /^[A-Z][A-Z0-9_]{0,63}$/u.test(value));
 }
 
 function hasExactChatSearchKeys(

--- a/common/chat-search.ts
+++ b/common/chat-search.ts
@@ -431,9 +431,71 @@ export type TranscriptSearchStatusResponse = TranscriptSearchStatusV1 & {
   readonly queryStats: TranscriptSearchQueryStatsV1;
 };
 
+const TRANSCRIPT_SEARCH_STATUS_KEYS = [
+  'version',
+  'phase',
+  'chats',
+  'queuedJobs',
+  'resync',
+  'backlogRows',
+  'activeChat',
+  'lastErrorCode',
+  'updatedAt',
+] as const;
+
+const TRANSCRIPT_SEARCH_QUERY_STAT_KEYS = [
+  'served',
+  'timedOut',
+  'rejectedBusy',
+  'p50Ms',
+  'p95Ms',
+  'maxMs',
+  'admissionP50Ms',
+  'admissionP95Ms',
+  'admissionMaxMs',
+  'totalP50Ms',
+  'totalP95Ms',
+  'totalMaxMs',
+] as const;
+
+export function parseTranscriptSearchStatusResponse(
+  value: unknown,
+): TranscriptSearchStatusResponse {
+  const response = chatSearchRecord(value);
+  if (!response || !hasExactChatSearchKeys(response, [
+    ...TRANSCRIPT_SEARCH_STATUS_KEYS,
+    'queryStats',
+  ])) {
+    throw new Error('Invalid transcript search status response: unexpected fields');
+  }
+  const { queryStats: rawQueryStats, ...rawStatus } = response;
+  if (!isTranscriptSearchStatusV1(rawStatus)) {
+    throw new Error('Invalid transcript search status response: invalid status');
+  }
+  if (!isTranscriptSearchQueryStatsV1(rawQueryStats)) {
+    throw new Error('Invalid transcript search status response: invalid query statistics');
+  }
+  return {
+    ...rawStatus,
+    queryStats: rawQueryStats,
+  };
+}
+
+function isTranscriptSearchQueryStatsV1(
+  value: unknown,
+): value is TranscriptSearchQueryStatsV1 {
+  const queryStats = chatSearchRecord(value);
+  return !!queryStats
+    && hasExactChatSearchKeys(queryStats, TRANSCRIPT_SEARCH_QUERY_STAT_KEYS)
+    && TRANSCRIPT_SEARCH_QUERY_STAT_KEYS.every(
+      (key) => isNonNegativeSafeInteger(queryStats[key]),
+    );
+}
+
 export function isTranscriptSearchStatusV1(value: unknown): value is TranscriptSearchStatusV1 {
-  if (!value || typeof value !== 'object') return false;
-  const candidate = value as Partial<TranscriptSearchStatusV1>;
+  const raw = chatSearchRecord(value);
+  if (!raw || !hasExactChatSearchKeys(raw, TRANSCRIPT_SEARCH_STATUS_KEYS)) return false;
+  const candidate = raw as Partial<TranscriptSearchStatusV1>;
   const chats = candidate.chats;
   const resync = candidate.resync;
   const activeChat = candidate.activeChat;
@@ -466,6 +528,33 @@ export function isTranscriptSearchStatusV1(value: unknown): value is TranscriptS
         && Number.isSafeInteger(activeChat.total)
         && activeChat.position >= 0
         && activeChat.total >= activeChat.position))
-    && (candidate.lastErrorCode === null || typeof candidate.lastErrorCode === 'string')
-    && typeof candidate.updatedAt === 'string';
+    && (candidate.lastErrorCode === null
+      || (typeof candidate.lastErrorCode === 'string'
+        && /^[A-Z][A-Z0-9_]{0,63}$/u.test(candidate.lastErrorCode)))
+    && isCanonicalChatSearchTimestamp(candidate.updatedAt)
+    && hasExactChatSearchKeys(chats, [
+      'total', 'indexed', 'pending', 'failed', 'unindexed',
+    ])
+    && (resync === null || hasExactChatSearchKeys(
+      resync,
+      ['completedChats', 'totalChats'],
+    ))
+    && (activeChat === null || hasExactChatSearchKeys(
+      activeChat,
+      ['position', 'total'],
+    ));
+}
+
+function hasExactChatSearchKeys(
+  value: object,
+  expected: readonly string[],
+): boolean {
+  const keys = Object.keys(value);
+  return keys.length === expected.length && expected.every((key) => Object.hasOwn(value, key));
+}
+
+function isCanonicalChatSearchTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
 }

--- a/common/chat-search.ts
+++ b/common/chat-search.ts
@@ -145,6 +145,7 @@ export function parseChatSearchResponse(
 ): ChatSearchResponse {
   const response = chatSearchRecord(value);
   if (!response || typeof response.query !== 'string') invalidChatSearchResponse('response');
+  if (response.query !== request.query) invalidChatSearchResponse('query does not match request');
   const expectedMode = request.mode ?? 'page';
   const expectedSnippetLimit = request.snippetLimit ?? CHAT_SEARCH_MAX_SNIPPETS_PER_CHAT;
   const expectedOffset = request.offset ?? 0;

--- a/common/chat-search.ts
+++ b/common/chat-search.ts
@@ -431,6 +431,11 @@ export type TranscriptSearchStatusResponse = TranscriptSearchStatusV1 & {
   readonly queryStats: TranscriptSearchQueryStatsV1;
 };
 
+export interface TranscriptSearchRebuildResponse {
+  readonly success: true;
+  readonly status: TranscriptSearchStatusResponse;
+}
+
 const TRANSCRIPT_SEARCH_STATUS_KEYS = [
   'version',
   'phase',
@@ -478,6 +483,28 @@ export function parseTranscriptSearchStatusResponse(
   return {
     ...rawStatus,
     queryStats: rawQueryStats,
+  };
+}
+
+export function parseTranscriptSearchRebuildResponse(
+  value: unknown,
+): TranscriptSearchRebuildResponse {
+  const response = chatSearchRecord(value);
+  if (!response || !hasExactChatSearchKeys(response, ['success', 'status'])) {
+    throw new Error('Invalid transcript search rebuild response: unexpected fields');
+  }
+  if (response.success !== true) {
+    throw new Error('Invalid transcript search rebuild response: rebuild was not accepted');
+  }
+  let status: TranscriptSearchStatusResponse;
+  try {
+    status = parseTranscriptSearchStatusResponse(response.status);
+  } catch (error) {
+    throw new Error('Invalid transcript search rebuild response: invalid status', { cause: error });
+  }
+  return {
+    success: true,
+    status,
   };
 }
 

--- a/common/chat-transient-feed.ts
+++ b/common/chat-transient-feed.ts
@@ -1,7 +1,6 @@
 import {
   PermissionRequestMessage,
   parseChatMessage,
-  type ChatMessage,
 } from './chat-types';
 
 export interface TransientFeedRow {
@@ -12,7 +11,7 @@ export interface TransientFeedRow {
     readonly afterOrdinal: number;
   };
   readonly displayOrder: number;
-  readonly message: ChatMessage;
+  readonly message: PermissionRequestMessage;
 }
 
 export type ChatTransientFeedMutationBody =

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -183,10 +183,18 @@ advance that activity field.
 Search normalized transcript content and join each hit to chat metadata:
 
 ```bash
+bun cli/main.ts --workspace default transcript-search enable
+bun cli/main.ts --workspace default transcript-search status --json
 bun cli/main.ts --workspace default search '"version bump"' \
   --filter 'project:/garcon agent:codex' \
   --sort relevance --limit 20 --offset 0 --snippets 3 --json
 ```
+
+Transcript search is disabled by default and is enabled or disabled explicitly
+with `transcript-search enable|disable`. `transcript-search status` reports the
+index phase, chat coverage, queued and active indexing work, backlog and resync
+progress, the last error code, and query admission/execution/total latency
+statistics. JSON status is the validated server status document.
 
 Search is lexical. Quoted phrases require adjacent words in one indexed entry.
 Unquoted terms are ANDed at chat scope and can occur in different messages;
@@ -220,9 +228,9 @@ If a transcript view changes after the index page is selected, the response
 reports how many stale hits were removed. The CLI warns for any positive count,
 including a partially retained page, and callers should rerun the search.
 `page.hasMore` and `page.nextOffset` remain authoritative.
-Disabled search exits with settings guidance. Busy, timeout, and unavailable
-index states remain retryable operational failures. Invalid search queries exit
-as argument failures.
+Disabled search exits with the exact enable-command guidance. Busy, timeout, and
+unavailable index states remain retryable operational failures. Invalid search
+queries exit as argument failures.
 
 Read bounded context around a search ordinal while pinning the transcript view:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,6 +184,7 @@ Search normalized transcript content and join each hit to chat metadata:
 
 ```bash
 bun cli/main.ts --workspace default transcript-search enable
+bun cli/main.ts --workspace default transcript-search rebuild --json
 bun cli/main.ts --workspace default transcript-search status --json
 bun cli/main.ts --workspace default search '"version bump"' \
   --filter 'project:/garcon agent:codex' \
@@ -191,7 +192,9 @@ bun cli/main.ts --workspace default search '"version bump"' \
 ```
 
 Transcript search is disabled by default and is enabled or disabled explicitly
-with `transcript-search enable|disable`. `transcript-search status` reports the
+with `transcript-search enable|disable`. While search is enabled,
+`transcript-search rebuild` deletes and recreates the derived index, then starts
+a complete resynchronization. `transcript-search status` reports the
 index phase, chat coverage, queued and active indexing work, backlog and resync
 progress, the last error code, and query admission/execution/total latency
 statistics. JSON status is the validated server status document.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -281,11 +281,11 @@ bun cli/main.ts --workspace default status 1785337200123456 \
 permission requests, and 10 recent normalized transcript messages by default.
 Plain permission rows include the exact occurrence, run, and server-instance
 fences plus shell-safe allow and deny commands where the request supports a
-boolean decision. They remain visible with `--messages 0` or an unavailable
-transcript. Structured questions must be answered in Garcon; allowing them does
-not supply question answers. `--messages` accepts 0 through 200; zero skips
-transcript loading. JSON is the stable machine-readable interface; plain text
-redacts image bodies and truncates long messages.
+boolean decision. Structured rows include a typed answer template instead of an
+allow command. They remain visible with `--messages 0` or an unavailable
+transcript. `--messages` accepts 0 through 200; zero skips transcript loading.
+JSON is the stable machine-readable interface; plain text redacts image bodies
+and truncates long messages.
 
 Status is a one-shot, non-transactional observation. Use `wait` with the exact accepted chat and turn IDs when completion identity matters.
 
@@ -296,6 +296,19 @@ bun cli/main.ts --workspace default permission-decision 1785337200123456 \
   permission-occurrence-id allow \
   --run run-id --server-instance server-instance-id --json
 ```
+
+Answer a structured question with the exact IDs shown by `status`:
+
+```bash
+bun cli/main.ts --workspace default permission-answer 1785337200123456 \
+  permission-occurrence-id \
+  --answers '[{"questionId":"question-id","selectedOptionIds":["option-id"]}]' \
+  --run run-id --server-instance server-instance-id --json
+```
+
+`--answers` is a JSON array with one row per answered question. Each row has a
+unique `questionId` and a `selectedOptionIds` array containing unique option
+IDs. Use `permission-decision ... deny` to skip or decline the request.
 
 The command never fetches or substitutes the newest request. Its deterministic
 idempotency identity binds the server instance, chat, run, and occurrence while

--- a/integration-tests/tests/server/claude-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/claude-scripted-permissions.test.ts
@@ -145,23 +145,22 @@ describe('scripted Claude permissions', () => {
         'permission-resolved',
       )).toEqual([]);
 
-      const decision = await fixture.client.sendPermissionDecision({
-        clientRequestId: crypto.randomUUID(),
+      const decision = await runCli(fixture, [
+        'permission-answer', chatId, permissionOccurrenceId,
+        '--answers', JSON.stringify([{
+          questionId: 'Which database?',
+          selectedOptionIds: ['Postgres'],
+        }]),
+        '--run', control.runId,
+        '--server-instance', control.serverInstanceId,
+        '--json',
+      ]);
+      expect(decision).toMatchObject({ exitCode: 0, stderr: '' });
+      expect(JSON.parse(decision.stdout)).toMatchObject({
+        commandType: 'permission-decision',
         chatId,
-        permissionOccurrenceId,
-        allow: true,
-        alwaysAllow: false,
-        control,
-        response: {
-          type: 'ask-user-question-response',
-          outcome: 'answered',
-          answers: [{
-            questionId: 'Which database?',
-            selectedOptionIds: ['Postgres'],
-          }],
-        },
+        status: 'accepted',
       });
-      expect(decision.status).toBe('accepted');
       await waitForVisibleResponse({
         fixture,
         chatId,
@@ -176,6 +175,7 @@ describe('scripted Claude permissions', () => {
         && entry.message.allowed)).toBe(true);
       testEnvironment.model.assertSettled();
     }, {
+      namedWorkspace: CLI_PERMISSION_WORKSPACE,
       serverEnvironment: testEnvironment.serverEnvironment,
     });
   }, 60_000);

--- a/integration-tests/tests/server/claude-scripted-permissions.test.ts
+++ b/integration-tests/tests/server/claude-scripted-permissions.test.ts
@@ -145,6 +145,23 @@ describe('scripted Claude permissions', () => {
         'permission-resolved',
       )).toEqual([]);
 
+      const invalidDecision = await runCli(fixture, [
+        'permission-answer', chatId, permissionOccurrenceId,
+        '--answers', JSON.stringify([{
+          questionId: 'Which database?',
+          selectedOptionIds: ['Unknown database'],
+        }]),
+        '--run', control.runId,
+        '--server-instance', control.serverInstanceId,
+        '--json',
+      ]);
+      expect(invalidDecision).toMatchObject({ exitCode: 2, stdout: '' });
+      expect(invalidDecision.stderr).toContain('unknown option ID');
+      expect(messagesOfType(
+        (await fixture.client.getMessages(chatId)).messages,
+        'permission-resolved',
+      )).toEqual([]);
+
       const decision = await runCli(fixture, [
         'permission-answer', chatId, permissionOccurrenceId,
         '--answers', JSON.stringify([{

--- a/integration-tests/tests/server/garcon-cli-search.test.ts
+++ b/integration-tests/tests/server/garcon-cli-search.test.ts
@@ -101,6 +101,14 @@ describe('garcon-cli chat research', () => {
         queryStats: { served: 0, timedOut: 0, rejectedBusy: 0 },
       });
 
+      const rebuilt = await runCli(fixture, ['transcript-search', 'rebuild', '--json']);
+      expect(rebuilt).toMatchObject({ exitCode: 0, stderr: '' });
+      expect(JSON.parse(rebuilt.stdout)).toMatchObject({
+        success: true,
+        status: { version: 1 },
+      });
+      await fixture.client.waitForSearchPhase(['ready'], { timeoutMs: 60_000 });
+
       const child = (await fixture.client.listChats()).sessions.find((entry) => entry.id === chatId);
       if (!child?.activity.createdAt || !child.activity.lastActivityAt) {
         throw new Error('Child chat is missing activity timestamps.');
@@ -209,7 +217,14 @@ describe('garcon-cli chat research', () => {
       const result = await runCli(fixture, ['search', 'needle', '--json']);
       expect(result.exitCode).toBe(2);
       expect(result.stdout).toBe('');
-      expect(result.stderr).toContain('garcon-cli transcript-search enable');
+      expect(result.stderr).toContain([
+        'garcon-cli',
+        '--workspace', `'${WORKSPACE}'`,
+        '--config-dir', `'${fixture.dirs.config}'`,
+        '--server', `'${fixture.garcon.baseUrl}'`,
+        'transcript-search',
+        'enable',
+      ].join(' '));
     }, { namedWorkspace: WORKSPACE });
   });
 });

--- a/integration-tests/tests/server/garcon-cli-search.test.ts
+++ b/integration-tests/tests/server/garcon-cli-search.test.ts
@@ -87,10 +87,19 @@ describe('garcon-cli chat research', () => {
         .toBe('agent-run-finished');
       await fs.rm(projectPath, { recursive: true, force: true });
 
-      await fixture.client.updateSettings({
-        features: { transcriptSearch: { enabled: true } },
-      });
+      const enabled = await runCli(fixture, ['transcript-search', 'enable', '--json']);
+      expect(enabled).toMatchObject({ exitCode: 0, stderr: '' });
+      expect(JSON.parse(enabled.stdout)).toMatchObject({ enabled: true });
       await fixture.client.waitForSearchPhase(['ready'], { timeoutMs: 60_000 });
+
+      const searchStatus = await runCli(fixture, ['transcript-search', 'status', '--json']);
+      expect(searchStatus).toMatchObject({ exitCode: 0, stderr: '' });
+      expect(JSON.parse(searchStatus.stdout)).toMatchObject({
+        version: 1,
+        phase: 'ready',
+        chats: { total: 2, indexed: 2, pending: 0, failed: 0, unindexed: 0 },
+        queryStats: { served: 0, timedOut: 0, rejectedBusy: 0 },
+      });
 
       const child = (await fixture.client.listChats()).sessions.find((entry) => entry.id === chatId);
       if (!child?.activity.createdAt || !child.activity.lastActivityAt) {
@@ -188,6 +197,10 @@ describe('garcon-cli chat research', () => {
       expect(readResult.messages.some(
         (entry: { ordinal: number }) => entry.ordinal === snippet.ordinal,
       )).toBe(true);
+
+      const disabled = await runCli(fixture, ['transcript-search', 'disable', '--json']);
+      expect(disabled).toMatchObject({ exitCode: 0, stderr: '' });
+      expect(JSON.parse(disabled.stdout)).toMatchObject({ enabled: false });
     }, { namedWorkspace: WORKSPACE });
   }, 120_000);
 
@@ -196,7 +209,7 @@ describe('garcon-cli chat research', () => {
       const result = await runCli(fixture, ['search', 'needle', '--json']);
       expect(result.exitCode).toBe(2);
       expect(result.stdout).toBe('');
-      expect(result.stderr).toContain('features.transcriptSearch.enabled');
+      expect(result.stderr).toContain('garcon-cli transcript-search enable');
     }, { namedWorkspace: WORKSPACE });
   });
 });

--- a/integration-tests/tests/server/garcon-cli.test.ts
+++ b/integration-tests/tests/server/garcon-cli.test.ts
@@ -523,6 +523,10 @@ describe('garcon-cli', () => {
       const puckId = catalog.preambles.find((entry) => entry.title === 'Puck only')?.id;
       if (!puckId) throw new Error('Puck preamble was not created.');
 
+      const listed = await runCli(controlArguments(fixture, ['list', 'preambles', '--json']));
+      expect(listed).toMatchObject({ exitCode: 0, stderr: '' });
+      expect(JSON.parse(listed.stdout)).toEqual(catalog);
+
       const parentArgs = startArguments(fixture, 'puck-parent');
       parentArgs.splice(-1, 0, '--tag', 'puck', '--preamble', puckId);
       const parent = await runCli(parentArgs);

--- a/server-agents/cursor/src/agents/cursor/__tests__/runtime.test.js
+++ b/server-agents/cursor/src/agents/cursor/__tests__/runtime.test.js
@@ -881,10 +881,9 @@ describe('Cursor ACP runtime', () => {
     });
 
     const answered = {
-      outcome: {
-        outcome: 'answered',
-        answers: [{ questionId: 'q1', selectedOptionIds: ['agent'] }],
-      },
+      type: 'ask-user-question-response',
+      outcome: 'answered',
+      answers: [{ questionId: 'q1', selectedOptionIds: ['agent'] }],
     };
     const permission = await operation.waitForEvent((event) => event.type === 'permission');
     expect(permission.lifecycle.requestedTool).toBeInstanceOf(CursorAskQuestionToolUseMessage);
@@ -892,7 +891,12 @@ describe('Cursor ACP runtime', () => {
     await permission.decision.respond({ allow: true, response: answered });
 
     const response = await acp.waitForWrite((message) => message.id === 'question-1' && message.result);
-    expect(response.result).toEqual(answered);
+    expect(response.result).toEqual({
+      outcome: {
+        outcome: 'answered',
+        answers: [{ questionId: 'q1', selectedOptionIds: ['agent'] }],
+      },
+    });
 
     acp.finishPrompt();
     runtime.shutdown();

--- a/server-agents/cursor/src/agents/cursor/cursor-acp-event-converter.ts
+++ b/server-agents/cursor/src/agents/cursor/cursor-acp-event-converter.ts
@@ -11,7 +11,10 @@ import {
   type CursorPlanTodoStatus,
   type ToolUseChatMessage,
 } from '@garcon/common/chat-types';
-import type { PermissionDecisionPayload } from '@garcon/common/chat-command-contracts';
+import {
+  normalizeAskUserQuestionDecisionResponse,
+  type PermissionDecisionPayload,
+} from '@garcon/common/chat-command-contracts';
 import { normalizeCursorToolResultContent } from './tool-result-converter.js';
 import { convertCursorToolUse } from './tool-use-converter.js';
 import {
@@ -245,6 +248,14 @@ function cursorPlanPhases(rawPhases: unknown): CursorPlanPhase[] | undefined {
 }
 
 function cursorAskQuestionResponse(decision: PermissionDecisionPayload): Record<string, unknown> {
+  const response = normalizeAskUserQuestionDecisionResponse(decision.response);
+  if (response) {
+    return {
+      outcome: response.outcome === 'answered'
+        ? { outcome: response.outcome, answers: response.answers }
+        : { outcome: response.outcome, ...(response.reason ? { reason: response.reason } : {}) },
+    };
+  }
   if (decision.response) return decision.response;
   if (!decision.allow) {
     return { outcome: { outcome: 'skipped', reason: 'User skipped question' } };

--- a/server-agents/cursor/src/agents/cursor/cursor-acp-event-converter.ts
+++ b/server-agents/cursor/src/agents/cursor/cursor-acp-event-converter.ts
@@ -249,11 +249,17 @@ function cursorPlanPhases(rawPhases: unknown): CursorPlanPhase[] | undefined {
 
 function cursorAskQuestionResponse(decision: PermissionDecisionPayload): Record<string, unknown> {
   const response = normalizeAskUserQuestionDecisionResponse(decision.response);
+  if (response?.outcome === 'answered') {
+    return {
+      outcome: { outcome: response.outcome, answers: response.answers },
+    };
+  }
   if (response) {
     return {
-      outcome: response.outcome === 'answered'
-        ? { outcome: response.outcome, answers: response.answers }
-        : { outcome: response.outcome, ...(response.reason ? { reason: response.reason } : {}) },
+      outcome: {
+        outcome: response.outcome,
+        ...(response.reason ? { reason: response.reason } : {}),
+      },
     };
   }
   if (decision.response) return decision.response;

--- a/server-agents/cursor/src/agents/shared/acp-agent-runtime.ts
+++ b/server-agents/cursor/src/agents/shared/acp-agent-runtime.ts
@@ -312,7 +312,7 @@ export class AcpAgentRuntime {
     }
     pending.session.client.respond(
       pending.requestId,
-      decision.response ?? pending.responseForDecision(decision),
+      pending.responseForDecision(decision),
     );
     this.#pendingPermissions.delete(pending);
     pending.turn.pendingPermissions.delete(pending);

--- a/server/__tests__/architecture-budgets.test.js
+++ b/server/__tests__/architecture-budgets.test.js
@@ -14,9 +14,10 @@ const MAX_LINES = 1000;
 // admission also gates direct work, queue creation, and pre-dequeue dispatch.
 // Includes exact public-terminal receipt observation, guarded delegated resume,
 // fixed-watermark snapshot initialization, and custom-title, preamble-free start
-// admission with compensation. Reply orchestration stays in chats; control view
-// fencing remains independent of receipt creation.
-const EXECUTION_FOOTPRINT_BUDGET = 8595;
+// admission with compensation. Structured permission decisions validate answers
+// against the exact pending question before ledger acceptance. Reply orchestration
+// stays in chats; control view fencing remains independent of receipt creation.
+const EXECUTION_FOOTPRINT_BUDGET = 8640;
 
 const GRANDFATHER = {
   'server/git/diff-engine.ts': 1575,

--- a/server/chats/search/__tests__/settings-coordinator.test.js
+++ b/server/chats/search/__tests__/settings-coordinator.test.js
@@ -113,6 +113,39 @@ describe('TranscriptSearchSettingsCoordinator', () => {
     });
   });
 
+  it('rebuilds an enabled derived index without changing its durable setting', async () => {
+    const harness = createHarness(true);
+
+    await harness.coordinator.rebuild();
+
+    expect(harness.events).toEqual(['delete', 'start']);
+    expect(harness.settings.setFeatureSettings).not.toHaveBeenCalled();
+  });
+
+  it('rejects rebuild while disabled before changing index lifecycle', async () => {
+    const harness = createHarness(false);
+
+    await expect(harness.coordinator.rebuild()).rejects.toMatchObject({
+      code: 'TRANSCRIPT_SEARCH_DISABLED',
+    });
+
+    expect(harness.controller.disableAndDelete).not.toHaveBeenCalled();
+    expect(harness.controller.start).not.toHaveBeenCalled();
+  });
+
+  it('reports rebuild admission failures through the existing typed error', async () => {
+    const harness = createHarness(true);
+    harness.controller.start.mockImplementationOnce(async () => {
+      harness.events.push('start');
+      throw new Error('reader unavailable');
+    });
+
+    await expect(harness.coordinator.rebuild()).rejects.toMatchObject({
+      code: 'TRANSCRIPT_SEARCH_ENABLE_FAILED',
+    });
+    expect(harness.events).toEqual(['delete', 'start']);
+  });
+
   it('keeps an additional feature patch when disabled cleanup fails', async () => {
     const harness = createHarness(false);
     harness.controller.disableAndDelete.mockImplementationOnce(async () => {

--- a/server/chats/search/settings-coordinator.ts
+++ b/server/chats/search/settings-coordinator.ts
@@ -7,7 +7,10 @@ const SETTINGS_LOCK_KEY = 'transcript-search-setting';
 
 export class TranscriptSearchSettingsError extends Error {
   constructor(
-    public readonly code: 'TRANSCRIPT_SEARCH_ENABLE_FAILED' | 'TRANSCRIPT_SEARCH_CLEANUP_FAILED',
+    public readonly code:
+      | 'TRANSCRIPT_SEARCH_DISABLED'
+      | 'TRANSCRIPT_SEARCH_ENABLE_FAILED'
+      | 'TRANSCRIPT_SEARCH_CLEANUP_FAILED',
     message: string,
   ) {
     super(message);
@@ -70,6 +73,27 @@ export class TranscriptSearchSettingsCoordinator {
 
       await this.#settings.setFeatureSettings(featurePatch);
       await this.#disableAndDelete();
+    });
+  }
+
+  async rebuild(): Promise<void> {
+    await this.#lock.runExclusive(SETTINGS_LOCK_KEY, async () => {
+      await this.#settings.confirmDurability();
+      if (!this.#settings.getFeatureSettings().transcriptSearch.enabled) {
+        throw new TranscriptSearchSettingsError(
+          'TRANSCRIPT_SEARCH_DISABLED',
+          'Transcript search must be enabled before rebuilding the index',
+        );
+      }
+      await this.#disableAndDelete();
+      try {
+        await this.#controller.start();
+      } catch (error) {
+        throw new TranscriptSearchSettingsError(
+          'TRANSCRIPT_SEARCH_ENABLE_FAILED',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     });
   }
 

--- a/server/chats/search/settings-coordinator.ts
+++ b/server/chats/search/settings-coordinator.ts
@@ -45,21 +45,14 @@ export class TranscriptSearchSettingsCoordinator {
           if (hasAdditionalPatch) await this.#settings.setFeatureSettings(featurePatch);
           await this.#disableAndDelete();
         } else {
-          try {
-            await this.#controller.start();
-          } catch (error) {
-            throw new TranscriptSearchSettingsError(
-              'TRANSCRIPT_SEARCH_ENABLE_FAILED',
-              error instanceof Error ? error.message : String(error),
-            );
-          }
+          await this.#start();
           if (hasAdditionalPatch) await this.#settings.setFeatureSettings(featurePatch);
         }
         return;
       }
       if (enabled) {
         try {
-          await this.#controller.start();
+          await this.#start();
           await this.#settings.setFeatureSettings(featurePatch);
         } catch (error) {
           await this.#controller.disableAndDelete().catch(() => undefined);
@@ -86,15 +79,19 @@ export class TranscriptSearchSettingsCoordinator {
         );
       }
       await this.#disableAndDelete();
-      try {
-        await this.#controller.start();
-      } catch (error) {
-        throw new TranscriptSearchSettingsError(
-          'TRANSCRIPT_SEARCH_ENABLE_FAILED',
-          error instanceof Error ? error.message : String(error),
-        );
-      }
+      await this.#start();
     });
+  }
+
+  async #start(): Promise<void> {
+    try {
+      await this.#controller.start();
+    } catch (error) {
+      throw new TranscriptSearchSettingsError(
+        'TRANSCRIPT_SEARCH_ENABLE_FAILED',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
   async #disableAndDelete(): Promise<void> {

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -8,7 +8,13 @@ import { AgentIntegrationError } from '@garcon/server-agent-interface';
 import { ChatCommandService } from '../chat-command-service.ts';
 import { projectAgentTurnReceipt } from '../agent-turn-receipt-projector.ts';
 import { CommandLedger, LEDGER_RECORD_LIMIT, commandLedgerKey } from '../command-ledger.ts';
-import { AssistantMessage, UserMessage } from '../../../common/chat-types.js';
+import {
+  AskUserQuestionToolUseMessage,
+  AssistantMessage,
+  BashToolUseMessage,
+  PermissionRequestMessage,
+  UserMessage,
+} from '../../../common/chat-types.js';
 import { TranscriptLedgerStore } from '../../ledger/store.ts';
 import { TranscriptLedgerService } from '../../ledger/service.ts';
 import { TranscriptAdoptionService } from '../../ledger/adoption.ts';
@@ -3934,6 +3940,113 @@ describe('ChatCommandService', () => {
 
     const record = await readLedgerRecord(ledger, 'permission-decision', 'req-perm-1');
     expect(record).toMatchObject({ status: 'finished', payload: {} });
+  });
+
+  it('rejects structured answers for non-question permissions before ledger acceptance', async () => {
+    const permissionOccurrenceId = 'incarnation-1';
+    const validateAction = mock(() => ({
+      permissionOccurrenceId,
+      runId: 'run-1',
+      transcript: { transcriptViewId: 'view-1', afterOrdinal: 1 },
+      displayOrder: 1,
+      message: new PermissionRequestMessage(
+        '2026-09-08T00:00:00.000Z',
+        permissionOccurrenceId,
+        new BashToolUseMessage('2026-09-08T00:00:00.000Z', 'tool-1', 'echo hello'),
+      ),
+    }));
+    const { service, agents, ledger } = makeService({ transientFeeds: { validateAction } });
+    const clientRequestId = 'req-perm-non-question';
+
+    await expect(service.submitPermissionDecision({
+      chatId: SOURCE_CHAT_ID,
+      permissionOccurrenceId,
+      allow: true,
+      alwaysAllow: false,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [{ questionId: 'mode', selectedOptionIds: ['careful'] }],
+      },
+      clientRequestId,
+      control: {
+        serverInstanceId: 'server-instance-test',
+        chatId: SOURCE_CHAT_ID,
+        runId: 'run-1',
+        permissionOccurrenceId,
+      },
+    })).rejects.toMatchObject({
+      code: 'VALIDATION_FAILED',
+      status: 400,
+    });
+
+    expect(await readLedgerRecord(ledger, 'permission-decision', clientRequestId)).toBeNull();
+    expect(agents.resolvePermission).not.toHaveBeenCalled();
+  });
+
+  it('validates structured answer identities and cardinality before reserving the retry key', async () => {
+    const permissionOccurrenceId = 'incarnation-1';
+    const validateAction = mock(() => ({
+      permissionOccurrenceId,
+      runId: 'run-1',
+      transcript: { transcriptViewId: 'view-1', afterOrdinal: 1 },
+      displayOrder: 1,
+      message: new PermissionRequestMessage(
+        '2026-09-08T00:00:00.000Z',
+        permissionOccurrenceId,
+        new AskUserQuestionToolUseMessage(
+          '2026-09-08T00:00:00.000Z',
+          'tool-1',
+          'Choose a mode',
+          [{
+            id: 'mode',
+            prompt: 'Which mode?',
+            options: [
+              { id: 'fast', label: 'Fast' },
+              { id: 'careful', label: 'Careful' },
+            ],
+          }],
+        ),
+      ),
+    }));
+    const { service, agents, ledger } = makeService({ transientFeeds: { validateAction } });
+    const clientRequestId = 'req-perm-structured-validation';
+    const request = {
+      chatId: SOURCE_CHAT_ID,
+      permissionOccurrenceId,
+      allow: true,
+      alwaysAllow: false,
+      clientRequestId,
+      control: {
+        serverInstanceId: 'server-instance-test',
+        chatId: SOURCE_CHAT_ID,
+        runId: 'run-1',
+        permissionOccurrenceId,
+      },
+    };
+
+    for (const answers of [
+      [{ questionId: 'unknown', selectedOptionIds: ['careful'] }],
+      [{ questionId: 'mode', selectedOptionIds: ['unknown'] }],
+      [{ questionId: 'mode', selectedOptionIds: ['fast', 'careful'] }],
+    ]) {
+      await expect(service.submitPermissionDecision({
+        ...request,
+        response: { type: 'ask-user-question-response', outcome: 'answered', answers },
+      })).rejects.toMatchObject({ code: 'VALIDATION_FAILED', status: 400 });
+      expect(await readLedgerRecord(ledger, 'permission-decision', clientRequestId)).toBeNull();
+    }
+
+    const result = await service.submitPermissionDecision({
+      ...request,
+      response: {
+        type: 'ask-user-question-response',
+        outcome: 'answered',
+        answers: [{ questionId: 'mode', selectedOptionIds: ['careful'] }],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    expect(agents.resolvePermission).toHaveBeenCalledTimes(1);
   });
 
   it('fails a stale permission action once and does not re-enter provider IO on retry', async () => {

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -4037,15 +4037,35 @@ describe('ChatCommandService', () => {
       expect(await readLedgerRecord(ledger, 'permission-decision', clientRequestId)).toBeNull();
     }
 
-    const result = await service.submitPermissionDecision({
+    const acceptedInput = {
       ...request,
       response: {
         type: 'ask-user-question-response',
         outcome: 'answered',
         answers: [{ questionId: 'mode', selectedOptionIds: ['careful'] }],
       },
-    });
+    };
+    const result = await service.submitPermissionDecision(acceptedInput);
     expect(result.status).toBe('accepted');
+    expect(agents.resolvePermission).toHaveBeenCalledTimes(1);
+
+    const validationCallCount = validateAction.mock.calls.length;
+    validateAction.mockImplementation(() => {
+      throw new TransientControlActionError('TRANSIENT_CONTROL_STALE');
+    });
+
+    await expect(service.submitPermissionDecision(acceptedInput)).resolves.toMatchObject({
+      status: 'duplicate',
+    });
+    await expect(service.submitPermissionDecision({
+      ...acceptedInput,
+      response: {
+        ...acceptedInput.response,
+        answers: [{ questionId: 'mode', selectedOptionIds: ['fast'] }],
+      },
+    })).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT', status: 409 });
+
+    expect(validateAction).toHaveBeenCalledTimes(validationCallCount);
     expect(agents.resolvePermission).toHaveBeenCalledTimes(1);
   });
 

--- a/server/commands/session-commands.ts
+++ b/server/commands/session-commands.ts
@@ -226,14 +226,11 @@ export class SessionCommands {
     };
 
     if (input.response?.type === 'ask-user-question-response') {
-      const observed = await this.deps.ledger.observe(ledgerInput);
-      if (observed) {
-        this.support.throwOnConflict(observed, 'Conflicting permission decision retry');
-        if (observed.kind === 'duplicate') {
-          return this.replayPermissionDecision(observed.record);
-        }
-        throw new Error('Command ledger observation unexpectedly accepted a permission decision');
+      const existing = await this.deps.ledger.observe(ledgerInput);
+      if (existing?.kind === 'duplicate') {
+        return this.replayPermissionDecision(existing.record);
       }
+      if (existing) this.support.throwOnConflict(existing, 'Conflicting permission decision retry');
       this.validateStructuredPermissionDecision(input);
     }
 

--- a/server/commands/session-commands.ts
+++ b/server/commands/session-commands.ts
@@ -6,6 +6,10 @@ import type {
   CommandAcceptedResponse,
   ProjectPathPatchResponse,
 } from '../../common/chat-command-contracts.js';
+import {
+  askUserQuestionDecisionValidationError,
+  normalizeAskUserQuestionDecisionResponse,
+} from '../../common/ask-user-question-response.js';
 import type { ChatRegistryEntry } from '../chats/store.js';
 import { isDirectDelegatedChild } from '../chats/agent-delegation.js';
 import { isStopSatisfied, type ChatStopOutcome } from '../../common/chat-types.js';
@@ -207,7 +211,7 @@ export class SessionCommands {
     input: PermissionDecisionInput,
   ): Promise<CommandAcceptedResponse> {
     this.support.requireChat(input.chatId);
-    const ledger = await this.deps.ledger.accept({
+    const ledgerInput = {
       commandType: 'permission-decision',
       chatId: input.chatId,
       clientRequestId: this.support.requireClientRequestId(input.clientRequestId),
@@ -219,15 +223,24 @@ export class SessionCommands {
         control: input.control,
         ...(input.response ? { response: input.response } : {}),
       },
-    });
+    };
+
+    if (input.response?.type === 'ask-user-question-response') {
+      const observed = await this.deps.ledger.observe(ledgerInput);
+      if (observed) {
+        this.support.throwOnConflict(observed, 'Conflicting permission decision retry');
+        if (observed.kind === 'duplicate') {
+          return this.replayPermissionDecision(observed.record);
+        }
+        throw new Error('Command ledger observation unexpectedly accepted a permission decision');
+      }
+      this.validateStructuredPermissionDecision(input);
+    }
+
+    const ledger = await this.deps.ledger.accept(ledgerInput);
     this.support.throwOnConflict(ledger, 'Conflicting permission decision retry');
     if (ledger.kind === 'duplicate') {
-      if (ledger.record.status === 'finished') return commandResultFromRecord(ledger.record, 'duplicate');
-      const failureCode = ledger.record.status === 'failed'
-        && ledger.record.errorCode === 'PERMISSION_NOT_ACTIONABLE'
-        ? 'PERMISSION_NOT_ACTIONABLE'
-        : 'PERMISSION_DECISION_OUTCOME_UNKNOWN';
-      throw permissionDecisionError(failureCode);
+      return this.replayPermissionDecision(ledger.record);
     }
     try {
       this.deps.transientFeeds.validateAction(input.control);
@@ -248,6 +261,43 @@ export class SessionCommands {
       throw failure;
     }
     return commandResultFromRecord(ledger.record);
+  }
+
+  private validateStructuredPermissionDecision(input: PermissionDecisionInput): void {
+    const response = normalizeAskUserQuestionDecisionResponse(input.response);
+    if (!response) {
+      throw new CommandValidationError(
+        'VALIDATION_FAILED',
+        'Permission response contains an invalid structured answer',
+      );
+    }
+
+    let pending;
+    try {
+      pending = this.deps.transientFeeds.validateAction(input.control);
+    } catch (error) {
+      if (error instanceof TransientControlActionError) {
+        throw permissionDecisionError('PERMISSION_NOT_ACTIONABLE');
+      }
+      throw error;
+    }
+    const validationError = askUserQuestionDecisionValidationError(
+      pending.message.requestedTool,
+      input.allow,
+      response,
+    );
+    if (validationError) {
+      throw new CommandValidationError('VALIDATION_FAILED', validationError);
+    }
+  }
+
+  private replayPermissionDecision(record: CommandLedgerRecord): CommandAcceptedResponse {
+    if (record.status === 'finished') return commandResultFromRecord(record, 'duplicate');
+    const failureCode = record.status === 'failed'
+      && record.errorCode === 'PERMISSION_NOT_ACTIONABLE'
+      ? 'PERMISSION_NOT_ACTIONABLE'
+      : 'PERMISSION_DECISION_OUTCOME_UNKNOWN';
+    throw permissionDecisionError(failureCode);
   }
 
   async submitStop(input: StopInput): Promise<AgentStopResponse> {

--- a/server/lib/http-route.ts
+++ b/server/lib/http-route.ts
@@ -22,6 +22,20 @@ export interface HttpRouteAuthOptions {
   localCapability?: string;
 }
 
+interface RequestTimeoutServer {
+  timeout(request: Request, seconds: number): void;
+}
+
+export function disableRequestIdleTimeout(request: Request, server: unknown): void {
+  if (
+    server !== null
+    && typeof server === 'object'
+    && typeof (server as { timeout?: unknown }).timeout === 'function'
+  ) {
+    (server as RequestTimeoutServer).timeout(request, 0);
+  }
+}
+
 // Marks a route handler as publicly accessible without JWT auth.
 export function markRouteNoAuth<T extends RouteHandler>(handler: T): T {
   if (typeof handler !== 'function') {

--- a/server/lib/http-route.ts
+++ b/server/lib/http-route.ts
@@ -26,14 +26,14 @@ interface RequestTimeoutServer {
   timeout(request: Request, seconds: number): void;
 }
 
-export function disableRequestIdleTimeout(request: Request, server: unknown): void {
-  if (
-    server !== null
+function supportsRequestTimeout(server: unknown): server is RequestTimeoutServer {
+  return server !== null
     && typeof server === 'object'
-    && typeof (server as { timeout?: unknown }).timeout === 'function'
-  ) {
-    (server as RequestTimeoutServer).timeout(request, 0);
-  }
+    && typeof (server as { timeout?: unknown }).timeout === 'function';
+}
+
+export function disableRequestIdleTimeout(request: Request, server: unknown): void {
+  if (supportsRequestTimeout(server)) server.timeout(request, 0);
 }
 
 // Marks a route handler as publicly accessible without JWT auth.

--- a/server/routes/__tests__/app.test.js
+++ b/server/routes/__tests__/app.test.js
@@ -905,8 +905,9 @@ describe('PUT /api/app/settings', () => {
     });
   });
 
-  it('forwards the complete agent command object through the transcript search coordinator', async () => {
+  it('forwards the complete agent command object through unbounded transcript search maintenance', async () => {
     const transcriptSearchSettings = { setEnabled: mock(async () => undefined) };
+    const server = { timeout: mock(() => undefined) };
     const routes = createWorkspaceRoutes(
       ctx.settings,
       ctx.agents,
@@ -922,8 +923,11 @@ describe('PUT /api/app/settings', () => {
       },
     }));
 
+    const request = makeRequest('http://localhost/api/app/settings', 'PUT', {});
     const response = await routes['/api/v1/app/settings'].PUT(
-      makeRequest('http://localhost/api/app/settings', 'PUT', {}),
+      request,
+      new URL(request.url),
+      server,
     );
 
     expect(response.status).toBe(200);
@@ -937,6 +941,7 @@ describe('PUT /api/app/settings', () => {
         schedule: true,
       },
     });
+    expect(server.timeout).toHaveBeenCalledWith(request, 0);
     expect(ctx.settings.setFeatureSettings).not.toHaveBeenCalled();
   });
 

--- a/server/routes/__tests__/chats-search.test.js
+++ b/server/routes/__tests__/chats-search.test.js
@@ -3,12 +3,14 @@ import { describe, expect, it, mock } from 'bun:test';
 import { compareChatOrderNewestFirst } from '../../../common/chat-order-sort.js';
 import createChatRoutes from '../chats.js';
 import { TranscriptSearchUnavailableError } from '../../chats/search/errors.js';
+import { TranscriptSearchSettingsError } from '../../chats/search/settings-coordinator.js';
 import { createRouteCommandLedger, createRouteCommandService } from './chat-routes-test-utils.js';
 
 function createRoutesFixture({
   lastActivityAtByChat = {},
   createdAtByChat = {},
   withoutSearchIndex = false,
+  withoutSearchMaintenance = false,
 } = {}) {
   const sessions = {
     c1: {
@@ -169,6 +171,9 @@ function createRoutesFixture({
       removedStaleResultCount: 0,
     })),
   };
+  const searchMaintenance = {
+    rebuild: mock(async () => undefined),
+  };
   const chatListProjector = {
     buildMany: mock((entries) => new Map(
       entries.map(([chatId]) => [chatId, {
@@ -191,6 +196,7 @@ function createRoutesFixture({
     chatViews,
     agents,
     searchIndex: withoutSearchIndex ? undefined : searchIndex,
+    transcriptSearchMaintenance: withoutSearchMaintenance ? undefined : searchMaintenance,
     chatListProjector,
     commandService: createRouteCommandService({
       registry,
@@ -202,7 +208,7 @@ function createRoutesFixture({
     }),
   });
 
-  return { routes, searchIndex, registry, agents, chatListProjector };
+  return { routes, searchIndex, searchMaintenance, registry, agents, chatListProjector };
 }
 
 async function postSearch(routes, body, signal) {
@@ -220,6 +226,14 @@ async function getStatus(routes) {
   const request = new Request('http://localhost/api/v1/chats/search/status');
   const url = new URL(request.url);
   return routes['/api/v1/chats/search/status'].GET(request, url);
+}
+
+async function postRebuild(routes) {
+  const request = new Request('http://localhost/api/v1/chats/search/rebuild', {
+    method: 'POST',
+  });
+  const url = new URL(request.url);
+  return routes['/api/v1/chats/search/rebuild'].POST(request, url);
 }
 
 describe('POST /api/v1/chats/search', () => {
@@ -618,6 +632,55 @@ describe('GET /api/v1/chats/search/status', () => {
         totalP95Ms: 0,
         totalMaxMs: 0,
       },
+    });
+  });
+});
+
+describe('POST /api/v1/chats/search/rebuild', () => {
+  it('rebuilds the index and returns its immediate typed status', async () => {
+    const { routes, searchIndex, searchMaintenance } = createRoutesFixture();
+
+    const response = await postRebuild(routes);
+
+    expect(response.status).toBe(200);
+    expect(searchMaintenance.rebuild).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      status: {
+        ...searchIndex.status(),
+        queryStats: searchIndex.queryStats(),
+      },
+    });
+  });
+
+  it('rejects rebuild when transcript search is disabled', async () => {
+    const { routes, searchMaintenance } = createRoutesFixture();
+    searchMaintenance.rebuild.mockRejectedValueOnce(new TranscriptSearchSettingsError(
+      'TRANSCRIPT_SEARCH_DISABLED',
+      'Transcript search must be enabled before rebuilding the index',
+    ));
+
+    const response = await postRebuild(routes);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      errorCode: 'TRANSCRIPT_SEARCH_DISABLED',
+      retryable: false,
+    });
+  });
+
+  it('reports unavailable rebuild infrastructure without invoking maintenance', async () => {
+    const { routes, searchMaintenance } = createRoutesFixture({
+      withoutSearchMaintenance: true,
+    });
+
+    const response = await postRebuild(routes);
+
+    expect(response.status).toBe(503);
+    expect(searchMaintenance.rebuild).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      errorCode: 'SEARCH_INDEX_UNAVAILABLE',
+      retryable: true,
     });
   });
 });

--- a/server/routes/__tests__/chats-search.test.js
+++ b/server/routes/__tests__/chats-search.test.js
@@ -228,12 +228,12 @@ async function getStatus(routes) {
   return routes['/api/v1/chats/search/status'].GET(request, url);
 }
 
-async function postRebuild(routes) {
+async function postRebuild(routes, server) {
   const request = new Request('http://localhost/api/v1/chats/search/rebuild', {
     method: 'POST',
   });
   const url = new URL(request.url);
-  return routes['/api/v1/chats/search/rebuild'].POST(request, url);
+  return routes['/api/v1/chats/search/rebuild'].POST(request, url, server);
 }
 
 describe('POST /api/v1/chats/search', () => {
@@ -639,11 +639,13 @@ describe('GET /api/v1/chats/search/status', () => {
 describe('POST /api/v1/chats/search/rebuild', () => {
   it('rebuilds the index and returns its immediate typed status', async () => {
     const { routes, searchIndex, searchMaintenance } = createRoutesFixture();
+    const server = { timeout: mock(() => undefined) };
 
-    const response = await postRebuild(routes);
+    const response = await postRebuild(routes, server);
 
     expect(response.status).toBe(200);
     expect(searchMaintenance.rebuild).toHaveBeenCalledTimes(1);
+    expect(server.timeout).toHaveBeenCalledWith(expect.any(Request), 0);
     await expect(response.json()).resolves.toEqual({
       success: true,
       status: {
@@ -652,6 +654,35 @@ describe('POST /api/v1/chats/search/rebuild', () => {
       },
     });
   });
+
+  it('completes beyond a short Bun idle timeout', async () => {
+    const { routes, searchMaintenance } = createRoutesFixture();
+    searchMaintenance.rebuild.mockImplementationOnce(async () => {
+      await Bun.sleep(4_500);
+    });
+    const server = Bun.serve({
+      hostname: '0.0.0.0',
+      port: 0,
+      idleTimeout: 1,
+      fetch(request, bunServer) {
+        return routes['/api/v1/chats/search/rebuild'].POST(
+          request,
+          new URL(request.url),
+          bunServer,
+        );
+      },
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/api/v1/chats/search/rebuild`, {
+        method: 'POST',
+      });
+      expect(response.status).toBe(200);
+      expect(searchMaintenance.rebuild).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.stop(true);
+    }
+  }, 10_000);
 
   it('rejects rebuild when transcript search is disabled', async () => {
     const { routes, searchMaintenance } = createRoutesFixture();

--- a/server/routes/__tests__/chats-search.test.js
+++ b/server/routes/__tests__/chats-search.test.js
@@ -285,6 +285,22 @@ describe('POST /api/v1/chats/search', () => {
     expect(chatListProjector.buildMany.mock.calls[0][0].map(([chatId]) => chatId)).toEqual(['c2']);
   });
 
+  it('echoes the exact submitted query while executing its normalized form', async () => {
+    const { routes, searchIndex } = createRoutesFixture();
+
+    const response = await postSearch(routes, {
+      query: '  needle  ',
+      textTokens: [' needle '],
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ query: '  needle  ' });
+    expect(searchIndex.search).toHaveBeenCalledWith(expect.objectContaining({
+      query: 'needle',
+      textTokens: ['needle'],
+    }));
+  });
+
   it('includes chats without checking project path availability', async () => {
     const { routes, searchIndex } = createRoutesFixture();
 

--- a/server/routes/chat-search-routes.ts
+++ b/server/routes/chat-search-routes.ts
@@ -71,6 +71,7 @@ interface ChatSearchRouteDeps {
 }
 
 interface NormalizedChatSearchRequest extends ChatSearchRequest {
+  effectiveQuery: string;
   sort: ChatSearchSort;
   mode: ChatSearchResultMode;
   offset: number;
@@ -118,7 +119,7 @@ export function createChatSearchRoutes(deps: ChatSearchRouteDeps): {
       request?.signal.throwIfAborted();
       const controllerStarted = performance.now();
       const result = await searchIndex.search({
-        query: search.query,
+        query: search.effectiveQuery,
         textTokens: search.textTokens,
         allowedChatIds,
         sort: search.sort,
@@ -248,10 +249,11 @@ function parseSearchRequest(body: unknown): NormalizedChatSearchRequest {
   if (rawQuery.length > MAX_SEARCH_QUERY_CHARS) {
     throw new ValidationDomainError(`query must be at most ${MAX_SEARCH_QUERY_CHARS} characters`);
   }
-  const query = rawQuery.trim();
+  const normalizedQuery = rawQuery.trim();
   const effectiveTerms = textTokens?.length
     ? textTokens
-    : [...query.matchAll(/"([^"]+)"|(\S+)/g)].map((match) => match[1] ?? match[2] ?? '');
+    : [...normalizedQuery.matchAll(/"([^"]+)"|(\S+)/g)]
+        .map((match) => match[1] ?? match[2] ?? '');
   if (effectiveTerms.length > CHAT_SEARCH_MAX_TERMS) {
     throw new ValidationDomainError(`search must contain at most ${CHAT_SEARCH_MAX_TERMS} terms`);
   }
@@ -262,7 +264,7 @@ function parseSearchRequest(body: unknown): NormalizedChatSearchRequest {
   if (wordCount > CHAT_SEARCH_MAX_WORDS) {
     throw new ValidationDomainError(`search must contain at most ${CHAT_SEARCH_MAX_WORDS} words`);
   }
-  const effectiveQuery = query || textTokens?.join(' ') || '';
+  const effectiveQuery = normalizedQuery || textTokens?.join(' ') || '';
   if (!effectiveQuery) throw new ValidationDomainError('query is required');
   const mode = optionalSearchResultMode(input.mode) ?? 'page';
   const offset = optionalBoundedOffset(input.offset) ?? 0;
@@ -273,7 +275,8 @@ function parseSearchRequest(body: unknown): NormalizedChatSearchRequest {
   }
 
   return {
-    query: effectiveQuery,
+    query: rawQuery,
+    effectiveQuery,
     textTokens,
     chatIds: optionalBoundedStringArrayField(input, 'chatIds', {
       maxItems: CHAT_SEARCH_MAX_CHAT_IDS,

--- a/server/routes/chat-search-routes.ts
+++ b/server/routes/chat-search-routes.ts
@@ -6,6 +6,7 @@ import type {
   ChatSearchResultMode,
   ChatSearchSort,
   TranscriptSearchQueryStatsV1,
+  TranscriptSearchRebuildResponse,
   TranscriptSearchStatusResponse,
   TranscriptSearchStatusV1,
 } from '../../common/chat-search.js';
@@ -28,6 +29,7 @@ import {
 } from '../../common/chat-order-sort.js';
 import type { ChatListProjector } from '../chats/chat-list-projector.js';
 import { TranscriptSearchUnavailableError } from '../chats/search/errors.js';
+import { TranscriptSearchSettingsError } from '../chats/search/settings-coordinator.js';
 import type { IChatRegistry } from '../chats/store.js';
 import { ValidationDomainError } from '../lib/domain-error.js';
 import { jsonError, jsonErrorFromUnknown } from '../lib/http-error.js';
@@ -64,10 +66,15 @@ export interface ChatSearchDep {
   }>;
 }
 
+export interface TranscriptSearchMaintenanceDep {
+  rebuild(): Promise<void>;
+}
+
 interface ChatSearchRouteDeps {
   registry: IChatRegistry;
   chatListProjector: ChatListProjector;
   searchIndex?: ChatSearchDep;
+  searchMaintenance?: TranscriptSearchMaintenanceDep;
 }
 
 interface NormalizedChatSearchRequest extends ChatSearchRequest {
@@ -83,9 +90,10 @@ const CLIENT_CLOSED_REQUEST_STATUS = 499;
 export function createChatSearchRoutes(deps: ChatSearchRouteDeps): {
   postSearchChats(body: unknown, request?: Request): Promise<Response>;
   postSearchNavigate(body: unknown): Promise<Response>;
+  postSearchRebuild(): Promise<Response>;
   getSearchStatus(): Response;
 } {
-  const { registry, chatListProjector, searchIndex } = deps;
+  const { registry, chatListProjector, searchIndex, searchMaintenance } = deps;
 
   async function postSearchChats(body: unknown, request?: Request): Promise<Response> {
     const requestStarted = performance.now();
@@ -177,41 +185,68 @@ export function createChatSearchRoutes(deps: ChatSearchRouteDeps): {
     }
   }
 
-  function getSearchStatus(): Response {
-    if (!searchIndex) {
+  async function postSearchRebuild(): Promise<Response> {
+    try {
+      if (!searchIndex || !searchMaintenance) {
+        throw new TranscriptSearchUnavailableError(
+          'SEARCH_INDEX_UNAVAILABLE',
+          'Chat search index is not available',
+          true,
+        );
+      }
+      await searchMaintenance.rebuild();
       return Response.json({
-        version: 1,
-        phase: 'disabled',
-        chats: { total: 0, indexed: 0, pending: 0, failed: 0, unindexed: 0 },
-        queuedJobs: 0,
-        resync: null,
-        backlogRows: 0,
-        activeChat: null,
-        lastErrorCode: null,
-        updatedAt: new Date(0).toISOString(),
-        queryStats: {
-          served: 0,
-          timedOut: 0,
-          rejectedBusy: 0,
-          p50Ms: 0,
-          p95Ms: 0,
-          maxMs: 0,
-          admissionP50Ms: 0,
-          admissionP95Ms: 0,
-          admissionMaxMs: 0,
-          totalP50Ms: 0,
-          totalP95Ms: 0,
-          totalMaxMs: 0,
-        },
-      } satisfies TranscriptSearchStatusResponse);
+        success: true,
+        status: currentSearchStatus(searchIndex),
+      } satisfies TranscriptSearchRebuildResponse);
+    } catch (error) {
+      if (error instanceof TranscriptSearchSettingsError) {
+        const disabled = error.code === 'TRANSCRIPT_SEARCH_DISABLED';
+        return jsonError(error.message, disabled ? 409 : 500, error.code, false);
+      }
+      return jsonErrorFromUnknown(error);
     }
-    return Response.json({
-      ...searchIndex.status(),
-      queryStats: searchIndex.queryStats(),
-    } satisfies TranscriptSearchStatusResponse);
   }
 
-  return { postSearchChats, postSearchNavigate, getSearchStatus };
+  function getSearchStatus(): Response {
+    return Response.json(currentSearchStatus(searchIndex));
+  }
+
+  return { postSearchChats, postSearchNavigate, postSearchRebuild, getSearchStatus };
+}
+
+function currentSearchStatus(searchIndex?: ChatSearchDep): TranscriptSearchStatusResponse {
+  if (!searchIndex) {
+    return {
+      version: 1,
+      phase: 'disabled',
+      chats: { total: 0, indexed: 0, pending: 0, failed: 0, unindexed: 0 },
+      queuedJobs: 0,
+      resync: null,
+      backlogRows: 0,
+      activeChat: null,
+      lastErrorCode: null,
+      updatedAt: new Date(0).toISOString(),
+      queryStats: {
+        served: 0,
+        timedOut: 0,
+        rejectedBusy: 0,
+        p50Ms: 0,
+        p95Ms: 0,
+        maxMs: 0,
+        admissionP50Ms: 0,
+        admissionP95Ms: 0,
+        admissionMaxMs: 0,
+        totalP50Ms: 0,
+        totalP95Ms: 0,
+        totalMaxMs: 0,
+      },
+    };
+  }
+  return {
+    ...searchIndex.status(),
+    queryStats: searchIndex.queryStats(),
+  };
 }
 
 function isAbortError(error: unknown): boolean {

--- a/server/routes/chat-search-routes.ts
+++ b/server/routes/chat-search-routes.ts
@@ -33,6 +33,7 @@ import { TranscriptSearchSettingsError } from '../chats/search/settings-coordina
 import type { IChatRegistry } from '../chats/store.js';
 import { ValidationDomainError } from '../lib/domain-error.js';
 import { jsonError, jsonErrorFromUnknown } from '../lib/http-error.js';
+import { disableRequestIdleTimeout } from '../lib/http-route.js';
 import { createLogger } from '../lib/log.js';
 
 const MAX_SEARCH_QUERY_CHARS = 4_096;
@@ -90,7 +91,7 @@ const CLIENT_CLOSED_REQUEST_STATUS = 499;
 export function createChatSearchRoutes(deps: ChatSearchRouteDeps): {
   postSearchChats(body: unknown, request?: Request): Promise<Response>;
   postSearchNavigate(body: unknown): Promise<Response>;
-  postSearchRebuild(): Promise<Response>;
+  postSearchRebuild(request: Request, url: URL, server?: unknown): Promise<Response>;
   getSearchStatus(): Response;
 } {
   const { registry, chatListProjector, searchIndex, searchMaintenance } = deps;
@@ -185,7 +186,11 @@ export function createChatSearchRoutes(deps: ChatSearchRouteDeps): {
     }
   }
 
-  async function postSearchRebuild(): Promise<Response> {
+  async function postSearchRebuild(
+    request: Request,
+    _url: URL,
+    server?: unknown,
+  ): Promise<Response> {
     try {
       if (!searchIndex || !searchMaintenance) {
         throw new TranscriptSearchUnavailableError(
@@ -194,6 +199,7 @@ export function createChatSearchRoutes(deps: ChatSearchRouteDeps): {
           true,
         );
       }
+      disableRequestIdleTimeout(request, server);
       await searchMaintenance.rebuild();
       return Response.json({
         success: true,

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -123,7 +123,11 @@ import type {
 } from '../../common/chat-title-contracts.js';
 import type { ChatDetailsResponse } from '../../common/chat-details.js';
 import type { ChatProcessingActivity } from '../chats/chat-processing-activity.js';
-import { createChatSearchRoutes, type ChatSearchDep } from './chat-search-routes.js';
+import {
+  createChatSearchRoutes,
+  type ChatSearchDep,
+  type TranscriptSearchMaintenanceDep,
+} from './chat-search-routes.js';
 import {
   generateChatTitleFromMessage,
   TitleGenerationError,
@@ -322,6 +326,7 @@ interface ChatRouteDeps {
   commandService: ChatCommandService;
   chatListProjector: import('../chats/chat-list-projector.js').ChatListProjector;
   searchIndex?: ChatSearchDep;
+  transcriptSearchMaintenance?: TranscriptSearchMaintenanceDep;
   lastSelectedChat?: LastSelectedChatState;
   inspectProject?: typeof inspectProjectDirectory;
 }
@@ -338,6 +343,7 @@ export default function createChatRoutes({
   commandService,
   chatListProjector,
   searchIndex,
+  transcriptSearchMaintenance,
   lastSelectedChat = new InMemoryLastSelectedChatState(),
   inspectProject = inspectProjectDirectory,
 }: ChatRouteDeps): RouteMap {
@@ -346,6 +352,7 @@ export default function createChatRoutes({
     registry,
     chatListProjector,
     searchIndex,
+    searchMaintenance: transcriptSearchMaintenance,
   });
 
   function validatedLastSelectedChatId(
@@ -1283,6 +1290,7 @@ export default function createChatRoutes({
     '/api/v1/chats/messages': { GET: getMessages },
     '/api/v1/chats/search': { POST: withJsonBody(searchRoutes.postSearchChats) },
     '/api/v1/chats/search/navigate': { POST: withJsonBody(searchRoutes.postSearchNavigate) },
+    '/api/v1/chats/search/rebuild': { POST: searchRoutes.postSearchRebuild },
     '/api/v1/chats/search/status': { GET: searchRoutes.getSearchStatus },
     '/api/v1/chats/running': { GET: getRunningChats },
     '/api/v1/chats/queue': { GET: getQueue },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -150,6 +150,7 @@ export default function createAllRoutes({
       chatListProjector,
       lastSelectedChat,
       searchIndex,
+      transcriptSearchMaintenance: transcriptSearchSettings,
     }),
     ...createShareRoutes(shareStore, registry, settings, metadata, shareSnapshots),
     ...createFilesRoutes(registry),

--- a/server/routes/workspace.ts
+++ b/server/routes/workspace.ts
@@ -18,6 +18,7 @@ import {
   type JsonBody,
 } from './route-helpers.js';
 import { jsonError, jsonErrorFromUnknown } from '../lib/http-error.js';
+import { disableRequestIdleTimeout } from '../lib/http-route.js';
 import {
   AGENT_COMMAND_SETTING_KEYS,
   DEFAULT_REMOTE_FEATURE_SETTINGS,
@@ -365,7 +366,12 @@ export default function createWorkspaceRoutes(
     }
   }
 
-  async function putAppSettings(body: JsonBody): Promise<Response> {
+  async function putAppSettings(
+    body: JsonBody,
+    request: Request,
+    _url: URL,
+    server?: unknown,
+  ): Promise<Response> {
     try {
       const input = asJsonBody(body);
       const promptPatchError = generationPromptPatchError(input.ui);
@@ -405,6 +411,7 @@ export default function createWorkspaceRoutes(
       }
       if (transcriptSearchEnabled !== undefined) {
         if (transcriptSearchSettings) {
+          disableRequestIdleTimeout(request, server);
           await transcriptSearchSettings.setEnabled(transcriptSearchEnabled, featurePatch);
         } else {
           await settings.setFeatureSettings({

--- a/web/src/lib/components/chat/PermissionRequestRow.svelte
+++ b/web/src/lib/components/chat/PermissionRequestRow.svelte
@@ -41,6 +41,8 @@
 	import type { PermissionQuestionDraft } from './ConversationFeedItemState.svelte.js';
 
 	type PlanExitChoice = 'bypass-new' | 'bypass' | 'approve-edits' | 'deny';
+	type StructuredQuestionOutcome = 'answered' | 'skipped';
+	type StructuredQuestionPrompt = AskUserQuestionPrompt | CursorAskQuestionPrompt;
 
 	interface Props {
 		request: PermissionRequestMessage;
@@ -241,8 +243,8 @@
 		return selectedOptionsFor(questionId).includes(optionId);
 	}
 
-	function updateAskUserQuestionOption(
-		question: AskUserQuestionPrompt,
+	function updateQuestionOption(
+		question: StructuredQuestionPrompt,
 		optionId: string,
 		checked: boolean,
 	): void {
@@ -262,8 +264,9 @@
 		return option?.preview;
 	}
 
-	function askUserQuestionResponse(
-		outcome: 'answered' | 'skipped',
+	function structuredQuestionResponse(
+		questions: readonly StructuredQuestionPrompt[],
+		outcome: StructuredQuestionOutcome,
 	): AskUserQuestionDecisionResponse {
 		if (outcome === 'skipped') {
 			return {
@@ -275,57 +278,30 @@
 		return {
 			type: 'ask-user-question-response',
 			outcome: 'answered',
-			answers: (askUserQuestionRequest?.questions ?? []).map((question) => ({
+			answers: questions.map((question) => ({
 				questionId: question.id,
 				selectedOptionIds: selectedOptionsFor(question.id),
 			})),
 		};
 	}
 
-	function respondToAskUserQuestion(outcome: 'answered' | 'skipped'): void {
+	function respondToAskUserQuestion(outcome: StructuredQuestionOutcome): void {
 		onDecision(request.permissionOccurrenceId, {
 			allow: outcome === 'answered',
-			response: askUserQuestionResponse(outcome),
+			response: structuredQuestionResponse(
+				askUserQuestionRequest?.questions ?? [],
+				outcome,
+			),
 		});
 	}
 
-	function updateQuestionOption(
-		question: CursorAskQuestionPrompt,
-		optionId: string,
-		checked: boolean,
-	): void {
-		if (question.allowMultiple) {
-			const current = new Set(selectedOptionsFor(question.id));
-			if (checked) current.add(optionId);
-			else current.delete(optionId);
-			setSelectedOptions(question.id, Array.from(current));
-			return;
-		}
-		setSelectedOptions(question.id, checked ? [optionId] : []);
-	}
-
-	function cursorQuestionResponse(outcome: 'answered' | 'skipped'): AskUserQuestionDecisionResponse {
-		if (outcome === 'skipped') {
-			return {
-				type: 'ask-user-question-response',
-				outcome: 'skipped',
-				reason: 'User skipped question',
-			};
-		}
-		return {
-			type: 'ask-user-question-response',
-			outcome: 'answered',
-			answers: (cursorAskQuestionRequest?.questions ?? []).map((question) => ({
-				questionId: question.id,
-				selectedOptionIds: selectedOptionsFor(question.id),
-			})),
-		};
-	}
-
-	function respondToCursorQuestion(outcome: 'answered' | 'skipped'): void {
+	function respondToCursorQuestion(outcome: StructuredQuestionOutcome): void {
 		onDecision(request.permissionOccurrenceId, {
 			allow: outcome === 'answered',
-			response: cursorQuestionResponse(outcome),
+			response: structuredQuestionResponse(
+				cursorAskQuestionRequest?.questions ?? [],
+				outcome,
+			),
 		});
 	}
 
@@ -512,7 +488,7 @@
 											checked={isOptionSelected(question.id, option.id)}
 											disabled={!isPending}
 											onchange={(event) =>
-												updateAskUserQuestionOption(
+												updateQuestionOption(
 													question,
 													option.id,
 													(event.currentTarget as HTMLInputElement).checked,

--- a/web/src/lib/components/chat/PermissionRequestRow.svelte
+++ b/web/src/lib/components/chat/PermissionRequestRow.svelte
@@ -304,18 +304,21 @@
 		setSelectedOptions(question.id, checked ? [optionId] : []);
 	}
 
-	function cursorQuestionResponse(outcome: 'answered' | 'skipped'): Record<string, unknown> {
+	function cursorQuestionResponse(outcome: 'answered' | 'skipped'): AskUserQuestionDecisionResponse {
 		if (outcome === 'skipped') {
-			return { outcome: { outcome: 'skipped', reason: 'User skipped question' } };
+			return {
+				type: 'ask-user-question-response',
+				outcome: 'skipped',
+				reason: 'User skipped question',
+			};
 		}
 		return {
-			outcome: {
-				outcome: 'answered',
-				answers: (cursorAskQuestionRequest?.questions ?? []).map((question) => ({
-					questionId: question.id,
-					selectedOptionIds: selectedOptionsFor(question.id),
-				})),
-			},
+			type: 'ask-user-question-response',
+			outcome: 'answered',
+			answers: (cursorAskQuestionRequest?.questions ?? []).map((question) => ({
+				questionId: question.id,
+				selectedOptionIds: selectedOptionsFor(question.id),
+			})),
 		};
 	}
 

--- a/web/src/lib/components/chat/__tests__/PermissionRequestRow.test.ts
+++ b/web/src/lib/components/chat/__tests__/PermissionRequestRow.test.ts
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	AskUserQuestionToolUseMessage,
+	CursorAskQuestionToolUseMessage,
 	ExitPlanModeToolUseMessage,
 	PermissionRequestMessage,
 } from '$shared/chat-types';
@@ -28,6 +29,20 @@ function askUserQuestionRequest(): PermissionRequestMessage {
 					},
 				],
 				allowMultiple: false,
+			},
+		]),
+	);
+}
+
+function cursorAskQuestionRequest(): PermissionRequestMessage {
+	return new PermissionRequestMessage(
+		TS,
+		'incarnation-cursor-question',
+		new CursorAskQuestionToolUseMessage(TS, 'tool-cursor-question', 'Choose a mode', [
+			{
+				id: 'mode',
+				prompt: 'Which mode?',
+				options: [{ id: 'agent', label: 'Agent' }],
 			},
 		]),
 	);
@@ -62,6 +77,23 @@ describe('PermissionRequestRow', () => {
 				type: 'ask-user-question-response',
 				outcome: 'answered',
 				answers: [{ questionId: 'Which mode?', selectedOptionIds: ['Careful'] }],
+			},
+		});
+	});
+
+	it('submits Cursor question answers through the provider-neutral permission response', async () => {
+		const onDecision = vi.fn();
+		render(PermissionRequestRowTestHost, { request: cursorAskQuestionRequest(), onDecision });
+
+		await fireEvent.click(screen.getByRole('radio', { name: /Agent/ }));
+		await fireEvent.click(screen.getByRole('button', { name: /submit answer/i }));
+
+		expect(onDecision).toHaveBeenCalledWith('incarnation-cursor-question', {
+			allow: true,
+			response: {
+				type: 'ask-user-question-response',
+				outcome: 'answered',
+				answers: [{ questionId: 'mode', selectedOptionIds: ['agent'] }],
 			},
 		});
 	});


### PR DESCRIPTION
Adds headless CLI discovery and control for preambles, structured permission questions, and transcript-search administration while tightening preamble limits and search-response correlation so automation can safely select inputs and manage indexing. Long-running search maintenance now survives ordinary client and server idle deadlines, and the touched validation and dispatch paths are simpler; server and CLI ship together, so no migration action is required.