### PR TITLE
Use collision-based names for forks and handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Garcon keeps the full loop together:
 - **Move context deliberately.** Fork where the provider supports it, export complete Markdown or XML transcripts, create token-budgeted handoff artifacts, or delegate into a fresh chat.
 - **Close the loop from anywhere.** Work with branches, worktrees, history, pull requests, commits, and pushes from desktop or phone, with optional Telegram alerts when attention is needed.
 
+Forks and `/handoff` continuations append the first unused numeric suffix to the source's visible title, checking all chats in the workspace, including archived chats. Deleted names can be reused. Existing suffixes remain literal: forking `Topic (1)` produces `Topic (1) (1)`, not `Topic (2)`.
+
 ## See It In Action
 
 <p align="center"><strong>Agents that can coordinate</strong></p>

--- a/integration-tests/tests/server/claude-scripted-fork-matrix.test.ts
+++ b/integration-tests/tests/server/claude-scripted-fork-matrix.test.ts
@@ -673,7 +673,6 @@ async function prepareChatRecord(
         projectPath: directories.project,
         tags: [],
         agentSessionId: native?.agentSessionId ?? null,
-        nextForkOrdinal: 1,
         model,
         apiProviderId: null,
         modelEndpointId: null,

--- a/integration-tests/tests/server/codex-compaction-retention-floor.test.ts
+++ b/integration-tests/tests/server/codex-compaction-retention-floor.test.ts
@@ -145,7 +145,6 @@ describe('Codex compaction interleaving', () => {
               projectPath: directories.project,
               tags: [],
               agentSessionId,
-              nextForkOrdinal: 1,
               model: 'gpt-5.6-sol',
               apiProviderId: null,
               modelEndpointId: null,

--- a/integration-tests/tests/server/codex-fork-at-message.test.ts
+++ b/integration-tests/tests/server/codex-fork-at-message.test.ts
@@ -326,7 +326,6 @@ describe('Codex fork at message', () => {
               projectPath: directories.project,
               tags: [],
               agentSessionId: sourceAgentSessionId,
-              nextForkOrdinal: 1,
               model: 'gpt-5.6-sol',
               apiProviderId: null,
               modelEndpointId: null,

--- a/integration-tests/tests/server/codex-fork-while-running.test.ts
+++ b/integration-tests/tests/server/codex-fork-while-running.test.ts
@@ -207,7 +207,6 @@ describe('Codex fork while a turn is running', () => {
               projectPath: directories.project,
               tags: [],
               agentSessionId: sourceAgentSessionId,
-              nextForkOrdinal: 1,
               model: 'gpt-5.6-sol',
               apiProviderId: null,
               modelEndpointId: null,

--- a/integration-tests/tests/server/codex-history-mode.test.ts
+++ b/integration-tests/tests/server/codex-history-mode.test.ts
@@ -62,10 +62,11 @@ describe('Codex history modes', () => {
 
       const registry = JSON.parse(
         await readFile(join(fixture.dirs.workspace, 'chats.json'), 'utf8'),
-      ) as { sessions: Record<string, { nextForkOrdinal?: number }> };
+      ) as { sessions: Record<string, unknown> };
       expect(registry.sessions[targetChatId]).toBeDefined();
       expect(registry.sessions[pointTargetChatId]).toBeDefined();
-      expect(registry.sessions[sourceChatId]?.nextForkOrdinal).toBe(3);
+      expect(registry.sessions[sourceChatId]).not.toHaveProperty('nextForkOrdinal');
+      expect(pointFork.chat.title).not.toBe(wholeFork.chat.title);
       const sessionDirectory = dirname(sourceNativePath);
       const sessionFiles = (await readdir(sessionDirectory)).filter((name) => name.endsWith('.jsonl'));
       expect(sessionFiles).toEqual([sourceNativePath.split('/').at(-1)!]);
@@ -123,7 +124,6 @@ describe('Codex history modes', () => {
               projectPath: directories.project,
               tags: [],
               agentSessionId: sourceAgentSessionId,
-              nextForkOrdinal: 1,
               model: 'gpt-5.6-sol',
               apiProviderId: null,
               modelEndpointId: null,
@@ -294,7 +294,6 @@ describe('Codex history modes', () => {
               projectPath: directories.project,
               tags: [],
               agentSessionId: sourceAgentSessionId,
-              nextForkOrdinal: 1,
               model: 'gpt-5.6-sol',
               apiProviderId: null,
               modelEndpointId: null,

--- a/integration-tests/tests/server/codex-scripted-fork-matrix.test.ts
+++ b/integration-tests/tests/server/codex-scripted-fork-matrix.test.ts
@@ -373,7 +373,6 @@ async function prepareEmptyChat(
         projectPath: directories.project,
         tags: [],
         agentSessionId: null,
-        nextForkOrdinal: 1,
         model,
         apiProviderId: null,
         modelEndpointId: null,

--- a/integration-tests/tests/server/opencode-scripted-fork-matrix.test.ts
+++ b/integration-tests/tests/server/opencode-scripted-fork-matrix.test.ts
@@ -259,7 +259,6 @@ async function prepareEmptyChat(
         projectPath: directories.project,
         tags: [],
         agentSessionId: null,
-        nextForkOrdinal: 1,
         model: OPENCODE_TEST_MODEL,
         apiProviderId: null,
         modelEndpointId: null,

--- a/integration-tests/tests/server/pi-scripted-persistence.test.ts
+++ b/integration-tests/tests/server/pi-scripted-persistence.test.ts
@@ -452,7 +452,6 @@ async function writeLegacyPiSession(input: {
         projectPath: input.projectPath,
         tags: [],
         agentSessionId: input.agentSessionId,
-        nextForkOrdinal: 1,
         model: PI_TEST_MODEL,
         apiProviderId: null,
         modelEndpointId: null,

--- a/integration-tests/tests/server/self-handoff.test.ts
+++ b/integration-tests/tests/server/self-handoff.test.ts
@@ -4,7 +4,11 @@
 // persisted registry, and that the continuation actually receives the archived
 // history as its carried context.
 import { describe, expect, test } from 'bun:test';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { ChatListEntry } from '../../../common/chat-list.js';
+import type { ForkRunCommandResponse } from '../../../common/chat-command-contracts.js';
+import { CURRENT_WORKSPACE_VERSION } from '../../../server/migrations/index.js';
 import { messagesOfType, userContents } from '../../support/chat-assertions.js';
 import { expectedCarriedInput } from '../../support/carried-context.js';
 import { withIntegrationFixture } from '../../support/integration-fixture.js';
@@ -41,6 +45,7 @@ describe('self handoff', () => {
 
       // The response names the continuation, which is what the client navigates to.
       expect(response.chat.id).toBe(targetChatId);
+      expect(response.chat.title).toBe('the original request (1)');
       expect(response.chat.parentChat).toEqual({
         chatId: sourceChatId,
         relation: 'handoff',
@@ -63,6 +68,7 @@ describe('self handoff', () => {
       const target = chats.find((chat) => chat.id === targetChatId);
       expect(target).toBeDefined();
       expect(target?.parentChat).toEqual(response.chat.parentChat);
+      expect(target?.title).toBe('the original request (1)');
       // Same agent and model; a fresh chat, not a switch in place.
       expect(target?.agentId).toBe(source?.agentId);
       expect(target?.agentOwnershipEpoch).not.toBe(source?.agentOwnershipEpoch);
@@ -79,6 +85,105 @@ describe('self handoff', () => {
           detail: undefined,
         }),
       );
+    });
+  }, 60_000);
+
+  test('shares collision-based names with forks, reuses gaps, and migrates legacy counters', async () => {
+    await withIntegrationFixture('self-handoff-names', async (fixture) => {
+      const client = fixture.client;
+      const sourceChatId = fixture.newChatId();
+      const started = await client.startDirectChat({
+        chatId: sourceChatId,
+        content: 'source request',
+        projectPath: fixture.dirs.project,
+        agent: fixture.directAgents.openAi,
+      });
+      await client.waitForTurnTerminal(sourceChatId, started.turnId);
+      await client.updateSessionName(sourceChatId, 'Topic');
+
+      const firstFork = await client.forkChat({ sourceChatId, chatId: fixture.newChatId() });
+      expect(firstFork.chat.title).toBe('Topic (1)');
+      expect((await client.toggleArchive(firstFork.chat.id)).isArchived).toBeTrue();
+
+      const handoff = async (sourceId: string) => {
+        const request = {
+          clientRequestId: crypto.randomUUID(),
+          clientMessageId: crypto.randomUUID(),
+          sourceChatId: sourceId,
+          chatId: fixture.newChatId(),
+          command: 'continue the work',
+        };
+        const response = await client.post<ForkRunCommandResponse>('/api/v1/chats/handoff-run', request);
+        await client.waitForTurnTerminal(response.chat.id, response.turnId);
+        return { request, response };
+      };
+      const second = await handoff(sourceChatId);
+      expect(second.response.chat.title).toBe('Topic (2)');
+      const replay = await client.post<ForkRunCommandResponse>('/api/v1/chats/handoff-run', second.request);
+      expect(replay.status).toBe('duplicate');
+      expect(replay.chat.title).toBe('Topic (2)');
+
+      const nested = await handoff(second.response.chat.id);
+      expect(nested.response.chat.title).toBe('Topic (2) (1)');
+      await client.deleteChat(firstFork.chat.id);
+      const replacement = await handoff(sourceChatId);
+      expect(replacement.response.chat.title).toBe('Topic (1)');
+
+      const registryPath = join(fixture.dirs.workspace, 'chats.json');
+      let beforeMigration: unknown;
+      await fixture.restartGarcon({
+        beforeStart: async () => {
+          const registry = JSON.parse(await readFile(registryPath, 'utf8')) as {
+            version: number;
+            sessions: Record<string, Record<string, unknown>>;
+          };
+          beforeMigration = structuredClone(registry);
+          for (const entry of Object.values(registry.sessions)) {
+            expect(entry).not.toHaveProperty('nextForkOrdinal');
+            entry.nextForkOrdinal = 42;
+          }
+          await writeFile(registryPath, JSON.stringify(registry));
+          await writeFile(join(fixture.dirs.workspace, 'workspace-version.json'), JSON.stringify({ version: 7 }));
+        },
+      });
+
+      expect(JSON.parse(await readFile(registryPath, 'utf8'))).toEqual(beforeMigration);
+      expect(JSON.parse(await readFile(join(fixture.dirs.workspace, 'workspace-version.json'), 'utf8')))
+        .toEqual({ version: CURRENT_WORKSPACE_VERSION });
+      const chats = (await fixture.client.listChats()).sessions;
+      expect(chats.find((chat) => chat.id === sourceChatId)?.title).toBe('Topic');
+      expect(chats.find((chat) => chat.id === second.response.chat.id)?.title).toBe('Topic (2)');
+      expect(chats.find((chat) => chat.id === replacement.response.chat.id)?.title).toBe('Topic (1)');
+      expect(chats.find((chat) => chat.id === nested.response.chat.id)?.title).toBe('Topic (2) (1)');
+    });
+  }, 60_000);
+
+  test('allocates distinct names for a concurrent fork and handoff from different sources', async () => {
+    await withIntegrationFixture('self-handoff-concurrent-names', async (fixture) => {
+      const client = fixture.client;
+      const sourceIds = [fixture.newChatId(), fixture.newChatId()];
+      for (const chatId of sourceIds) {
+        const started = await client.startDirectChat({
+          chatId,
+          content: 'shared title',
+          projectPath: fixture.dirs.project,
+          agent: fixture.directAgents.openAi,
+        });
+        await client.waitForTurnTerminal(chatId, started.turnId);
+      }
+
+      const [fork, handoff] = await Promise.all([
+        client.forkChat({ sourceChatId: sourceIds[0]!, chatId: fixture.newChatId() }),
+        client.post<ForkRunCommandResponse>('/api/v1/chats/handoff-run', {
+          clientRequestId: crypto.randomUUID(),
+          clientMessageId: crypto.randomUUID(),
+          sourceChatId: sourceIds[1]!,
+          chatId: fixture.newChatId(),
+          command: 'continue the work',
+        }),
+      ]);
+      expect([fork.chat.title, handoff.chat.title].sort()).toEqual(['shared title (1)', 'shared title (2)']);
+      await client.waitForTurnTerminal(handoff.chat.id, handoff.turnId);
     });
   }, 60_000);
 

--- a/server/chats/__tests__/fork-chat.test.js
+++ b/server/chats/__tests__/fork-chat.test.js
@@ -81,9 +81,8 @@ function makeDeps(overrides = {}) {
     ...overrides.ledger,
   };
   const settings = {
-    getChatName: mock(() => 'Source title'),
     ensureInNormal: mock(async () => undefined),
-    setSessionName: mock(async () => undefined),
+    setDerivedSessionName: mock(async () => 'Source title (1)'),
     removeFromAllOrderLists: mock(async () => undefined),
     removeSessionName: mock(async () => undefined),
     ...overrides.settings,
@@ -750,7 +749,8 @@ describe('forkChatFileCopy', () => {
   });
 
   it('rolls back registry, ledger, presentation, and native artifacts once', async () => {
-    const deps = makeDeps({ source: sourceSession({ nextForkOrdinal: 3 }) });
+    const deps = makeDeps();
+    const sourceBefore = structuredClone(deps.sessions.get('source-chat'));
     const result = await forkChatFileCopy({
       sourceSession: deps.sessions.get('source-chat'),
       sourceChatId: 'source-chat',
@@ -762,7 +762,7 @@ describe('forkChatFileCopy', () => {
     await result.rollback();
 
     expect(deps.sessions.get('target-chat')).toBeUndefined();
-    expect(deps.sessions.get('source-chat').nextForkOrdinal).toBe(3);
+    expect(deps.sessions.get('source-chat')).toEqual(sourceBefore);
     expect(deps.ownership.delete).toHaveBeenCalledOnce();
     expect(deps.settings.removeFromAllOrderLists).toHaveBeenCalledOnce();
     expect(deps.settings.removeSessionName).toHaveBeenCalledOnce();

--- a/server/chats/__tests__/fork-ordinal-migration.test.js
+++ b/server/chats/__tests__/fork-ordinal-migration.test.js
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { removeLegacyForkOrdinals } from '../fork-ordinal-migration.js';
+
+const SOURCE_ID = '1786077000000001';
+const CHILD_ID = '1786077000000002';
+let workspaceDir;
+let registryPath;
+
+function entry(overrides = {}) {
+  return {
+    agentId: 'test',
+    model: 'model-a',
+    projectPath: '/repo',
+    agentOwnershipEpoch: 'synthetic-epoch',
+    agentSettingsById: {},
+    carryOverSegments: [],
+    nativeSeedReceipt: null,
+    carryOverMigrationQuarantine: null,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-fork-ordinal-migration-'));
+  registryPath = path.join(workspaceDir, 'chats.json');
+});
+
+afterEach(async () => {
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+describe('fork ordinal cleanup', () => {
+  it('removes only the obsolete field and is idempotent', async () => {
+    const source = entry({ nextForkOrdinal: 4, retainedExtra: 'preserved' });
+    const child = entry({
+      nextForkOrdinal: 'invalid legacy value',
+      parentChat: { chatId: SOURCE_ID, relation: 'fork', transcriptViewId: 'view-1', ordinal: 2 },
+    });
+    const original = { version: 5, retainedExtra: true, sessions: { [SOURCE_ID]: source, [CHILD_ID]: child } };
+    await fs.writeFile(registryPath, JSON.stringify(original));
+
+    await removeLegacyForkOrdinals(workspaceDir);
+
+    delete source.nextForkOrdinal;
+    delete child.nextForkOrdinal;
+    expect(JSON.parse(await fs.readFile(registryPath, 'utf8'))).toEqual(original);
+    const rename = spyOn(fs, 'rename');
+    try {
+      await removeLegacyForkOrdinals(workspaceDir);
+      expect(rename).not.toHaveBeenCalled();
+    } finally {
+      rename.mockRestore();
+    }
+  });
+
+  it('does not create a missing registry or rewrite one without counters', async () => {
+    await removeLegacyForkOrdinals(workspaceDir);
+    await expect(fs.stat(registryPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    const raw = JSON.stringify({ version: 5, sessions: { [SOURCE_ID]: entry() } });
+    await fs.writeFile(registryPath, raw);
+
+    await removeLegacyForkOrdinals(workspaceDir);
+
+    expect(await fs.readFile(registryPath, 'utf8')).toBe(raw);
+  });
+
+  it.each([
+    { version: 4, sessions: {} },
+    { version: 5, sessions: [] },
+    { version: 5, sessions: { [SOURCE_ID]: entry({ nextForkOrdinal: 1 }), [CHILD_ID]: null } },
+    { version: 5, sessions: { invalid: entry({ nextForkOrdinal: 1 }) } },
+    { version: 5, sessions: { [SOURCE_ID]: entry({ nextForkOrdinal: 1, agentOwnershipEpoch: null }) } },
+  ])('refuses malformed registries without rewriting them', async (registry) => {
+    const raw = JSON.stringify(registry);
+    await fs.writeFile(registryPath, raw);
+
+    await expect(removeLegacyForkOrdinals(workspaceDir)).rejects.toThrow();
+    expect(await fs.readFile(registryPath, 'utf8')).toBe(raw);
+  });
+
+  it('preserves the original after a failed write and can retry', async () => {
+    const raw = JSON.stringify({ version: 5, sessions: { [SOURCE_ID]: entry({ nextForkOrdinal: 4 }) } });
+    await fs.writeFile(registryPath, raw);
+    const rename = spyOn(fs, 'rename').mockRejectedValue(new Error('disk unavailable'));
+    try {
+      await expect(removeLegacyForkOrdinals(workspaceDir)).rejects.toThrow('disk unavailable');
+      expect(await fs.readFile(registryPath, 'utf8')).toBe(raw);
+    } finally {
+      rename.mockRestore();
+    }
+
+    await removeLegacyForkOrdinals(workspaceDir);
+    expect(JSON.parse(await fs.readFile(registryPath, 'utf8')).sessions[SOURCE_ID])
+      .not.toHaveProperty('nextForkOrdinal');
+  });
+});

--- a/server/chats/__tests__/store.test.js
+++ b/server/chats/__tests__/store.test.js
@@ -216,10 +216,10 @@ describe('ChatRegistry', () => {
       agentSettingsById: { test: envelope('test') },
       permissionMode: 'default',
       thinkingMode: 'none',
-      nextForkOrdinal: 1,
       parentChat: null,
     });
     expect(added).toHaveBeenCalledWith(CHAT_ID);
+    expect(registry.getChat(CHAT_ID)).not.toHaveProperty('nextForkOrdinal');
   });
 
   it('rejects duplicate IDs and native sessions owned by another integration', () => {

--- a/server/chats/chat-list-projector.ts
+++ b/server/chats/chat-list-projector.ts
@@ -10,6 +10,7 @@ import { normalizeTags } from '../../common/tags.js';
 import type { ChatMetadata } from './metadata-store.js';
 import type { ChatRegistryEntry, IChatRegistry } from './store.js';
 import { extractFirstLine } from '../lib/text.js';
+import { resolveChatTitle } from './chat-title.js';
 import { carryOverRevision } from './carryover-segments.js';
 
 interface ChatListProjectorSettings {
@@ -106,9 +107,7 @@ export class ChatListProjector {
   ): ChatSummaryProjection {
     const inferredCreatedAt = chatIdCreatedAt(chatId).toISOString();
     const overrideTitle = this.deps.settings.getChatName(chatId);
-    const title = extractFirstLine(
-      overrideTitle || metadata?.firstMessage || 'New Session',
-    ) || 'New Session';
+    const title = resolveChatTitle(overrideTitle, metadata?.firstMessage);
     return {
       chat: {
         id: chatId,

--- a/server/chats/chat-title.ts
+++ b/server/chats/chat-title.ts
@@ -1,0 +1,18 @@
+import { extractFirstLine } from '../lib/text.js';
+import type { IChatRegistry } from './store.js';
+
+export interface DerivedChatNameInput {
+  chatId: string;
+  sourceChatId: string;
+  registry: Pick<IChatRegistry, 'listChatIds'>;
+  metadata: {
+    getChatMetadata(chatId: string): { firstMessage?: string | null } | null;
+  };
+}
+
+export function resolveChatTitle(
+  name: string | null | undefined,
+  firstMessage: string | null | undefined,
+): string {
+  return extractFirstLine(name || firstMessage || 'New Session') || 'New Session';
+}

--- a/server/chats/fork-chat.ts
+++ b/server/chats/fork-chat.ts
@@ -3,7 +3,7 @@ import type {
   ForkedAgentSessionOutcome,
   StartedAgentSession,
 } from '../agents/session-types.js';
-import { extractFirstLine } from '../lib/text.js';
+import type { DerivedChatNameInput } from './chat-title.js';
 import type { AgentOwnershipJournal } from './agent-ownership-journal.js';
 import { DomainError } from '../lib/domain-error.js';
 import { createLogger } from '../lib/log.js';
@@ -45,9 +45,8 @@ function isUnsettledForkPoint(error: unknown): boolean {
 }
 
 interface ForkChatSettings {
-  getChatName(chatId: string): string | null | undefined;
   ensureInNormal(chatId: string): Promise<unknown>;
-  setSessionName(chatId: string, title: string): Promise<unknown>;
+  setDerivedSessionName(input: DerivedChatNameInput): Promise<string>;
   removeFromAllOrderLists(chatId: string): Promise<unknown>;
   removeSessionName(chatId: string): Promise<unknown>;
 }
@@ -99,38 +98,25 @@ export interface ForkChatFileCopyResult {
   chatId: string;
   agentId: string;
   agentSessionId: string | null;
-  sourceNextForkOrdinal: number;
   rollback(): Promise<void>;
 }
 
 export interface ForkTargetRollbackInput {
-  sourceChatId: string;
   targetChatId: string;
-  registry: IChatRegistry;
   settings: ForkChatSettings;
   ownership: Pick<AgentOwnershipJournal, 'delete'>;
-  sourceNextForkOrdinal?: number;
 }
 
 export async function rollbackForkTarget({
-  sourceChatId,
   targetChatId,
-  registry,
   settings,
   ownership,
-  sourceNextForkOrdinal,
 }: ForkTargetRollbackInput): Promise<void> {
   await Promise.all([
     settings.removeFromAllOrderLists(targetChatId),
     settings.removeSessionName(targetChatId),
   ]);
   await ownership.delete(targetChatId);
-  const source = registry.getChat(sourceChatId);
-  if (source && sourceNextForkOrdinal !== undefined) {
-    await registry.updateChat(sourceChatId, {
-      nextForkOrdinal: sourceNextForkOrdinal,
-    }, { flush: true });
-  }
 }
 
 export async function forkChatFileCopy({
@@ -302,9 +288,6 @@ export async function forkChatFileCopy({
     throw error;
   }
 
-  const sourceTitle = resolveVisibleChatTitle(sourceChatId, settings, metadata);
-  const nextForkOrdinal = normalizeNextForkOrdinal(sourceSession.nextForkOrdinal) ?? 1;
-  const forkTitle = `${sourceTitle} (${nextForkOrdinal})`;
   let created: boolean;
   try {
     created = registry.addChat({
@@ -319,7 +302,6 @@ export async function forkChatFileCopy({
       ...createPreambleBoundaryBinding('fork'),
       tags: [...sourceSession.tags],
       agentSessionId: nativeFork?.agentSessionId ?? null,
-      nextForkOrdinal: 1,
       permissionMode: sourceSession.permissionMode,
       thinkingMode: sourceSession.thinkingMode,
       agentSettingsById: { ...sourceSession.agentSettingsById },
@@ -370,12 +352,9 @@ export async function forkChatFileCopy({
     const cleanupErrors: unknown[] = [];
     try {
       await rollbackForkTarget({
-        sourceChatId,
         targetChatId,
-        registry,
         settings,
         ownership,
-        sourceNextForkOrdinal: nextForkOrdinal,
       });
     } catch (error) {
       cleanupErrors.push(error);
@@ -399,16 +378,17 @@ export async function forkChatFileCopy({
   try {
     await registry.flush();
     signal.throwIfAborted();
-    await registry.updateChat(sourceChatId, {
-      nextForkOrdinal: nextForkOrdinal + 1,
-    }, { flush: true });
-    signal.throwIfAborted();
     await settings.ensureInNormal(targetChatId);
     signal.throwIfAborted();
 
     const sourceMeta = metadata.getChatMetadata(sourceChatId);
     if (sourceMeta?.firstMessage) metadata.addNewChatMetadata(targetChatId, sourceMeta.firstMessage);
-    await settings.setSessionName(targetChatId, forkTitle);
+    await settings.setDerivedSessionName({
+      chatId: targetChatId,
+      sourceChatId,
+      registry,
+      metadata,
+    });
     signal.throwIfAborted();
   } catch (error) {
     const cleanupErrors: unknown[] = [];
@@ -440,7 +420,6 @@ export async function forkChatFileCopy({
     chatId: targetChatId,
     agentId: sourceSession.agentId,
     agentSessionId: nativeFork?.agentSessionId ?? null,
-    sourceNextForkOrdinal: nextForkOrdinal,
     rollback,
   };
 }
@@ -511,23 +490,4 @@ function validateForkedSeedReceipt(
   if (JSON.stringify(receipt) !== JSON.stringify(expected)) {
     throw new Error('Forked agent returned an invalid carried-context receipt');
   }
-}
-
-function normalizeNextForkOrdinal(value: unknown): number | null {
-  const parsed = typeof value === 'string'
-    ? Number.parseInt(value, 10)
-    : typeof value === 'number'
-      ? value
-      : Number.NaN;
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function resolveVisibleChatTitle(
-  chatId: string,
-  settings: ForkChatSettings,
-  metadata: ForkChatMetadata,
-): string {
-  const overrideTitle = settings.getChatName(chatId);
-  const fallbackTitle = metadata.getChatMetadata(chatId)?.firstMessage;
-  return extractFirstLine(overrideTitle || fallbackTitle || 'New Session') || 'New Session';
 }

--- a/server/chats/fork-ordinal-migration.ts
+++ b/server/chats/fork-ordinal-migration.ts
@@ -1,0 +1,37 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { parseChatId } from '../../common/chat-id.js';
+import { writeJsonFileAtomic } from '../lib/json-file-store.js';
+import { isObjectRecord, normalizeChatRegistryEntry } from './registry-entry-codec.js';
+import { CHAT_REGISTRY_VERSION } from './store.js';
+
+export async function removeLegacyForkOrdinals(workspaceDir: string): Promise<void> {
+  const registryPath = path.join(workspaceDir, 'chats.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(registryPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+
+  const registry: unknown = JSON.parse(raw);
+  if (!isObjectRecord(registry)
+    || registry.version !== CHAT_REGISTRY_VERSION
+    || !isObjectRecord(registry.sessions)) {
+    throw new Error('Invalid chat registry for fork ordinal cleanup');
+  }
+
+  let changed = false;
+  for (const [chatId, entry] of Object.entries(registry.sessions)) {
+    if (!isObjectRecord(entry)) {
+      throw new Error(`Invalid chat registry entry for ${chatId}`);
+    }
+    normalizeChatRegistryEntry(entry, parseChatId(chatId));
+    if (Object.hasOwn(entry, 'nextForkOrdinal')) {
+      delete entry.nextForkOrdinal;
+      changed = true;
+    }
+  }
+  if (changed) await writeJsonFileAtomic(registryPath, registry, { mode: 0o600 });
+}

--- a/server/chats/registry-entry-codec.ts
+++ b/server/chats/registry-entry-codec.ts
@@ -57,15 +57,6 @@ export function normalizeRegistryModes(entry: {
   };
 }
 
-export function normalizeNextForkOrdinal(value: unknown): number | undefined {
-  const parsed = typeof value === 'string'
-    ? Number.parseInt(value, 10)
-    : typeof value === 'number'
-      ? value
-      : Number.NaN;
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
 function normalizeString(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback;
 }
@@ -144,10 +135,6 @@ export function normalizeChatRegistryEntry(
       ? rawEntry.modelProtocol
       : null,
     lastReadAt: normalizeNullableString(rawEntry.lastReadAt),
-    ...(() => {
-      const nextForkOrdinal = normalizeNextForkOrdinal(rawEntry.nextForkOrdinal);
-      return nextForkOrdinal === undefined ? {} : { nextForkOrdinal };
-    })(),
     ...normalizeRegistryModes(rawEntry),
     carryOverSegments,
     nativeSeedReceipt,

--- a/server/chats/store.ts
+++ b/server/chats/store.ts
@@ -33,7 +33,6 @@ import {
   normalizeChatRegistryEntry,
   normalizeMigrationQuarantine,
   normalizeNativeSeedReceipt,
-  normalizeNextForkOrdinal,
   normalizePreambleSelection,
   normalizeRegistryModes,
   parseCarryOverSegmentRefs,
@@ -76,7 +75,6 @@ const ALLOWED_PATCH_FIELDS = [
   'agentSettingsById',
   'tags',
   'agentSessionId',
-  'nextForkOrdinal',
   'model',
   'apiProviderId',
   'modelEndpointId',
@@ -119,7 +117,6 @@ export interface ChatRegistryEntry {
   projectPath: string;
   tags: string[];
   agentSessionId: string | null;
-  nextForkOrdinal?: number;
   model: string;
   apiProviderId?: string | null;
   modelEndpointId?: string | null;
@@ -173,7 +170,6 @@ export interface NewChatRegistryEntry {
   agentSettingsById?: Record<string, AgentSettingsEnvelope>;
   tags?: string[];
   agentSessionId?: string | null;
-  nextForkOrdinal?: number;
   apiProviderId?: string | null;
   modelEndpointId?: string | null;
   modelProtocol?: ApiProtocol | null;
@@ -441,7 +437,6 @@ export class ChatRegistry extends EventEmitter<ChatRegistryEvents> implements IC
     agentSettingsById = {},
     tags = [],
     agentSessionId = null,
-    nextForkOrdinal = 1,
     apiProviderId = null,
     modelEndpointId = null,
     modelProtocol = null,
@@ -489,7 +484,6 @@ export class ChatRegistry extends EventEmitter<ChatRegistryEvents> implements IC
       projectPath,
       tags: [...tags],
       agentSessionId,
-      nextForkOrdinal: normalizeNextForkOrdinal(nextForkOrdinal) ?? 1,
       model,
       apiProviderId,
       modelEndpointId,
@@ -582,9 +576,6 @@ export class ChatRegistry extends EventEmitter<ChatRegistryEvents> implements IC
     }
     if ('thinkingMode' in normalizedPatch) {
       normalizedPatch.thinkingMode = normalizeThinkingMode(normalizedPatch.thinkingMode);
-    }
-    if ('nextForkOrdinal' in normalizedPatch) {
-      normalizedPatch.nextForkOrdinal = normalizeNextForkOrdinal(normalizedPatch.nextForkOrdinal);
     }
     if ('nativeSession' in normalizedPatch && normalizedPatch.nativeSession?.ownerId !== (normalizedPatch.agentId ?? existing.agentId)) {
       if (normalizedPatch.nativeSession !== null) throw new Error(`Native session owner mismatch for ${id}`);

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -604,7 +604,6 @@ function makeService(overrides = {}) {
     chatId: TARGET_CHAT_ID,
     agentId: 'claude',
     agentSessionId: 'agent-2',
-    sourceNextForkOrdinal: 1,
     rollback: mock(() => Promise.resolve(undefined)),
   }));
   const carryOver = {
@@ -3337,7 +3336,6 @@ describe('ChatCommandService', () => {
         chatId: TARGET_CHAT_ID,
         agentId: 'claude',
         agentSessionId: 'agent-2',
-        sourceNextForkOrdinal: 1,
         rollback,
       };
     });
@@ -3379,7 +3377,6 @@ describe('ChatCommandService', () => {
         chatId: TARGET_CHAT_ID,
         agentId: 'claude',
         agentSessionId: null,
-        sourceNextForkOrdinal: 1,
         rollback: mock(async () => undefined),
       };
     });
@@ -3419,7 +3416,6 @@ describe('ChatCommandService', () => {
         model: 'opus',
         tags: [],
       });
-      registry.updateChat(SOURCE_CHAT_ID, { nextForkOrdinal: 2 });
       throw new Error('fork setup failed');
     });
     const { service, ownership, sessions, settings } = makeService({ forkChatFileCopy });
@@ -3434,7 +3430,7 @@ describe('ChatCommandService', () => {
 
     expect(ownership.delete).toHaveBeenCalledWith(TARGET_CHAT_ID);
     expect(sessions.has(TARGET_CHAT_ID)).toBeFalse();
-    expect(sessions.get(SOURCE_CHAT_ID).nextForkOrdinal).toBe(1);
+    expect(sessions.has(SOURCE_CHAT_ID)).toBeTrue();
     expect(settings.removeFromAllOrderLists).toHaveBeenCalledWith(TARGET_CHAT_ID);
     expect(settings.removeSessionName).toHaveBeenCalledWith(TARGET_CHAT_ID);
   });
@@ -3448,7 +3444,6 @@ describe('ChatCommandService', () => {
       chatId: TARGET_CHAT_ID,
       agentId: 'claude',
       agentSessionId: 'agent-2',
-      sourceNextForkOrdinal: 1,
       rollback,
     }));
     const { service, queue, ledger } = makeService({ forkChatFileCopy });
@@ -3474,7 +3469,6 @@ describe('ChatCommandService', () => {
       forkPreparation: {
         phase: 'created',
         sourceChatId: SOURCE_CHAT_ID,
-        sourceNextForkOrdinal: 1,
       },
     });
   });
@@ -3559,7 +3553,6 @@ describe('ChatCommandService', () => {
         chatId: TARGET_CHAT_ID,
         agentId: 'claude',
         agentSessionId: 'agent-2',
-        sourceNextForkOrdinal: 1,
         rollback: mock(() => Promise.resolve(undefined)),
       };
     });
@@ -3615,7 +3608,6 @@ describe('ChatCommandService', () => {
         chatId: TARGET_CHAT_ID,
         agentId: 'claude',
         agentSessionId: 'agent-2',
-        sourceNextForkOrdinal: 1,
         rollback: mock(() => Promise.resolve(undefined)),
       };
     });

--- a/server/commands/__tests__/self-handoff-commands.test.js
+++ b/server/commands/__tests__/self-handoff-commands.test.js
@@ -68,7 +68,7 @@ function harness({ source = sourceChat() } = {}) {
       settings: {
         ensureInNormal: mock(async () => undefined),
         getChatName: mock(() => 'the source chat'),
-        setSessionName: mock(async () => undefined),
+        setDerivedSessionName: mock(async () => 'the source chat (1)'),
         removeFromAllOrderLists: mock(async () => undefined),
         removeSessionName: mock(async () => undefined),
       },
@@ -409,7 +409,12 @@ describe('self handoff commands', () => {
     await commands.submitSelfHandoffRun(request());
 
     expect(support.deps.settings.ensureInNormal).toHaveBeenCalledWith(TARGET_ID);
-    expect(support.deps.settings.setSessionName).toHaveBeenCalledWith(TARGET_ID, 'the source chat');
+    expect(support.deps.settings.setDerivedSessionName).toHaveBeenCalledWith({
+      chatId: TARGET_ID,
+      sourceChatId: SOURCE_ID,
+      registry: support.deps.chats,
+      metadata: support.deps.metadata,
+    });
     expect(support.deps.metadata.addNewChatMetadata)
       .toHaveBeenCalledWith(TARGET_ID, 'the original ask');
   });

--- a/server/commands/command-ledger.ts
+++ b/server/commands/command-ledger.ts
@@ -14,7 +14,6 @@ export type CommandLedgerStatus =
 export interface ForkPreparationState {
   phase: 'creating' | 'created';
   sourceChatId: string;
-  sourceNextForkOrdinal?: number;
 }
 
 export type CommandTurnResult =

--- a/server/commands/command-support.ts
+++ b/server/commands/command-support.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import type { DerivedChatNameInput } from '../chats/chat-title.js';
 import type { ApiProtocol } from '../../common/api-providers.js';
 import type { AgentSettingsEnvelope } from '../../common/agent-integration.js';
 import {
@@ -73,6 +74,7 @@ export interface SettingsDep {
   getChatName(chatId: string): string | null | undefined;
   setSessionName(chatId: string, title: string): Promise<unknown>;
   setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean>;
+  setDerivedSessionName(input: DerivedChatNameInput): Promise<string>;
   recordChatStartup(defaults: ChatStartupPreferences): Promise<void>;
   ensureInNormal(chatId: string): Promise<void>;
   removeFromAllOrderLists(chatId: string): Promise<void>;

--- a/server/commands/fork-commands.ts
+++ b/server/commands/fork-commands.ts
@@ -21,7 +21,6 @@ interface ForkContext {
   sourceChatId: string;
   targetChatId: string;
   sourceSession: ChatRegistryEntry;
-  sourceNextForkOrdinal: number;
   upToOrdinal?: number;
   allowHandoffFork?: boolean;
 }
@@ -114,9 +113,6 @@ export class ForkCommands {
       modelEndpointId: input.options?.modelEndpointId === undefined ? source.modelEndpointId : input.options.modelEndpointId,
       attachments: input.images ?? [],
     });
-    if (preparedFork?.sourceNextForkOrdinal !== undefined) {
-      forkContext.sourceNextForkOrdinal = preparedFork.sourceNextForkOrdinal;
-    }
 
     const submit = async () => {
       const ledger = await this.deps.ledger.accept(ledgerInput);
@@ -151,7 +147,6 @@ export class ForkCommands {
             forkPreparation: {
               phase: 'creating',
               sourceChatId: forkContext.sourceChatId,
-              sourceNextForkOrdinal: forkContext.sourceNextForkOrdinal,
             },
           });
           forkResult = await this.forkChatFromContext(forkContext, signal);
@@ -159,7 +154,6 @@ export class ForkCommands {
             forkPreparation: {
               phase: 'created',
               sourceChatId: forkContext.sourceChatId,
-              sourceNextForkOrdinal: forkResult.sourceNextForkOrdinal,
             },
           });
         },
@@ -266,7 +260,6 @@ export class ForkCommands {
           sourceSession.thinkingMode,
         ),
       },
-      sourceNextForkOrdinal: normalizeNextForkOrdinal(sourceSession.nextForkOrdinal) ?? 1,
       ...(upToOrdinal ? { upToOrdinal } : {}),
       ...(input.allowHandoffFork ? { allowHandoffFork: true } : {}),
     };
@@ -277,12 +270,9 @@ export class ForkCommands {
     const failures: unknown[] = [];
     try {
       await rollbackForkTarget({
-        sourceChatId: context.sourceChatId,
         targetChatId: context.targetChatId,
-        registry: this.deps.chats,
         settings: this.deps.settings,
         ownership: this.deps.ownership,
-        sourceNextForkOrdinal: context.sourceNextForkOrdinal,
       });
     } catch (error) {
       failures.push(error);
@@ -328,15 +318,6 @@ export class ForkCommands {
       readForkedNativeHistory: this.deps.readForkedNativeHistory,
     });
   }
-}
-
-function normalizeNextForkOrdinal(value: unknown): number | null {
-  const parsed = typeof value === 'string'
-    ? Number.parseInt(value, 10)
-    : typeof value === 'number'
-      ? value
-      : Number.NaN;
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function forkPayload(input: NormalizedSubmitForkRunInput, clientMessageId: string): Record<string, unknown> {

--- a/server/commands/self-handoff-commands.ts
+++ b/server/commands/self-handoff-commands.ts
@@ -193,7 +193,6 @@ export class SelfHandoffCommands {
         ...createPreambleBoundaryBinding('continuation'),
         tags: [...source.tags],
         agentSessionId: null,
-        nextForkOrdinal: 1,
         permissionMode: source.permissionMode,
         thinkingMode: this.deps.agents.normalizeThinkingModeForAgent(
           source.agentId,
@@ -237,8 +236,12 @@ export class SelfHandoffCommands {
       if (sourceMeta?.firstMessage) {
         this.deps.metadata.addNewChatMetadata(input.chatId, sourceMeta.firstMessage);
       }
-      const sourceName = this.deps.settings.getChatName(input.sourceChatId);
-      if (sourceName) await this.deps.settings.setSessionName(input.chatId, sourceName);
+      await this.deps.settings.setDerivedSessionName({
+        chatId: input.chatId,
+        sourceChatId: input.sourceChatId,
+        registry: this.deps.chats,
+        metadata: this.deps.metadata,
+      });
     } catch (error) {
       if (!registered) this.deps.handoffs.deleteContinuationLedger(input.chatId);
       throw error;

--- a/server/migrations/README.md
+++ b/server/migrations/README.md
@@ -10,3 +10,8 @@ entry ends direct upgrade support for workspaces older than that entry; those
 workspaces must first upgrade through an intermediate release that still
 contains it. Keep entries idempotent because a failed startup can rerun the
 ladder before the final version stamp is written.
+
+Version 8 removes the obsolete `nextForkOrdinal` field from `chats.json` entries.
+The registry schema remains version 5; existing chat names and other fields are
+preserved. Fork and handoff names now depend on current visible titles rather
+than persisted counters.

--- a/server/migrations/__tests__/workspace-migrations.test.js
+++ b/server/migrations/__tests__/workspace-migrations.test.js
@@ -36,6 +36,7 @@ describe('WorkspaceMigrationRunner', () => {
     await runner.run('carryover-segment-migration', migrate);
     await runner.run('agent-integration-settings-refresh', migrate);
     await runner.run('agent-execution-mode-refresh', migrate);
+    await runner.run('fork-ordinal-cleanup', migrate);
     await runner.finish();
 
     expect(migrate).not.toHaveBeenCalled();
@@ -69,6 +70,7 @@ describe('WorkspaceMigrationRunner', () => {
     await runner.run('carryover-segment-migration', async () => { events.push('carryover-segment'); });
     await runner.run('agent-integration-settings-refresh', async () => { events.push('settings-refresh'); });
     await runner.run('agent-execution-mode-refresh', async () => { events.push('execution-mode-refresh'); });
+    await runner.run('fork-ordinal-cleanup', async () => { events.push('fork-ordinal-cleanup'); });
     await runner.finish();
 
     expect(events).toEqual([
@@ -79,6 +81,7 @@ describe('WorkspaceMigrationRunner', () => {
       'carryover-segment',
       'settings-refresh',
       'execution-mode-refresh',
+      'fork-ordinal-cleanup',
     ]);
     await expect(fs.stat(queuesDir)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fs.stat(path.join(workspaceDir, 'pending-user-inputs.json'))).rejects.toMatchObject({
@@ -109,10 +112,11 @@ describe('WorkspaceMigrationRunner', () => {
     await runner.run('carryover-segment-migration', cleanup);
     await runner.run('agent-integration-settings-refresh', cleanup);
     await runner.run('agent-execution-mode-refresh', cleanup);
+    await runner.run('fork-ordinal-cleanup', cleanup);
     await runner.finish();
 
     expect(early).not.toHaveBeenCalled();
-    expect(cleanup).toHaveBeenCalledTimes(5);
+    expect(cleanup).toHaveBeenCalledTimes(6);
     expect(await readVersion()).toEqual({ version: CURRENT_WORKSPACE_VERSION });
   });
 
@@ -133,10 +137,40 @@ describe('WorkspaceMigrationRunner', () => {
     await runner.run('carryover-segment-migration', previous);
     await runner.run('agent-integration-settings-refresh', previous);
     await runner.run('agent-execution-mode-refresh', executionModeRefresh);
+    await runner.run('fork-ordinal-cleanup', async () => undefined);
     await runner.finish();
 
     expect(previous).not.toHaveBeenCalled();
     expect(executionModeRefresh).toHaveBeenCalledOnce();
+    expect(await readVersion()).toEqual({ version: CURRENT_WORKSPACE_VERSION });
+  });
+
+  it('runs only fork ordinal cleanup for version 7 and stamps only after success', async () => {
+    await fs.writeFile(path.join(workspaceDir, 'workspace-version.json'), JSON.stringify({ version: 7 }));
+    const previous = mock(async () => undefined);
+    const cleanup = mock(async () => { throw new Error('cleanup failed'); });
+
+    for (const attempt of [1, 2]) {
+      const runner = await WorkspaceMigrationRunner.open(workspaceDir);
+      await runner.run('chat-id-migration', previous);
+      await runner.run('core-record-migration', previous);
+      await runner.run('ephemeral-queue-state-cleanup', previous);
+      await runner.run('carryover-node-migration', previous);
+      await runner.run('carryover-segment-migration', previous);
+      await runner.run('agent-integration-settings-refresh', previous);
+      await runner.run('agent-execution-mode-refresh', previous);
+      if (attempt === 1) {
+        await expect(runner.run('fork-ordinal-cleanup', cleanup)).rejects.toThrow('cleanup failed');
+        expect(await readVersion()).toEqual({ version: 7 });
+        cleanup.mockImplementation(async () => undefined);
+      } else {
+        await runner.run('fork-ordinal-cleanup', cleanup);
+        await runner.finish();
+      }
+    }
+
+    expect(previous).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(2);
     expect(await readVersion()).toEqual({ version: CURRENT_WORKSPACE_VERSION });
   });
 

--- a/server/migrations/index.ts
+++ b/server/migrations/index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { writeJsonFileAtomic } from '../lib/json-file-store.js';
 
-export const CURRENT_WORKSPACE_VERSION = 7;
+export const CURRENT_WORKSPACE_VERSION = 8;
 
 const WORKSPACE_VERSION_FILE = 'workspace-version.json';
 const FRESH_WORKSPACE_IGNORED_FILES = new Set([
@@ -18,6 +18,7 @@ const MIGRATIONS = [
   { name: 'carryover-segment-migration', version: 5 },
   { name: 'agent-integration-settings-refresh', version: 6 },
   { name: 'agent-execution-mode-refresh', version: 7 },
+  { name: 'fork-ordinal-cleanup', version: 8 },
 ] as const;
 
 export type WorkspaceMigrationName = typeof MIGRATIONS[number]['name'];

--- a/server/server.ts
+++ b/server/server.ts
@@ -136,6 +136,7 @@ import {
   cleanupLegacyQueueState,
   WorkspaceMigrationRunner,
 } from './migrations/index.js';
+import { removeLegacyForkOrdinals } from './chats/fork-ordinal-migration.js';
 import {
   LOCAL_SERVER_PRINCIPAL,
   type ServerPrincipal,
@@ -285,6 +286,7 @@ export async function startServer(): Promise<void> {
     await workspaceMigrations.run('agent-execution-mode-refresh', () => (
       refreshAgentExecutionModeCoreRecords({ workspaceDir, integrations: integrationRegistry })
     ));
+    await workspaceMigrations.run('fork-ordinal-cleanup', () => removeLegacyForkOrdinals(workspaceDir));
     await chatRegistry.init();
     await settings.init();
     let queue: ChatExecutionCoordinator | null = null;

--- a/server/settings/__tests__/derived-chat-name.test.js
+++ b/server/settings/__tests__/derived-chat-name.test.js
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SettingsStore } from '../store.js';
+
+let workspaceDir;
+let settings;
+let chatIds;
+let firstMessages;
+
+beforeEach(async () => {
+  workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-derived-chat-name-'));
+  settings = new SettingsStore(workspaceDir);
+  await settings.init();
+  chatIds = new Set(['source', 'target']);
+  firstMessages = new Map();
+});
+
+afterEach(async () => {
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+function nameChild(chatId = 'target', sourceChatId = 'source') {
+  return settings.setDerivedSessionName({
+    chatId,
+    sourceChatId,
+    registry: { listChatIds: () => [...chatIds] },
+    metadata: {
+      getChatMetadata: (id) => ({ firstMessage: firstMessages.get(id) }),
+    },
+  });
+}
+
+describe('derived chat names', () => {
+  it.each([
+    ['Custom title', 'Original prompt', 'Custom title (1)'],
+    [null, 'Original prompt\nMore context', 'Original prompt (1)'],
+    ['  Custom title\nMore context', 'Original prompt', 'Custom title (1)'],
+    [null, null, 'New Session (1)'],
+    [null, '\nMore context', 'New Session (1)'],
+    ['Topic (1)', null, 'Topic (1) (1)'],
+  ])('suffixes the visible source title %j / %j', async (name, firstMessage, expected) => {
+    if (name) await settings.setSessionName('source', name);
+    firstMessages.set('source', firstMessage);
+
+    expect(await nameChild()).toBe(expected);
+    expect(settings.getChatName('target')).toBe(expected);
+    const reloaded = new SettingsStore(workspaceDir);
+    await reloaded.init();
+    expect(reloaded.getChatName('target')).toBe(expected);
+  });
+
+  it('skips visible names across all chats and reuses gaps', async () => {
+    await settings.setSessionName('source', 'Topic');
+    chatIds.add('renamed');
+    chatIds.add('fallback');
+    chatIds.add('later');
+    await settings.setSessionName('renamed', 'Topic (1)');
+    firstMessages.set('fallback', 'Topic (2)\nMore context');
+    await settings.setSessionName('later', 'Topic (4)');
+    await settings.setSessionName('deleted', 'Topic (3)');
+
+    expect(await nameChild()).toBe('Topic (3)');
+  });
+
+  it('reuses a deleted child name without changing the source', async () => {
+    await settings.setSessionName('source', 'Topic');
+    expect(await nameChild()).toBe('Topic (1)');
+    chatIds.delete('target');
+    await settings.removeSessionName('target');
+    chatIds.add('replacement');
+
+    expect(await nameChild('replacement')).toBe('Topic (1)');
+    expect(settings.getChatName('source')).toBe('Topic');
+  });
+
+  it('serializes allocation across different source chats with the same title', async () => {
+    chatIds.add('other-source');
+    chatIds.add('other-target');
+    await settings.setSessionName('source', 'Topic');
+    await settings.setSessionName('other-source', 'Topic');
+
+    expect(await Promise.all([
+      nameChild(),
+      nameChild('other-target', 'other-source'),
+    ])).toEqual(['Topic (1)', 'Topic (2)']);
+  });
+
+  it('reads source renames and occupied names after earlier queued writes', async () => {
+    chatIds.add('occupied');
+    await settings.setSessionName('source', 'Original');
+    const rename = settings.setSessionName('source', 'Renamed');
+    const occupy = settings.setSessionName('occupied', 'Renamed (1)');
+    const child = nameChild();
+
+    await Promise.all([rename, occupy]);
+    expect(await child).toBe('Renamed (2)');
+  });
+});

--- a/server/settings/domain-stores.ts
+++ b/server/settings/domain-stores.ts
@@ -1,4 +1,5 @@
 import type { IChatRegistry } from '../chats/store.js';
+import { resolveChatTitle, type DerivedChatNameInput } from '../chats/chat-title.js';
 import { createLogger } from '../lib/log.js';
 import { isRecord } from '../../common/json.js';
 
@@ -264,6 +265,25 @@ export class ChatNameStore {
       if (settings.chatNames?.[String(chatId)]) return false;
       await this.#persistSessionName(settings, chatId, title);
       return true;
+    });
+  }
+
+  async setDerivedSessionName(input: DerivedChatNameInput): Promise<string> {
+    return this.#context.mutate(async () => {
+      const settings = this.#context.readSettings();
+      const titleFor = (chatId: string) => resolveChatTitle(
+        settings.chatNames[chatId],
+        input.metadata.getChatMetadata(chatId)?.firstMessage,
+      );
+      const sourceTitle = titleFor(input.sourceChatId);
+      const occupiedTitles = new Set(input.registry.listChatIds()
+        .filter((chatId) => chatId !== input.chatId)
+        .map(titleFor));
+      let suffix = 1;
+      while (occupiedTitles.has(`${sourceTitle} (${suffix})`)) suffix += 1;
+      const title = `${sourceTitle} (${suffix})`;
+      await this.#persistSessionName(settings, input.chatId, title);
+      return title;
     });
   }
 

--- a/server/settings/store.ts
+++ b/server/settings/store.ts
@@ -42,6 +42,7 @@ import {
   sanitizeRecentAgentSettings,
 } from './startup-recents.js';
 import type { IChatRegistry } from '../chats/store.js';
+import type { DerivedChatNameInput } from '../chats/chat-title.js';
 import { isRecord } from '../../common/json.js';
 import type { ReorderChatRequest } from '../../common/chat-order-contracts.js';
 import type { ChatOrderIdComparator } from '../../common/chat-order-sort.js';
@@ -461,6 +462,10 @@ export class SettingsStore extends EventEmitter<SettingsStoreEvents> {
 
   async setSessionNameIfAbsent(chatId: string, title: string): Promise<boolean> {
     return this.#chatNames.setSessionNameIfAbsent(chatId, title);
+  }
+
+  async setDerivedSessionName(input: DerivedChatNameInput): Promise<string> {
+    return this.#chatNames.setDerivedSessionName(input);
   }
 
   async removeSessionName(chatId: string): Promise<void> {


### PR DESCRIPTION
forks and /handoff continuations now use the first unused numeric suffix from current workspace titles, so handoffs no longer duplicate the source name and we no longer need a persisted fork counter. name selection is serialized with title writes, includes archived chats, reuses deleted names, and preserves nested suffixes. workspace migration 8 removes nextForkOrdinal while keeping existing names and the version-5 chat registry unchanged.