### PR TITLE
Default delegated agent starts to the parent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Under the hood, `<garcon-get-chat-id />` gives an agent its runtime identity and
 Agents can also start a delegated child, resume or stop that child, or schedule a prompt back to their own chat:
 
 ```xml
-<garcon-start-agent ref="parser-review" agent="codex" model="gpt-5.4-nano" reasoning-effort="low" title="Parser review">
+<garcon-start-agent ref="parser-review" title="Parser review">
 Review the parser tests and report missing cases.
 </garcon-start-agent>
 
@@ -165,7 +165,19 @@ Review the revised error handling.
 <garcon-schedule every="5m" busy="skip" />
 ```
 
-Place each command at an assistant message's leading or trailing edge, outside code fences. Attribute values use double quotes; escape body text with `&amp;` and `&lt;`. Starts require `agent`, `model`, and `ref`; optional `provider` selects a configured provider by ID or exact, case-sensitive display name, and optional `reasoning-effort` selects a supported effort. IDs take precedence; duplicate provider names reject with `ambiguous-provider` and require an ID, even with an exact model selection. Children inherit the parent's current project path and permission mode, use target-agent execution defaults, and retain a delegation edge. Commands cannot override permissions, paths, tags, or preambles. Unsupported inherited permissions reject the start.
+Place each command at an assistant message's leading or trailing edge, outside code fences. Attribute values use double quotes; escape body text with `&amp;` and `&lt;`. Starts require `ref` and a nonblank prompt. Selection attributes follow this hierarchy:
+
+| Attributes supplied | Child selection |
+| --- | --- |
+| None | Parent's current agent, model, and exact route |
+| `model` | Parent's agent and exact route, with the requested model |
+| `provider`, `model` | Parent's agent, with the requested provider and model |
+| `agent`, `provider`, `model` | Fully explicit selection |
+| `agent`, `model` | Requested agent's native route, without a configured API provider |
+
+Providing `agent` or `provider` requires `model`; empty attributes are invalid. An explicit `agent` without `provider` always selects native execution, even when it names the parent's agent. Native routing uses that agent's own authentication/configuration, not a configured provider's display label. It requires a known native catalog model; endpoint-only agents and unknown models reject instead of falling back to another route. Inherited routing pins the parent's provider, endpoint, and protocol; unavailable or incompatible selections reject. An explicit provider does not borrow the parent's endpoint to resolve ambiguity.
+
+`provider` accepts a configured provider ID or exact, case-sensitive display name. IDs take precedence; duplicate names reject with `ambiguous-provider` and require an ID, even with an exact model selection. With `agent` omitted, children inherit the parent's current reasoning effort and active agent settings. An explicit `agent` uses target-agent execution defaults instead; optional `reasoning-effort` overrides either choice and must be supported. Every child inherits the parent's current project path and permission mode and retains a delegation edge. Commands cannot override permissions, paths, tags, or preambles. Unsupported inherited modes reject the start. These defaults apply to markup commands; CLI start still requires explicit agent/model selection and retains its existing catalog search when `--provider` is omitted.
 
 Starts have **no preambles**: neither new-chat defaults nor the parent's selection applies. Optional `fork="true"` copies the parent's committed transcript through the requesting row into a fresh child, including across agents. It never clones a native session or filesystem, and the parent continues independently. Historical preamble notices remain history, not newly applied prefixes. Optional `title` sets a custom name before dispatch and bypasses automatic title generation; omitted titles follow ordinary generation policy.
 

