### PR TITLE
test(agent-commands): document Codex late-steer race

### DIFF
--- a/integration-tests/tests/server/scripted-agent-commands.test.ts
+++ b/integration-tests/tests/server/scripted-agent-commands.test.ts
@@ -126,6 +126,9 @@ describe('scripted provider agent commands', () => {
   }
 
   for (const agent of ['claude', 'codex']) {
+    // Codex can acknowledge terminal-adjacent steering after its final pending-input check,
+    // then persist the input during finalization without sampling it. These gates expose the loss.
+    // Tracks https://github.com/openai/codex/issues/15842; candidate fix: https://github.com/openai/codex/pull/30341.
     test(`${agent} reports exact snapshot-child and resumed-turn results through its real binary`, async () => {
       const environment = await environmentFor(agent);
       const admitted = Promise.withResolvers<void>();


### PR DESCRIPTION
## Summary

- Documents the terminal-adjacent Codex steering race beside the scripted delegated-resume regression.
- Links the upstream issue and candidate atomic-continuation fix.
- Explains why the cross-chat gates intentionally expose accepted-but-unsampled control input.

## Validation

- Focused scripted Codex snapshot/resume test passed: 1 test, 13 filtered.
- git diff --check passed.

## Upstream status

Codex main at 3ef3cecd20 still has the vulnerable non-atomic final pending-input check. openai/codex#30341 remains open and conflicting.