### PR TITLE
Prevent repeated transcript drift warnings

### DIFF
--- a/web/src/lib/chat/transcript/__tests__/conversation-transcript-overlay-store.test.ts
+++ b/web/src/lib/chat/transcript/__tests__/conversation-transcript-overlay-store.test.ts
@@ -141,6 +141,45 @@ describe('ConversationTranscriptOverlayStore', () => {
 		]);
 	});
 
+	it('suppresses only adjacent duplicate server notices', () => {
+		const overlays = new ConversationTranscriptOverlayStore();
+		overlays.appendServerNotice('chat-1', 'warning', 'native history changed');
+		const revision = overlays.noticeRevisionFor('chat-1');
+		const firstNoticeId = overlays.forChat('chat-1').notices[0]?.id;
+
+		const duplicate = overlays.appendServerNotice(
+			'chat-1',
+			'warning',
+			'native history changed',
+		);
+
+		expect(duplicate.feedStructureChanged).toBe(false);
+		expect(overlays.noticeRevisionFor('chat-1')).toBe(revision);
+		expect(overlays.forChat('chat-1').notices.map((notice) => notice.content)).toEqual([
+			'native history changed',
+		]);
+
+		overlays.applyCommittedBatch({
+			chatId: 'chat-1',
+			messages: [echoed('input-1', 1)],
+			resendCandidates: [],
+			noticeRevision: revision,
+		});
+		overlays.appendServerNotice('chat-1', 'warning', 'native history changed');
+
+		expect(overlays.forChat('chat-1').notices).toHaveLength(1);
+		expect(overlays.forChat('chat-1').notices[0]?.id).not.toBe(firstNoticeId);
+
+		overlays.appendServerNotice('chat-1', 'info', 'intervening notice');
+		overlays.appendServerNotice('chat-1', 'warning', 'native history changed');
+
+		expect(overlays.forChat('chat-1').notices.map((notice) => notice.content)).toEqual([
+			'native history changed',
+			'intervening notice',
+			'native history changed',
+		]);
+	});
+
 	it('prunes only chats outside the active session set', () => {
 		const overlays = new ConversationTranscriptOverlayStore();
 		overlays.appendLocalNotice('chat-1', 'progress', 'one');

--- a/web/src/lib/chat/transcript/conversation-transcript-overlay-store.svelte.ts
+++ b/web/src/lib/chat/transcript/conversation-transcript-overlay-store.svelte.ts
@@ -79,6 +79,14 @@ class ConversationTranscriptOverlayEntry implements ConversationTranscriptOverla
 		noticeType: LocalNoticeType,
 		content: string,
 	): ConversationTranscriptOverlayMutation {
+		const previous = this.#notices.at(-1);
+		if (
+			source === 'server' &&
+			previous?.noticeType === noticeType &&
+			previous.content === content
+		) {
+			return feedMutation(false);
+		}
 		const notice: OverlayNotice = {
 			kind: 'local-notice',
 			id: `${source}_${createRandomId()}`,


### PR DESCRIPTION
Repeated chat activation can emit the same transient native-history warning multiple times, cluttering the conversation feed. This change coalesces an incoming server notice when the feed tail already has the same type and content while preserving re-emission after another notice or committed transcript batch, with focused regression coverage.