--- a/common/__tests__/garcon-start-agent.test.js
+++ b/common/__tests__/garcon-start-agent.test.js
@@ -5,7 +5,7 @@ const start = (attributes = 'agent="codex" model="example-model"', body = 'Inspe
   `<garcon-start-agent ref="task" ${attributes}>\n${body}\n</garcon-start-agent>`;
 
 describe('single-child start grammar', () => {
-  it('requires only target selection and preserves decoded prompt text', () => {
+  it('preserves explicit target selection and decoded prompt text', () => {
     expect(parseGarconStartAgent(start())).toEqual({
       type: 'start-agent', ref: 'task', async: false, fork: false, title: null, agentId: 'codex', model: 'example-model',
       providerId: null, reasoningEffort: null, prompt: 'Inspect the parser.',
@@ -13,6 +13,31 @@ describe('single-child start grammar', () => {
     expect(parseGarconStartAgent(start('model="example-model" reasoning-effort="low" provider="example" agent="codex"',
       '\n  A &amp; B &lt; C &gt; D &quot;quote&quot; &apos;x&apos; &amp;lt;  \n'))).toMatchObject({
       providerId: 'example', reasoningEffort: 'low', prompt: '\n  A & B < C > D "quote" \'x\' &lt;  \n',
+    });
+  });
+
+  it.each([
+    ['', null, null, null],
+    ['model="example-model"', null, null, 'example-model'],
+    ['provider="example" model="example-model"', null, 'example', 'example-model'],
+    ['agent="example-agent" model="example-model"', 'example-agent', null, 'example-model'],
+    ['agent="example-agent" provider="example" model="example-model"', 'example-agent', 'example', 'example-model'],
+  ])('accepts the selection shape %s without filling in omitted values', (attributes, agentId, providerId, model) => {
+    expect(parseGarconStartAgent(start(attributes))).toMatchObject({ agentId, providerId, model });
+  });
+
+  it.each(['agent="example-agent"', 'provider="example"', 'agent="example-agent" provider="example"'])
+  ('requires a model when selecting %s', (attributes) => {
+    expect(parseGarconStartAgent(start(attributes))).toBeNull();
+  });
+
+  it.each(['agent', 'provider', 'model'])('rejects an explicitly empty %s', (attribute) => {
+    for (const value of ['', ' ']) expect(parseGarconStartAgent(start(`${attribute}="${value}"`))).toBeNull();
+  });
+
+  it('allows a reasoning override without overriding the inherited selection', () => {
+    expect(parseGarconStartAgent(start('reasoning-effort="low"'))).toMatchObject({
+      agentId: null, providerId: null, model: null, reasoningEffort: 'low',
     });
   });
 
@@ -28,7 +53,7 @@ describe('single-child start grammar', () => {
 
   it('rejects incomplete, duplicate, unquoted, nested, batch, and malformed text', () => {
     for (const content of [
-      start('model="example-model"'), start('agent="codex"'), start('agent="" model="example-model"'),
+      start('agent="codex"'), start('agent="" model="example-model"'),
       start('agent="codex" model="x" model="y"'), start("agent='codex' model=\"x\""),
       start('agent="codex" model="x"suffix'), start('agent="codex" model="x"', ''),
       start('agent="codex" model="x"', '<garcon-schedule in="1m" />'),

--- a/common/__tests__/start-selection-native.test.js
+++ b/common/__tests__/start-selection-native.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveModelSelection, StartSelectionError } from '../start-selection.js';
+
+const native = { value: 'native-model', label: 'Native model', rawModel: 'shared-model' };
+const routed = {
+  value: 'endpoint:shared-model', label: 'Routed model', rawModel: 'shared-model',
+  apiProviderId: 'provider', endpointId: 'endpoint', protocol: 'openai-compatible',
+};
+
+function catalog(models = [native, routed]) {
+  return { catalog: {
+    agents: [{
+      id: 'test', models, defaultModel: 'native-model',
+      supportedPermissionModes: ['default'], supportedThinkingModes: ['none'],
+      supportedProtocols: ['openai-compatible'], acceptsApiProviderEndpoints: true,
+      requiresStrictModelDiscovery: false,
+      defaultSettings: { ownerId: 'test', schemaVersion: 1, values: {} },
+    }],
+    apiProviders: [{ id: 'provider', label: 'Example Proxy', endpoints: [
+      { id: 'endpoint', protocol: 'openai-compatible' },
+    ] }],
+  } };
+}
+
+function expectCode(operation, code) {
+  try { operation(); } catch (error) {
+    expect(error).toBeInstanceOf(StartSelectionError);
+    expect(error.code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected ${code}`);
+}
+
+describe('native-only model selection', () => {
+  test('pins native routing instead of searching configured endpoints', () => {
+    expect(resolveModelSelection(catalog(), 'test', { model: 'shared-model', providerId: null })).toEqual({
+      model: 'shared-model', apiProviderId: null, modelEndpointId: null, modelProtocol: null,
+    });
+    expectCode(() => resolveModelSelection(catalog(), 'test', { model: 'shared-model' }), 'AMBIGUOUS_MODEL');
+    expect(resolveModelSelection(catalog(), 'test', {
+      model: 'shared-model', providerId: 'Example Proxy',
+    }).apiProviderId).toBe('provider');
+  });
+
+  test('requires known native models even when discovery is non-strict', () => {
+    for (const models of [[native, routed], [routed], []]) {
+      for (const model of ['future-model', routed.value]) {
+        expectCode(() => resolveModelSelection(catalog(models), 'test', { model, providerId: null }), 'UNKNOWN_MODEL');
+      }
+    }
+    expect(resolveModelSelection(catalog(), 'test', { model: 'future-model' })).toEqual({
+      model: 'future-model', apiProviderId: null, modelEndpointId: null, modelProtocol: null,
+    });
+  });
+
+  test('rejects native requests with endpoints and malformed native model routing', () => {
+    expectCode(() => resolveModelSelection(catalog(), 'test', {
+      model: native.value, providerId: null, endpointId: 'endpoint',
+    }), 'INCOMPATIBLE_ENDPOINT');
+    for (const metadata of [{ endpointId: 'endpoint' }, { protocol: 'openai-compatible' }]) {
+      expectCode(() => resolveModelSelection(catalog([{ ...native, ...metadata }]), 'test', {
+        model: native.value, providerId: null,
+      }), 'INVALID_CATALOG');
+    }
+  });
+});

--- a/common/garcon-start-agent.ts
+++ b/common/garcon-start-agent.ts
@@ -7,9 +7,9 @@ export const GARCON_START_PROMPT_MAX_BYTES = GARCON_AGENT_PROMPT_MAX_BYTES;
 
 export interface GarconStartAgentCommand extends GarconAgentRequestOptions {
   readonly type: 'start-agent';
-  readonly agentId: string;
+  readonly agentId: string | null;
   readonly providerId: string | null;
-  readonly model: string;
+  readonly model: string | null;
   readonly reasoningEffort: string | null;
   readonly prompt: string;
   readonly fork: boolean;
@@ -26,15 +26,16 @@ export function parseGarconStartAgent(content: string): GarconStartAgentCommand 
   if (!options || attributes.fork !== undefined && attributes.fork !== 'true' && attributes.fork !== 'false') return null;
   let title: string | null;
   try { title = parseChatRowTitle(attributes.title) ?? null; } catch { return null; }
-  if (!attributes.agent || !attributes.model || new TextEncoder().encode(body).byteLength > GARCON_START_PROMPT_MAX_BYTES) return null;
+  if ((attributes.agent !== undefined || attributes.provider !== undefined) && attributes.model === undefined) return null;
+  if (new TextEncoder().encode(body).byteLength > GARCON_START_PROMPT_MAX_BYTES) return null;
   return {
     type: 'start-agent',
     ...options,
     fork: attributes.fork === 'true',
     title,
-    agentId: attributes.agent,
+    agentId: attributes.agent ?? null,
     providerId: attributes.provider ?? null,
-    model: attributes.model,
+    model: attributes.model ?? null,
     reasoningEffort: attributes['reasoning-effort'] ?? null,
     prompt: body,
   };

--- a/common/start-selection.ts
+++ b/common/start-selection.ts
@@ -43,8 +43,8 @@ export class StartSelectionError extends Error {
 
 export interface RequestedModelSelection {
   readonly model: string;
-  /** Accepts a canonical ID or an exact, unique display name. */
-  readonly providerId?: string;
+  /** A selector resolves by ID or exact unique name; null selects native models, omission searches all routes. */
+  readonly providerId?: string | null;
   readonly endpointId?: string;
 }
 
@@ -190,6 +190,12 @@ function resolveProviderAndEndpoint(
   agent: AgentCatalogEntry,
   requested: RequestedModelSelection,
 ): RequestedModelSelection {
+  if (requested.providerId === null) {
+    if (requested.endpointId !== undefined) {
+      fail('INCOMPATIBLE_ENDPOINT', 'native model selection cannot specify an API endpoint');
+    }
+    return requested;
+  }
   if (requested.providerId === undefined) return requested;
   const provider = requireCatalogProvider(catalog.catalog.apiProviders, requested.providerId);
   if (!agent.acceptsApiProviderEndpoints) {
@@ -221,7 +227,7 @@ function matchingModels(
   requested: RequestedModelSelection,
 ): AgentModelOption[] {
   const routed = models.filter((model) => (
-    (requested.providerId === undefined || model.apiProviderId === requested.providerId)
+    (requested.providerId === undefined || (model.apiProviderId ?? null) === requested.providerId)
     && (requested.endpointId === undefined || model.endpointId === requested.endpointId)
   ));
   const exact = routed.filter((model) => model.value === requested.model);
@@ -258,7 +264,7 @@ function resolveModelSelectionForAgent(
   }
   const selected = matches[0];
   if (!selected) {
-    if (requested.providerId || requested.endpointId || agent.requiresStrictModelDiscovery) {
+    if (requested.providerId !== undefined || requested.endpointId || agent.requiresStrictModelDiscovery) {
       fail('UNKNOWN_MODEL', `model ${requested.model} is not available for agent ${agent.id}`);
     }
     return {

--- a/integration-tests/support/live-codex.ts
+++ b/integration-tests/support/live-codex.ts
@@ -91,6 +91,7 @@ interface LiveCodexTestEnvironmentOptions {
   // credential needs to exist in the environment.
   testingKey?: string;
   toolMode?: CodexTestToolMode;
+  model?: string;
 }
 
 type CodexProxyProcess = Bun.Subprocess<'pipe', 'ignore', 'ignore'>;
@@ -235,6 +236,7 @@ export async function startLiveCodexTestEnvironment(
         ...LIVE_MODEL_CATALOG,
         models: LIVE_MODEL_CATALOG.models.map((model) => ({
           ...model,
+          slug: options.model ?? model.slug,
           tool_mode: options.toolMode ?? model.tool_mode,
         })),
       };

--- a/integration-tests/support/scripted-codex.ts
+++ b/integration-tests/support/scripted-codex.ts
@@ -16,6 +16,7 @@ export interface ScriptedCodexTestEnvironment extends LiveCodexTestEnvironment {
 
 export async function startScriptedCodexTestEnvironment(options: {
   readonly toolMode?: CodexTestToolMode;
+  readonly model?: string;
 } = {}): Promise<ScriptedCodexTestEnvironment> {
   const model = FakeCodexModel.start();
   let environment: LiveCodexTestEnvironment;
@@ -24,6 +25,7 @@ export async function startScriptedCodexTestEnvironment(options: {
       upstreamUrl: model.responsesUrl,
       testingKey: `garcon-scripted-codex-${crypto.randomUUID()}`,
       toolMode: options.toolMode,
+      model: options.model,
     });
   } catch (error) {
     model.stop();

--- a/integration-tests/tests/server/garcon-agent-commands.test.ts
+++ b/integration-tests/tests/server/garcon-agent-commands.test.ts
@@ -4,9 +4,11 @@ import { join } from 'node:path';
 import type { ChatRegistrySnapshot } from '../../../server/chats/store.js';
 import type { ChatMessagesMessage } from '../../../common/ws-events.js';
 import type { PreamblesMutationResponse } from '../../../common/preambles.js';
+import type { ApiProviderCatalogEntry } from '../../../common/api-providers.js';
 import { garconCommandResultContent } from '../../../common/garcon-command-results.js';
 import { messagesOfType, userContents } from '../../support/chat-assertions.js';
 import { withIntegrationFixture, type IntegrationFixture } from '../../support/integration-fixture.js';
+import { INTEGRATION_OPENAI_API_KEY } from '../../support/openai-test-contract.js';
 
 async function waitForOutcome(fixture: IntegrationFixture, chatId: string, type: 'agent-start-outcome' | 'agent-schedule-outcome', cursor: number) {
   const event = await fixture.client.waitForEvent(
@@ -20,6 +22,70 @@ async function waitForOutcome(fixture: IntegrationFixture, chatId: string, type:
 }
 
 describe('assistant start and schedule commands', () => {
+  test.each(['inherited', 'model-only', 'provider-model', 'native-only'])('resolves delegated %s selection through the server and persistence', async (selection) => {
+    await withIntegrationFixture(`agent-command-selection-${selection}`, async (fixture) => {
+      const original = fixture.directAgents.openAi;
+      const provider = await fixture.client.post<ApiProviderCatalogEntry>('/api/v1/api-providers', {
+        templateId: 'custom', label: 'Synthetic Selection', endpoint: {
+          protocol: 'openai-compatible', baseUrl: `${fixture.fakeProviders.openAi.baseUrl}/v1`,
+          apiKey: INTEGRATION_OPENAI_API_KEY, capabilities: { chatCompletions: true, responses: false },
+          defaultModel: original.provider.model,
+          models: [
+            { value: original.provider.model, label: 'Original' }, { value: 'synthetic-alternate', label: 'Alternate' },
+          ], supportsImages: false, modelDiscovery: 'none',
+        },
+      });
+      const endpoint = provider.endpoints[0]!;
+      const source = fixture.newChatId();
+      const prompt = 'Delegate using the selected configuration.';
+      const childPrompt = 'Synthetic selection child task.';
+      const held = fixture.fakeProviders.openAi.holdNext({ lastUserText: prompt });
+      const cursor = fixture.client.markEvents();
+      const parentRequest = fixture.client.directStartRequest({
+        chatId: source, content: prompt, projectPath: fixture.dirs.project, agent: original,
+      });
+      await fixture.client.startChat({ ...parentRequest, apiProviderId: provider.id, modelEndpointId: endpoint.id });
+      await held.received;
+      let attributes = '';
+      let expectedProvider = provider.id;
+      let expectedEndpoint = endpoint.id;
+      let expectedModel = original.provider.model;
+      if (selection === 'model-only') {
+        attributes = 'model="synthetic-alternate"'; expectedModel = 'synthetic-alternate';
+      } else if (selection === 'provider-model') {
+        attributes = `provider="${original.provider.providerId}" model="${original.provider.model}"`;
+        expectedProvider = original.provider.providerId; expectedEndpoint = original.provider.endpointId;
+      } else if (selection === 'native-only') {
+        attributes = `agent="${original.agentId}" model="${original.provider.model}"`;
+      }
+      held.releaseText(`<garcon-start-agent ref="selection" async="true" ${attributes}>${childPrompt}</garcon-start-agent>`);
+      const outcome = await waitForOutcome(fixture, source, 'agent-start-outcome', cursor);
+      if (selection === 'native-only') {
+        expect(outcome).toMatchObject({ status: 'rejected', reason: 'unknown-model' });
+      } else {
+        if (outcome.type !== 'agent-start-outcome' || outcome.status !== 'accepted') throw new Error('Missing selection child');
+        const request = await fixture.fakeProviders.openAi.waitForRequest({ lastUserText: childPrompt });
+        expect(request.body.model).toBe(expectedModel);
+        const persisted: ChatRegistrySnapshot = JSON.parse(await readFile(join(fixture.dirs.workspace, 'chats.json'), 'utf8'));
+        expect(persisted.sessions[outcome.chatId]).toMatchObject({
+          agentId: original.agentId, model: expectedModel,
+          apiProviderId: expectedProvider, modelEndpointId: expectedEndpoint, modelProtocol: original.provider.protocol,
+          thinkingMode: parentRequest.thinkingMode, permissionMode: parentRequest.permissionMode,
+          agentSettingsById: { [original.agentId]: original.agentSettings },
+          projectPath: fixture.dirs.project, parentChat: { chatId: source, relation: 'delegation' },
+          preambleSelection: { revision: 0, orderedPreambleIds: [] },
+        });
+      }
+      await fixture.fakeProviders.openAi.waitForRequest({ lastUserText: garconCommandResultContent(outcome) });
+      await fixture.restartGarcon();
+      expect((await fixture.client.listChats()).sessions).toHaveLength(selection === 'native-only' ? 1 : 2);
+      expect(userContents((await fixture.client.getMessages(source)).messages)).toEqual([prompt]);
+      if (selection === 'native-only') {
+        expect(fixture.fakeProviders.openAi.requests().some((request) => request.lastUserText === childPrompt)).toBe(false);
+      }
+    });
+  }, 60_000);
+
   test.each([false, true])('resolves provider display names before child admission (ambiguous: %s)', async (ambiguous) => {
     await withIntegrationFixture(`agent-command-provider-name-${ambiguous}`, async (fixture) => {
       const agent = fixture.directAgents.openAi;

--- a/integration-tests/tests/server/scripted-agent-commands.test.ts
+++ b/integration-tests/tests/server/scripted-agent-commands.test.ts
@@ -202,66 +202,75 @@ describe('scripted provider agent commands', () => {
   }
 
   for (const [agent, createsChild] of [['claude', true], ['codex', true], ['claude', false], ['codex', false], ['pi', false]] as const) {
-    test(`${agent} accepts ${createsChild ? 'a child start' : 'a schedule'} and receives its private result through its real binary`, async () => {
-      const environment = await environmentFor(agent);
-      try {
-        await withIntegrationFixture(`${agent}-scripted-agent-commands`, async (fixture) => {
-          const source = fixture.newChatId();
-          const start = environment.startRequest({ chatId: source, projectPath: fixture.dirs.project, command: 'Issue the synthetic command.' });
-          const childPrompt = 'Independent synthetic child task.';
-          const command = createsChild
-            ? `<garcon-start-agent ref="task" async="true" agent="${agent}" model="${escapeGarconXmlText(start.model)}" reasoning-effort="${start.thinkingMode}">${childPrompt}</garcon-start-agent>`
-            : '<garcon-schedule every="5m" busy="skip" />';
-          const received: string[] = [];
-          environment.script(() => command);
-          const reply = (input: string) => {
-            received.push(input);
-            return input.includes(childPrompt) ? 'Synthetic child complete.' : 'Synthetic result acknowledged.';
-          };
-          environment.script(reply);
-          if (createsChild) environment.script(reply);
-          const cursor = fixture.client.markEvents();
-          await fixture.client.startChat(start);
-          await fixture.client.waitForEvent(
-            (event): event is ChatMessagesMessage => event.type === 'chat-messages' && event.chatId === source
-              && event.messages.some(({ message }) => message.type === 'assistant-message' && message.content === 'Synthetic result acknowledged.'),
-            'private action result acknowledged', { afterIndex: cursor, timeoutMs: 90_000 },
-          );
-          if (createsChild) {
+    for (const selection of createsChild ? ['explicit', 'inherited', 'model-only'] : ['explicit']) {
+      test(`${agent} accepts ${createsChild ? 'a child start' : 'a schedule'} with ${selection} selection and receives its private result through its real binary`, async () => {
+        const environment = await environmentFor(agent);
+        try {
+          await withIntegrationFixture(`${agent}-scripted-agent-commands`, async (fixture) => {
+            const source = fixture.newChatId();
+            const start = environment.startRequest({ chatId: source, projectPath: fixture.dirs.project, command: 'Issue the synthetic command.' });
+            const childPrompt = 'Independent synthetic child task.';
+            let selectionAttributes = '';
+            if (selection === 'explicit') selectionAttributes = `agent="${agent}" model="${escapeGarconXmlText(start.model)}" reasoning-effort="${start.thinkingMode}"`;
+            else if (selection === 'model-only') selectionAttributes = `model="${escapeGarconXmlText(start.model)}"`;
+            const command = createsChild
+              ? `<garcon-start-agent ref="task" async="true" ${selectionAttributes}>${childPrompt}</garcon-start-agent>`
+              : '<garcon-schedule every="5m" busy="skip" />';
+            const received: string[] = [];
+            environment.script(() => command);
+            const reply = (input: string) => {
+              received.push(input);
+              return input.includes(childPrompt) ? 'Synthetic child complete.' : 'Synthetic result acknowledged.';
+            };
+            environment.script(reply);
+            if (createsChild) environment.script(reply);
+            const cursor = fixture.client.markEvents();
+            await fixture.client.startChat(start);
             await fixture.client.waitForEvent(
-              (event): event is ChatMessagesMessage => event.type === 'chat-messages' && event.chatId !== source
-                && event.messages.some(({ message }) => message.type === 'assistant-message' && message.content === 'Synthetic child complete.'),
-              'independent child completed', { afterIndex: cursor, timeoutMs: 90_000 },
+              (event): event is ChatMessagesMessage => event.type === 'chat-messages' && event.chatId === source
+                && event.messages.some(({ message }) => message.type === 'assistant-message' && message.content === 'Synthetic result acknowledged.'),
+              'private action result acknowledged', { afterIndex: cursor, timeoutMs: 90_000 },
             );
-          }
-          const transcript = await fixture.client.getMessages(source);
-          expect(userContents(transcript.messages)).toEqual([start.command]);
-          const outcomes = messagesOfType(transcript.messages, 'transcript-notice').filter((notice) =>
-            notice.detail?.type === (createsChild ? 'agent-start-outcome' : 'agent-schedule-outcome'));
-          expect(outcomes).toHaveLength(1);
-          expect(outcomes[0]!.detail).toMatchObject({ status: createsChild ? 'accepted' : 'created' });
-          const outcome = outcomes[0]!.detail;
-          if (outcome?.type !== 'agent-start-outcome' && outcome?.type !== 'agent-schedule-outcome') throw new Error('Missing typed outcome');
-          expect(received.some((input) => input.endsWith(garconCommandResultContent(outcome)))).toBe(true);
-          expect(JSON.stringify(transcript.messages)).not.toContain('<garcon-start-agent');
-          expect(JSON.stringify(transcript.messages)).not.toContain('<garcon-schedule');
-          if (createsChild) {
-            const chats = await fixture.client.listChats();
-            const child = chats.sessions.find((chat) => chat.id !== source);
-            expect(chats.sessions).toHaveLength(2);
-            expect(child?.parentChat).toEqual({ chatId: source, relation: 'delegation' });
-            expect(received.some((input) => input.endsWith(childPrompt))).toBe(true);
-            expect(userContents((await fixture.client.getMessages(child!.id)).messages)).toEqual([childPrompt]);
-          } else {
-            expect((await fixture.client.getScheduledPrompts()).prompts).toMatchObject([{
-              target: { type: 'existing-chat', chatId: source, busyBehavior: 'skip' },
-              schedule: { intervalMinutes: 5 }, prompt: '<garcon-schedule-action />',
-            }]);
-          }
-          environment.settled();
-        }, environment.fixtureOptions);
-      } finally { await environment.dispose(); }
-    }, 120_000);
+            if (createsChild) {
+              await fixture.client.waitForEvent(
+                (event): event is ChatMessagesMessage => event.type === 'chat-messages' && event.chatId !== source
+                  && event.messages.some(({ message }) => message.type === 'assistant-message' && message.content === 'Synthetic child complete.'),
+                'independent child completed', { afterIndex: cursor, timeoutMs: 90_000 },
+              );
+            }
+            const transcript = await fixture.client.getMessages(source);
+            expect(userContents(transcript.messages)).toEqual([start.command]);
+            const outcomes = messagesOfType(transcript.messages, 'transcript-notice').filter((notice) =>
+              notice.detail?.type === (createsChild ? 'agent-start-outcome' : 'agent-schedule-outcome'));
+            expect(outcomes).toHaveLength(1);
+            expect(outcomes[0]!.detail).toMatchObject({ status: createsChild ? 'accepted' : 'created' });
+            const outcome = outcomes[0]!.detail;
+            if (outcome?.type !== 'agent-start-outcome' && outcome?.type !== 'agent-schedule-outcome') throw new Error('Missing typed outcome');
+            expect(received.some((input) => input.endsWith(garconCommandResultContent(outcome)))).toBe(true);
+            expect(JSON.stringify(transcript.messages)).not.toContain('<garcon-start-agent');
+            expect(JSON.stringify(transcript.messages)).not.toContain('<garcon-schedule');
+            if (createsChild) {
+              const chats = await fixture.client.listChats();
+              const child = chats.sessions.find((chat) => chat.id !== source);
+              expect(chats.sessions).toHaveLength(2);
+              expect(child?.parentChat).toEqual({ chatId: source, relation: 'delegation' });
+              expect(child).toMatchObject({
+                agentId: start.agentId, model: start.model, apiProviderId: null, modelEndpointId: null, modelProtocol: null,
+                thinkingMode: start.thinkingMode, permissionMode: start.permissionMode,
+              });
+              expect(received.some((input) => input.endsWith(childPrompt))).toBe(true);
+              expect(userContents((await fixture.client.getMessages(child!.id)).messages)).toEqual([childPrompt]);
+            } else {
+              expect((await fixture.client.getScheduledPrompts()).prompts).toMatchObject([{
+                target: { type: 'existing-chat', chatId: source, busyBehavior: 'skip' },
+                schedule: { intervalMinutes: 5 }, prompt: '<garcon-schedule-action />',
+              }]);
+            }
+            environment.settled();
+          }, environment.fixtureOptions);
+        } finally { await environment.dispose(); }
+      }, 120_000);
+    }
   }
 
   (process.platform === 'linux' ? test : test.skip)('opencode accepts a schedule and consumes its result at an active tool boundary', async () => {

--- a/integration-tests/tests/server/scripted-agent-commands.test.ts
+++ b/integration-tests/tests/server/scripted-agent-commands.test.ts
@@ -6,6 +6,7 @@ import type { AgentStartOutcomeNoticeDetail } from '../../../common/garcon-agent
 import type { ChatMessagesMessage } from '../../../common/ws-events.js';
 import { escapeGarconXmlText } from '../../../common/garcon-command-envelope.js';
 import { garconCommandResultContent } from '../../../common/garcon-command-results.js';
+import { CODEX_MODELS } from '../../../common/models.js';
 import { messagesOfType, userContents } from '../../support/chat-assertions.js';
 import { codexAssistantMessage } from '../../support/fake-codex-model.js';
 import { claudeText } from '../../support/fake-claude-model.js';
@@ -29,14 +30,15 @@ interface ScriptedCommands {
 
 async function environmentFor(agent: string): Promise<ScriptedCommands> {
   if (agent === 'codex') {
-    const environment = await startScriptedCodexTestEnvironment();
-    return { fixtureOptions: environment, startRequest: liveCodexStartRequest,
+    const model = CODEX_MODELS.DEFAULT;
+    const environment = await startScriptedCodexTestEnvironment({ model });
+    return { fixtureOptions: environment, startRequest: (input) => ({ ...liveCodexStartRequest(input), model }),
       script: (reply) => environment.model.scriptTurn(async (request) => [codexAssistantMessage(await reply(request.lastUserText))]),
       settled: () => environment.model.assertSettled(), dispose: () => environment.dispose() };
   }
   if (agent === 'claude') {
     const environment = await startScriptedClaudeTestEnvironment();
-    return { fixtureOptions: environment, startRequest: liveClaudeStartRequest,
+    return { fixtureOptions: environment, startRequest: (input) => ({ ...liveClaudeStartRequest(input), model: 'haiku' }),
       script: (reply) => environment.model.scriptTurn(async (request) => [claudeText(await reply(request.lastUserText))]),
       settled: () => environment.model.assertSettled(), dispose: () => environment.dispose() };
   }

--- a/integration-tests/tests/server/scripted-final-response.test.ts
+++ b/integration-tests/tests/server/scripted-final-response.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { parseAgentTurnReceipt } from '../../../common/agent-turn-receipt.js';
 import { parseGarconCommandResult } from '../../../common/garcon-command-results.js';
 import { escapeGarconXmlText } from '../../../common/garcon-command-envelope.js';
+import { CODEX_MODELS } from '../../../common/models.js';
 import type { StartChatCommandRequest } from '../../../common/chat-command-contracts.js';
 import { assistantContents } from '../../support/chat-assertions.js';
 import { withIntegrationFixture, type IntegrationFixtureOptions } from '../../support/integration-fixture.js';
@@ -26,8 +27,9 @@ interface FinalResponseEnvironment {
 
 async function environmentFor(agent: string): Promise<FinalResponseEnvironment> {
   if (agent === 'codex') {
-    const environment = await startScriptedCodexTestEnvironment();
-    return { options: environment, start: liveCodexStartRequest,
+    const model = CODEX_MODELS.DEFAULT;
+    const environment = await startScriptedCodexTestEnvironment({ model });
+    return { options: environment, start: (input) => ({ ...liveCodexStartRequest(input), model }),
       script(commentary, final) {
         environment.model.scriptTurn([{ ...codexAssistantMessage(commentary), phase: 'commentary' },
           codexExecCommandCall('synthetic_tool', 'printf synthetic')]);
@@ -36,7 +38,7 @@ async function environmentFor(agent: string): Promise<FinalResponseEnvironment> 
   }
   if (agent === 'claude') {
     const environment = await startScriptedClaudeTestEnvironment();
-    return { options: environment, start: liveClaudeStartRequest,
+    return { options: environment, start: (input) => ({ ...liveClaudeStartRequest(input), model: 'haiku' }),
       script(commentary, final) {
         environment.model.scriptTurn([claudeText(commentary), claudeToolUse('synthetic_tool', 'Bash', { command: 'printf synthetic' })]);
         environment.model.scriptTurn([claudeText(final)]);

--- a/server/agents/__tests__/agent-start-selection-service.test.js
+++ b/server/agents/__tests__/agent-start-selection-service.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import { AgentStartSelectionService } from '../agent-start-selection-service.js';
+import { StartSelectionError } from '../../../common/start-selection.js';
+
+function fixture() {
+  const envelope = (source) => ({ ownerId: 'test', schemaVersion: 1, values: { nested: { source } } });
+  const entry = {
+    id: 'test', models: [
+      { value: 'first', label: 'First' }, { value: 'second', label: 'Second' },
+      ...['east', 'west'].flatMap((endpointId) => ['first', 'second'].map((rawModel) => ({
+        value: `${endpointId}:${rawModel}`, label: rawModel, rawModel,
+        apiProviderId: 'provider', endpointId, protocol: 'openai-compatible',
+      }))),
+    ],
+    defaultModel: 'first', supportedPermissionModes: ['default', 'bypassPermissions'],
+    supportedThinkingModes: ['none', 'high'], supportedProtocols: ['openai-compatible'],
+    acceptsApiProviderEndpoints: true, requiresStrictModelDiscovery: false,
+    defaultSettings: envelope('integration'),
+  };
+  const catalog = { catalog: { agents: [entry], apiProviders: [{
+    id: 'provider', label: 'Example Proxy', endpoints: [
+      { id: 'east', protocol: 'openai-compatible' }, { id: 'west', protocol: 'openai-compatible' },
+    ],
+  }] } };
+  const parent = {
+    agentId: 'test', model: 'first', apiProviderId: 'provider', modelEndpointId: 'west',
+    modelProtocol: 'openai-compatible', permissionMode: 'bypassPermissions', thinkingMode: 'none',
+    agentSettingsById: { test: envelope('parent') },
+  };
+  const defaults = {
+    global: { permissionMode: 'default', thinkingMode: 'high', agentSettingsById: { test: envelope('global') } },
+    byAgent: { test: { agentSettingsById: { test: envelope('target') } } },
+  };
+  const command = {
+    type: 'start-agent', agentId: null, providerId: null, model: null, reasoningEffort: null,
+    ref: 'task', async: true, fork: false, title: null, prompt: 'Synthetic task',
+  };
+  const service = new AgentStartSelectionService({
+    agents: { getAgentCatalogEntry: async () => entry }, apiProviders: { getCatalog: () => catalog.catalog.apiProviders },
+  });
+  return { entry, catalog, parent, defaults, command,
+    resolve: (overrides = {}) => service.resolve(catalog, { ...command, ...overrides }, defaults, parent) };
+}
+
+function expectCode(operation, code) {
+  try { operation(); } catch (error) {
+    expect(error).toBeInstanceOf(StartSelectionError);
+    expect(error.code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected ${code}`);
+}
+
+describe('delegated start selection', () => {
+  test.each([
+    [{}, 'first', 'provider', 'west', 'none', 'parent'],
+    [{ model: 'second' }, 'second', 'provider', 'west', 'none', 'parent'],
+    [{ providerId: 'Example Proxy', model: 'east:second' }, 'second', 'provider', 'east', 'none', 'parent'],
+    [{ agentId: 'test', providerId: 'Example Proxy', model: 'east:second' }, 'second', 'provider', 'east', 'high', 'target'],
+    [{ agentId: 'test', model: 'second' }, 'second', null, null, 'high', 'target'],
+  ])('resolves attribute presence %j', (command, model, apiProviderId, modelEndpointId, thinkingMode, source) => {
+    const f = fixture();
+    const selected = f.resolve(command);
+    expect(selected).toEqual({
+      agentId: 'test', model, apiProviderId, modelEndpointId,
+      modelProtocol: apiProviderId === null ? null : 'openai-compatible',
+      permissionMode: 'bypassPermissions', thinkingMode,
+      agentSettings: { ownerId: 'test', schemaVersion: 1, values: { nested: { source } } },
+    });
+    selected.agentSettings.values.nested.source = 'mutated';
+    expect(f.parent.agentSettingsById.test.values.nested.source).toBe('parent');
+    expect(f.defaults.byAgent.test.agentSettingsById.test.values.nested.source).toBe('target');
+  });
+
+  test('normalizes absent native routing fields without choosing a configured route', () => {
+    const f = fixture();
+    delete f.parent.apiProviderId; delete f.parent.modelEndpointId; delete f.parent.modelProtocol;
+    for (const command of [{}, { model: 'second' }]) {
+      expect(f.resolve(command)).toMatchObject({ apiProviderId: null, modelEndpointId: null, modelProtocol: null });
+    }
+    f.parent.model = 'unlisted';
+    expectCode(() => f.resolve(), 'UNKNOWN_MODEL');
+  });
+
+  test('uses the explicit agent rather than the parent for native selection and defaults', () => {
+    const f = fixture();
+    f.parent.agentId = 'other';
+    expect(f.resolve({ agentId: 'test', model: 'second' })).toMatchObject({
+      agentId: 'test', apiProviderId: null, thinkingMode: 'high',
+    });
+    expectCode(() => f.resolve(), 'UNKNOWN_AGENT');
+  });
+
+  test('rejects unknown native models and endpoint-only agents before admission', () => {
+    const f = fixture();
+    for (const model of ['unlisted', 'east:first']) {
+      expectCode(() => f.resolve({ agentId: 'test', model }), 'UNKNOWN_MODEL');
+    }
+    f.entry.models = f.entry.models.filter((model) => model.apiProviderId);
+    expectCode(() => f.resolve({ agentId: 'test', model: 'first' }), 'UNKNOWN_MODEL');
+  });
+
+  test('never borrows the parent endpoint for an explicit provider', () => {
+    const f = fixture();
+    expectCode(() => f.resolve({ providerId: 'provider', model: 'second' }), 'AMBIGUOUS_MODEL');
+    expectCode(() => f.resolve({ model: 'east:second' }), 'UNKNOWN_MODEL');
+  });
+
+  test('rejects incomplete or changed inherited routes', () => {
+    for (const field of ['apiProviderId', 'modelEndpointId', 'modelProtocol']) {
+      const f = fixture(); f.parent[field] = null;
+      expectCode(() => f.resolve(), 'INCOMPATIBLE_ENDPOINT');
+    }
+    const f = fixture(); f.parent.modelProtocol = 'anthropic-messages';
+    expectCode(() => f.resolve(), 'INCOMPATIBLE_ENDPOINT');
+    f.parent.modelProtocol = 'openai-compatible'; f.parent.modelEndpointId = 'removed';
+    expectCode(() => f.resolve(), 'UNKNOWN_ENDPOINT');
+  });
+
+  test('does not resolve a removed inherited provider ID through another provider name', () => {
+    const f = fixture();
+    f.catalog.catalog.apiProviders[0].id = 'replacement';
+    f.catalog.catalog.apiProviders[0].label = 'provider';
+    expectCode(() => f.resolve(), 'UNKNOWN_PROVIDER');
+  });
+
+  test('does not reinterpret an inherited canonical model as a catalog alias', () => {
+    const f = fixture(); f.parent.model = 'west:first';
+    expectCode(() => f.resolve(), 'INCOMPATIBLE_ENDPOINT');
+  });
+
+  test('inherits active settings with integration fallback and honors reasoning overrides', () => {
+    const f = fixture();
+    expect(f.resolve({ reasoningEffort: 'high' }).thinkingMode).toBe('high');
+    expect(f.resolve({ agentId: 'test', model: 'first', reasoningEffort: 'none' }).thinkingMode).toBe('none');
+    expectCode(() => f.resolve({ reasoningEffort: 'invalid' }), 'UNSUPPORTED_REASONING_EFFORT');
+    f.parent.thinkingMode = 'unsupported';
+    expectCode(() => f.resolve(), 'UNSUPPORTED_REASONING_EFFORT');
+    f.parent.thinkingMode = 'none';
+    delete f.parent.agentSettingsById.test;
+    expect(f.resolve().agentSettings).toEqual(f.entry.defaultSettings);
+    f.parent.agentSettingsById.test = { ownerId: 'other', schemaVersion: 1, values: {} };
+    expect(f.resolve().agentSettings).toEqual(f.entry.defaultSettings);
+  });
+
+  test('leaves omitted command values untouched', () => {
+    const f = fixture();
+    Object.freeze(f.command); f.resolve();
+    expect(f.command).toMatchObject({ agentId: null, providerId: null, model: null });
+  });
+});

--- a/server/agents/agent-start-selection-service.ts
+++ b/server/agents/agent-start-selection-service.ts
@@ -1,10 +1,15 @@
-import type { PermissionMode } from '../../common/chat-modes.js';
+import { normalizeAgentSettings } from '../../common/agent-settings.js';
 import type { GarconStartAgentCommand } from '../../common/garcon-start-agent.js';
 import type { ModelCatalogResponse } from '../../common/model-catalog.js';
 import type { RemoteExecutionDefaults } from '../../common/settings.js';
-import { resolveStartSelection } from '../../common/start-selection.js';
+import { requireCatalogAgent, resolveStartSelection, StartSelectionError } from '../../common/start-selection.js';
 import type { ApiProviderService } from '../api-providers/service.js';
+import type { ChatRegistryEntry } from '../chats/store.js';
 import type { AgentRegistryServiceContract } from './registry.js';
+
+type ParentSelection = Pick<ChatRegistryEntry,
+  'agentId' | 'model' | 'apiProviderId' | 'modelEndpointId' | 'modelProtocol'
+  | 'permissionMode' | 'thinkingMode' | 'agentSettingsById'>;
 
 export class AgentStartSelectionService {
   constructor(private readonly deps: {
@@ -25,14 +30,47 @@ export class AgentStartSelectionService {
     catalog: ModelCatalogResponse,
     command: GarconStartAgentCommand,
     executionDefaults: RemoteExecutionDefaults,
-    permissionMode: PermissionMode,
+    parent: ParentSelection,
   ) {
-    return resolveStartSelection(catalog, { executionDefaults }, {
-      agentId: command.agentId,
-      model: command.model,
-      permissionMode,
-      ...(command.providerId === null ? {} : { providerId: command.providerId }),
-      ...(command.reasoningEffort === null ? {} : { thinkingMode: command.reasoningEffort }),
+    const agentId = command.agentId ?? parent.agentId;
+    const inheritAgent = command.agentId === null;
+    const inheritRoute = inheritAgent && command.providerId === null;
+    const inheritedProvider = parent.apiProviderId ?? null;
+    const inheritedEndpoint = parent.modelEndpointId ?? null;
+    const inheritedProtocol = parent.modelProtocol ?? null;
+    if (inheritRoute) {
+      const native = inheritedProvider === null && inheritedEndpoint === null && inheritedProtocol === null;
+      const routed = inheritedProvider !== null && inheritedEndpoint !== null && inheritedProtocol !== null;
+      if (!native && !routed) {
+        throw new StartSelectionError('INCOMPATIBLE_ENDPOINT', 'parent model routing is incomplete');
+      }
+      if (inheritedProvider !== null && !catalog.catalog.apiProviders.some((entry) => entry.id === inheritedProvider)) {
+        throw new StartSelectionError('UNKNOWN_PROVIDER', 'parent API provider is no longer available');
+      }
+    }
+    const thinkingMode = command.reasoningEffort ?? (inheritAgent ? parent.thinkingMode : undefined);
+    const selection = resolveStartSelection(catalog, { executionDefaults }, {
+      agentId,
+      model: command.model ?? parent.model,
+      permissionMode: parent.permissionMode,
+      providerId: inheritRoute ? inheritedProvider : command.providerId,
+      ...(inheritRoute && inheritedEndpoint !== null ? { endpointId: inheritedEndpoint } : {}),
+      ...(thinkingMode === undefined ? {} : { thinkingMode }),
     });
+    if (inheritRoute && (
+      selection.apiProviderId !== inheritedProvider
+      || selection.modelEndpointId !== inheritedEndpoint
+      || selection.modelProtocol !== inheritedProtocol
+      || (command.model === null && selection.model !== parent.model)
+    )) {
+      throw new StartSelectionError('INCOMPATIBLE_ENDPOINT', 'parent model routing is no longer available');
+    }
+    return {
+      ...selection,
+      agentId,
+      agentSettings: inheritAgent ? normalizeAgentSettings(
+        agentId, parent.agentSettingsById[agentId], requireCatalogAgent(catalog, agentId).defaultSettings,
+      ) : selection.agentSettings,
+    };
   }
 }

--- a/server/chats/__tests__/agent-action-controllers.test.js
+++ b/server/chats/__tests__/agent-action-controllers.test.js
@@ -24,7 +24,10 @@ function deferred() {
 async function drain() { for (let i = 0; i < 60; i++) await Promise.resolve(); }
 
 function fixture(options = {}) {
-  const parent = { projectPath: '/synthetic/project', permissionMode: 'bypassPermissions' };
+  const parent = {
+    agentId: 'test', model: 'test-model', thinkingMode: 'none', agentSettingsById: {},
+    projectPath: '/synthetic/project', permissionMode: 'bypassPermissions',
+  };
   const chats = new Map([[SOURCE.chatId, parent]]);
   let currentView = SOURCE.viewId;
   let enabled = true;
@@ -32,7 +35,7 @@ function fixture(options = {}) {
   const notices = [];
   const events = [];
   const context = {
-    registry: { getChat: (id) => chats.get(id) ?? null },
+    registry: { getChat: (id) => structuredClone(chats.get(id) ?? null) },
     notices: {
       existingCurrentView: () => ({ viewId: currentView }),
       appendNotice: mock((_chatId, _viewId, notice) => { events.push('notice'); notices.push(notice); }),
@@ -118,6 +121,67 @@ describe('assistant action controllers', () => {
     expect(f.events).toEqual(['start', 'notice', 'reply']);
     expect(f.replies[0].input.receipt).toBeNull();
     expect(parseGarconCommandResult(f.replies[0].input.content)).toMatchObject({ status: 'accepted', chatId: CHILD, requestViewId: SOURCE.viewId, requestOrdinal: 2 });
+  });
+
+  it('inherits the latest locked configuration after catalog discovery', async () => {
+    const f = fixture();
+    const discovered = deferred(); const release = deferred();
+    f.agents.getAgentCatalogEntry.mockImplementation(async () => {
+      discovered.resolve(); await release.promise; return f.entry;
+    });
+    f.start.request(SOURCE, { ...START, agentId: null, model: null });
+    await discovered.promise;
+    f.entry.models.push({ value: 'current-model', label: 'Current' });
+    Object.assign(f.parent, {
+      model: 'current-model', thinkingMode: 'high', permissionMode: 'default', projectPath: '/synthetic/current',
+      agentSettingsById: { test: { ownerId: 'test', schemaVersion: 1, values: { current: true } } },
+    });
+    release.resolve(); await drain();
+    expect(f.commands.submitAgentCommandStartLocked).toHaveBeenCalledTimes(1);
+    expect(f.commands.submitAgentCommandStartLocked.mock.calls[0][0]).toMatchObject({
+      agentId: 'test', model: 'current-model', thinkingMode: 'high', permissionMode: 'default',
+      projectPath: '/synthetic/current', agentSettings: f.parent.agentSettingsById.test,
+    });
+  });
+
+  it.each([false, true])('rediscovers a changed parent agent outside locks (old discovery fails: %s)', async (fails) => {
+    const allocate = mock(() => CHILD);
+    const f = fixture({ chatIds: { allocate } });
+    const discovered = deferred(); const release = deferred();
+    const successor = { ...f.entry, id: 'successor', defaultSettings: { ownerId: 'successor', schemaVersion: 1, values: {} } };
+    f.agents.getAgentCatalogEntry.mockImplementation(async (agentId) => {
+      if (agentId === 'test') {
+        discovered.resolve(); await release.promise;
+        if (fails) throw new Error('Old discovery failed');
+        return f.entry;
+      }
+      await f.context.chatMutationLock.runExclusiveMany([`chat:${SOURCE.chatId}`, `chat:${CHILD}`], async () => {});
+      return successor;
+    });
+    f.start.request(SOURCE, { ...START, agentId: null, model: null });
+    await discovered.promise;
+    f.parent.agentId = 'successor';
+    release.resolve(); await drain();
+    expect(f.agents.getAgentCatalogEntry.mock.calls.map(([id]) => id)).toEqual(['test', 'successor']);
+    expect(allocate).toHaveBeenCalledTimes(1);
+    expect(f.commands.submitAgentCommandStartLocked).toHaveBeenCalledTimes(1);
+    expect(f.commands.submitAgentCommandStartLocked.mock.calls[0][0]).toMatchObject({ agentId: 'successor', thinkingMode: 'none' });
+    expect(f.notices).toHaveLength(1);
+    expect(f.notices[0].detail.status).toBe('accepted');
+  });
+
+  it('bounds rediscovery under repeated ownership changes without admitting a child', async () => {
+    const f = fixture();
+    f.agents.getAgentCatalogEntry.mockImplementation(async (agentId) => {
+      f.parent.agentId = `${agentId}-next`;
+      return f.entry;
+    });
+    f.start.request(SOURCE, { ...START, agentId: null, model: null });
+    await drain();
+    expect(f.agents.getAgentCatalogEntry).toHaveBeenCalledTimes(3);
+    expect(f.commands.submitAgentCommandStartLocked).not.toHaveBeenCalled();
+    expect(f.notices).toHaveLength(1);
+    expect(f.notices[0].detail).toMatchObject({ status: 'rejected', reason: 'action-failed' });
   });
 
   it.each([

--- a/server/chats/__tests__/agent-action-controllers.test.js
+++ b/server/chats/__tests__/agent-action-controllers.test.js
@@ -4,6 +4,8 @@ import { AgentScheduleController } from '../agent-schedule-controller.js';
 import { AgentStartSelectionService } from '../../agents/agent-start-selection-service.js';
 import { KeyedPromiseLock } from '../../lib/keyed-lock.js';
 import { DomainError } from '../../lib/domain-error.js';
+import { AtomicJsonWriteError } from '../../lib/json-file-store.js';
+import { AgentStartCompensatedError } from '../../commands/agent-start-compensated-error.js';
 import { resolveStartProjectPath } from '../../lib/command-project-path.js';
 import { ScheduledPromptCreationOutcomeUnknownError } from '../../scheduled-prompts/scheduler.js';
 import { ScheduledPromptDomainError } from '../../scheduled-prompts/store.js';
@@ -197,16 +199,28 @@ describe('assistant action controllers', () => {
     expect(f.notices[0].detail).toMatchObject({ status: 'rejected', reason });
   });
 
-  it('distinguishes compensated and uncertain retained starts', async () => {
-    for (const [error, retained, status] of [
-      [new Error('failed start'), false, 'rejected'],
-      [new Error('post-admission failure'), true, 'outcome-unknown'],
-      [new AggregateError([new Error('rollback flush failed')]), false, 'outcome-unknown'],
+  it('preserves admission failure precedence and retained-child outcomes', async () => {
+    for (const [error, retained, outcome] of [
+      [new Error('failed start'), false, { status: 'rejected', reason: 'action-failed' }],
+      [new Error('post-admission failure'), true, { status: 'outcome-unknown', chatId: CHILD }],
+      [new AggregateError([new Error('rollback flush failed')]), false, { status: 'outcome-unknown', chatId: CHILD }],
+      [new AtomicJsonWriteError('write failed', false), false, { status: 'rejected', reason: 'action-failed' }],
+      [new AtomicJsonWriteError('directory sync failed', true), false, { status: 'outcome-unknown', chatId: CHILD }],
+      [new DomainError('PREAMBLE_SLASH_COMMAND_BLOCKED', 'blocked'), true,
+        { status: 'preamble-rejected', chatId: CHILD, reason: 'slash-command-blocked' }],
+      [new DomainError('PREAMBLE_SELECTION_COMPOSITION_INVALID', 'invalid'), true,
+        { status: 'preamble-rejected', chatId: CHILD, reason: 'composition-invalid' }],
+      [new DomainError('PREAMBLE_SLASH_COMMAND_BLOCKED', 'blocked'), false, { status: 'rejected', reason: 'action-failed' }],
+      [new AgentStartCompensatedError(new DomainError('UNSUPPORTED_AGENT', 'unsupported')), true,
+        { status: 'rejected', reason: 'unsupported-agent' }],
     ]) {
       const f = fixture();
       f.commands.submitAgentCommandStartLocked.mockImplementation(async () => { if (retained) f.chats.set(CHILD, {}); throw error; });
       f.start.request(SOURCE, START); await drain();
-      expect(f.notices[0].detail.status).toBe(status);
+      expect(f.notices[0].detail).toEqual({
+        type: 'agent-start-outcome', ref: START.ref, async: START.async,
+        requestViewId: SOURCE.viewId, requestOrdinal: SOURCE.requestOrdinal, ...outcome,
+      });
     }
   });
 

--- a/server/chats/agent-start-controller.ts
+++ b/server/chats/agent-start-controller.ts
@@ -29,10 +29,7 @@ export class AgentStartController {
 
   request(source: AgentCommandSource, command: GarconStartAgentCommand): void {
     this.#replies.launchChild(source, async (signal) => {
-      if (signal.aborted) return null;
-      const catalog = await this.options.selection.catalog(command.agentId).then(
-        (value) => ({ value }), (error: unknown) => ({ error }),
-      );
+      if (!this.#replies.current(source, signal)) return null;
       let allocated: string;
       try { allocated = this.options.chatIds.allocate(); }
       catch (error) {
@@ -47,60 +44,72 @@ export class AgentStartController {
           return { detail, turnId: null, recorded: this.#replies.record(source, detail) !== null };
         });
       }
-      return this.options.chatMutationLock.runExclusiveMany([`chat:${source.chatId}`, `chat:${allocated}`], async () => {
+      const rediscover = Symbol('rediscover');
+      for (let attempt = 0; ; attempt++) {
         if (!this.#replies.current(source, signal)) return null;
-        let outcome: AgentChildAdmissionOutcome;
-        let turnId: string | null = null;
-        if (!this.options.isEnabled()) outcome = { status: 'rejected', reason: 'disabled' };
-        else if ('error' in catalog) {
-          this.#replies.report(source, 'selection', catalog.error);
-          outcome = { status: 'rejected', reason: 'action-failed' };
-        } else {
-          let childChatId: string | undefined;
-          try {
-            const parent = this.options.registry.getChat(source.chatId)!;
-            const selection = this.options.selection.resolve(
-              catalog.value, command, this.options.settings.getExecutionDefaults(), parent.permissionMode,
-            );
-            childChatId = allocated;
-            const result = await this.options.commands.submitAgentCommandStartLocked({
-              ...selection,
-              chatId: allocated,
-              parentChatId: source.chatId,
-              sourceViewId: source.viewId,
-              clientRequestId: crypto.randomUUID(),
-              clientMessageId: crypto.randomUUID(),
-              command: command.prompt,
-              agentId: command.agentId,
-              projectPath: parent.projectPath,
-              ...(command.title === null ? {} : { title: command.title }),
-              ...(command.fork ? { transcriptSnapshot: { viewId: source.viewId, ordinal: source.requestOrdinal } } : {}),
-            }, signal);
-            turnId = result.turnId;
-            outcome = { status: 'accepted', chatId: allocated };
-          } catch (error) {
-            const child = childChatId ? this.options.registry.getChat(childChatId) : null;
-            if (error instanceof AgentStartCompensatedError) outcome = { status: 'rejected', reason: startFailureReason(error.cause) };
-            else if (child && isRecoverablePreambleAdmissionError(error)) {
-              outcome = { status: 'preamble-rejected', chatId: childChatId!,
-                reason: error.code === 'PREAMBLE_SLASH_COMMAND_BLOCKED' ? 'slash-command-blocked' : 'composition-invalid' };
-            } else if (child) outcome = { status: 'outcome-unknown', chatId: childChatId! };
-            else if (childChatId && (error instanceof AggregateError || error instanceof AtomicJsonWriteError && error.renamed)) {
-              outcome = { status: 'outcome-unknown', chatId: childChatId };
-            } else outcome = { status: 'rejected', reason: startFailureReason(error) };
-            this.#replies.report(source, 'admission', error, {
-              type: 'agent-start-outcome', ref: command.ref, async: command.async,
-              requestViewId: source.viewId, requestOrdinal: source.requestOrdinal, ...outcome,
-            });
+        const agentId = command.agentId ?? this.options.registry.getChat(source.chatId)!.agentId;
+        const catalog = await this.options.selection.catalog(agentId).then(
+          (value) => ({ value }), (error: unknown) => ({ error }),
+        );
+        const result = await this.options.chatMutationLock.runExclusiveMany([`chat:${source.chatId}`, `chat:${allocated}`], async () => {
+          if (!this.#replies.current(source, signal)) return null;
+          const parent = this.options.registry.getChat(source.chatId)!;
+          const agentChanged = agentId !== (command.agentId ?? parent.agentId);
+          let outcome: AgentChildAdmissionOutcome;
+          let turnId: string | null = null;
+          if (!this.options.isEnabled()) outcome = { status: 'rejected', reason: 'disabled' };
+          else if (agentChanged) {
+            if (attempt < 2) return rediscover;
+            outcome = { status: 'rejected', reason: 'action-failed' };
+          } else if ('error' in catalog) {
+            this.#replies.report(source, 'selection', catalog.error);
+            outcome = { status: 'rejected', reason: 'action-failed' };
+          } else {
+            let childChatId: string | undefined;
+            try {
+              const selection = this.options.selection.resolve(
+                catalog.value, command, this.options.settings.getExecutionDefaults(), parent,
+              );
+              childChatId = allocated;
+              const result = await this.options.commands.submitAgentCommandStartLocked({
+                ...selection,
+                chatId: allocated,
+                parentChatId: source.chatId,
+                sourceViewId: source.viewId,
+                clientRequestId: crypto.randomUUID(),
+                clientMessageId: crypto.randomUUID(),
+                command: command.prompt,
+                projectPath: parent.projectPath,
+                ...(command.title === null ? {} : { title: command.title }),
+                ...(command.fork ? { transcriptSnapshot: { viewId: source.viewId, ordinal: source.requestOrdinal } } : {}),
+              }, signal);
+              turnId = result.turnId;
+              outcome = { status: 'accepted', chatId: allocated };
+            } catch (error) {
+              const child = childChatId ? this.options.registry.getChat(childChatId) : null;
+              if (error instanceof AgentStartCompensatedError) outcome = { status: 'rejected', reason: startFailureReason(error.cause) };
+              else if (child && isRecoverablePreambleAdmissionError(error)) {
+                outcome = { status: 'preamble-rejected', chatId: childChatId!,
+                  reason: error.code === 'PREAMBLE_SLASH_COMMAND_BLOCKED' ? 'slash-command-blocked' : 'composition-invalid' };
+              } else if (child) outcome = { status: 'outcome-unknown', chatId: childChatId! };
+              else if (childChatId && (error instanceof AggregateError || error instanceof AtomicJsonWriteError && error.renamed)) {
+                outcome = { status: 'outcome-unknown', chatId: childChatId };
+              } else outcome = { status: 'rejected', reason: startFailureReason(error) };
+              this.#replies.report(source, 'admission', error, {
+                type: 'agent-start-outcome', ref: command.ref, async: command.async,
+                requestViewId: source.viewId, requestOrdinal: source.requestOrdinal, ...outcome,
+              });
+            }
           }
-        }
-        if (!this.#replies.current(source, signal)) return null;
-        const detail: AgentStartOutcomeNoticeDetail = {
-          type: 'agent-start-outcome', ref: command.ref, async: command.async, requestViewId: source.viewId,
-          requestOrdinal: source.requestOrdinal, ...outcome,
-        };
-        return { detail, turnId, recorded: this.#replies.record(source, detail) !== null };
-      });
+          if (!this.#replies.current(source, signal)) return null;
+          const detail: AgentStartOutcomeNoticeDetail = {
+            type: 'agent-start-outcome', ref: command.ref, async: command.async, requestViewId: source.viewId,
+            requestOrdinal: source.requestOrdinal, ...outcome,
+          };
+          return { detail, turnId, recorded: this.#replies.record(source, detail) !== null };
+        });
+        if (result !== rediscover) return result;
+      }
     });
   }
 

--- a/server/chats/agent-start-controller.ts
+++ b/server/chats/agent-start-controller.ts
@@ -14,6 +14,8 @@ import type { SettingsStore } from '../settings/store.js';
 import type { ChatIdAllocator } from './chat-id-allocator.js';
 import { AgentChildTurnReplies, type AgentChildTurnReplyOptions } from './agent-child-turn-replies.js';
 
+const MAX_CATALOG_DISCOVERIES = 3;
+
 export interface AgentStartControllerOptions extends AgentChildTurnReplyOptions {
   readonly selection: Pick<AgentStartSelectionService, 'catalog' | 'resolve'>;
   readonly settings: Pick<SettingsStore, 'getExecutionDefaults'>;
@@ -45,7 +47,7 @@ export class AgentStartController {
         });
       }
       const rediscover = Symbol('rediscover');
-      for (let attempt = 0; ; attempt++) {
+      for (let discoveryAttempt = 1; ; discoveryAttempt++) {
         if (!this.#replies.current(source, signal)) return null;
         const agentId = command.agentId ?? this.options.registry.getChat(source.chatId)!.agentId;
         const catalog = await this.options.selection.catalog(agentId).then(
@@ -59,7 +61,7 @@ export class AgentStartController {
           let turnId: string | null = null;
           if (!this.options.isEnabled()) outcome = { status: 'rejected', reason: 'disabled' };
           else if (agentChanged) {
-            if (attempt < 2) return rediscover;
+            if (discoveryAttempt < MAX_CATALOG_DISCOVERIES) return rediscover;
             outcome = { status: 'rejected', reason: 'action-failed' };
           } else if ('error' in catalog) {
             this.#replies.report(source, 'selection', catalog.error);
@@ -86,15 +88,7 @@ export class AgentStartController {
               turnId = result.turnId;
               outcome = { status: 'accepted', chatId: allocated };
             } catch (error) {
-              const child = childChatId ? this.options.registry.getChat(childChatId) : null;
-              if (error instanceof AgentStartCompensatedError) outcome = { status: 'rejected', reason: startFailureReason(error.cause) };
-              else if (child && isRecoverablePreambleAdmissionError(error)) {
-                outcome = { status: 'preamble-rejected', chatId: childChatId!,
-                  reason: error.code === 'PREAMBLE_SLASH_COMMAND_BLOCKED' ? 'slash-command-blocked' : 'composition-invalid' };
-              } else if (child) outcome = { status: 'outcome-unknown', chatId: childChatId! };
-              else if (childChatId && (error instanceof AggregateError || error instanceof AtomicJsonWriteError && error.renamed)) {
-                outcome = { status: 'outcome-unknown', chatId: childChatId };
-              } else outcome = { status: 'rejected', reason: startFailureReason(error) };
+              outcome = this.#admissionFailureOutcome(error, childChatId);
               this.#replies.report(source, 'admission', error, {
                 type: 'agent-start-outcome', ref: command.ref, async: command.async,
                 requestViewId: source.viewId, requestOrdinal: source.requestOrdinal, ...outcome,
@@ -115,6 +109,25 @@ export class AgentStartController {
 
   discardSource(chatId: string): void { this.#replies.discardSource(chatId); }
   shutdown(): void { this.#replies.shutdown(); }
+
+  #admissionFailureOutcome(error: unknown, chatId: string | undefined): AgentChildAdmissionOutcome {
+    const child = chatId ? this.options.registry.getChat(chatId) : null;
+    if (error instanceof AgentStartCompensatedError) {
+      return { status: 'rejected', reason: startFailureReason(error.cause) };
+    }
+    if (chatId) {
+      if (child && isRecoverablePreambleAdmissionError(error)) {
+        return {
+          status: 'preamble-rejected', chatId,
+          reason: error.code === 'PREAMBLE_SLASH_COMMAND_BLOCKED' ? 'slash-command-blocked' : 'composition-invalid',
+        };
+      }
+      if (child || error instanceof AggregateError || error instanceof AtomicJsonWriteError && error.renamed) {
+        return { status: 'outcome-unknown', chatId };
+      }
+    }
+    return { status: 'rejected', reason: startFailureReason(error) };
+  }
 }
 
 function startFailureReason(error: unknown): AgentChildRejectionReason {

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -918,6 +918,7 @@ describe('ChatCommandService', () => {
       chatIds: { allocate: () => TARGET_CHAT_ID }, isEnabled: () => true,
       settings: { getExecutionDefaults: () => ({}) },
       selection: { catalog: async () => ({}), resolve: () => ({
+        agentId: agentSettings().ownerId,
         permissionMode: 'default', thinkingMode: 'none', model: 'opus', agentSettings: agentSettings(),
       }) },
       notices: { existingCurrentView: () => ({ viewId }), appendNotice: (_id, _view, notice) => outcomes.push(notice.detail) },
@@ -1132,6 +1133,7 @@ describe('ChatCommandService', () => {
       chatIds: { allocate: () => TARGET_CHAT_ID }, isEnabled: () => true,
       settings: { getExecutionDefaults: () => ({}) },
       selection: { catalog: async () => ({}), resolve: () => ({
+        agentId: agentSettings().ownerId,
         permissionMode: 'default', thinkingMode: 'none', model: 'opus', agentSettings: agentSettings(),
       }) },
       notices: { existingCurrentView: () => ({ viewId }), appendNotice: (_id, _view, notice) => {

--- a/server/ledger/__tests__/agent-command-evidence.test.js
+++ b/server/ledger/__tests__/agent-command-evidence.test.js
@@ -26,6 +26,34 @@ async function withLedger(run, options = {}) {
 }
 
 describe('agent command durable evidence', () => {
+  it.each(['', 'model="example"', 'provider="example" model="example"'])
+  ('preserves omitted start selections through commit and native import: %s', async (attributes) => {
+    const request = mock();
+    const content = `<garcon-start-agent ref="inherited" ${attributes}>Synthetic child task.</garcon-start-agent>`;
+    await withLedger(async ({ ledger, store }) => {
+      const view = ledger.initializeChat(CHAT);
+      const lease = ledger.openProducer(CHAT, 'test');
+      request.mockImplementation((source, command) => {
+        const [row] = ledger.currentRows(CHAT);
+        expect(source.requestOrdinal).toBe(row.ordinal);
+        expect(row.detail.command).toEqual(command);
+        expect(command.agentId).toBeNull();
+        expect(command.model).toBe(attributes ? 'example' : null);
+      });
+      lease.sink.publish({ type: 'rows', rows: [{ message: new AssistantMessage(AT, content) }] });
+      expect(request).toHaveBeenCalledTimes(1);
+      const committed = ledger.currentRows(CHAT)[0].detail;
+      request.mockClear();
+      const drafts = importedDrafts([{ message: new AssistantMessage(AT, content), providerMeta: null }], () => AT);
+      const staged = ledger.stageView(CHAT, drafts, 1);
+      ledger.replaceCurrentView(CHAT, view.viewId, staged.viewId);
+      store.closeChat(CHAT);
+      expect(ledger.currentRows(CHAT)[0].detail).toEqual(committed);
+      expect(ledgerRowsToTranscriptMessages(ledger.currentRows(CHAT))).toEqual([]);
+      expect(request).not.toHaveBeenCalled();
+    }, { agentStarts: { request } });
+  });
+
   it('commits private stop evidence before dispatch and imports it without dispatch or visible outcomes', async () => {
     const request = mock();
     await withLedger(async ({ ledger, store }) => {


### PR DESCRIPTION
let delegated starts reuse the parent's current configuration without repeating selection attributes. support model-only and provider/model overrides, pin inherited routing to the exact endpoint, and keep explicit agent/model selections native-only when no provider is given. agent or provider overrides still require a model; invalid or stale selections reject before child admission. CLI selection behavior stays unchanged.