### PR TITLE
Support Claude context limits in model suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Garcon keeps that development loop coherent:
 
 Use an existing agent login or subscription where its CLI supports one, or configure API providers in Settings. Each chat keeps its own agent, model, effort, permission, provider, endpoint, and preamble settings where supported.
 
+Claude Code requires version 2.1.238 or newer. A model ending in `[Nk]` sets a per-chat auto-compaction window without a per-model configuration table. For example, `gpt-6-astra[922k]` launches Claude with `--model gpt-6-astra[1m] --autocompact 922k`; Claude strips `[1m]` before calling the provider. `N` must be an integer from 100 through 1000 (thousands of tokens). The suffix should reflect the model's supported **input** limit, not input plus output; Claude reserves additional compaction headroom below it. Garcon retains the annotated model in the chat configuration. Custom endpoints must include that exact annotated ID in their model catalog.
+
+Existing `[1m]` names keep Claude's native compaction policy. An explicit `[Nk]` annotation overrides `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for that child process only; other environment and Claude settings remain in effect. Changing or removing the numeric cap resumes the same native session in a new Claude process between turns, since the model-switch control cannot update the startup compaction flag. See [Claude's context-window documentation](https://code.claude.com/docs/en/model-config#context-window-and-auto-compaction).
+
 ## Automate And Delegate
 
 The CLI drives ordinary visible Garcon chats through an already-running server. It covers live catalog discovery, synchronous or detached starts and resumes, steering, exact-turn waiting, status and fenced permission decisions, chat metadata, transcript search and bounded reads, export, handoff, and stop controls.

--- a/integration-tests/support/fake-claude-cli.ts
+++ b/integration-tests/support/fake-claude-cli.ts
@@ -18,7 +18,7 @@ let heldInput: {
 let heldAbortPoll: ReturnType<typeof setInterval> | null = null;
 
 if (args.includes('--version')) {
-  console.log('2.1.220 (Claude Code)');
+  console.log('2.1.238 (Claude Code)');
 } else if (args[0] === 'auth' && args[1] === 'status') {
   console.log(JSON.stringify({ loggedIn: true, authMethod: 'api_key' }));
 } else {

--- a/integration-tests/support/fake-claude-model.ts
+++ b/integration-tests/support/fake-claude-model.ts
@@ -25,6 +25,12 @@ export type ClaudeScriptedFault =
   | { readonly kind: 'stream-error'; readonly message: string }
   | { readonly kind: 'truncated-stream' };
 
+interface QueuedClaudeTurn {
+  readonly kind: 'turn';
+  readonly turn: ClaudeScriptedTurn;
+  readonly inputTokens: number;
+}
+
 export interface HeldClaudeTurn {
   readonly requested: Promise<RecordedClaudeModelRequest>;
   release(): void;
@@ -146,6 +152,7 @@ function blockEvents(block: ClaudeScriptedBlock, index: number): SseEvent[] {
 function turnEvents(
   blocks: ClaudeScriptedBlock[],
   request: RecordedClaudeModelRequest,
+  inputTokens = 42,
 ): SseEvent[] {
   const stopReason = blocks.some((block) => block.kind === 'tool_use') ? 'tool_use' : 'end_turn';
   return [
@@ -162,7 +169,7 @@ function turnEvents(
           stop_reason: null,
           stop_sequence: null,
           usage: {
-            input_tokens: 42,
+            input_tokens: inputTokens,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
             output_tokens: 1,
@@ -212,7 +219,7 @@ function errorEvents(message: string): SseEvent[] {
 
 export class FakeClaudeModel {
   readonly #server: Bun.Server<undefined>;
-  readonly #turns: Array<ClaudeScriptedTurn | ClaudeScriptedFault> = [];
+  readonly #turns: Array<QueuedClaudeTurn | ClaudeScriptedFault> = [];
   readonly #requests: RecordedClaudeModelRequest[] = [];
   readonly #issues: string[] = [];
   readonly #otherRequests: string[] = [];
@@ -222,7 +229,7 @@ export class FakeClaudeModel {
 
   private constructor() {
     this.#server = Bun.serve({
-      hostname: '127.0.0.1',
+      hostname: '0.0.0.0',
       port: 0,
       idleTimeout: 0,
       fetch: (request) => this.#handleRequest(request),
@@ -234,11 +241,11 @@ export class FakeClaudeModel {
   }
 
   get baseUrl(): string {
-    return `http://${this.#server.hostname}:${this.#server.port}`;
+    return `http://127.0.0.1:${this.#server.port}`;
   }
 
-  scriptTurn(turn: ClaudeScriptedTurn): void {
-    this.#turns.push(turn);
+  scriptTurn(turn: ClaudeScriptedTurn, { inputTokens = 42 }: { inputTokens?: number } = {}): void {
+    this.#turns.push({ kind: 'turn', turn, inputTokens });
   }
 
   // Holds the response before its first SSE event. The CLI enforces request timeouts, so
@@ -260,7 +267,7 @@ export class FakeClaudeModel {
       releaseGate();
     };
     this.#pendingReleases.add(release);
-    this.#turns.push(async (request) => {
+    this.scriptTurn(async (request) => {
       resolveRequested(request);
       await gate;
       return typeof turn === 'function' ? turn(request) : turn;
@@ -355,7 +362,7 @@ export class FakeClaudeModel {
       );
       return sseResponse(errorEvents('no scripted turn available'));
     }
-    if (!Array.isArray(turn) && typeof turn !== 'function') {
+    if (turn.kind !== 'turn') {
       if (turn.kind === 'http-error') {
         return Response.json({
           error: { type: 'api_error', message: turn.message },
@@ -366,7 +373,7 @@ export class FakeClaudeModel {
       }
       return sseResponse(turnEvents([], recorded).slice(0, 1));
     }
-    const blocks = typeof turn === 'function' ? await turn(recorded) : turn;
-    return sseResponse(turnEvents(blocks, recorded));
+    const blocks = typeof turn.turn === 'function' ? await turn.turn(recorded) : turn.turn;
+    return sseResponse(turnEvents(blocks, recorded, turn.inputTokens));
   }
 }

--- a/integration-tests/support/fake-claude-model.ts
+++ b/integration-tests/support/fake-claude-model.ts
@@ -355,25 +355,27 @@ export class FakeClaudeModel {
       receivedAt: Date.now(),
     };
     this.#requests.push(recorded);
-    const turn = this.#turns.shift();
-    if (!turn) {
+    const queuedTurn = this.#turns.shift();
+    if (!queuedTurn) {
       this.#issues.push(
         `Request ${recorded.id} arrived with no scripted turn (lastUserText: ${JSON.stringify(recorded.lastUserText)})`,
       );
       return sseResponse(errorEvents('no scripted turn available'));
     }
-    if (turn.kind !== 'turn') {
-      if (turn.kind === 'http-error') {
+    if (queuedTurn.kind !== 'turn') {
+      if (queuedTurn.kind === 'http-error') {
         return Response.json({
-          error: { type: 'api_error', message: turn.message },
-        }, { status: turn.status });
+          error: { type: 'api_error', message: queuedTurn.message },
+        }, { status: queuedTurn.status });
       }
-      if (turn.kind === 'stream-error') {
-        return sseResponse(errorEvents(turn.message));
+      if (queuedTurn.kind === 'stream-error') {
+        return sseResponse(errorEvents(queuedTurn.message));
       }
       return sseResponse(turnEvents([], recorded).slice(0, 1));
     }
-    const blocks = typeof turn.turn === 'function' ? await turn.turn(recorded) : turn.turn;
-    return sseResponse(turnEvents(blocks, recorded, turn.inputTokens));
+    const blocks = typeof queuedTurn.turn === 'function'
+      ? await queuedTurn.turn(recorded)
+      : queuedTurn.turn;
+    return sseResponse(turnEvents(blocks, recorded, queuedTurn.inputTokens));
   }
 }

--- a/integration-tests/tests/server/claude-scripted-model-context.test.ts
+++ b/integration-tests/tests/server/claude-scripted-model-context.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from 'bun:test';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { AgentTurnCommandResponse } from '../../../common/chat-command-contracts.js';
 import { CURRENT_WORKSPACE_VERSION } from '../../../server/migrations/index.js';
 import { messagesOfType } from '../../support/chat-assertions.js';
 import { claudeText, claudeToolUse } from '../../support/fake-claude-model.js';
-import { withIntegrationFixture } from '../../support/integration-fixture.js';
+import { withIntegrationFixture, type IntegrationDirectories } from '../../support/integration-fixture.js';
 import { waitForVisibleResponse } from '../../support/live-agent.js';
 import { liveClaudeRunRequest, liveClaudeStartRequest } from '../../support/live-claude.js';
 import { waitForPersistedNativeSession } from '../../support/persisted-chat.js';
@@ -26,29 +27,15 @@ test('Claude validates unstarted chat settings before persistence and can start 
       environment.model.scriptTurn([claudeText(reply)]);
       const cursor = fixture.client.markEvents();
       const turn = await fixture.client.runChat({
-        ...liveClaudeRunRequest({ chatId, command: 'Confirm the corrected model.' }), model,
+        ...liveClaudeRunRequest({ chatId, command: 'Confirm the corrected model.' }),
+        model,
       });
       await waitForVisibleResponse({ fixture, chatId, turnId: turn.turnId, marker: reply, afterIndex: cursor });
       expect(environment.model.requests().at(-1)?.body.model).toBe('custom');
       environment.model.assertSettled();
     }, {
       serverEnvironment: environment.serverEnvironment,
-      prepareWorkspace: async (dirs) => {
-        await writeFile(join(dirs.workspace, 'workspace-version.json'), JSON.stringify({ version: CURRENT_WORKSPACE_VERSION }));
-        await writeFile(join(dirs.workspace, 'chats.json'), JSON.stringify({
-          version: 5,
-          sessions: {
-            [chatId]: {
-              agentId: 'claude', model: 'custom[1m]', projectPath: dirs.project,
-              agentOwnershipEpoch: '00000000-0000-4000-8000-000000000003',
-              agentSessionId: null, nativeSession: null, nativeSeedReceipt: null,
-              apiProviderId: null, modelEndpointId: null, modelProtocol: null,
-              agentSettingsById: {}, permissionMode: 'default', thinkingMode: 'low',
-              tags: [], carryOverSegments: [], carryOverMigrationQuarantine: null, lastReadAt: null,
-            },
-          },
-        }));
-      },
+      prepareWorkspace: (dirs) => prepareUnstartedClaudeChat(dirs, chatId),
     });
   } finally {
     environment.dispose();
@@ -60,6 +47,8 @@ for (const suffix of ['[922k]', '[1m]']) {
     const environment = await startScriptedClaudeTestEnvironment();
     const model = `integration-context-model${suffix}`;
     const reply = 'The scripted context turn is complete.';
+    const referenceNote = 'Synthetic context entry for the scripted compaction test.';
+    const summary = 'The previous turn recorded synthetic reference notes.';
     const expectsCompaction = suffix === '[922k]';
     try {
       // Reported usage exercises the CLI's budgeting without sending a 900K-token fixture.
@@ -68,7 +57,7 @@ for (const suffix of ['[922k]', '[1m]']) {
       environment.model.scriptTurn([claudeText(firstReply)]);
       environment.model.scriptTurn([claudeText(historyReply)], { inputTokens: 900_000 });
       if (expectsCompaction) {
-        environment.model.scriptTurn([claudeText('The previous turn recorded synthetic reference notes.')]);
+        environment.model.scriptTurn([claudeText(summary)]);
       }
       environment.model.scriptTurn([
         claudeToolUse('toolu_context_budget', 'Bash', { command: 'echo context-check' }),
@@ -84,7 +73,7 @@ for (const suffix of ['[922k]', '[1m]']) {
             projectPath: fixture.dirs.project,
             // Mutable history keeps the fake usage from looking like an oversized fixed system prefix.
             command: 'Record these reference notes for a later turn:\n'
-              + 'Synthetic context entry for the scripted compaction test.\n'.repeat(4_000),
+              + `${referenceNote}\n`.repeat(4_000),
             permissionMode: 'bypassPermissions',
           }),
           model,
@@ -117,10 +106,10 @@ for (const suffix of ['[922k]', '[1m]']) {
         expect(requests).toHaveLength(expectsCompaction ? 5 : 4);
         const finalHistory = JSON.stringify(requests.at(-1)?.body.messages);
         if (expectsCompaction) {
-          expect(finalHistory).toContain('The previous turn recorded synthetic reference notes.');
-          expect(finalHistory).not.toContain('Synthetic context entry for the scripted compaction test.');
+          expect(finalHistory).toContain(summary);
+          expect(finalHistory).not.toContain(referenceNote);
         } else {
-          expect(finalHistory).toContain('Synthetic context entry for the scripted compaction test.');
+          expect(finalHistory).toContain(referenceNote);
         }
         expect(requests.every(request =>
           request.body.model === 'integration-context-model')).toBe(true);
@@ -149,15 +138,16 @@ test('Claude preserves the native session across context-cap changes and removal
         environment.model.scriptTurn([claudeText(reply)]);
         const cursor = fixture.client.markEvents();
         const command = `Respond to scripted model switch ${index}.`;
-        if (index > 0) {
+        let turn: AgentTurnCommandResponse;
+        if (index === 0) {
+          turn = await fixture.client.startChat({
+            ...liveClaudeStartRequest({ chatId, command, projectPath: fixture.dirs.project }),
+            model,
+          });
+        } else {
           await fixture.client.patch('/api/v1/chats/model', { chatId, model });
+          turn = await fixture.client.runChat({ ...liveClaudeRunRequest({ chatId, command }), model });
         }
-        const turn = index === 0
-          ? await fixture.client.startChat({
-              ...liveClaudeStartRequest({ chatId, command, projectPath: fixture.dirs.project }),
-              model,
-            })
-          : await fixture.client.runChat({ ...liveClaudeRunRequest({ chatId, command }), model });
         await waitForVisibleResponse({
           fixture, chatId, turnId: turn.turnId, marker: reply, afterIndex: cursor,
         });
@@ -181,3 +171,34 @@ test('Claude preserves the native session across context-cap changes and removal
     environment.dispose();
   }
 }, 60_000);
+
+async function prepareUnstartedClaudeChat(dirs: IntegrationDirectories, chatId: string): Promise<void> {
+  await writeFile(
+    join(dirs.workspace, 'workspace-version.json'),
+    JSON.stringify({ version: CURRENT_WORKSPACE_VERSION }),
+  );
+  await writeFile(join(dirs.workspace, 'chats.json'), JSON.stringify({
+    version: 5,
+    sessions: {
+      [chatId]: {
+        agentId: 'claude',
+        model: 'custom[1m]',
+        projectPath: dirs.project,
+        agentOwnershipEpoch: '00000000-0000-4000-8000-000000000003',
+        agentSessionId: null,
+        nativeSession: null,
+        nativeSeedReceipt: null,
+        apiProviderId: null,
+        modelEndpointId: null,
+        modelProtocol: null,
+        agentSettingsById: {},
+        permissionMode: 'default',
+        thinkingMode: 'low',
+        tags: [],
+        carryOverSegments: [],
+        carryOverMigrationQuarantine: null,
+        lastReadAt: null,
+      },
+    },
+  }));
+}

--- a/integration-tests/tests/server/claude-scripted-model-context.test.ts
+++ b/integration-tests/tests/server/claude-scripted-model-context.test.ts
@@ -127,13 +127,19 @@ for (const suffix of ['[922k]', '[1m]']) {
   }, 60_000);
 }
 
-test('Claude preserves the native session across context-cap changes and removal', async () => {
+test('Claude preserves the native session and only restarts when the context cap changes', async () => {
   const environment = await startScriptedClaudeTestEnvironment();
   try {
     await withIntegrationFixture('claude-model-context-switch', async (fixture) => {
       const chatId = fixture.newChatId();
       let sessionId: string | undefined;
-      for (const [index, model] of ['first[922k]', 'second[850k]', 'third[1m]'].entries()) {
+      const selections = [
+        { model: 'first[922k]', expectedLaunches: 1 },
+        { model: 'second[922k]', expectedLaunches: 1 },
+        { model: 'second[850k]', expectedLaunches: 2 },
+        { model: 'third[1m]', expectedLaunches: 3 },
+      ];
+      for (const [index, { model, expectedLaunches }] of selections.entries()) {
         const reply = `Scripted model switch ${index} complete.`;
         environment.model.scriptTurn([claudeText(reply)]);
         const cursor = fixture.client.markEvents();
@@ -159,9 +165,11 @@ test('Claude preserves the native session across context-cap changes and removal
         expect(persisted.agentSessionId).toBe(sessionId);
         expect((await fixture.client.getChatSnapshot(chatId)).chat.model).toBe(model);
         expect(environment.model.requests().at(-1)?.body.model).toBe(model.split('[')[0]);
+        const launches = fixture.garcon.logs.filter(line => line.includes('Spawning Claude CLI'));
+        expect(launches).toHaveLength(expectedLaunches);
       }
       const transcript = await fixture.client.getMessages(chatId);
-      expect(messagesOfType(transcript.messages, 'user-message')).toHaveLength(3);
+      expect(messagesOfType(transcript.messages, 'user-message')).toHaveLength(4);
       await expect(fixture.client.patch('/api/v1/chats/model', { chatId, model: 'third[99k]' }))
         .rejects.toThrow(/returned 422:.*context suffix/);
       expect((await fixture.client.getChatSnapshot(chatId)).chat.model).toBe('third[1m]');

--- a/integration-tests/tests/server/claude-scripted-model-context.test.ts
+++ b/integration-tests/tests/server/claude-scripted-model-context.test.ts
@@ -11,6 +11,38 @@ import { liveClaudeRunRequest, liveClaudeStartRequest } from '../../support/live
 import { waitForPersistedNativeSession } from '../../support/persisted-chat.js';
 import { startScriptedClaudeTestEnvironment } from '../../support/scripted-claude.js';
 
+test('Claude rejects invalid initial models consistently before creating a chat', async () => {
+  const environment = await startScriptedClaudeTestEnvironment();
+  try {
+    await withIntegrationFixture('claude-model-context-start-validation', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const request = {
+        ...liveClaudeStartRequest({ chatId, projectPath: fixture.dirs.project, command: 'Confirm the model.' }),
+        model: 'custom[99k]',
+      };
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await expect(fixture.client.startChat(request)).rejects.toMatchObject({
+          status: 422,
+          body: { errorCode: 'VALIDATION_FAILED', retryable: false },
+        });
+      }
+      await expect(fixture.client.getChatSnapshot(chatId)).rejects.toMatchObject({ status: 404 });
+      expect(environment.model.requests()).toHaveLength(0);
+      expect(fixture.garcon.logs.filter(line => line.includes('Spawning Claude CLI'))).toHaveLength(0);
+
+      // Reusing the rejected request identity proves preflight did not reserve a command or chat.
+      const reply = 'The initial model is corrected.';
+      environment.model.scriptTurn([claudeText(reply)]);
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.startChat({ ...request, model: 'custom[922k]' });
+      await waitForVisibleResponse({ fixture, chatId, turnId: turn.turnId, marker: reply, afterIndex: cursor });
+      environment.model.assertSettled();
+    }, { serverEnvironment: environment.serverEnvironment });
+  } finally {
+    environment.dispose();
+  }
+}, 60_000);
+
 test('Claude validates unstarted chat settings before persistence and can start after correction', async () => {
   const environment = await startScriptedClaudeTestEnvironment();
   const chatId = '1786120000000003';

--- a/integration-tests/tests/server/claude-scripted-model-context.test.ts
+++ b/integration-tests/tests/server/claude-scripted-model-context.test.ts
@@ -1,0 +1,183 @@
+import { expect, test } from 'bun:test';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { CURRENT_WORKSPACE_VERSION } from '../../../server/migrations/index.js';
+import { messagesOfType } from '../../support/chat-assertions.js';
+import { claudeText, claudeToolUse } from '../../support/fake-claude-model.js';
+import { withIntegrationFixture } from '../../support/integration-fixture.js';
+import { waitForVisibleResponse } from '../../support/live-agent.js';
+import { liveClaudeRunRequest, liveClaudeStartRequest } from '../../support/live-claude.js';
+import { waitForPersistedNativeSession } from '../../support/persisted-chat.js';
+import { startScriptedClaudeTestEnvironment } from '../../support/scripted-claude.js';
+
+test('Claude validates unstarted chat settings before persistence and can start after correction', async () => {
+  const environment = await startScriptedClaudeTestEnvironment();
+  const chatId = '1786120000000003';
+  try {
+    await withIntegrationFixture('claude-model-context-validation', async (fixture) => {
+      await expect(fixture.client.patch('/api/v1/chats/model', { chatId, model: 'custom[99k]' }))
+        .rejects.toThrow(/returned 422:.*context suffix/);
+      const registry = JSON.parse(await readFile(join(fixture.dirs.workspace, 'chats.json'), 'utf8'));
+      expect(registry.sessions[chatId]).toMatchObject({ model: 'custom[1m]', agentSessionId: null });
+
+      const model = 'custom[922k]';
+      await fixture.client.patch('/api/v1/chats/model', { chatId, model });
+      const reply = 'The corrected model is ready.';
+      environment.model.scriptTurn([claudeText(reply)]);
+      const cursor = fixture.client.markEvents();
+      const turn = await fixture.client.runChat({
+        ...liveClaudeRunRequest({ chatId, command: 'Confirm the corrected model.' }), model,
+      });
+      await waitForVisibleResponse({ fixture, chatId, turnId: turn.turnId, marker: reply, afterIndex: cursor });
+      expect(environment.model.requests().at(-1)?.body.model).toBe('custom');
+      environment.model.assertSettled();
+    }, {
+      serverEnvironment: environment.serverEnvironment,
+      prepareWorkspace: async (dirs) => {
+        await writeFile(join(dirs.workspace, 'workspace-version.json'), JSON.stringify({ version: CURRENT_WORKSPACE_VERSION }));
+        await writeFile(join(dirs.workspace, 'chats.json'), JSON.stringify({
+          version: 5,
+          sessions: {
+            [chatId]: {
+              agentId: 'claude', model: 'custom[1m]', projectPath: dirs.project,
+              agentOwnershipEpoch: '00000000-0000-4000-8000-000000000003',
+              agentSessionId: null, nativeSession: null, nativeSeedReceipt: null,
+              apiProviderId: null, modelEndpointId: null, modelProtocol: null,
+              agentSettingsById: {}, permissionMode: 'default', thinkingMode: 'low',
+              tags: [], carryOverSegments: [], carryOverMigrationQuarantine: null, lastReadAt: null,
+            },
+          },
+        }));
+      },
+    });
+  } finally {
+    environment.dispose();
+  }
+}, 60_000);
+
+for (const suffix of ['[922k]', '[1m]']) {
+  test(`Claude applies the ${suffix} compaction policy through a real tool turn`, async () => {
+    const environment = await startScriptedClaudeTestEnvironment();
+    const model = `integration-context-model${suffix}`;
+    const reply = 'The scripted context turn is complete.';
+    const expectsCompaction = suffix === '[922k]';
+    try {
+      // Reported usage exercises the CLI's budgeting without sending a 900K-token fixture.
+      const firstReply = 'The initial reference notes are recorded.';
+      const historyReply = 'The reference notes are recorded.';
+      environment.model.scriptTurn([claudeText(firstReply)]);
+      environment.model.scriptTurn([claudeText(historyReply)], { inputTokens: 900_000 });
+      if (expectsCompaction) {
+        environment.model.scriptTurn([claudeText('The previous turn recorded synthetic reference notes.')]);
+      }
+      environment.model.scriptTurn([
+        claudeToolUse('toolu_context_budget', 'Bash', { command: 'echo context-check' }),
+      ]);
+      environment.model.scriptTurn([claudeText(reply)]);
+
+      await withIntegrationFixture('claude-model-context-budget', async (fixture) => {
+        const chatId = fixture.newChatId();
+        const historyCursor = fixture.client.markEvents();
+        const historyTurn = await fixture.client.startChat({
+          ...liveClaudeStartRequest({
+            chatId,
+            projectPath: fixture.dirs.project,
+            // Mutable history keeps the fake usage from looking like an oversized fixed system prefix.
+            command: 'Record these reference notes for a later turn:\n'
+              + 'Synthetic context entry for the scripted compaction test.\n'.repeat(4_000),
+            permissionMode: 'bypassPermissions',
+          }),
+          model,
+        });
+        // Reactive compaction retains the last assistant-led group; an older assistant must remain.
+        await waitForVisibleResponse({
+          fixture, chatId, turnId: historyTurn.turnId, marker: firstReply, afterIndex: historyCursor,
+        });
+        const accumulatedCursor = fixture.client.markEvents();
+        const accumulated = await fixture.client.runChat({
+          ...liveClaudeRunRequest({ chatId, command: 'Acknowledge the recorded reference notes.' }),
+          model,
+        });
+        await waitForVisibleResponse({
+          fixture, chatId, turnId: accumulated.turnId, marker: historyReply, afterIndex: accumulatedCursor,
+        });
+        const cursor = fixture.client.markEvents();
+        const turn = await fixture.client.runChat({
+          ...liveClaudeRunRequest({
+            chatId,
+            command: 'Run the scripted command, then report completion.',
+            permissionMode: 'bypassPermissions',
+          }),
+          model,
+        });
+        await waitForVisibleResponse({
+          fixture, chatId, turnId: turn.turnId, marker: reply, afterIndex: cursor,
+        });
+        const requests = environment.model.requests();
+        expect(requests).toHaveLength(expectsCompaction ? 5 : 4);
+        const finalHistory = JSON.stringify(requests.at(-1)?.body.messages);
+        if (expectsCompaction) {
+          expect(finalHistory).toContain('The previous turn recorded synthetic reference notes.');
+          expect(finalHistory).not.toContain('Synthetic context entry for the scripted compaction test.');
+        } else {
+          expect(finalHistory).toContain('Synthetic context entry for the scripted compaction test.');
+        }
+        expect(requests.every(request =>
+          request.body.model === 'integration-context-model')).toBe(true);
+        environment.model.assertSettled();
+      }, {
+        serverEnvironment: {
+          ...environment.serverEnvironment,
+          // The explicit [922k] cap must win; native [1m] preserves this override.
+          CLAUDE_CODE_AUTO_COMPACT_WINDOW: '1000000',
+        },
+      });
+    } finally {
+      environment.dispose();
+    }
+  }, 60_000);
+}
+
+test('Claude preserves the native session across context-cap changes and removal', async () => {
+  const environment = await startScriptedClaudeTestEnvironment();
+  try {
+    await withIntegrationFixture('claude-model-context-switch', async (fixture) => {
+      const chatId = fixture.newChatId();
+      let sessionId: string | undefined;
+      for (const [index, model] of ['first[922k]', 'second[850k]', 'third[1m]'].entries()) {
+        const reply = `Scripted model switch ${index} complete.`;
+        environment.model.scriptTurn([claudeText(reply)]);
+        const cursor = fixture.client.markEvents();
+        const command = `Respond to scripted model switch ${index}.`;
+        if (index > 0) {
+          await fixture.client.patch('/api/v1/chats/model', { chatId, model });
+        }
+        const turn = index === 0
+          ? await fixture.client.startChat({
+              ...liveClaudeStartRequest({ chatId, command, projectPath: fixture.dirs.project }),
+              model,
+            })
+          : await fixture.client.runChat({ ...liveClaudeRunRequest({ chatId, command }), model });
+        await waitForVisibleResponse({
+          fixture, chatId, turnId: turn.turnId, marker: reply, afterIndex: cursor,
+        });
+        const persisted = await waitForPersistedNativeSession({
+          directories: fixture.dirs, chatId, agentId: 'claude',
+        });
+        if (!persisted.agentSessionId) throw new Error('Claude session was not persisted.');
+        if (sessionId === undefined) sessionId = persisted.agentSessionId;
+        expect(persisted.agentSessionId).toBe(sessionId);
+        expect((await fixture.client.getChatSnapshot(chatId)).chat.model).toBe(model);
+        expect(environment.model.requests().at(-1)?.body.model).toBe(model.split('[')[0]);
+      }
+      const transcript = await fixture.client.getMessages(chatId);
+      expect(messagesOfType(transcript.messages, 'user-message')).toHaveLength(3);
+      await expect(fixture.client.patch('/api/v1/chats/model', { chatId, model: 'third[99k]' }))
+        .rejects.toThrow(/returned 422:.*context suffix/);
+      expect((await fixture.client.getChatSnapshot(chatId)).chat.model).toBe('third[1m]');
+      environment.model.assertSettled();
+    }, { serverEnvironment: environment.serverEnvironment });
+  } finally {
+    environment.dispose();
+  }
+}, 60_000);

--- a/integration-tests/tests/server/claude-scripted-model.test.ts
+++ b/integration-tests/tests/server/claude-scripted-model.test.ts
@@ -89,14 +89,15 @@ describe('Claude against a scripted model', () => {
     });
   });
 
-  test('pins subagents to the selected custom endpoint model', async () => {
+  test.each(['', '[922k]'])('pins subagents to the selected custom endpoint model with suffix %j', async (suffix) => {
     if (!environment) throw new Error('Scripted Claude environment was not initialized.');
     const testEnvironment = environment;
     const childPrompt = `Inspect the scripted project ${crypto.randomUUID()}.`;
     const childReply = `SCRIPTED_CHILD_${crypto.randomUUID().replaceAll('-', '')}`;
     const reply = `SCRIPTED_PARENT_${crypto.randomUUID().replaceAll('-', '')}`;
     // An unknown custom ID reproduces Claude Code's Opus fallback; a Haiku alias cannot.
-    const selectedModel = 'integration-custom-claude-model';
+    const wireModel = 'integration-custom-claude-model';
+    const selectedModel = `${wireModel}${suffix}`;
     const requestStart = testEnvironment.model.markRequests();
     testEnvironment.model.scriptTurn([
       claudeToolUse('toolu_scripted_agent', 'Agent', {
@@ -151,8 +152,8 @@ describe('Claude against a scripted model', () => {
       const requests = testEnvironment.model.requestsSince(requestStart);
       const childRequest = requests.find((candidate) => candidate.lastUserText.includes(childPrompt));
       if (!childRequest) throw new Error('The scripted subagent never reached the fake model.');
-      expect(childRequest.body.model).toBe(selectedModel);
-      expect(requests[0]?.body.model).toBe(selectedModel);
+      expect(childRequest.body.model).toBe(wireModel);
+      expect(requests[0]?.body.model).toBe(wireModel);
       testEnvironment.model.assertSettled();
     }, {
       serverEnvironment: testEnvironment.serverEnvironment,

--- a/integration-tests/tests/server/claude-turn-correlation.test.ts
+++ b/integration-tests/tests/server/claude-turn-correlation.test.ts
@@ -15,7 +15,7 @@ const { dirname, join, resolve } = await import('node:path');
 const args = process.argv.slice(2);
 
 if (args.includes('--version')) {
-  console.log('2.1.220 (Claude Code)');
+  console.log('2.1.238 (Claude Code)');
   process.exit(0);
 }
 

--- a/server-agents/amp/src/index.ts
+++ b/server-agents/amp/src/index.ts
@@ -39,6 +39,7 @@ const AMP_DESCRIPTOR = {
 } as const;
 
 export default class AmpAgentIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = 'amp';
   static readonly apiVersion = 5 as const;
   readonly descriptor = AMP_DESCRIPTOR;

--- a/server-agents/claude/src/__tests__/integration.test.js
+++ b/server-agents/claude/src/__tests__/integration.test.js
@@ -24,6 +24,21 @@ function createHost(root = '/tmp/garcon-claude-integration-test') {
 }
 
 describe('ClaudeAgentIntegration', () => {
+  it('validates model annotations without requiring an active native session', async () => {
+    const integration = new ClaudeAgentIntegration(createHost());
+    const configuration = {
+      model: 'custom[922k]',
+      permissionMode: 'default',
+      thinkingMode: 'none',
+      settings: integration.settings.defaults(),
+      endpoint: null,
+    };
+    await expect(integration.configurationValidation.validate(configuration)).resolves.toBeUndefined();
+    await expect(integration.configurationValidation.validate({
+      ...configuration, model: 'custom[99k]',
+    })).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
+  });
+
   it('composes the provider facets without reading environment during construction', () => {
     const host = createHost();
     const integration = new ClaudeAgentIntegration(host);

--- a/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/abort-timer.test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-let versionProbe = () => Promise.resolve([2, 1, 220]);
+let versionProbe = () => Promise.resolve([2, 1, 238]);
 
 import { ClaudeCliRuntime } from '../claude-cli.js';
 
@@ -201,7 +201,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
 
     spawnMock = mock();
     Bun.spawn = spawnMock;
-    versionProbe = () => Promise.resolve([2, 1, 220]);
+    versionProbe = () => Promise.resolve([2, 1, 238]);
 
     scheduled = [];
     cleared = [];
@@ -795,7 +795,7 @@ describe('ClaudeCliRuntime abort force-kill fallback', () => {
     await flush();
     expect(secondPublished.events).toEqual([]);
 
-    resolveProbe([2, 1, 220]);
+    resolveProbe([2, 1, 238]);
     await flush();
     expect(spawnMock).toHaveBeenCalledTimes(2);
 

--- a/server-agents/claude/src/agents/claude/__tests__/agent.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/agent.test.js
@@ -77,6 +77,26 @@ function startRequest(projectPath, signal = new AbortController().signal) {
 }
 
 describe('ClaudeExecution', () => {
+  it('rejects invalid models before native-path creation, runtime admission, or activation', async () => {
+    const configHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-claude-validation-'));
+    const runtime = createClaudeStub();
+    const execution = createExecution(runtime, configHomeDir);
+    const publish = mock(() => undefined);
+    const request = { ...startRequest(configHomeDir), model: 'custom[99k]' };
+    try {
+      await expect(execution.start(request, publish)).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
+      await expect(execution.resume({
+        ...request, agentSessionId: 'session-1', nativeSession: null,
+      }, publish)).rejects.toMatchObject({ code: 'INVALID_SETTINGS' });
+      expect(await fs.readdir(configHomeDir)).toEqual([]);
+      expect(runtime.startClaudeCliSession).not.toHaveBeenCalled();
+      expect(runtime.runClaudeTurn).not.toHaveBeenCalled();
+      expect(publish).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(configHomeDir, { recursive: true, force: true });
+    }
+  });
+
   it('emits a failed event when fire-and-forget startup rejects', async () => {
     const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'garcon-claude-agent-'));
     try {

--- a/server-agents/claude/src/agents/claude/__tests__/cli-invocation.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-invocation.test.js
@@ -3,8 +3,12 @@ import { buildClaudeCLIArgs, runSingleQuery } from '../cli-invocation.js';
 import { buildClaudeCLIEnvironment } from '../cli-environment.js';
 
 describe('Claude model context invocation', () => {
-  for (const sessionOptions of [{}, { streamJson: true, sessionId: 'session-context' }, { streamJson: true, resumeSessionId: 'session-context' }]) {
-    it(`translates a numeric suffix for ${JSON.stringify(sessionOptions)}`, () => {
+  for (const [scenario, sessionOptions] of [
+    ['a one-shot query', {}],
+    ['a new session', { streamJson: true, sessionId: 'session-context' }],
+    ['a resumed session', { streamJson: true, resumeSessionId: 'session-context' }],
+  ]) {
+    it(`translates a numeric suffix for ${scenario}`, () => {
       const args = buildClaudeCLIArgs({ ...sessionOptions, model: 'custom[922k]' });
       expect(args[args.indexOf('--model') + 1]).toBe('custom[1m]');
       expect(args[args.indexOf('--autocompact') + 1]).toBe('922k');
@@ -12,9 +16,15 @@ describe('Claude model context invocation', () => {
     });
   }
 
-  it('leaves native [1m] compaction behavior unchanged', () => {
-    const args = buildClaudeCLIArgs({ model: 'custom[1m]' });
-    expect(args).toContain('custom[1m]');
+  it.each(['custom', 'custom[1m]', 'custom[preview]'])('leaves compaction policy unchanged for %s', (model) => {
+    const args = buildClaudeCLIArgs({ model });
+    expect(args[args.indexOf('--model') + 1]).toBe(model);
+    expect(args).not.toContain('--autocompact');
+  });
+
+  it.each([undefined, ''])('adds no model or compaction flags when the selection is %j', (model) => {
+    const args = buildClaudeCLIArgs({ model });
+    expect(args).not.toContain('--model');
     expect(args).not.toContain('--autocompact');
   });
 

--- a/server-agents/claude/src/agents/claude/__tests__/cli-invocation.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-invocation.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { buildClaudeCLIArgs, runSingleQuery } from '../cli-invocation.js';
+import { buildClaudeCLIEnvironment } from '../cli-environment.js';
+
+describe('Claude model context invocation', () => {
+  for (const sessionOptions of [{}, { streamJson: true, sessionId: 'session-context' }, { streamJson: true, resumeSessionId: 'session-context' }]) {
+    it(`translates a numeric suffix for ${JSON.stringify(sessionOptions)}`, () => {
+      const args = buildClaudeCLIArgs({ ...sessionOptions, model: 'custom[922k]' });
+      expect(args[args.indexOf('--model') + 1]).toBe('custom[1m]');
+      expect(args[args.indexOf('--autocompact') + 1]).toBe('922k');
+      expect(args).not.toContain('custom[922k]');
+    });
+  }
+
+  it('leaves native [1m] compaction behavior unchanged', () => {
+    const args = buildClaudeCLIArgs({ model: 'custom[1m]' });
+    expect(args).toContain('custom[1m]');
+    expect(args).not.toContain('--autocompact');
+  });
+
+  it('only clears the compaction override when the model supplies a cap', () => {
+    const previous = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '500000';
+    const overrides = {
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: '600000',
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+      ANTHROPIC_AUTH_TOKEN: 'test-credential',
+    };
+    try {
+      const env = buildClaudeCLIEnvironment('custom[922k]', overrides);
+      expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+      expect(env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe('1');
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBe('test-credential');
+      expect(env.CLAUDECODE).toBeUndefined();
+      expect(buildClaudeCLIEnvironment('custom[922k]').CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+      expect(buildClaudeCLIEnvironment('custom[1m]', overrides).CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('600000');
+      expect(buildClaudeCLIEnvironment('custom').CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('500000');
+      expect(process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('500000');
+      expect(overrides.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('600000');
+    } finally {
+      if (previous === undefined) delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+      else process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = previous;
+    }
+  });
+
+  it('uses the same argument and environment policy for a one-shot query', async () => {
+    const originalSpawn = Bun.spawn;
+    const options = {
+      model: 'custom[922k]',
+      envOverrides: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: '600000' },
+    };
+    Bun.spawn = mock(() => ({
+      stdout: new Response('one-shot reply').body,
+      stderr: new Response('').body,
+      exited: Promise.resolve(0),
+    }));
+    try {
+      await expect(runSingleQuery('A synthetic prompt.', options, {
+        binary: () => 'claude',
+        versionProbe: { assertCompatible: async () => [2, 1, 238] },
+        logger: { debug() {}, info() {}, warn() {}, error() {} },
+      })).resolves.toBe('one-shot reply');
+      const [args, spawnOptions] = Bun.spawn.mock.calls[0];
+      expect(args[args.indexOf('--model') + 1]).toBe('custom[1m]');
+      expect(args[args.indexOf('--autocompact') + 1]).toBe('922k');
+      expect(spawnOptions.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+      expect(options.model).toBe('custom[922k]');
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+  });
+});

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -2055,6 +2055,9 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
       const start = runtime.startClaudeCliSession(startOptions({ model: 'first[922k]' }));
       await enqueueResult(fake);
       await start;
+      runtime.setInternalThinkingMode('expected-session', 'none');
+      runtime.setInternalClaudeThinkingMode('expected-session', 'auto');
+      expect(fake.proc.stdin.end).not.toHaveBeenCalled();
       const switched = runtime.runClaudeTurn(startOptions({ model: 'second[922k]' }));
       await enqueueResult(fake);
       await switched;

--- a/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-runtime.test.js
@@ -20,7 +20,7 @@ function createRuntime(logger = createLogger(), overrides = {}) {
     binary: () => 'claude',
     logger,
     versionProbe: {
-      assertCompatible: mock(() => Promise.resolve([2, 1, 220])),
+      assertCompatible: mock(() => Promise.resolve([2, 1, 238])),
     },
     ...overrides,
   });
@@ -2006,7 +2006,123 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
     }
   });
 
-  it('does not spawn a replacement until the previous native-session writer exits', async () => {
+  it.each([
+    ['custom', 'custom[922k]', 'custom[1m]', '922k'],
+    ['custom[922k]', 'custom[850k]', 'custom[1m]', '850k'],
+    ['custom[922k]', 'custom', 'custom', null],
+    ['custom[922k]', 'custom[1m]', 'custom[1m]', null],
+  ])('resumes the same session when its context cap changes: %s -> %s', async (from, to, wireModel, cap) => {
+    const originalSpawn = Bun.spawn;
+    const first = createFakeClaudeProcess();
+    const second = createFakeClaudeProcess();
+    const runtime = createRuntime();
+    Bun.spawn = mock().mockReturnValueOnce(first.proc).mockReturnValueOnce(second.proc);
+    try {
+      const start = runtime.startClaudeCliSession(startOptions({
+        model: from,
+        envOverrides: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: '700000' },
+      }));
+      await enqueueResult(first);
+      await start;
+      const resumed = runtime.runClaudeTurn(startOptions({ model: to }));
+      await enqueueResult(second);
+      await resumed;
+
+      expect(first.proc.stdin.end).toHaveBeenCalledTimes(1);
+      expect(Bun.spawn).toHaveBeenCalledTimes(2);
+      const [args, options] = Bun.spawn.mock.calls[1];
+      expect(args).toContain('--resume=expected-session');
+      expect(args[args.indexOf('--model') + 1]).toBe(wireModel);
+      if (cap === null) {
+        expect(args).not.toContain('--autocompact');
+        expect(options.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('700000');
+      } else {
+        expect(args[args.indexOf('--autocompact') + 1]).toBe(cap);
+        expect(options.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+      }
+    } finally {
+      await runtime.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('uses a normalized set_model for same-cap changes and remembers the annotated selection', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    const runtime = createRuntime();
+    Bun.spawn = mock(() => fake.proc);
+    try {
+      const start = runtime.startClaudeCliSession(startOptions({ model: 'first[922k]' }));
+      await enqueueResult(fake);
+      await start;
+      const switched = runtime.runClaudeTurn(startOptions({ model: 'second[922k]' }));
+      await enqueueResult(fake);
+      await switched;
+      const continued = runtime.runClaudeTurn({
+        agentSessionId: 'expected-session', chatId: 'chat-1', command: 'continue',
+        operation: { runId: 'run-context-continue', publish() {} },
+      });
+      await enqueueResult(fake);
+      await continued;
+      const models = fake.proc.stdin.write.mock.calls
+        .map(([line]) => JSON.parse(line).request)
+        .filter(request => request?.subtype === 'set_model');
+      expect(models).toEqual([{ subtype: 'set_model', model: 'second[1m]' }]);
+      expect(Bun.spawn).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it.each(['startClaudeCliSession', 'runClaudeTurn'])('rejects invalid %s models without poisoning subsequent resumes', async (method) => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    const runtime = createRuntime();
+    const onSessionActivated = mock(() => undefined);
+    Bun.spawn = mock(() => fake.proc);
+    try {
+      await expect(runtime[method](startOptions({ model: 'custom[99k]', onSessionActivated })))
+        .rejects.toThrow('context suffix');
+      expect(onSessionActivated).not.toHaveBeenCalled();
+      expect(Bun.spawn).not.toHaveBeenCalled();
+      const resumed = runtime.runClaudeTurn(startOptions({ model: 'custom[922k]' }));
+      await enqueueResult(fake);
+      await resumed;
+      expect(Bun.spawn).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it('rejects an invalid cap before changing the healthy process or its saved options', async () => {
+    const originalSpawn = Bun.spawn;
+    const fake = createFakeClaudeProcess();
+    const runtime = createRuntime();
+    Bun.spawn = mock(() => fake.proc);
+    try {
+      const start = runtime.startClaudeCliSession(startOptions({ model: 'custom[922k]' }));
+      await enqueueResult(fake);
+      await start;
+      await expect(runtime.runClaudeTurn(startOptions({ model: 'custom[99k]' })))
+        .rejects.toThrow('context suffix');
+      const continued = runtime.runClaudeTurn({
+        agentSessionId: 'expected-session', chatId: 'chat-1', command: 'continue',
+        operation: { runId: 'run-context-recover', publish() {} },
+      });
+      await enqueueResult(fake);
+      await continued;
+      expect(Bun.spawn).toHaveBeenCalledTimes(1);
+      expect(fake.proc.stdin.end).not.toHaveBeenCalled();
+      expect(fake.proc.stdin.write.mock.calls.some(([line]) => JSON.parse(line).request?.subtype === 'set_model')).toBe(false);
+    } finally {
+      await runtime.shutdown();
+      Bun.spawn = originalSpawn;
+    }
+  });
+
+  it.each([{ thinkingMode: 'high' }, { model: 'custom[922k]' }])('waits for the previous native-session writer before restarting for %j', async (change) => {
     const originalSpawn = Bun.spawn;
     const first = createFakeClaudeProcess({ onEnd: () => null });
     const second = createFakeClaudeProcess();
@@ -2023,7 +2139,7 @@ describe('ClaudeCliRuntime stdout protocol handling', () => {
 
       const resumed = runtime.runClaudeTurn(startOptions({
         command: 'restart after config change',
-        thinkingMode: 'high',
+        ...change,
       }));
       for (
         let attempt = 0;

--- a/server-agents/claude/src/agents/claude/__tests__/cli-version.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/cli-version.test.js
@@ -31,7 +31,7 @@ if [ ! -f ${successMarker} ]; then
   echo "transient failure" >&2
   exit 1
 fi
-echo "2.1.220 (Claude Code)"
+echo "2.1.238 (Claude Code)"
 `, { mode: 0o755 });
   return { binaryPath, callLogPath };
 }
@@ -50,9 +50,9 @@ describe('parseClaudeCliVersion', () => {
 
 describe('isVersionBefore', () => {
   it('compares versions numerically per component', () => {
-    expect(isVersionBefore([2, 1, 219], MINIMUM_CLAUDE_CLI_VERSION)).toBe(true);
+    expect(isVersionBefore([2, 1, 237], MINIMUM_CLAUDE_CLI_VERSION)).toBe(true);
     expect(isVersionBefore([1, 9, 999], MINIMUM_CLAUDE_CLI_VERSION)).toBe(true);
-    expect(isVersionBefore([2, 1, 220], MINIMUM_CLAUDE_CLI_VERSION)).toBe(false);
+    expect(isVersionBefore([2, 1, 238], MINIMUM_CLAUDE_CLI_VERSION)).toBe(false);
     expect(isVersionBefore([2, 2, 0], MINIMUM_CLAUDE_CLI_VERSION)).toBe(false);
     expect(isVersionBefore([3, 0, 0], MINIMUM_CLAUDE_CLI_VERSION)).toBe(false);
   });
@@ -63,18 +63,18 @@ function createProbe() {
 }
 
 describe('ClaudeCliVersionProbe', () => {
-  it('requires the tested persistent protocol version', async () => {
-    const supported = await createFakeClaudeBinary('2.1.220 (Claude Code)');
-    const unsupported = await createFakeClaudeBinary('2.1.219 (Claude Code)');
+  it('requires the tested persistent protocol and context-window version', async () => {
+    const supported = await createFakeClaudeBinary('2.1.238 (Claude Code)');
+    const unsupported = await createFakeClaudeBinary('2.1.237 (Claude Code)');
 
     await expect(createProbe().assertCompatible(supported.binaryPath))
       .resolves.toEqual(MINIMUM_CLAUDE_CLI_VERSION);
     await expect(createProbe().assertCompatible(unsupported.binaryPath))
-      .rejects.toThrow('Upgrade to 2.1.220 or newer');
+      .rejects.toThrow('Upgrade to 2.1.238 or newer');
   });
 
   it('probes each binary path only once', async () => {
-    const { binaryPath, callLogPath } = await createFakeClaudeBinary('2.1.220 (Claude Code)');
+    const { binaryPath, callLogPath } = await createFakeClaudeBinary('2.1.238 (Claude Code)');
     const probe = createProbe();
     expect(await probe.assertCompatible(binaryPath)).toEqual(MINIMUM_CLAUDE_CLI_VERSION);
     expect(await probe.assertCompatible(binaryPath)).toEqual(MINIMUM_CLAUDE_CLI_VERSION);

--- a/server-agents/claude/src/agents/claude/__tests__/endpoint-runtime.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/endpoint-runtime.test.js
@@ -18,6 +18,13 @@ function selection(endpoint = {}) {
 }
 
 describe('buildClaudeEndpointRuntime', () => {
+  it('normalizes the custom endpoint subagent model without changing the selection', () => {
+    const endpoint = selection({ model: 'acme-claude[922k]' });
+    expect(buildClaudeEndpointRuntime(endpoint).envOverrides.CLAUDE_CODE_SUBAGENT_MODEL)
+      .toBe('acme-claude[1m]');
+    expect(endpoint.selection.model).toBe('acme-claude[922k]');
+  });
+
   it('builds Anthropic environment overrides for Claude endpoint-backed runs', () => {
     expect(buildClaudeEndpointRuntime(selection())).toEqual({
       envOverrides: {

--- a/server-agents/claude/src/agents/claude/__tests__/model-context.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/model-context.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { resolveClaudeModel } from '../model-context.js';
+
+describe('resolveClaudeModel', () => {
+  for (const model of ['', 'sonnet', 'gateway/model', 'gateway/model[1m]', 'gateway/model[preview]']) {
+    it(`preserves the native model spelling ${JSON.stringify(model)}`, () => {
+      expect(resolveClaudeModel(model)).toEqual({ model, autoCompactWindow: null });
+    });
+  }
+
+  for (const [suffix, tokens] of [['100k', 100_000], ['922k', 922_000], ['1000k', 1_000_000], ['0922K', 922_000]]) {
+    it(`resolves [${suffix}] without looking up the model`, () => {
+      expect(resolveClaudeModel(`gateway/custom-model[${suffix}]`)).toEqual({
+        model: 'gateway/custom-model[1m]',
+        autoCompactWindow: tokens,
+      });
+    });
+  }
+
+  for (const model of [
+    'custom[0k]', 'custom[99k]', 'custom[1001k]', 'custom[999999999999999999999k]',
+    '[922k]', 'custom[1m][922k]', 'custom[922k][1m]', 'custom[922k]]',
+    'custom[[922k]', 'custom[922k', 'custom922k]', 'custom[922k]extra',
+  ]) {
+    it(`rejects an invalid context annotation: ${model}`, () => {
+      expect(() => resolveClaudeModel(model)).toThrow('context suffix');
+    });
+  }
+});

--- a/server-agents/claude/src/agents/claude/__tests__/model-context.test.js
+++ b/server-agents/claude/src/agents/claude/__tests__/model-context.test.js
@@ -8,7 +8,12 @@ describe('resolveClaudeModel', () => {
     });
   }
 
-  for (const [suffix, tokens] of [['100k', 100_000], ['922k', 922_000], ['1000k', 1_000_000], ['0922K', 922_000]]) {
+  for (const [suffix, tokens] of [
+    ['100k', 100_000],
+    ['922k', 922_000],
+    ['1000k', 1_000_000],
+    ['0922K', 922_000],
+  ]) {
     it(`resolves [${suffix}] without looking up the model`, () => {
       expect(resolveClaudeModel(`gateway/custom-model[${suffix}]`)).toEqual({
         model: 'gateway/custom-model[1m]',
@@ -17,6 +22,15 @@ describe('resolveClaudeModel', () => {
     });
   }
 
+  it('resolves every supported integer cap', () => {
+    for (let thousands = 100; thousands <= 1000; thousands += 1) {
+      expect(resolveClaudeModel(`custom[${thousands}k]`)).toEqual({
+        model: 'custom[1m]',
+        autoCompactWindow: thousands * 1_000,
+      });
+    }
+  });
+
   for (const model of [
     'custom[0k]', 'custom[99k]', 'custom[1001k]', 'custom[999999999999999999999k]',
     '[922k]', 'custom[1m][922k]', 'custom[922k][1m]', 'custom[922k]]',
@@ -24,6 +38,11 @@ describe('resolveClaudeModel', () => {
   ]) {
     it(`rejects an invalid context annotation: ${model}`, () => {
       expect(() => resolveClaudeModel(model)).toThrow('context suffix');
+      expect(() => resolveClaudeModel(model)).toThrow(expect.objectContaining({
+        code: 'INVALID_SETTINGS',
+        message: 'Claude model context suffix requires a model followed by [100k] through [1000k].',
+        retryable: false,
+      }));
     });
   }
 });

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -773,7 +773,7 @@ class ClaudeCliRuntime {
 
     session.options = { ...session.options, thinkingMode: mode };
 
-    if (session.process && !session.activeTurn) {
+    if (session.process && !session.activeTurn && mode !== session.currentThinkingMode) {
       this.#retireSessionProcessInBackground(session);
     }
   }
@@ -784,7 +784,7 @@ class ClaudeCliRuntime {
 
     session.options = { ...session.options, claudeThinkingMode: mode };
 
-    if (session.process && !session.activeTurn) {
+    if (session.process && !session.activeTurn && mode !== session.currentClaudeThinkingMode) {
       this.#retireSessionProcessInBackground(session);
     }
   }

--- a/server-agents/claude/src/agents/claude/claude-cli.ts
+++ b/server-agents/claude/src/agents/claude/claude-cli.ts
@@ -5,6 +5,8 @@ import { extractCompactionSummary, isCompactionSummaryText, parseCompactMetadata
 import { attachNativeMessageSource } from '@garcon/server-agent-common/shared/native-message-source';
 import { convertClaudePermissionTool } from "./permission-tool-converter.js";
 import { ClaudeCliVersionProbe } from "./cli-version.js";
+import { buildClaudeCLIEnvironment } from './cli-environment.js';
+import { resolveClaudeModel } from './model-context.js';
 import {
   type AgentRuntimeOperation,
 } from '@garcon/server-agent-common/execution/runtime-events';
@@ -946,14 +948,10 @@ class ClaudeCliRuntime {
       stdin: 'pipe',
       stdout: 'pipe',
       stderr: 'pipe',
-      env: (() => {
-        const { CLAUDECODE, ...env } = process.env;
-        return {
-          ...env,
-          ...options.envOverrides,
-          CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
-        };
-      })(),
+      env: {
+        ...buildClaudeCLIEnvironment(options.model, options.envOverrides),
+        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+      },
     });
 
     session.options = options;
@@ -1025,6 +1023,7 @@ class ClaudeCliRuntime {
 
   async startClaudeCliSession(request: ClaudeStartRequest): Promise<string> {
     assertClaudeExecutionOpen(request);
+    resolveClaudeModel(request.model || '');
     const {
       command,
       agentSessionId,
@@ -1127,6 +1126,7 @@ class ClaudeCliRuntime {
 
   async runClaudeTurn(request: ClaudeResumeRequest): Promise<void> {
     assertClaudeExecutionOpen(request);
+    resolveClaudeModel(request.model || '');
     const {
       command,
       agentSessionId,
@@ -1207,18 +1207,19 @@ class ClaudeCliRuntime {
     let ownedTurn: ClaudeActiveTurn | null = null;
     let cleanupVideoAttachments = async () => {};
     try {
-      if (chatId !== session.chatId) {
-        throw new Error('Chat ID mismatch');
-      }
+      if (chatId !== session.chatId) throw new Error('Chat ID mismatch');
 
-      session.options = mergeClaudeSessionOptions(session.options, allOpts);
+      const desiredOptions = mergeClaudeSessionOptions(session.options, allOpts);
+      const desiredModel = desiredOptions.model || '';
+      const resolvedModel = resolveClaudeModel(desiredModel);
+      const currentModel = resolveClaudeModel(session.currentModel);
+      session.options = desiredOptions;
       session.chatId = chatId;
       session.lastActivityAt = Date.now();
       const desiredThinkingMode = session.options.thinkingMode || 'none';
       const desiredClaudeThinkingMode = normalizeClaudeThinkingModeForState(
         session.options.claudeThinkingMode,
       );
-      const desiredModel = session.options.model || '';
       const desiredPermissionMode = session.options.permissionMode || 'default';
       const previousProviderPermissionMode = session.process
         ? providerStartupPermissionMode(session.currentPermissionMode)
@@ -1233,11 +1234,15 @@ class ClaudeCliRuntime {
         session.currentEnvOverrides,
         session.options.envOverrides,
       );
+      // set_model cannot change --autocompact; resuming reapplies the cap without losing history.
+      // https://github.com/anthropics/claude-agent-sdk-python/blob/3379406f18fcea64617d25663d811dfdde8cd171/src/claude_agent_sdk/_internal/query.py#L697-L704
+      const contextWindowChanged = currentModel.autoCompactWindow !== resolvedModel.autoCompactWindow;
       if (session.process && (
         desiredThinkingMode !== session.currentThinkingMode
         || desiredClaudeThinkingMode !== session.currentClaudeThinkingMode
         || permissionStartupChanged
         || envChanged
+        || contextWindowChanged
       )) {
         await this.#retireSessionProcess(session);
       }
@@ -1245,18 +1250,13 @@ class ClaudeCliRuntime {
       if (!session.process) {
         // Always resumes because the native transcript owns conversation context.
         assertClaudeExecutionOpen(requestAdmission);
-        await this.#spawnCLI(
-          session,
-          session.options,
-          true,
-          cliVersion,
-        );
+        await this.#spawnCLI(session, session.options, true, cliVersion);
       }
 
       if (session.process && desiredModel !== session.currentModel) {
         await this.#controlBroker.request(session.id, {
           subtype: 'set_model',
-          model: desiredModel,
+          model: resolvedModel.model,
         });
         session.currentModel = desiredModel;
       }

--- a/server-agents/claude/src/agents/claude/cli-environment.ts
+++ b/server-agents/claude/src/agents/claude/cli-environment.ts
@@ -1,0 +1,12 @@
+import { resolveClaudeModel } from './model-context.js';
+
+export function buildClaudeCLIEnvironment(model = '', overrides?: Record<string, string>) {
+  const { CLAUDECODE, ...inherited } = process.env;
+  const env = { ...inherited, ...overrides };
+  if (resolveClaudeModel(model).autoCompactWindow !== null) {
+    // Claude gives this variable precedence over --autocompact; an explicit model cap wins.
+    // https://code.claude.com/docs/en/model-config#set-the-auto-compact-window
+    delete env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+  }
+  return env;
+}

--- a/server-agents/claude/src/agents/claude/cli-invocation.ts
+++ b/server-agents/claude/src/agents/claude/cli-invocation.ts
@@ -8,6 +8,7 @@ import { providerStartupPermissionMode } from '@garcon/server-agent-common/execu
 import { withSingleQueryControl } from '@garcon/server-agent-common/shared/single-query-control';
 import type { AgentLogger } from '@garcon/server-agent-interface';
 import { ClaudeCliVersionProbe } from './cli-version.js';
+import { resolveClaudeModel } from './model-context.js';
 import { runClaudeSingleQueryProcess } from './single-query-process.js';
 
 const NOOP_LOGGER: AgentLogger = {
@@ -83,7 +84,13 @@ export function buildClaudeCLIArgs({
       ]
     : ['--print', '--no-session-persistence'];
 
-  if (model) args.push('--model', model);
+  if (model) {
+    const resolved = resolveClaudeModel(model);
+    args.push('--model', resolved.model);
+    if (resolved.autoCompactWindow !== null) {
+      args.push('--autocompact', `${resolved.autoCompactWindow / 1_000}k`);
+    }
+  }
 
   const effectiveMode = permissionMode || 'default';
   const providerMode = providerStartupPermissionMode(effectiveMode);
@@ -145,6 +152,7 @@ export async function runSingleQuery(
     return runClaudeSingleQueryProcess({
       binary: claudeBinary,
       args,
+      model,
       cwd: cwd || process.cwd(),
       signal: querySignal,
       envOverrides,

--- a/server-agents/claude/src/agents/claude/cli-version.ts
+++ b/server-agents/claude/src/agents/claude/cli-version.ts
@@ -1,4 +1,5 @@
-const MINIMUM_CLAUDE_CLI_VERSION: readonly [number, number, number] = [2, 1, 220];
+// The pinned scripted-model suite verifies --autocompact as well as the persistent protocol.
+const MINIMUM_CLAUDE_CLI_VERSION: readonly [number, number, number] = [2, 1, 238];
 const VERSION_PROBE_TIMEOUT_MS = 5_000;
 const VERSION_PROBE_EXIT_GRACE_MS = 1_000;
 const MAX_VERSION_OUTPUT_BYTES = 16 * 1024;

--- a/server-agents/claude/src/agents/claude/endpoint-runtime.ts
+++ b/server-agents/claude/src/agents/claude/endpoint-runtime.ts
@@ -1,5 +1,6 @@
 import type { ResolvedAgentEndpoint } from '@garcon/server-agent-common/execution/resolve-endpoint';
 import type { ClaudeConfig } from '../../config.js';
+import { resolveClaudeModel } from './model-context.js';
 
 export interface ClaudeEndpointRuntime {
   readonly envOverrides: Record<string, string>;
@@ -15,7 +16,7 @@ export function buildClaudeEndpointRuntime(
       ANTHROPIC_BASE_URL: endpoint.selection.baseUrl,
       ...(endpoint.credential ? { ANTHROPIC_AUTH_TOKEN: endpoint.credential } : {}),
       ANTHROPIC_API_KEY: '',
-      CLAUDE_CODE_SUBAGENT_MODEL: endpoint.selection.model,
+      CLAUDE_CODE_SUBAGENT_MODEL: resolveClaudeModel(endpoint.selection.model).model,
     },
   };
 }

--- a/server-agents/claude/src/agents/claude/execution.ts
+++ b/server-agents/claude/src/agents/claude/execution.ts
@@ -131,6 +131,7 @@ export class ClaudeExecution implements AgentRuntimeExecution {
     agentSessionId: string,
     configuration: Parameters<import('@garcon/server-agent-interface').AgentSessionConfigurationUpdates['apply']>[1],
   ): Promise<void> {
+    // Model-only patches reapply these options; unchanged values must preserve the process.
     this.runtime.setInternalPermissionMode(agentSessionId, configuration.permissionMode);
     this.runtime.setInternalThinkingMode(agentSessionId, configuration.thinkingMode);
     this.runtime.setInternalClaudeThinkingMode(

--- a/server-agents/claude/src/agents/claude/execution.ts
+++ b/server-agents/claude/src/agents/claude/execution.ts
@@ -25,6 +25,7 @@ import {
 } from './native-path.js';
 import type { ClaudeCliRuntime } from './claude-cli.js';
 import type { ClaudeConfig } from '../../config.js';
+import { resolveClaudeModel } from './model-context.js';
 
 export class ClaudeExecution implements AgentRuntimeExecution {
   constructor(
@@ -40,6 +41,7 @@ export class ClaudeExecution implements AgentRuntimeExecution {
     publish: AgentRuntimePublisher,
   ) {
     request.admission.signal.throwIfAborted();
+    resolveClaudeModel(request.model);
     const envOverrides = await this.#endpointEnvironment(request);
     const agentSessionId = crypto.randomUUID();
     const nativePath = await createClaudeNativePath(request.projectPath, agentSessionId, {
@@ -97,6 +99,7 @@ export class ClaudeExecution implements AgentRuntimeExecution {
     request: Parameters<AgentRuntimeExecution['resume']>[0],
     publish: AgentRuntimePublisher,
   ): Promise<void> {
+    resolveClaudeModel(request.model);
     await this.runtime.runClaudeTurn({
       ...executionFields(request),
       agentSessionId: request.agentSessionId,

--- a/server-agents/claude/src/agents/claude/model-context.ts
+++ b/server-agents/claude/src/agents/claude/model-context.ts
@@ -6,23 +6,28 @@ interface ClaudeModelContext {
 }
 
 export function resolveClaudeModel(model: string): ClaudeModelContext {
-  const match = /^(.*)\[(\d+)k\]$/i.exec(model);
-  const autoCompactWindow = match ? Number(match[2]) * 1_000 : null;
-  const validBrackets = !/[\[\]]/.test(model) || /^[^\[\]]+\[[^\[\]]+\]$/.test(model);
-  if (
-    !validBrackets
-    || (match && !match[1].trim())
-    || (autoCompactWindow !== null && (autoCompactWindow < 100_000 || autoCompactWindow > 1_000_000))
-  ) {
-    throw new AgentIntegrationError(
-      'INVALID_SETTINGS',
-      'Claude model context suffix requires a model followed by [100k] through [1000k].',
-      false,
-    );
+  if (/[\[\]]/.test(model) && !/^[^\[\]]+\[[^\[\]]+\]$/.test(model)) {
+    throw invalidContextSuffix();
   }
+
+  const match = /^(.*)\[(\d+)k\]$/i.exec(model);
   if (!match) return { model, autoCompactWindow: null };
+
+  const [, baseModel, thousands] = match;
+  const autoCompactWindow = Number(thousands) * 1_000;
+  if (!baseModel.trim() || autoCompactWindow < 100_000 || autoCompactWindow > 1_000_000) {
+    throw invalidContextSuffix();
+  }
 
   // The flag caps compaction but cannot enlarge an unknown model's default 200K window.
   // https://code.claude.com/docs/en/model-config#correct-the-window-for-a-gateway-or-custom-model-id
-  return { model: `${match[1]}[1m]`, autoCompactWindow };
+  return { model: `${baseModel}[1m]`, autoCompactWindow };
+}
+
+function invalidContextSuffix(): AgentIntegrationError {
+  return new AgentIntegrationError(
+    'INVALID_SETTINGS',
+    'Claude model context suffix requires a model followed by [100k] through [1000k].',
+    false,
+  );
 }

--- a/server-agents/claude/src/agents/claude/model-context.ts
+++ b/server-agents/claude/src/agents/claude/model-context.ts
@@ -1,0 +1,28 @@
+import { AgentIntegrationError } from '@garcon/server-agent-interface';
+
+interface ClaudeModelContext {
+  readonly model: string;
+  readonly autoCompactWindow: number | null;
+}
+
+export function resolveClaudeModel(model: string): ClaudeModelContext {
+  const match = /^(.*)\[(\d+)k\]$/i.exec(model);
+  const autoCompactWindow = match ? Number(match[2]) * 1_000 : null;
+  const validBrackets = !/[\[\]]/.test(model) || /^[^\[\]]+\[[^\[\]]+\]$/.test(model);
+  if (
+    !validBrackets
+    || (match && !match[1].trim())
+    || (autoCompactWindow !== null && (autoCompactWindow < 100_000 || autoCompactWindow > 1_000_000))
+  ) {
+    throw new AgentIntegrationError(
+      'INVALID_SETTINGS',
+      'Claude model context suffix requires a model followed by [100k] through [1000k].',
+      false,
+    );
+  }
+  if (!match) return { model, autoCompactWindow: null };
+
+  // The flag caps compaction but cannot enlarge an unknown model's default 200K window.
+  // https://code.claude.com/docs/en/model-config#correct-the-window-for-a-gateway-or-custom-model-id
+  return { model: `${match[1]}[1m]`, autoCompactWindow };
+}

--- a/server-agents/claude/src/agents/claude/single-query-process.ts
+++ b/server-agents/claude/src/agents/claude/single-query-process.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { errorMessage } from '@garcon/server-agent-common/lib/errors';
 import type { AgentLogger } from '@garcon/server-agent-interface';
+import { buildClaudeCLIEnvironment } from './cli-environment.js';
 
 const MAX_SINGLE_QUERY_STDOUT_BYTES = 4 * 1024 * 1024;
 const MAX_SINGLE_QUERY_STDERR_BYTES = 16 * 1024;
@@ -9,6 +10,7 @@ const SINGLE_QUERY_EXIT_GRACE_MS = 1_000;
 interface ClaudeSingleQueryProcessOptions {
   readonly binary: string;
   readonly args: string[];
+  readonly model?: string;
   readonly cwd: string;
   readonly envOverrides?: Record<string, string>;
   readonly signal: AbortSignal;
@@ -18,19 +20,19 @@ interface ClaudeSingleQueryProcessOptions {
 export async function runClaudeSingleQueryProcess({
   binary,
   args,
+  model,
   cwd,
   envOverrides,
   signal,
   logger,
 }: ClaudeSingleQueryProcessOptions): Promise<string> {
-  const { CLAUDECODE, ...env } = process.env;
   const proc = Bun.spawn([binary, ...args], {
     cwd,
     stdin: 'ignore',
     stdout: 'pipe',
     stderr: 'pipe',
     signal,
-    env: { ...env, ...envOverrides },
+    env: buildClaudeCLIEnvironment(model, envOverrides),
   });
 
   let stdout: string;

--- a/server-agents/claude/src/index.ts
+++ b/server-agents/claude/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from './agents/claude/native-path.js';
 import { ClaudeSlashCommandDiscovery } from './agents/claude/slash-command-discovery.js';
 import { createClaudeNativeActivityProbe } from './agents/claude/native-activity.js';
+import { resolveClaudeModel } from './agents/claude/model-context.js';
 
 const CLAUDE_DESCRIPTOR = {
   id: 'claude',
@@ -79,6 +80,11 @@ export default class ClaudeAgentIntegration implements AgentIntegration {
   readonly nativeHistoryImport;
   readonly nativeActivity;
   readonly nativeSessions;
+  readonly configurationValidation: NonNullable<AgentIntegration['configurationValidation']> = {
+    async validate(configuration) {
+      resolveClaudeModel(configuration.model);
+    },
+  };
   readonly sessionConfiguration: NonNullable<AgentIntegration['sessionConfiguration']>;
   readonly projectPathUpdates: NonNullable<AgentIntegration['projectPathUpdates']>;
   readonly catalog;

--- a/server-agents/codex/src/index.ts
+++ b/server-agents/codex/src/index.ts
@@ -65,6 +65,7 @@ const CODEX_DESCRIPTOR = {
 } as const;
 
 export default class CodexAgentIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = 'codex';
   static readonly apiVersion = 5 as const;
   readonly descriptor = CODEX_DESCRIPTOR;

--- a/server-agents/cursor/src/index.ts
+++ b/server-agents/cursor/src/index.ts
@@ -66,6 +66,7 @@ const CURSOR_DESCRIPTOR = {
 } as const;
 
 export default class CursorAgentIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = 'cursor';
   static readonly apiVersion = 5 as const;
   readonly descriptor = CURSOR_DESCRIPTOR;

--- a/server-agents/direct-anthropic-compatible/src/index.ts
+++ b/server-agents/direct-anthropic-compatible/src/index.ts
@@ -42,6 +42,7 @@ const DESCRIPTOR = {
 } as const;
 
 export default class DirectAnthropicCompatibleIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = DIRECT_ANTHROPIC_COMPATIBLE_AGENT_ID;
   static readonly apiVersion = 5 as const;
   readonly descriptor = DESCRIPTOR;

--- a/server-agents/direct-openai-compatible/src/index.ts
+++ b/server-agents/direct-openai-compatible/src/index.ts
@@ -39,6 +39,7 @@ const DESCRIPTOR = {
 } as const;
 
 export default class DirectOpenAiCompatibleIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = DIRECT_OPENAI_CHAT_COMPLETIONS_COMPATIBLE_AGENT_ID;
   static readonly apiVersion = 5 as const;
   readonly descriptor = DESCRIPTOR;

--- a/server-agents/direct-openai-responses-compatible/src/index.ts
+++ b/server-agents/direct-openai-responses-compatible/src/index.ts
@@ -39,6 +39,7 @@ const DESCRIPTOR = {
 } as const;
 
 export default class DirectOpenAiResponsesCompatibleIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = DIRECT_OPENAI_RESPONSES_COMPATIBLE_AGENT_ID;
   static readonly apiVersion = 5 as const;
   readonly descriptor = DESCRIPTOR;

--- a/server-agents/factory/src/index.ts
+++ b/server-agents/factory/src/index.ts
@@ -46,6 +46,7 @@ const FACTORY_DESCRIPTOR = {
 } as const;
 
 export default class FactoryAgentIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = 'factory';
   static readonly apiVersion = 5 as const;
   readonly descriptor = FACTORY_DESCRIPTOR;

--- a/server-agents/interface/src/contracts/execution.ts
+++ b/server-agents/interface/src/contracts/execution.ts
@@ -37,6 +37,11 @@ export interface AgentRunningSession {
   readonly startedAt: string | null;
 }
 
+export interface AgentConfigurationValidation {
+  // Runs without a native session and must not mutate provider or persisted state.
+  validate(configuration: AgentSessionConfiguration): Promise<void>;
+}
+
 export interface AgentSessionConfigurationUpdates {
   apply(
     agentSessionId: string,

--- a/server-agents/interface/src/contracts/integration.ts
+++ b/server-agents/interface/src/contracts/integration.ts
@@ -16,6 +16,7 @@ import type {
 } from './services.js';
 import type { AgentNativeFork } from './native-fork.js';
 import type {
+  AgentConfigurationValidation,
   AgentProjectPathUpdates,
   AgentSessionConfigurationUpdates,
 } from './execution.js';
@@ -46,6 +47,7 @@ export interface AgentIntegration {
   readonly nativeHistoryImport: AgentHistoryImport | null;
   readonly nativeActivity: AgentNativeActivityProbe | null;
   readonly nativeSessions: AgentNativeSessionAccess | null;
+  readonly configurationValidation: AgentConfigurationValidation | null;
   readonly sessionConfiguration: AgentSessionConfigurationUpdates | null;
   readonly projectPathUpdates: AgentProjectPathUpdates | null;
 }

--- a/server-agents/interface/src/testing/__tests__/conformance.test.ts
+++ b/server-agents/interface/src/testing/__tests__/conformance.test.ts
@@ -30,6 +30,7 @@ const integration = {
   nativeHistoryImport: null,
   nativeActivity: null,
   nativeSessions: null,
+  configurationValidation: null,
   sessionConfiguration: null,
   projectPathUpdates: null,
   catalog: {
@@ -118,6 +119,7 @@ describe('validateAgentIntegration', () => {
       'nativeHistoryImport',
       'nativeActivity',
       'nativeSessions',
+      'configurationValidation',
       'sessionConfiguration',
       'projectPathUpdates',
     ] as const;
@@ -155,6 +157,7 @@ describe('validateAgentIntegration', () => {
       ['nativeHistoryImport', {}],
       ['nativeActivity', {}],
       ['nativeSessions', { resolveNativeSession: async () => null }],
+      ['configurationValidation', {}],
       ['sessionConfiguration', {}],
       ['projectPathUpdates', {}],
     ] as const;

--- a/server-agents/interface/src/testing/conformance.ts
+++ b/server-agents/interface/src/testing/conformance.ts
@@ -25,6 +25,7 @@ const NULLABLE_FACET_METHODS = {
   nativeHistoryImport: ['load'],
   nativeActivity: ['lastActivity'],
   nativeSessions: ['resolveNativeSession', 'describeSource', 'release'],
+  configurationValidation: ['validate'],
   sessionConfiguration: ['apply'],
   projectPathUpdates: ['prepare'],
 } as const;

--- a/server-agents/opencode/src/index.ts
+++ b/server-agents/opencode/src/index.ts
@@ -55,6 +55,7 @@ const OPENCODE_DESCRIPTOR = {
 } as const;
 
 export default class OpenCodeAgentIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = 'opencode';
   static readonly apiVersion = 5 as const;
   readonly descriptor = OPENCODE_DESCRIPTOR;

--- a/server-agents/pi/src/index.ts
+++ b/server-agents/pi/src/index.ts
@@ -55,6 +55,7 @@ const PI_DESCRIPTOR = {
 } as const;
 
 export default class PiAgentIntegration implements AgentIntegration {
+  readonly configurationValidation = null;
   static readonly integrationId = 'pi';
   static readonly apiVersion = 5 as const;
   readonly descriptor = PI_DESCRIPTOR;

--- a/server/agents/__tests__/integration-registry.test.js
+++ b/server/agents/__tests__/integration-registry.test.js
@@ -32,6 +32,7 @@ function createFacetIntegration(host, id, lifecycle = {}) {
     nativeHistoryImport: null,
     nativeActivity: null,
     nativeSessions: null,
+    configurationValidation: null,
     sessionConfiguration: null,
     projectPathUpdates: null,
     catalog: {

--- a/server/agents/__tests__/session-settings-service.test.js
+++ b/server/agents/__tests__/session-settings-service.test.js
@@ -22,6 +22,7 @@ function makeService(thinkingMode = 'high') {
       supportedThinkingModes: [],
     },
     endpoints: null,
+    configurationValidation: null,
     sessionConfiguration: null,
     settings: {
       defaults: () => ({ ownerId: 'amp', schemaVersion: 2, values: {} }),
@@ -51,6 +52,27 @@ function makeService(thinkingMode = 'high') {
 }
 
 describe('AgentSessionSettingsService', () => {
+  it.each([null, 'session-1'])('validates before live changes or persistence with native session %s', async (agentSessionId) => {
+    const { service, updateChat, entry, integration } = makeService('none');
+    entry.agentSessionId = agentSessionId;
+    const validate = mock(async () => { throw new Error('invalid model'); });
+    const apply = mock(async () => undefined);
+    integration.configurationValidation = { validate };
+    integration.sessionConfiguration = { apply };
+
+    await expect(service.updateSessionSettings('chat-1', { model: 'invalid' }))
+      .rejects.toThrow('invalid model');
+    expect(validate).toHaveBeenCalledWith({
+      model: 'invalid',
+      permissionMode: 'bypassPermissions',
+      thinkingMode: 'none',
+      settings: { ownerId: 'amp', schemaVersion: 2, values: {} },
+      endpoint: null,
+    });
+    expect(apply).not.toHaveBeenCalled();
+    expect(updateChat).not.toHaveBeenCalled();
+  });
+
   it('rejects an explicit thinking mode outside the agent capability', async () => {
     const { service, updateChat } = makeService('none');
 

--- a/server/agents/__tests__/session-settings-service.test.js
+++ b/server/agents/__tests__/session-settings-service.test.js
@@ -52,6 +52,27 @@ function makeService(thinkingMode = 'high') {
 }
 
 describe('AgentSessionSettingsService', () => {
+  it('preflights a new configuration without applying settings or saving a chat', async () => {
+    const { service, updateChat, integration } = makeService();
+    const validate = mock(async () => undefined);
+    const apply = mock(async () => undefined);
+    integration.configurationValidation = { validate };
+    integration.sessionConfiguration = { apply };
+    const agentSettings = { ownerId: 'amp', schemaVersion: 2, values: {} };
+
+    await service.validateConfiguration({
+      agentId: 'amp', model: 'next-model', permissionMode: 'default',
+      thinkingMode: 'none', agentSettings,
+    });
+
+    expect(validate).toHaveBeenCalledWith({
+      model: 'next-model', permissionMode: 'default', thinkingMode: 'none',
+      settings: agentSettings, endpoint: null,
+    });
+    expect(apply).not.toHaveBeenCalled();
+    expect(updateChat).not.toHaveBeenCalled();
+  });
+
   it.each([null, 'session-1'])('validates before live changes or persistence with native session %s', async (agentSessionId) => {
     const { service, updateChat, entry, integration } = makeService('none');
     entry.agentSessionId = agentSessionId;

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -42,7 +42,7 @@ import {
   type CreateCarriedContextInput,
   type RunSingleQueryOptions,
 } from './runtime-router.js';
-import { AgentSessionSettingsService } from './session-settings-service.js';
+import { AgentSessionSettingsService, type AgentConfigurationInput } from './session-settings-service.js';
 import { toAgentChatReference } from './integration-chat-reference.js';
 import { createLogger } from '../lib/log.js';
 import type { UserMessage } from '@garcon/common/chat-types';
@@ -154,6 +154,7 @@ export interface AgentRegistryServiceContract {
     session: AgentChatEntry,
     chatId: string,
   ): Promise<AgentTranscriptSourceLocation | null>;
+  validateConfiguration(input: AgentConfigurationInput): Promise<void>;
   updateSessionSettings(chatId: string, patch: AgentSessionSettingsPatch): Promise<AgentChatEntry>;
 }
 
@@ -369,6 +370,9 @@ export class AgentRegistry implements AgentRegistryServiceContract {
   }
   discardForkedAgentSession(agentId: string, session: StartedAgentSession): Promise<void> {
     return this.#runtime.discardForkedAgentSession(agentId, session);
+  }
+  validateConfiguration(input: AgentConfigurationInput): Promise<void> {
+    return this.#settings.validateConfiguration(input);
   }
   updateSessionSettings(chatId: string, patch: AgentSessionSettingsPatch) {
     return this.#settings.updateSessionSettings(chatId, patch);

--- a/server/agents/session-settings-service.ts
+++ b/server/agents/session-settings-service.ts
@@ -1,4 +1,6 @@
 import { normalizePermissionMode } from '../../common/chat-modes.js';
+import type { PermissionMode, ThinkingMode } from '../../common/chat-modes.js';
+import type { AgentSettingsEnvelope } from '../../common/agent-integration.js';
 import type { IChatRegistry } from '../chats/store.js';
 import type { ApiProviderEndpointResolver } from '../api-providers/endpoint-resolver.js';
 import { assertSameApiProviderBoundary } from '../api-providers/endpoint-resolver.js';
@@ -12,6 +14,16 @@ import {
 } from '../../common/execution-defaults.js';
 import { DomainError } from '../lib/domain-error.js';
 
+export interface AgentConfigurationInput {
+  readonly agentId: string;
+  readonly model: string;
+  readonly apiProviderId?: string | null;
+  readonly modelEndpointId?: string | null;
+  readonly permissionMode: PermissionMode;
+  readonly thinkingMode: ThinkingMode;
+  readonly agentSettings: AgentSettingsEnvelope;
+}
+
 export class AgentSessionSettingsService {
   readonly #lock: KeyedPromiseLock;
 
@@ -22,6 +34,22 @@ export class AgentSessionSettingsService {
     chatMutationLock?: KeyedPromiseLock;
   }) {
     this.#lock = deps.chatMutationLock ?? new KeyedPromiseLock();
+  }
+
+  async validateConfiguration(input: AgentConfigurationInput): Promise<void> {
+    const integration = this.deps.directory.require(input.agentId);
+    if (!integration.configurationValidation) return;
+    const selection = this.deps.endpointResolver.resolveSelection(input);
+    await integration.configurationValidation.validate({
+      model: selection.model,
+      permissionMode: normalizePermissionMode(input.permissionMode),
+      thinkingMode: normalizeSupportedThinkingMode(
+        input.thinkingMode,
+        integration.descriptor.supportedThinkingModes,
+      ),
+      settings: integration.settings.parse(input.agentSettings),
+      endpoint: toAgentEndpointSelection(this.deps.endpointResolver, selection),
+    });
   }
 
   updateSessionSettings(

--- a/server/agents/session-settings-service.ts
+++ b/server/agents/session-settings-service.ts
@@ -80,14 +80,15 @@ export class AgentSessionSettingsService {
         ? integration.settings.applyPatch(currentSettings, patch.agentSettingsPatch)
         : currentSettings;
 
+      const configuration = {
+        model: next.model,
+        permissionMode,
+        thinkingMode,
+        settings,
+        endpoint,
+      };
+      await integration.configurationValidation?.validate(configuration);
       if (entry.agentSessionId && integration.sessionConfiguration) {
-        const configuration = {
-          model: next.model,
-          permissionMode,
-          thinkingMode,
-          settings,
-          endpoint,
-        };
         await integration.sessionConfiguration.apply(
           entry.agentSessionId,
           configuration,

--- a/server/commands/__tests__/chat-command-service.test.js
+++ b/server/commands/__tests__/chat-command-service.test.js
@@ -210,6 +210,7 @@ function executionModeMethods({
   thinkingModes = ['none', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
 } = {}) {
   return {
+    validateConfiguration: mock(async () => undefined),
     assertExecutionModeSelectionSupported: mock((agentId, selection) => {
       if (selection.permissionMode !== undefined && !permissionModes.includes(selection.permissionMode)) {
         throw new DomainError(
@@ -1461,6 +1462,35 @@ describe('ChatCommandService', () => {
       'req-start-unsupported-thinking',
       TARGET_CHAT_ID,
     )).toBeNull();
+  });
+
+  it('rejects provider configuration before chat creation or command acceptance', async () => {
+    const { service, chats, ledger, agents } = makeService();
+    agents.validateConfiguration.mockRejectedValue(new AgentIntegrationError(
+      'INVALID_SETTINGS', 'Synthetic invalid model configuration.', false,
+    ));
+    const input = {
+      origin: 'interactive',
+      chatId: TARGET_CHAT_ID,
+      agentId: 'claude',
+      projectPath: projectBaseDir,
+      command: 'Synthetic initial prompt.',
+      model: 'invalid-model',
+      permissionMode: 'default',
+      thinkingMode: 'low',
+      agentSettings: agentSettings('claude'),
+      clientRequestId: 'req-start-invalid-model',
+      clientMessageId: 'msg-start-invalid-model',
+    };
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await expect(service.submitStart(input)).rejects.toMatchObject({
+        code: 'VALIDATION_FAILED', status: 422, retryable: false,
+      });
+    }
+    expect(agents.validateConfiguration).toHaveBeenCalledWith(input);
+    expect(chats.addChat).not.toHaveBeenCalled();
+    expect(agents.startSession).not.toHaveBeenCalled();
+    expect(await readLedgerRecord(ledger, 'chat-start', input.clientRequestId, TARGET_CHAT_ID)).toBeNull();
   });
 
   it('persists the neutral chat-start value for an agent without thinking modes', async () => {

--- a/server/commands/command-support.ts
+++ b/server/commands/command-support.ts
@@ -98,6 +98,7 @@ export type AgentRegistryDep = Pick<
   | 'getAgentReadinessMap'
   | 'getAgentCatalogEntries'
   | 'assertExecutionModeSelectionSupported'
+  | 'validateConfiguration'
   | 'normalizeThinkingModeForAgent'
   | 'runSingleQuery'
   | 'supportsFork'

--- a/server/commands/start-commands.ts
+++ b/server/commands/start-commands.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { AgentIntegrationError } from '@garcon/server-agent-interface';
 import { parseChatRowTitle } from '../../common/chat-row-contracts.js';
 import {
   recordsStartupPreferences,
@@ -158,6 +159,16 @@ export class StartCommands {
 
     if (!input.agentSettings || input.agentSettings.ownerId !== input.agentId) {
       throw new CommandValidationError('VALIDATION_FAILED', 'agentSettings must be owned by agentId');
+    }
+
+    // Rejected configuration must not reserve a request identity or publish a partial chat.
+    try {
+      await this.deps.agents.validateConfiguration(input);
+    } catch (error) {
+      if (error instanceof AgentIntegrationError && error.code === 'INVALID_SETTINGS') {
+        throw new CommandValidationError('VALIDATION_FAILED', error.message, 422, error.retryable);
+      }
+      throw error;
     }
 
     const projectPath = await resolveStartProjectPath(input.projectPath);

--- a/server/routes/__tests__/chats-start.test.js
+++ b/server/routes/__tests__/chats-start.test.js
@@ -123,6 +123,7 @@ const agents = {
   isAgentSessionRunning: mock(() => false),
   hasAgent: mock(() => true),
   assertExecutionModeSelectionSupported: mock(() => undefined),
+  validateConfiguration: mock(async () => undefined),
   supportsFork: mock(() => true),
   supportsImages: mock(() => false),
   modelSupportsImages: mock(() => Promise.resolve(false)),

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -2,6 +2,7 @@
 
 import { withJsonBody } from '../lib/json-route.js';
 import type { IChatRegistry } from '../chats/store.js';
+import { AgentIntegrationError } from '@garcon/server-agent-interface';
 import {
   normalizePermissionMode,
   normalizeThinkingMode,
@@ -294,6 +295,9 @@ function optionalStringOrNull(value: unknown): string | null | undefined {
 function chatSettingsPatchErrorResponse(error: unknown): Response {
   if (error instanceof ModelSelectionError) {
     return jsonError(error.message, 422, 'MODEL_SELECTION_ERROR');
+  }
+  if (error instanceof AgentIntegrationError && error.code === 'INVALID_SETTINGS') {
+    return jsonError(error.message, 422, error.code, error.retryable);
   }
   return jsonErrorFromUnknown(error);
 }


### PR DESCRIPTION
Allow Claude chats to select an auto-compaction limit such as `gpt-6-astra[922k]` without per-model configuration. Translate numeric suffixes into Claude’s `[1m]` model hint and `--autocompact` flag while preserving the stored selection and normalizing endpoint subagent models. Keep the process for same-cap model changes, resume the same native session when the cap changes, and reject invalid initial configurations with HTTP 422 before recording a chat or command. Preserve native behavior for unannotated models and require Claude Code 2.1.238 or newer.