### PR TITLE
Center unavailable project notice

### DIFF
--- a/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
+++ b/web/src/lib/components/chat/__tests__/PromptComposer.test.ts
@@ -1858,7 +1858,9 @@ describe('PromptComposer focus', () => {
 
 		await screen.findByText('Project folder unavailable');
 		const notice = container.querySelector('[data-project-availability-notice]');
+		const noticeContent = notice?.querySelector<HTMLElement>('[role="status"]');
 		const noticeFrame = notice?.parentElement;
+		expect(noticeContent?.className).toContain('mx-auto');
 		expect(noticeFrame?.querySelector('[data-composer]')).toBeTruthy();
 		expect(noticeFrame?.className).toContain('w-full');
 		expect(noticeFrame?.className).toContain('lg:mx-auto');

--- a/web/src/lib/components/workspace/ProjectAvailabilityNotice.svelte
+++ b/web/src/lib/components/workspace/ProjectAvailabilityNotice.svelte
@@ -32,7 +32,7 @@
 	});
 </script>
 
-<div class="max-w-md text-center" role="status">
+<div class="mx-auto max-w-md text-center" role="status">
 	<p class="font-medium text-foreground">{m.workspace_project_unavailable()}</p>
 	<p class="mt-1 text-sm text-muted-foreground">{detail}</p>
 	<p class="mt-1 break-all text-xs text-muted-foreground">{projectPath}</p>


### PR DESCRIPTION
Center the project-folder recovery notice within the chat composer’s configured maximum-width frame, keeping it aligned with the composer and queue rows, and add a regression assertion for the centered layout.