### PR TITLE
Make ticket command notices descriptive and clickable

### DIFF
--- a/common/__tests__/garcon-ticket-result.test.js
+++ b/common/__tests__/garcon-ticket-result.test.js
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import { TICKET_ACTIONS } from '../ticket-commands.js';
-import { garconTicketResultContent, ticketCommandOutcome, ticketMutationReceipt,
+import { garconTicketResultContent, ticketCommandOutcome, ticketCommandContext, ticketMutationReceipt,
   parseGarconTicketResult, parseTicketCommandOutcome, parseTicketCommandResult } from '../garcon-ticket-result.js';
 import { TICKET_LIMITS } from '../tickets.js';
 import { ticketBytes } from '../ticket-validation.js';
+import { parseGarconTicketCommand } from '../garcon-ticket-command.js';
+import { ticketCommandNoticeParts, ticketCommandNoticeText } from '../ticket-command-notice.js';
+import { escapeGarconXmlText } from '../garcon-command-envelope.js';
 
 const version = { storeId: '11111111-1111-4111-8111-111111111111', collectionRevision: 7 };
 const correlation = { requestViewId: '22222222-2222-4222-8222-222222222222', requestOrdinal: 12 };
@@ -31,6 +34,95 @@ function result(command, status = 'ok') {
 }
 
 describe('command-specific ticket results', () => {
+  test.each([
+    ['create', 'Created ticket G-1'], ['update', 'Updated ticket G-1'],
+    ['claim', 'Assigned ticket G-1 to this chat'], ['release', 'Released ticket G-1'],
+    ['reopen', 'Reopened ticket G-1'], ['close', 'Closed ticket G-1'],
+    ['comment', 'Added comment to ticket G-1'], ['comment-edit', 'Edited comment on ticket G-1'],
+    ['comment-delete', 'Deleted comment from ticket G-1'], ['list', 'Listed tickets'],
+    ['read', 'Read ticket G-1'], ['history', 'Read history for ticket G-1'],
+    ['link', 'G-1 updated, added link'], ['unlink', 'G-1 updated, removed link'],
+  ])('describes %s without a redundant title', (command, expected) => {
+    expect(ticketCommandNoticeText(ticketCommandOutcome(result(command)))).toBe(expected);
+    const failure = ticketCommandNoticeText(ticketCommandOutcome(result(command, 'error')));
+    expect(failure).toStartWith("Couldn't ");
+    expect(failure).toContain('TICKET_NOT_FOUND');
+    expect(failure).not.toContain('completed');
+    if (command !== 'list' && command !== 'create') expect(failure).toContain('G-1');
+  });
+
+  test.each(['link', 'unlink'])('preserves both targets and relationship direction for %s', (command) => {
+    for (const kind of ['blocks', 'related']) for (const status of ['ok', 'error']) {
+      const context = ticketCommandContext(parseGarconTicketCommand(
+        `<garcon-ticket-${command} ref="link" ticket-id="G-1" expected-revision="1">{"kind":"${kind}","targetId":"G-2","targetRevision":1}</garcon-ticket-${command}>`,
+      ));
+      const output = { ...result(command, status), context };
+      expect(parseGarconTicketResult(garconTicketResultContent(output))).toEqual(output);
+      const outcome = ticketCommandOutcome(output);
+      expect(parseTicketCommandOutcome(outcome)).toEqual(outcome);
+      expect(ticketCommandNoticeParts(outcome).filter((part) => part.kind === 'ticket'))
+        .toEqual([{ kind: 'ticket', ticketId: 'G-1' }, { kind: 'ticket', ticketId: 'G-2' }]);
+      const label = kind === 'blocks' ? 'blocking' : 'related';
+      expect(ticketCommandNoticeText(outcome)).toBe(status === 'ok'
+        ? `G-1 updated, ${command === 'link' ? 'added' : 'removed'} ${label} link to G-2`
+        : `Couldn't ${command === 'link' ? 'add' : 'remove'} ${label} link from G-1 to G-2: "TICKET_NOT_FOUND"`);
+    }
+  });
+
+  test('round-trips bounded list filters without pagination or Markdown interpretation', () => {
+    const filters = { project: 'Synthetic `<path> & [link](https://example.test)', priority: 0,
+      status: 'in-progress', includeClosed: true, ready: false, label: 'ui', query: 'G-2',
+      assignee: { kind: 'chat', chatId: actor.chatId } };
+    const command = parseGarconTicketCommand(`<garcon-ticket-list>${escapeGarconXmlText(JSON.stringify({ ...filters,
+      limit: 1, beforeNumber: 3, expectedCollectionRevision: 7 }))}</garcon-ticket-list>`);
+    expect(command).not.toBeNull();
+    const context = ticketCommandContext(command);
+    expect(context).toEqual({ filters });
+    for (const status of ['ok', 'error']) {
+      const output = { ...result('list', status), context };
+      expect(parseGarconTicketResult(garconTicketResultContent(output))).toEqual(output);
+      const outcome = ticketCommandOutcome(output);
+      expect(parseTicketCommandOutcome(outcome)).toEqual(outcome);
+      expect(ticketCommandNoticeParts(outcome)).toContainEqual({ kind: 'code', text: filters.project });
+      const prefix = status === 'ok' ? 'Listed tickets' : "Couldn't list tickets";
+      const suffix = status === 'error' ? ': "TICKET_NOT_FOUND"' : '';
+      expect(ticketCommandNoticeText(outcome)).toBe(`${prefix} with filters project ${JSON.stringify(filters.project)}, status "in progress", include closed "true", priority "urgent", label "ui", assignee "chat ${actor.chatId}", ready "false", search "G-2"${suffix}`);
+      expect(ticketCommandNoticeText(outcome)).not.toContain('limit');
+    }
+    expect(ticketCommandContext(parseGarconTicketCommand('<garcon-ticket-list />'))).toEqual({ filters: {} });
+    expect(ticketCommandNoticeText(ticketCommandOutcome({ ...result('list'), context: { filters: {} } }))).toBe('Listed tickets');
+  });
+
+  test.each([
+    ['unassigned', 'unassigned'],
+    [{ kind: 'user', username: 'synthetic-user' }, 'synthetic-user'],
+    [{ kind: 'chat', chatId: actor.chatId }, `chat ${actor.chatId}`],
+  ])('formats the list assignee %j without changing its identity', (assignee, expected) => {
+    const outcome = ticketCommandOutcome({ ...result('list'), context: { filters: { assignee } } });
+    expect(ticketCommandNoticeText(outcome)).toBe(`Listed tickets with filters assignee ${JSON.stringify(expected)}`);
+    expect(ticketCommandNoticeParts(outcome)).toEqual([
+      { kind: 'text', text: 'Listed tickets' },
+      { kind: 'text', text: ' with filters assignee ' },
+      { kind: 'code', text: expected },
+    ]);
+  });
+
+  test('rejects context on the wrong action, unbounded values and private fields', () => {
+    for (const [command, context] of [
+      ['create', { filters: {} }], ['list', { link: { kind: 'blocks', targetId: 'G-2' } }],
+      ['list', { filters: { limit: 1 } }], ['list', { filters: { project: 'a'.repeat(4097) } }],
+      ['list', { filters: { priority: 4 } }], ['list', { filters: { assignee: { kind: 'admin' } } }],
+      ['link', { link: { kind: 'parent', targetId: 'G-2' } }],
+      ['link', { link: { kind: 'blocks', targetId: 'javascript:evil' } }],
+      ['link', { link: { kind: 'blocks', targetId: 'G-2', body: 'private' } }],
+    ]) {
+      const output = { ...result(command), context };
+      expect(() => parseTicketCommandResult(output)).toThrow();
+      expect(parseGarconTicketResult(garconTicketResultContent(output))).toBeNull();
+      expect(parseTicketCommandOutcome(ticketCommandOutcome(output))).toBeNull();
+    }
+  });
+
   test('uses only ticket names for result envelopes and notices', () => {
     for (const command of TICKET_ACTIONS) for (const status of ['ok', 'error']) {
       const expected = result(command, status);

--- a/common/garcon-ticket-result.ts
+++ b/common/garcon-ticket-result.ts
@@ -1,12 +1,48 @@
 import { TICKET_ACTIONS, type TicketAction } from './ticket-commands.js';
 import type { AgentCommandCorrelation } from './garcon-command-results.js';
-import { isTicketReadAction } from './garcon-ticket-command.js';
+import { isTicketReadAction, type GarconTicketCommand } from './garcon-ticket-command.js';
+import { parseTicketListQuery } from './ticket-query.js';
 import { escapeGarconXmlText, parseGarconCommandEnvelope } from './garcon-command-envelope.js';
 import { parseTicketDetail, parseTicketHistoryPage, parseTicketPage } from './ticket-responses.js';
-import { ticketBytes, storedTicketId, ticketInteger, ticketInvalid, ticketRecord, ticketRef, ticketStatus, ticketUuid } from './ticket-validation.js';
+import { ticketBytes, storedTicketId, ticketInteger, ticketInvalid, ticketLinkKind, ticketRecord, ticketRef, ticketStatus, ticketUuid } from './ticket-validation.js';
 import { isErrorCode } from './error-codes.js';
 import { TICKET_LIMITS, type TicketActivity, type TicketDetail, type TicketErrorCode, type TicketPage,
-  type TicketSequencePage, type TicketStatus, type TicketWriteResult } from './tickets.js';
+  type TicketSequencePage, type TicketStatus, type TicketWriteResult, type TicketListQuery, type TicketLinkKind } from './tickets.js';
+
+const FILTER_KEYS = ['project', 'status', 'includeClosed', 'priority', 'label', 'assignee', 'ready', 'query'] as const;
+export type TicketNoticeContext = {
+  readonly filters?: Pick<TicketListQuery, typeof FILTER_KEYS[number]>;
+  readonly link?: { readonly kind: TicketLinkKind; readonly targetId: string };
+};
+
+function parseNoticeContext(command: TicketAction, value: unknown): TicketNoticeContext {
+  let contextKeys: readonly string[] = [];
+  if (command === 'list') contextKeys = ['filters'];
+  else if (command === 'link' || command === 'unlink') contextKeys = ['link'];
+  const raw = ticketRecord(value, contextKeys);
+  if (raw.filters !== undefined) {
+    const { limit: _limit, ...filters } = parseTicketListQuery(ticketRecord(raw.filters, FILTER_KEYS));
+    return { filters };
+  }
+  if (raw.link !== undefined) {
+    const link = ticketRecord(raw.link, ['kind', 'targetId']);
+    return { link: { kind: ticketLinkKind(link.kind), targetId: storedTicketId(link.targetId) } };
+  }
+  return {};
+}
+
+export function ticketCommandContext(command: GarconTicketCommand): TicketNoticeContext | undefined {
+  const payload = command.payload;
+  if (payload.action === 'list') {
+    const filters = Object.fromEntries(FILTER_KEYS.filter((key) => payload.query[key] !== undefined)
+      .map((key) => [key, payload.query[key]]));
+    return parseNoticeContext('list', { filters });
+  }
+  if (payload.action === 'link' || payload.action === 'unlink') {
+    return { link: { kind: payload.kind, targetId: payload.targetId } };
+  }
+  return undefined;
+}
 
 export interface TicketMutationReceipt {
   readonly storeId: string;
@@ -18,7 +54,7 @@ export interface TicketMutationReceipt {
   readonly relatedTicket?: { readonly id: string; readonly revision: number };
 }
 
-type RequestIdentity<A extends TicketAction> = { readonly command: A }
+type RequestIdentity<A extends TicketAction> = { readonly command: A; readonly context?: TicketNoticeContext }
   & (A extends 'list' | 'read' | 'history' ? { readonly ref?: string } : { readonly ref: string })
   & (A extends 'create' ? { readonly ticketId?: string } : A extends 'list' ? object : { readonly ticketId: string });
 type SuccessIdentity<A extends TicketAction> = RequestIdentity<A> & (A extends 'create' ? { readonly ticketId: string } : unknown);
@@ -65,6 +101,7 @@ function requestIdentity(raw: Record<string, unknown>) {
   if (command === 'list' && raw.ticketId !== undefined) return ticketInvalid('List result cannot target a ticket.');
   const target = raw.ticketId === undefined && (command === 'create' || command === 'list') ? undefined : storedTicketId(raw.ticketId);
   return { command, ...(ref === undefined ? {} : { ref }), ...(target === undefined ? {} : { ticketId: target }),
+    ...(raw.context === undefined ? {} : { context: parseNoticeContext(command, raw.context) }),
     requestViewId: ticketUuid(raw.requestViewId, 'requestViewId'), requestOrdinal: ticketInteger(raw.requestOrdinal, 'requestOrdinal') };
 }
 
@@ -74,7 +111,7 @@ export function parseTicketErrorCode(value: unknown): TicketErrorCode {
 }
 
 export function parseTicketCommandResult(value: unknown): GarconTicketResult {
-  const raw = ticketRecord(value, ['command', 'ref', 'ticketId', 'requestViewId', 'requestOrdinal', 'status', 'data', 'errorCode', 'message']);
+  const raw = ticketRecord(value, ['command', 'ref', 'ticketId', 'requestViewId', 'requestOrdinal', 'status', 'data', 'errorCode', 'message', 'context']);
   const identity = requestIdentity(raw);
   if (raw.status === 'error') {
     if (raw.data !== undefined) return ticketInvalid('A ticket error cannot contain result data.');
@@ -107,13 +144,22 @@ const ATTRIBUTES = { command: 'command', ref: 'ref', 'ticket-id': 'ticketId',
 
 export function garconTicketResultContent(result: GarconTicketResult): string {
   const attributes = Object.entries(ATTRIBUTES).flatMap(([name, key]) => {
-    const value = key === 'ticketId' ? ('ticketId' in result ? result.ticketId : undefined) : result[key];
-    if (key === 'command' || value === undefined) return [];
+    if (key === 'command') return [];
+    let value: string | number | undefined;
+    if (key === 'ticketId') {
+      if (!('ticketId' in result)) return [];
+      value = result.ticketId;
+    } else {
+      value = result[key];
+    }
+    if (value === undefined) return [];
     return [`${name}="${escapeGarconXmlText(String(value)).replaceAll('"', '&quot;')}"`];
   });
-  const data = result.status === 'ok' ? result.data : { errorCode: result.errorCode, message: result.message };
+  const body = result.status === 'ok'
+    ? { data: result.data, context: result.context }
+    : { errorCode: result.errorCode, message: result.message, context: result.context };
   const name = `garcon-ticket-${result.command}-result`;
-  return `<${name} ${attributes.join(' ')}>\n${escapeGarconXmlText(JSON.stringify(data))}\n</${name}>`;
+  return `<${name} ${attributes.join(' ')}>\n${escapeGarconXmlText(JSON.stringify(body))}\n</${name}>`;
 }
 
 export function parseGarconTicketResult(content: string): GarconTicketResult | null {
@@ -132,9 +178,8 @@ export function parseGarconTicketResult(content: string): GarconTicketResult | n
       }
       if (typeof raw.requestOrdinal !== 'string' || !/^[1-9][0-9]*$/u.test(raw.requestOrdinal)) return null;
       raw.requestOrdinal = Number(raw.requestOrdinal);
-      const data: unknown = JSON.parse(envelope.body);
-      if (raw.status === 'error') Object.assign(raw, ticketRecord(data, ['errorCode', 'message']));
-      else raw.data = data;
+      Object.assign(raw, ticketRecord(JSON.parse(envelope.body), raw.status === 'error'
+        ? ['errorCode', 'message', 'context'] : ['data', 'context']));
       return parseTicketCommandResult(raw);
     } catch { return null; }
   }
@@ -142,9 +187,10 @@ export function parseGarconTicketResult(content: string): GarconTicketResult | n
 }
 
 export function ticketCommandOutcome(result: GarconTicketResult): TicketCommandOutcome {
-  const { requestViewId, requestOrdinal, command, ref } = result;
+  const { requestViewId, requestOrdinal, command, ref, context } = result;
   const ticketId = 'ticketId' in result ? result.ticketId : undefined;
   const identity = { type: 'ticket-command-outcome' as const, requestViewId, requestOrdinal, command,
+    ...(context === undefined ? {} : { context }),
     ...(ref === undefined ? {} : { ref }), ...(ticketId === undefined ? {} : { ticketId }) };
   if (result.status === 'error') return { ...identity, status: 'error', errorCode: result.errorCode } as TicketCommandOutcome;
   let revision: number | undefined;
@@ -155,7 +201,7 @@ export function ticketCommandOutcome(result: GarconTicketResult): TicketCommandO
 
 export function parseTicketCommandOutcome(value: unknown): TicketCommandOutcome | null {
   try {
-    const raw = ticketRecord(value, ['type', 'command', 'ref', 'ticketId', 'requestViewId', 'requestOrdinal', 'status', 'revision', 'errorCode']);
+    const raw = ticketRecord(value, ['type', 'command', 'ref', 'ticketId', 'requestViewId', 'requestOrdinal', 'status', 'revision', 'errorCode', 'context']);
     if (raw.type !== 'ticket-command-outcome') return null;
     const identity = { type: 'ticket-command-outcome' as const, ...requestIdentity(raw) };
     if (raw.status === 'error' && raw.revision === undefined) {
@@ -169,9 +215,4 @@ export function parseTicketCommandOutcome(value: unknown): TicketCommandOutcome 
     if (!identity.ticketId) return null;
     return { ...identity, status: 'ok', revision: ticketInteger(raw.revision, 'revision') } as TicketCommandOutcome;
   } catch { return null; }
-}
-
-export function ticketCommandOutcomeContent(detail: TicketCommandOutcome): string {
-  if (detail.status === 'error') return `Ticket ${detail.command} failed: ${detail.errorCode}.`;
-  return `Ticket ${detail.command} completed${'ticketId' in detail && detail.ticketId ? ` for ${detail.ticketId}` : ''}.`;
 }

--- a/common/ticket-command-notice.ts
+++ b/common/ticket-command-notice.ts
@@ -1,0 +1,96 @@
+import type { TicketCommandOutcome, TicketNoticeContext } from './garcon-ticket-result.js';
+
+export type TicketNoticePart =
+  | { readonly kind: 'text' | 'code'; readonly text: string }
+  | { readonly kind: 'ticket'; readonly ticketId: string };
+
+const NOTICE_LABELS = {
+  create: { success: 'Created ticket', failure: 'create ticket' },
+  update: { success: 'Updated ticket', failure: 'update ticket' },
+  claim: { success: 'Assigned ticket', failure: 'assign ticket' },
+  release: { success: 'Released ticket', failure: 'release ticket' },
+  reopen: { success: 'Reopened ticket', failure: 'reopen ticket' },
+  close: { success: 'Closed ticket', failure: 'close ticket' },
+  comment: { success: 'Added comment to ticket', failure: 'add comment to ticket' },
+  'comment-edit': { success: 'Edited comment on ticket', failure: 'edit comment on ticket' },
+  'comment-delete': { success: 'Deleted comment from ticket', failure: 'delete comment from ticket' },
+  list: { success: 'Listed tickets', failure: 'list tickets' },
+  read: { success: 'Read ticket', failure: 'read ticket' },
+  history: { success: 'Read history for ticket', failure: 'read history for ticket' },
+};
+
+function listFilterValues(filters: NonNullable<TicketNoticeContext['filters']>): [label: string, value: string][] {
+  const values: [string, string][] = [];
+  if (filters.project !== undefined) values.push(['project', filters.project]);
+  if (filters.status !== undefined) values.push(['status', filters.status.replaceAll('-', ' ')]);
+  if (filters.includeClosed !== undefined) values.push(['include closed', String(filters.includeClosed)]);
+  if (filters.priority !== undefined) values.push(['priority', ['urgent', 'high', 'normal', 'low'][filters.priority]!]);
+  if (filters.label !== undefined) values.push(['label', filters.label]);
+  const assignee = filters.assignee;
+  if (assignee === 'unassigned') {
+    values.push(['assignee', assignee]);
+  } else if (assignee?.kind === 'user') {
+    values.push(['assignee', assignee.username]);
+  } else if (assignee) {
+    values.push(['assignee', `chat ${assignee.chatId}`]);
+  }
+  if (filters.ready !== undefined) values.push(['ready', String(filters.ready)]);
+  if (filters.query !== undefined) values.push(['search', filters.query]);
+  return values;
+}
+
+export function ticketCommandNoticeParts(outcome: TicketCommandOutcome): TicketNoticePart[] {
+  const parts: TicketNoticePart[] = [];
+  const addText = (text: string) => parts.push({ kind: 'text', text });
+  const addCode = (text: string) => parts.push({ kind: 'code', text });
+  const addTicket = (ticketId: string) => parts.push({ kind: 'ticket', ticketId });
+  const failed = outcome.status === 'error';
+  if (outcome.command === 'link' || outcome.command === 'unlink') {
+    const adding = outcome.command === 'link';
+    const link = outcome.context?.link;
+    let linkLabel = 'link';
+    if (link?.kind === 'blocks') linkLabel = 'blocking link';
+    else if (link?.kind === 'related') linkLabel = 'related link';
+    if (failed) {
+      addText(`Couldn't ${adding ? 'add' : 'remove'} ${linkLabel} from `);
+      addTicket(outcome.ticketId);
+    } else {
+      addTicket(outcome.ticketId);
+      addText(` updated, ${adding ? 'added' : 'removed'} ${linkLabel}`);
+    }
+    if (link) {
+      addText(' to ');
+      addTicket(link.targetId);
+    }
+  } else {
+    const labels = NOTICE_LABELS[outcome.command];
+    addText(failed ? `Couldn't ${labels.failure}` : labels.success);
+    if ('ticketId' in outcome && outcome.ticketId) {
+      addText(' ');
+      addTicket(outcome.ticketId);
+    }
+    if (outcome.command === 'claim' && !failed) addText(' to this chat');
+  }
+  if (outcome.command === 'list' && outcome.context?.filters) {
+    const values = listFilterValues(outcome.context.filters);
+    for (const [index, [name, value]] of values.entries()) {
+      addText(`${index === 0 ? ' with filters ' : ', '}${name} `);
+      addCode(value);
+    }
+  }
+  if (outcome.status === 'error') {
+    addText(': ');
+    addCode(outcome.errorCode);
+  }
+  return parts;
+}
+
+export function ticketCommandNoticeText(outcome: TicketCommandOutcome): string {
+  return ticketCommandNoticeParts(outcome).map((part) => {
+    switch (part.kind) {
+      case 'ticket': return part.ticketId;
+      case 'code': return JSON.stringify(part.text);
+      case 'text': return part.text;
+    }
+  }).join('');
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,8 @@ Priorities are `0` Urgent, `1` High, `2` Normal (default), and `3` Low. Create a
 
 Read the current revision before a field or workflow mutation. Comment append does not need a ticket revision and does not advance it. Claim atomically assigns the caller (or declared chat) and moves Open to In progress; release removes only that caller's assignment. Neither is an access-control lock. `--from-chat` records declared provenance alongside the actual HTTP principal; it cannot grant permission to edit a chat-authored comment.
 
+Agent ticket commands produce one concise transcript notice per command, with clickable ticket IDs in the workspace. Relationship notices name both tickets and the link kind; list notices include supplied filters as literal values. Each notice keeps its own source address, including when an assistant message contains multiple commands. Native `garcon-ticket-*-result` envelopes carry JSON `{data, context?}` on success or `{errorCode, message, context?}` on failure. Optional context contains only list filters or relationship kind/target, so native history reload can reconstruct the same notices without copying ticket descriptions or comment bodies.
+
 Additional mutations:
 
 ```bash

--- a/integration-tests/tests/chromium/ticket-command-notices.test.ts
+++ b/integration-tests/tests/chromium/ticket-command-notices.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'bun:test';
+import { mkdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { withChromiumFixture } from '../../support/chromium-fixture.js';
+import { collapseCanonicalFilesWindow } from '../../support/chromium-workspace.js';
+import { createTicketSource } from '../../support/ticket-source-fixture.js';
+
+for (const width of [1440, 390]) {
+  test(`ticket notices open the exact ticket repeatedly without losing the chat draft at ${width}px`, async () => {
+    await withChromiumFixture(`ticket-notice-${width}`, async ({ page, integration, assertNoBrowserErrors }) => {
+      const { chatId, ticketId } = await createTicketSource(integration);
+      await page.goto(`${integration.garcon.baseUrl}/chat/${chatId}`);
+      await collapseCanonicalFilesWindow(page);
+      await page.setViewportSize({ width, height: 900 });
+      const composer = page.locator('textarea:visible');
+      await composer.fill('Synthetic retained notice draft.');
+      const notice = page.locator('[data-ticket-command="create"]');
+      await notice.waitFor();
+      expect((await notice.innerText()).trim()).toBe(`Created ticket ${ticketId}`);
+      expect(await page.getByText('Ticket command', { exact: true }).count()).toBe(0);
+      const link = notice.getByRole('link', { name: ticketId, exact: true });
+      expect(await link.getAttribute('href')).toBe(`/?ticket=${ticketId}`);
+      const bounds = await notice.boundingBox();
+      expect(bounds!.width).toBeGreaterThan(0);
+      expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(width);
+      const artifacts = new URL('../../artifacts/chromium/', import.meta.url);
+      await mkdir(artifacts, { recursive: true });
+      await page.screenshot({ path: fileURLToPath(new URL(`ticket-notice-${width}.png`, artifacts)) });
+      for (let click = 0; click < 2; click++) {
+        await link.click();
+        const detail = page.getByRole('region', { name: 'Ticket details', exact: true });
+        await detail.waitFor();
+        expect(await detail.getByRole('heading', { name: 'Synthetic source ticket', exact: true }).count()).toBe(1);
+        expect(new URL(page.url()).pathname).toBe(`/chat/${chatId}`);
+        if (width < 600) await page.getByRole('button', { name: 'Close Tickets', exact: true }).click();
+        else await page.getByRole('tab', { name: 'Synthetic source navigation instruction.', exact: true }).click();
+        await notice.waitFor();
+        expect(await composer.inputValue()).toBe('Synthetic retained notice draft.');
+      }
+      assertNoBrowserErrors();
+    });
+  });
+}

--- a/integration-tests/tests/server/garcon-tickets.test.ts
+++ b/integration-tests/tests/server/garcon-tickets.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { garconTicketResultContent, parseGarconTicketResult, type GarconTicketResult } from '../../../common/garcon-ticket-result.js';
+import { garconTicketResultContent, parseGarconTicketResult, ticketCommandOutcome, type GarconTicketResult } from '../../../common/garcon-ticket-result.js';
+import { ticketCommandNoticeText } from '../../../common/ticket-command-notice.js';
+import { escapeGarconXmlText } from '../../../common/garcon-command-envelope.js';
 import { parseTicketWriteResult } from '../../../common/ticket-records.js';
 import { parseTicketBootstrap, parseTicketCommentsPage, parseTicketDetail, parseTicketHistoryPage,
   parseTicketPage, parseTicketProjectDefault } from '../../../common/ticket-responses.js';
@@ -27,6 +29,13 @@ function ticketCommands(fixture: IntegrationFixture, chatId: string) {
     const cursor = fixture.client.markEvents();
     acknowledgment.releaseText('Synthetic acknowledgment received.');
     expect((await fixture.client.waitForTurnTerminal(chatId, undefined, { afterIndex: cursor })).type).toBe('agent-run-finished');
+    const transcript = await fixture.client.getMessages(chatId);
+    const notice = messagesOfType(transcript.messages, 'transcript-notice').find((message) =>
+      message.detail?.type === 'ticket-command-outcome' && message.detail.requestViewId === result.requestViewId
+      && message.detail.requestOrdinal === result.requestOrdinal);
+    expect(notice?.detail).toEqual(ticketCommandOutcome(result));
+    expect(notice?.content).toBe(ticketCommandNoticeText(ticketCommandOutcome(result)));
+    expect(notice?.title).toBeUndefined();
     return result;
   };
 }
@@ -38,6 +47,33 @@ function mutation(result: GarconTicketResult) {
 }
 
 describe('Garcon ticket commands', () => {
+  test('retains descriptive relationship and filter notices through native reload', async () => {
+    await withIntegrationFixture('garcon-ticket-notices', async (fixture) => {
+      const chatId = fixture.newChatId();
+      const emit = ticketCommands(fixture, chatId);
+      const first = mutation(await emit('<garcon-ticket-create ref="first">{"title":"Synthetic first","project":"Release"}</garcon-ticket-create>'));
+      const second = mutation(await emit('<garcon-ticket-create ref="second">{"title":"Synthetic second","project":"Release"}</garcon-ticket-create>'));
+      const link = await emit(`<garcon-ticket-link ref="link" ticket-id="${first.ticketId}" expected-revision="1">{"targetId":"${second.ticketId}","targetRevision":1,"kind":"blocks"}</garcon-ticket-link>`);
+      expect(ticketCommandNoticeText(ticketCommandOutcome(link))).toBe(`${first.ticketId} updated, added blocking link to ${second.ticketId}`);
+      const receipt = mutation(link);
+      const unlink = await emit(`<garcon-ticket-unlink ref="unlink" ticket-id="${first.ticketId}" expected-revision="${receipt.revision}">{"targetId":"${second.ticketId}","targetRevision":${receipt.relatedTicket!.revision},"kind":"blocks"}</garcon-ticket-unlink>`);
+      expect(ticketCommandNoticeText(ticketCommandOutcome(unlink))).toBe(`${first.ticketId} updated, removed blocking link to ${second.ticketId}`);
+      const filters = { project: 'Synthetic `<group> & [link](https://example.test)', priority: 1, label: 'ui' } as const;
+      const list = await emit(`<garcon-ticket-list>${escapeGarconXmlText(JSON.stringify(filters))}</garcon-ticket-list>`);
+      expect(list.status).toBe('ok');
+      expect(list.context).toEqual({ filters });
+      await emit('<garcon-ticket-list />');
+      const before = messagesOfType((await fixture.client.getMessages(chatId)).messages, 'transcript-notice')
+        .filter((message) => message.detail?.type === 'ticket-command-outcome');
+      await fixture.client.reloadChat(chatId);
+      const after = messagesOfType((await fixture.client.getMessages(chatId)).messages, 'transcript-notice')
+        .filter((message) => message.detail?.type === 'ticket-command-outcome');
+      expect(after.map(({ content, title, detail }) => ({ content, title, detail })))
+        .toEqual(before.map(({ content, title, detail }) => ({ content, title, detail })));
+      expect(after).toHaveLength(6);
+    });
+  }, 60_000);
+
   test('uses the captured chat project when Git metadata is broken, through commands and HTTP defaults', async () => {
     await withIntegrationFixture('garcon-tickets-broken-git', async (fixture) => {
       const project = await realpath(fixture.dirs.project);

--- a/server/ledger/__tests__/ticket-command-publication.test.js
+++ b/server/ledger/__tests__/ticket-command-publication.test.js
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { AssistantMessage, UserMessage } from '../../../common/chat-types.js';
 import { garconTicketResultContent, ticketCommandOutcome } from '../../../common/garcon-ticket-result.js';
+import { ticketCommandNoticeText } from '../../../common/ticket-command-notice.js';
 import { TranscriptLedgerService } from '../service.js';
 import { TranscriptLedgerStore } from '../store.js';
 import { ledgerRowsToTranscriptMessages } from '../presentation.js';
@@ -80,22 +81,45 @@ describe('ticket command ledger evidence', () => {
       { message: new UserMessage(LATER, garconTicketResultContent(result)), providerMeta: null },
     ], () => AT);
     expect(drafts[0].detail.type).toBe('ticket-command-request');
-    expect(drafts[1].detail).toEqual({ ...outcome, title: 'Ticket command', nativeResultInput: true });
+    expect(drafts[1].detail).toEqual({ ...outcome, nativeResultInput: true });
+    expect(drafts[1].message).toBe('Created ticket G-1');
     const staged = ledger.stageView(CHAT, drafts, 1);
     ledger.replaceCurrentView(CHAT, view.viewId, staged.viewId);
     store.closeChat(CHAT);
     const rendered = ledgerRowsToTranscriptMessages(ledger.currentRows(CHAT));
     expect(rendered).toHaveLength(1);
     expect(rendered[0].message.detail).toEqual(outcome);
+    expect(rendered[0].message.title).toBeUndefined();
     expect(JSON.stringify(rendered)).not.toContain('nativeResultInput');
     expect(JSON.stringify(rendered)).not.toContain('storeId');
     expect(ledger.conversationMessages(CHAT)).toEqual([]);
     expect(frozenDrafts(rendered.map(({ message }) => message))).toEqual([]);
     expect(calls).toEqual([]);
     expect(ledger.nativeActivityState(CHAT).providerWatermark).toEqual({ ordinal: 2, at: LATER });
-    ledger.appendNotice(CHAT, staged.viewId, { at: '2026-01-01T01:00:00.000Z', title: 'Ticket command',
+    ledger.appendNotice(CHAT, staged.viewId, { at: '2026-01-01T01:00:00.000Z',
       content: 'Local outcome.', detail: outcome });
     expect(ledger.nativeActivityState(CHAT).providerWatermark).toEqual({ ordinal: 2, at: LATER });
+  });
+
+  test('live and imported outcomes retain the same safe filter and relationship context', () => {
+    const { ledger } = fixture();
+    const view = ledger.initializeChat(CHAT);
+    for (const [command, context] of [
+      ['list', { filters: { project: 'Synthetic `[group]`', priority: 1 } }],
+      ['link', { link: { kind: 'blocks', targetId: 'G-2' } }],
+    ]) {
+      const result = { command, context, ref: 'synthetic', requestViewId: view.viewId, requestOrdinal: 1,
+        ...(command === 'list' ? {} : { ticketId: 'G-1' }), status: 'error',
+        errorCode: 'TICKET_COMMANDS_DISABLED', message: 'Synthetic failure.' };
+      const detail = ticketCommandOutcome(result);
+      ledger.appendNotice(CHAT, view.viewId, { at: AT, detail, content: ticketCommandNoticeText(detail) });
+      const drafts = importedDrafts([{ message: new UserMessage(AT, garconTicketResultContent(result)), providerMeta: null }], () => AT);
+      expect(drafts[0].detail).toEqual({ ...detail, nativeResultInput: true });
+      const live = ledgerRowsToTranscriptMessages(ledger.currentRows(CHAT)).at(-1).message;
+      expect(live.detail.context).toEqual(context);
+      expect(live.content).toBe(drafts[0].message);
+      expect(live.title).toBeUndefined();
+    }
   });
 
   test('read results never persist descriptions or comments in imported notices', () => {

--- a/server/ledger/contracts.ts
+++ b/server/ledger/contracts.ts
@@ -37,7 +37,7 @@ export type LedgerTicketCommandOutcomeDetail = TicketCommandOutcome & {
 };
 
 export function projectLedgerTicketCommandOutcome(detail: JsonObject): TicketCommandOutcome | null {
-  const publicFields = ['type', 'command', 'ref', 'ticketId', 'requestViewId', 'requestOrdinal', 'status', 'revision', 'errorCode'];
+  const publicFields = ['type', 'command', 'ref', 'ticketId', 'requestViewId', 'requestOrdinal', 'status', 'revision', 'errorCode', 'context'];
   return parseTicketCommandOutcome(Object.fromEntries(publicFields
     .filter((key) => Object.hasOwn(detail, key)).map((key) => [key, detail[key]])));
 }

--- a/server/ledger/imported-drafts.ts
+++ b/server/ledger/imported-drafts.ts
@@ -23,7 +23,8 @@ import {
   ticketCommandRequestNoticeDraft,
 } from './garcon-command-request.js';
 import type { LedgerRowDraft, LedgerAgentCommandOutcomeDetail, LedgerTicketCommandOutcomeDetail } from './contracts.js';
-import { ticketCommandOutcome, ticketCommandOutcomeContent, parseGarconTicketResult } from '../../common/garcon-ticket-result.js';
+import { ticketCommandOutcome, parseGarconTicketResult } from '../../common/garcon-ticket-result.js';
+import { ticketCommandNoticeText } from '../../common/ticket-command-notice.js';
 import { agentCommandOutcomeContent, agentCommandOutcomeTitle, parseGarconCommandResult } from '../../common/garcon-command-results.js';
 import type { PreambleHistoryEvidence } from './preamble-history.js';
 
@@ -95,8 +96,8 @@ function importedDraftFor(
     const ticketResult = parseGarconTicketResult(original.content);
     if (ticketResult) {
       const outcome = ticketCommandOutcome(ticketResult);
-      return [{ kind: 'notice', at, message: ticketCommandOutcomeContent(outcome),
-        detail: { ...outcome, title: 'Ticket command', nativeResultInput: true } satisfies LedgerTicketCommandOutcomeDetail,
+      return [{ kind: 'notice', at, message: ticketCommandNoticeText(outcome),
+        detail: { ...outcome, nativeResultInput: true } satisfies LedgerTicketCommandOutcomeDetail,
         providerMeta: null }];
     }
     const result = parseGarconCommandResult(original.content);

--- a/server/ledger/service.ts
+++ b/server/ledger/service.ts
@@ -133,7 +133,7 @@ interface ActivePermission {
 }
 
 interface TranscriptNoticeInput {
-  readonly title: string;
+  readonly title?: string;
   readonly content: string;
   readonly detail?: TranscriptNoticeDetail;
   readonly at?: string;
@@ -935,10 +935,9 @@ export class TranscriptLedgerService {
 
 function normalizeNotice(input: TranscriptNoticeInput): NormalizedTranscriptNotice {
   const title = parseChatRowTitle(input.title);
-  if (!title) throw new TypeError('Notice title is required');
   return {
     content: parseChatRowContent(input.content),
-    detail: { ...(input.detail ?? {}), title },
+    detail: { ...(input.detail ?? {}), ...(title ? { title } : {}) },
     at: input.at,
   };
 }

--- a/server/tickets/__tests__/command-controller.test.js
+++ b/server/tickets/__tests__/command-controller.test.js
@@ -4,6 +4,7 @@ import { parseGarconTicketCommand } from '../../../common/garcon-ticket-command.
 import { parseGarconTicketResult } from '../../../common/garcon-ticket-result.js';
 import { ticketBytes } from '../../../common/ticket-validation.js';
 import { TICKET_LIMITS } from '../../../common/tickets.js';
+import { escapeGarconXmlText } from '../../../common/garcon-command-envelope.js';
 import { KeyedPromiseLock } from '../../lib/keyed-lock.js';
 import { CHAT_ID, VIEW_ID, ticketFixture } from './fixture.js';
 
@@ -67,6 +68,8 @@ describe('ticket command controller', () => {
     expect(f.service.history({ ticketId: 'G-1' }).items[0].source)
       .toEqual({ chatId: CHAT_ID, transcriptViewId: VIEW_ID, ordinal: 1 });
     expect(f.notices).toHaveLength(1);
+    expect(f.notices[0].content).toBe('Created ticket G-1');
+    expect(f.notices[0].title).toBeUndefined();
     expect(JSON.stringify(f.notices)).not.toContain('Synthetic ticket');
     expect(f.deliveries[0].input.receipt).toBeNull();
   });
@@ -184,13 +187,14 @@ describe('ticket command controller', () => {
     const f = fixture();
     for (let index = 0; index < 15; index++) f.create({ project: '&'.repeat(3000), title: `Synthetic ${index}` });
     const numbers = [];
-    let query = { limit: 100 };
+    let query = { limit: 100, project: '&'.repeat(3000) };
     do {
-      const response = await f.send(`<garcon-ticket-list>${JSON.stringify(query)}</garcon-ticket-list>`);
+      const response = await f.send(`<garcon-ticket-list>${escapeGarconXmlText(JSON.stringify(query))}</garcon-ticket-list>`);
       expect(response.status).toBe('ok');
+      expect(response.context).toEqual({ filters: { project: query.project } });
       expect(ticketBytes(f.deliveries.at(-1).input.content)).toBeLessThanOrEqual(TICKET_LIMITS.markupBytes);
       numbers.push(...response.data.items.map((ticket) => ticket.number));
-      query = { limit: 100, beforeNumber: response.data.nextBeforeNumber, expectedCollectionRevision: response.data.collectionRevision };
+      query = { limit: 100, project: query.project, beforeNumber: response.data.nextBeforeNumber, expectedCollectionRevision: response.data.collectionRevision };
     } while (query.beforeNumber !== null);
     expect(numbers).toEqual(Array.from({ length: 15 }, (_, index) => 15 - index));
     for (let index = 0; index < 5; index++) f.write({ action: 'comment', ticketId: 'G-1', body: `Comment ${index}` });

--- a/server/tickets/command-controller.ts
+++ b/server/tickets/command-controller.ts
@@ -1,8 +1,9 @@
 import { isTicketReadCommand, type GarconTicketCommand, type GarconTicketMutationCommand,
   type GarconTicketReadCommand } from '../../common/garcon-ticket-command.js';
-import { garconTicketResultContent, ticketCommandOutcome, ticketCommandOutcomeContent,
+import { garconTicketResultContent, ticketCommandOutcome, ticketCommandContext,
   ticketMutationReceipt, parseTicketCommandResult, type GarconTicketResult } from '../../common/garcon-ticket-result.js';
 import { parseMarkupTicketMutationPayload } from '../../common/ticket-commands.js';
+import { ticketCommandNoticeText } from '../../common/ticket-command-notice.js';
 import { ticketBytes } from '../../common/ticket-validation.js';
 import { TICKET_LIMITS, type TicketProjectDefault } from '../../common/tickets.js';
 import { AgentCommandReplies, type AgentCommandContext } from '../chats/agent-command-replies.js';
@@ -124,7 +125,7 @@ export class TicketCommandController {
       const detail = ticketCommandOutcome(result);
       try {
         this.options.notices.appendNotice(source.chatId, source.viewId, {
-          title: 'Ticket command', content: ticketCommandOutcomeContent(detail), detail,
+          content: ticketCommandNoticeText(detail), detail,
           at: new Date().toISOString(),
         });
       } catch (error) { this.#replies.report(source, 'ticket-outcome', error); }
@@ -145,7 +146,9 @@ function identity(source: AgentCommandSource, command: GarconTicketCommand) {
   const payload = command.payload;
   const ticketId = payload.action === 'list' || payload.action === 'create' ? undefined
     : 'query' in payload ? payload.query.ticketId : payload.ticketId;
+  const context = ticketCommandContext(command);
   return { command: payload.action, ...(command.ref === undefined ? {} : { ref: command.ref }),
+    ...(context === undefined ? {} : { context }),
     ...(ticketId === undefined ? {} : { ticketId }), requestViewId: source.viewId, requestOrdinal: source.requestOrdinal };
 }
 

--- a/web/src/lib/components/chat/ConversationMessage.svelte
+++ b/web/src/lib/components/chat/ConversationMessage.svelte
@@ -786,6 +786,7 @@
 					{:else if asNotice}
 						<TranscriptNoticeRow
 							message={asNotice}
+							onOpenTicket={(id) => workspace.openTicket(id)}
 							fileLinkBasePath={projectBasePath}
 							onLinkNavigate={handleLinkNavigate}
 							{acquireTransientActivity}

--- a/web/src/lib/components/chat/__tests__/TranscriptNoticeRow.test.ts
+++ b/web/src/lib/components/chat/__tests__/TranscriptNoticeRow.test.ts
@@ -1,15 +1,119 @@
-import { render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
 import { TranscriptNoticeMessage } from '$shared/chat-types';
 import TranscriptNoticeRow from '../rows/TranscriptNoticeRow.svelte';
+import type { TicketCommandOutcome } from '$shared/garcon-ticket-result';
 
 const AT = '2026-08-28T00:00:00.000Z';
+const ticketOutcome = {
+	type: 'ticket-command-outcome',
+	command: 'create',
+	ref: 'synthetic',
+	requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+	requestOrdinal: 1,
+	status: 'ok',
+	ticketId: 'G-2',
+	revision: 1,
+} satisfies TicketCommandOutcome;
 
 describe('TranscriptNoticeRow', () => {
+	it('renders a title-free ticket notice with repeatable navigation and a native new-tab href', async () => {
+		const onOpenTicket = vi.fn<(id: string) => Promise<void>>().mockResolvedValue();
+		const { container } = render(TranscriptNoticeRow, {
+			message: new TranscriptNoticeMessage(
+				AT,
+				'Created ticket G-2',
+				ticketOutcome,
+				'Ticket command',
+			),
+			onOpenTicket,
+		});
+		expect(screen.queryByText('Ticket command')).toBeNull();
+		expect(container.querySelector('[data-ticket-command]')?.textContent?.trim()).toBe(
+			'Created ticket G-2',
+		);
+		const link = screen.getByRole('link', { name: 'G-2' });
+		expect(link.getAttribute('href')).toBe('/?ticket=G-2');
+		await fireEvent.click(link);
+		await fireEvent.click(link);
+		expect(onOpenTicket.mock.calls).toEqual([['G-2'], ['G-2']]);
+		for (const modifier of ['ctrlKey', 'metaKey', 'shiftKey', 'altKey']) {
+			expect(await fireEvent.click(link, { [modifier]: true })).toBe(true);
+		}
+		expect(onOpenTicket).toHaveBeenCalledTimes(2);
+	});
+
+	it('keeps ticket references inert without workspace navigation, including shared snapshots', () => {
+		render(TranscriptNoticeRow, {
+			message: new TranscriptNoticeMessage(AT, 'Created ticket G-2', ticketOutcome),
+		});
+		expect(screen.getByText('G-2')).toBeTruthy();
+		expect(screen.queryByRole('link')).toBeNull();
+	});
+
+	it('renders both relationship targets and filters as literal text, not Markdown or HTML', async () => {
+		const onOpenTicket = vi.fn<(id: string) => Promise<void>>().mockResolvedValue();
+		const { container, rerender } = render(TranscriptNoticeRow, {
+			message: new TranscriptNoticeMessage(AT, '', {
+				...ticketOutcome,
+				command: 'link',
+				context: { link: { kind: 'blocks', targetId: 'G-7' } },
+			}),
+			onOpenTicket,
+		});
+		expect(container.textContent?.trim()).toBe('G-2 updated, added blocking link to G-7');
+		await fireEvent.click(screen.getByRole('link', { name: 'G-7' }));
+		expect(onOpenTicket).toHaveBeenCalledWith('G-7');
+		const project = '`<script>alert(1)</script> [G-8](https://example.test)`';
+		await rerender({
+			message: new TranscriptNoticeMessage(AT, '', {
+				type: 'ticket-command-outcome',
+				command: 'list',
+				status: 'ok',
+				requestViewId: ticketOutcome.requestViewId,
+				requestOrdinal: 2,
+				context: { filters: { project, priority: 1 } },
+			}),
+		});
+		expect([...container.querySelectorAll('code')].map((node) => node.textContent)).toEqual([
+			project,
+			'high',
+		]);
+		expect(container.querySelector('script')).toBeNull();
+		expect(screen.queryByRole('link')).toBeNull();
+		expect(container.textContent).toContain('Listed tickets with filters project');
+	});
+
+	it('uses error styling for failed commands and reports failed navigation without a false success', async () => {
+		const onOpenTicket = vi
+			.fn<(id: string) => Promise<void>>()
+			.mockRejectedValueOnce(new Error('Synthetic open failure.'))
+			.mockResolvedValue();
+		const { container } = render(TranscriptNoticeRow, {
+			message: new TranscriptNoticeMessage(AT, '', {
+				...ticketOutcome,
+				command: 'read',
+				status: 'error',
+				errorCode: 'TICKET_NOT_FOUND',
+			}),
+			onOpenTicket,
+		});
+		expect(container.querySelector('article')?.className).toContain('border-status-error-border');
+		expect(container.textContent).toContain("Couldn't read ticket");
+		expect(screen.getByText('TICKET_NOT_FOUND')).toBeTruthy();
+		await fireEvent.click(screen.getByRole('link', { name: 'G-2' }));
+		await waitFor(() =>
+			expect(screen.getByRole('alert').textContent).toBe('Synthetic open failure.'),
+		);
+		await fireEvent.click(screen.getByRole('link', { name: 'G-2' }));
+		expect(screen.queryByRole('alert')).toBeNull();
+	});
+
 	it('renders startup failures as durable error cards', () => {
 		const { container } = render(TranscriptNoticeRow, {
 			message: new TranscriptNoticeMessage(AT, 'Agent startup failed. The task was retained.', {
-				type: 'agent-start-progress', phase: 'failed',
+				type: 'agent-start-progress',
+				phase: 'failed',
 			}),
 		});
 		expect(screen.getByText('Agent startup failed. The task was retained.')).toBeTruthy();
@@ -18,24 +122,33 @@ describe('TranscriptNoticeRow', () => {
 	it('links an accepted delegated start to its child before the agent produces output', () => {
 		render(TranscriptNoticeRow, {
 			message: new TranscriptNoticeMessage(AT, 'Start agent accepted.', {
-				type: 'agent-start-outcome', ref: 'synthetic-task', async: true,
-				requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174', requestOrdinal: 1,
-				status: 'accepted', chatId: '1234567890123456',
+				type: 'agent-start-outcome',
+				ref: 'synthetic-task',
+				async: true,
+				requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+				requestOrdinal: 1,
+				status: 'accepted',
+				chatId: '1234567890123456',
 			}),
 			resolveChatReference: () => ({ title: 'Synthetic child', isCurrent: false }),
 		});
 
 		expect(screen.getByText('Started')).toBeTruthy();
-		expect(screen.getByRole('link', { name: 'Open chat' }).getAttribute('href'))
-			.toBe('/chat/1234567890123456');
+		expect(screen.getByRole('link', { name: 'Open chat' }).getAttribute('href')).toBe(
+			'/chat/1234567890123456',
+		);
 	});
 
 	it('keeps a deleted child reference inert and preserves rejection details', async () => {
 		const { rerender } = render(TranscriptNoticeRow, {
 			message: new TranscriptNoticeMessage(AT, 'Start agent accepted.', {
-				type: 'agent-start-outcome', ref: 'synthetic-task', async: true,
-				requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174', requestOrdinal: 1,
-				status: 'accepted', chatId: '1234567890123456',
+				type: 'agent-start-outcome',
+				ref: 'synthetic-task',
+				async: true,
+				requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+				requestOrdinal: 1,
+				status: 'accepted',
+				chatId: '1234567890123456',
 			}),
 			resolveChatReference: () => null,
 		});
@@ -43,9 +156,13 @@ describe('TranscriptNoticeRow', () => {
 		expect(screen.getByText('(1234567890123456)')).toBeTruthy();
 		await rerender({
 			message: new TranscriptNoticeMessage(AT, 'Could not start: unknown-model.', {
-				type: 'agent-start-outcome', ref: 'synthetic-task', async: true,
-				requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174', requestOrdinal: 1,
-				status: 'rejected', reason: 'unknown-model',
+				type: 'agent-start-outcome',
+				ref: 'synthetic-task',
+				async: true,
+				requestViewId: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+				requestOrdinal: 1,
+				status: 'rejected',
+				reason: 'unknown-model',
 			}),
 		});
 		expect(screen.getByText('Could not start: unknown-model.')).toBeTruthy();
@@ -54,23 +171,19 @@ describe('TranscriptNoticeRow', () => {
 
 	it('renders an ordered title-only preamble update notice', () => {
 		const { container } = render(TranscriptNoticeRow, {
-			message: new TranscriptNoticeMessage(
-				AT,
-				'Preambles updated',
-				{
-					type: 'preamble-selection-changed',
-					preambles: [
-						{
-							id: '3502b645-222b-49d2-ac39-1c91f9fb1174',
-							title: 'Security constraints',
-						},
-						{
-							id: '80becfa6-c9c7-4b31-9190-fd23c0bedf9c',
-							title: 'Repository conventions',
-						},
-					],
-				},
-			),
+			message: new TranscriptNoticeMessage(AT, 'Preambles updated', {
+				type: 'preamble-selection-changed',
+				preambles: [
+					{
+						id: '3502b645-222b-49d2-ac39-1c91f9fb1174',
+						title: 'Security constraints',
+					},
+					{
+						id: '80becfa6-c9c7-4b31-9190-fd23c0bedf9c',
+						title: 'Repository conventions',
+					},
+				],
+			}),
 		});
 
 		expect(screen.getByText('Preambles updated')).toBeTruthy();
@@ -84,11 +197,10 @@ describe('TranscriptNoticeRow', () => {
 
 	it('renders None enabled for an empty preamble update notice', () => {
 		render(TranscriptNoticeRow, {
-			message: new TranscriptNoticeMessage(
-				AT,
-				'Preambles updated',
-				{ type: 'preamble-selection-changed', preambles: [] },
-			),
+			message: new TranscriptNoticeMessage(AT, 'Preambles updated', {
+				type: 'preamble-selection-changed',
+				preambles: [],
+			}),
 		});
 
 		expect(screen.getByText('None enabled')).toBeTruthy();

--- a/web/src/lib/components/chat/rows/TicketCommandOutcomeRow.svelte
+++ b/web/src/lib/components/chat/rows/TicketCommandOutcomeRow.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import type { TicketCommandOutcome } from '$shared/garcon-ticket-result';
+	import { ticketCommandNoticeParts } from '$shared/ticket-command-notice';
+	import { ticketHref } from '$lib/tickets/catalog/ticket-deep-link.js';
+	import * as m from '$lib/paraglide/messages.js';
+	import ChatEventCard from './ChatEventCard.svelte';
+
+	let {
+		detail,
+		onOpenTicket,
+	}: {
+		detail: TicketCommandOutcome;
+		onOpenTicket?: (id: string) => Promise<void>;
+	} = $props();
+	const parts = $derived(ticketCommandNoticeParts(detail));
+	let navigationError = $state<string | null>(null);
+
+	function open(event: MouseEvent, id: string): void {
+		if (
+			!onOpenTicket ||
+			event.button !== 0 ||
+			event.metaKey ||
+			event.ctrlKey ||
+			event.shiftKey ||
+			event.altKey
+		)
+			return;
+		event.preventDefault();
+		event.stopPropagation();
+		navigationError = null;
+		void onOpenTicket(id).catch((error: unknown) => {
+			navigationError = error instanceof Error ? error.message : m.workspace_open_failed();
+		});
+	}
+</script>
+
+<ChatEventCard variant={detail.status === 'error' ? 'error' : 'info'} compact>
+	{#snippet body()}
+		<div class="text-sm whitespace-pre-wrap break-words" data-ticket-command={detail.command}>
+			{#each parts as part, index (index)}
+				{#if part.kind === 'ticket'}
+					{#if onOpenTicket}
+						<a
+							href={ticketHref(part.ticketId)}
+							class="text-primary font-medium underline decoration-primary/40 underline-offset-2 hover:decoration-primary focus-visible:outline-2 focus-visible:outline-ring"
+							data-ticket-reference-id={part.ticketId}
+							onclick={(event) => open(event, part.ticketId)}
+							onpointerdowncapture={(event) => event.stopPropagation()}
+							oncontextmenu={(event) => event.stopPropagation()}>{part.ticketId}</a
+						>
+					{:else}
+						<span class="font-medium">{part.ticketId}</span>
+					{/if}
+				{:else if part.kind === 'code'}
+					<code class="rounded bg-muted px-1 font-mono text-[0.9em] [overflow-wrap:anywhere]"
+						>{part.text}</code
+					>
+				{:else}{part.text}{/if}
+			{/each}
+		</div>
+		{#if navigationError}
+			<p role="alert" class="mt-1 text-sm text-status-error-foreground">{navigationError}</p>
+		{/if}
+	{/snippet}
+</ChatEventCard>

--- a/web/src/lib/components/chat/rows/TranscriptNoticeRow.svelte
+++ b/web/src/lib/components/chat/rows/TranscriptNoticeRow.svelte
@@ -18,6 +18,7 @@
 	import InterAgentMessageRow from './InterAgentMessageRow.svelte';
 	import PreambleApplicationRow from './PreambleApplicationRow.svelte';
 	import PreambleSelectionChangedRow from './PreambleSelectionChangedRow.svelte';
+	import TicketCommandOutcomeRow from './TicketCommandOutcomeRow.svelte';
 	import Markdown from '../Markdown.svelte';
 	import type { MarkdownLinkNavigateEvent } from '../Markdown.svelte';
 	import type { ConversationDisclosureStatePort } from '../ConversationFeedItemState.svelte.js';
@@ -28,6 +29,7 @@
 		resolveChatReference?: ResolveChatReference;
 		fileLinkBasePath?: string | null;
 		onLinkNavigate?: (link: MarkdownLinkNavigateEvent) => boolean | void;
+		onOpenTicket?: (id: string) => Promise<void>;
 		acquireTransientActivity?: (close: () => void) => () => void;
 		disclosureState?: ConversationDisclosureStatePort;
 	}
@@ -37,6 +39,7 @@
 		resolveChatReference,
 		fileLinkBasePath,
 		onLinkNavigate,
+		onOpenTicket,
 		acquireTransientActivity,
 		disclosureState,
 	}: Props = $props();
@@ -80,6 +83,8 @@
 			</div>
 		{/snippet}
 	</ChatEventCard>
+{:else if message.detail?.type === 'ticket-command-outcome'}
+	<TicketCommandOutcomeRow detail={message.detail} {onOpenTicket} />
 {:else if preambleApplication}
 	<PreambleApplicationRow detail={preambleApplication} />
 {:else if preambleSelectionChanged}

--- a/web/src/lib/components/tickets/ticket-presentation.ts
+++ b/web/src/lib/components/tickets/ticket-presentation.ts
@@ -1,5 +1,6 @@
 import type { TicketActivity, TicketPriority, TicketStatus } from '$shared/tickets';
 import * as m from '$lib/paraglide/messages.js';
+import { ticketHref } from '$lib/tickets/catalog/ticket-deep-link.js';
 
 export function ticketStatusLabel(status: TicketStatus): string {
 	return {
@@ -37,7 +38,5 @@ export function isTicketProjectPath(project: string): boolean {
 }
 
 export function ticketDeepLink(ticketId: string): string {
-	const url = new URL('/', window.location.origin);
-	url.searchParams.set('ticket', ticketId);
-	return url.href;
+	return new URL(ticketHref(ticketId), window.location.origin).href;
 }

--- a/web/src/lib/tickets/catalog/ticket-deep-link.ts
+++ b/web/src/lib/tickets/catalog/ticket-deep-link.ts
@@ -1,5 +1,9 @@
 import { ticketId } from '$shared/ticket-validation';
 
+export function ticketHref(id: string): string {
+	return `/?${new URLSearchParams({ ticket: id })}`;
+}
+
 export function selectedTicketFromUrl(url: URL): string | null {
 	const values = url.searchParams.getAll('ticket');
 	if (values.length !== 1) return null;

--- a/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
+++ b/web/src/lib/workspace/__tests__/workspace-coordinator.test.ts
@@ -170,6 +170,10 @@ function createHarness(
 		commitIfPresent: () => commit,
 		chatCanvasIfPresent: () => options.canvas ?? null,
 		ticketsIfPresent: () => options.tickets ?? null,
+		tickets: () => {
+			if (!options.tickets) throw new Error('Synthetic tickets controller not configured');
+			return options.tickets;
+		},
 		setPresentationVisible: vi.fn(),
 		disposeSurface: vi.fn((kind: string) => {
 			if (kind === 'commit') commit.resetAfterClose();
@@ -226,6 +230,21 @@ function createHarness(
 }
 
 describe('WorkspaceCoordinator', () => {
+	it.each([false, true])('opens ticket references repeatedly with mobile=%s', async (isMobile) => {
+		const { controller } = ticketTestHarness();
+		try {
+			const { coordinator, layout } = createHarness({ tickets: controller });
+			if (isMobile) await coordinator.enterMobilePresentation();
+			const select = vi.spyOn(controller, 'select').mockImplementation(() => {});
+			for (const id of ['G-2', 'G-7', 'G-2']) await coordinator.openTicket(id);
+			expect(select.mock.calls).toEqual([['G-2'], ['G-7'], ['G-2']]);
+			expect(layout.surface('singleton:tickets')).not.toBeNull();
+			if (isMobile) expect(layout.snapshot.mobileActiveSurfaceId).toBe('singleton:tickets');
+		} finally {
+			controller.dispose();
+		}
+	});
+
 	it.each(['tab', 'window', 'other-windows'] as const)(
 		'guards retained Tickets drafts before closing %s',
 		async (kind) => {

--- a/web/src/lib/workspace/workspace-coordinator.svelte.ts
+++ b/web/src/lib/workspace/workspace-coordinator.svelte.ts
@@ -449,6 +449,11 @@ export class WorkspaceCoordinator implements FilePlacementPort {
 		);
 	}
 
+	async openTicket(id: string): Promise<void> {
+		await this.openSingletonAsTab('tickets', this.currentWindowId);
+		this.#deps.singletons.tickets().select(id);
+	}
+
 	async openSingletonAsTab(
 		kind: PortableSingletonKind,
 		windowId: WorkspaceWindowId,


### PR DESCRIPTION
Make ticket activity easier to scan with concise, title-free notices, explicit relationship changes, literal list filters, and ticket links that preserve chat drafts. Bounded result context keeps live and reloaded notices consistent, while separate outcomes preserve exact source navigation. Success result bodies now use `{data, context?}`; prior bare-data envelopes are no longer accepted.